### PR TITLE
HIVE-25504: Fix HMS C++ Thrift client compilation

### DIFF
--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -1136,6 +1136,122 @@ void FieldSchema::printTo(std::ostream& out) const {
 }
 
 
+EnvironmentContext::~EnvironmentContext() noexcept {
+}
+
+
+void EnvironmentContext::__set_properties(const std::map<std::string, std::string> & val) {
+  this->properties = val;
+}
+std::ostream& operator<<(std::ostream& out, const EnvironmentContext& obj)
+{
+  obj.printTo(out);
+  return out;
+}
+
+
+uint32_t EnvironmentContext::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_MAP) {
+          {
+            this->properties.clear();
+            uint32_t _size4;
+            ::apache::thrift::protocol::TType _ktype5;
+            ::apache::thrift::protocol::TType _vtype6;
+            xfer += iprot->readMapBegin(_ktype5, _vtype6, _size4);
+            uint32_t _i8;
+            for (_i8 = 0; _i8 < _size4; ++_i8)
+            {
+              std::string _key9;
+              xfer += iprot->readString(_key9);
+              std::string& _val10 = this->properties[_key9];
+              xfer += iprot->readString(_val10);
+            }
+            xfer += iprot->readMapEnd();
+          }
+          this->__isset.properties = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t EnvironmentContext::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("EnvironmentContext");
+
+  xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 1);
+  {
+    xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
+    std::map<std::string, std::string> ::const_iterator _iter11;
+    for (_iter11 = this->properties.begin(); _iter11 != this->properties.end(); ++_iter11)
+    {
+      xfer += oprot->writeString(_iter11->first);
+      xfer += oprot->writeString(_iter11->second);
+    }
+    xfer += oprot->writeMapEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(EnvironmentContext &a, EnvironmentContext &b) {
+  using ::std::swap;
+  swap(a.properties, b.properties);
+  swap(a.__isset, b.__isset);
+}
+
+EnvironmentContext::EnvironmentContext(const EnvironmentContext& other12) {
+  properties = other12.properties;
+  __isset = other12.__isset;
+}
+EnvironmentContext& EnvironmentContext::operator=(const EnvironmentContext& other13) {
+  properties = other13.properties;
+  __isset = other13.__isset;
+  return *this;
+}
+void EnvironmentContext::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "EnvironmentContext(";
+  out << "properties=" << to_string(properties);
+  out << ")";
+}
+
+
 SQLPrimaryKey::~SQLPrimaryKey() noexcept {
 }
 
@@ -1349,29 +1465,29 @@ void swap(SQLPrimaryKey &a, SQLPrimaryKey &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLPrimaryKey::SQLPrimaryKey(const SQLPrimaryKey& other4) {
-  table_db = other4.table_db;
-  table_name = other4.table_name;
-  column_name = other4.column_name;
-  key_seq = other4.key_seq;
-  pk_name = other4.pk_name;
-  enable_cstr = other4.enable_cstr;
-  validate_cstr = other4.validate_cstr;
-  rely_cstr = other4.rely_cstr;
-  catName = other4.catName;
-  __isset = other4.__isset;
+SQLPrimaryKey::SQLPrimaryKey(const SQLPrimaryKey& other14) {
+  table_db = other14.table_db;
+  table_name = other14.table_name;
+  column_name = other14.column_name;
+  key_seq = other14.key_seq;
+  pk_name = other14.pk_name;
+  enable_cstr = other14.enable_cstr;
+  validate_cstr = other14.validate_cstr;
+  rely_cstr = other14.rely_cstr;
+  catName = other14.catName;
+  __isset = other14.__isset;
 }
-SQLPrimaryKey& SQLPrimaryKey::operator=(const SQLPrimaryKey& other5) {
-  table_db = other5.table_db;
-  table_name = other5.table_name;
-  column_name = other5.column_name;
-  key_seq = other5.key_seq;
-  pk_name = other5.pk_name;
-  enable_cstr = other5.enable_cstr;
-  validate_cstr = other5.validate_cstr;
-  rely_cstr = other5.rely_cstr;
-  catName = other5.catName;
-  __isset = other5.__isset;
+SQLPrimaryKey& SQLPrimaryKey::operator=(const SQLPrimaryKey& other15) {
+  table_db = other15.table_db;
+  table_name = other15.table_name;
+  column_name = other15.column_name;
+  key_seq = other15.key_seq;
+  pk_name = other15.pk_name;
+  enable_cstr = other15.enable_cstr;
+  validate_cstr = other15.validate_cstr;
+  rely_cstr = other15.rely_cstr;
+  catName = other15.catName;
+  __isset = other15.__isset;
   return *this;
 }
 void SQLPrimaryKey::printTo(std::ostream& out) const {
@@ -1705,41 +1821,41 @@ void swap(SQLForeignKey &a, SQLForeignKey &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLForeignKey::SQLForeignKey(const SQLForeignKey& other6) {
-  pktable_db = other6.pktable_db;
-  pktable_name = other6.pktable_name;
-  pkcolumn_name = other6.pkcolumn_name;
-  fktable_db = other6.fktable_db;
-  fktable_name = other6.fktable_name;
-  fkcolumn_name = other6.fkcolumn_name;
-  key_seq = other6.key_seq;
-  update_rule = other6.update_rule;
-  delete_rule = other6.delete_rule;
-  fk_name = other6.fk_name;
-  pk_name = other6.pk_name;
-  enable_cstr = other6.enable_cstr;
-  validate_cstr = other6.validate_cstr;
-  rely_cstr = other6.rely_cstr;
-  catName = other6.catName;
-  __isset = other6.__isset;
+SQLForeignKey::SQLForeignKey(const SQLForeignKey& other16) {
+  pktable_db = other16.pktable_db;
+  pktable_name = other16.pktable_name;
+  pkcolumn_name = other16.pkcolumn_name;
+  fktable_db = other16.fktable_db;
+  fktable_name = other16.fktable_name;
+  fkcolumn_name = other16.fkcolumn_name;
+  key_seq = other16.key_seq;
+  update_rule = other16.update_rule;
+  delete_rule = other16.delete_rule;
+  fk_name = other16.fk_name;
+  pk_name = other16.pk_name;
+  enable_cstr = other16.enable_cstr;
+  validate_cstr = other16.validate_cstr;
+  rely_cstr = other16.rely_cstr;
+  catName = other16.catName;
+  __isset = other16.__isset;
 }
-SQLForeignKey& SQLForeignKey::operator=(const SQLForeignKey& other7) {
-  pktable_db = other7.pktable_db;
-  pktable_name = other7.pktable_name;
-  pkcolumn_name = other7.pkcolumn_name;
-  fktable_db = other7.fktable_db;
-  fktable_name = other7.fktable_name;
-  fkcolumn_name = other7.fkcolumn_name;
-  key_seq = other7.key_seq;
-  update_rule = other7.update_rule;
-  delete_rule = other7.delete_rule;
-  fk_name = other7.fk_name;
-  pk_name = other7.pk_name;
-  enable_cstr = other7.enable_cstr;
-  validate_cstr = other7.validate_cstr;
-  rely_cstr = other7.rely_cstr;
-  catName = other7.catName;
-  __isset = other7.__isset;
+SQLForeignKey& SQLForeignKey::operator=(const SQLForeignKey& other17) {
+  pktable_db = other17.pktable_db;
+  pktable_name = other17.pktable_name;
+  pkcolumn_name = other17.pkcolumn_name;
+  fktable_db = other17.fktable_db;
+  fktable_name = other17.fktable_name;
+  fkcolumn_name = other17.fkcolumn_name;
+  key_seq = other17.key_seq;
+  update_rule = other17.update_rule;
+  delete_rule = other17.delete_rule;
+  fk_name = other17.fk_name;
+  pk_name = other17.pk_name;
+  enable_cstr = other17.enable_cstr;
+  validate_cstr = other17.validate_cstr;
+  rely_cstr = other17.rely_cstr;
+  catName = other17.catName;
+  __isset = other17.__isset;
   return *this;
 }
 void SQLForeignKey::printTo(std::ostream& out) const {
@@ -1975,29 +2091,29 @@ void swap(SQLUniqueConstraint &a, SQLUniqueConstraint &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLUniqueConstraint::SQLUniqueConstraint(const SQLUniqueConstraint& other8) {
-  catName = other8.catName;
-  table_db = other8.table_db;
-  table_name = other8.table_name;
-  column_name = other8.column_name;
-  key_seq = other8.key_seq;
-  uk_name = other8.uk_name;
-  enable_cstr = other8.enable_cstr;
-  validate_cstr = other8.validate_cstr;
-  rely_cstr = other8.rely_cstr;
-  __isset = other8.__isset;
+SQLUniqueConstraint::SQLUniqueConstraint(const SQLUniqueConstraint& other18) {
+  catName = other18.catName;
+  table_db = other18.table_db;
+  table_name = other18.table_name;
+  column_name = other18.column_name;
+  key_seq = other18.key_seq;
+  uk_name = other18.uk_name;
+  enable_cstr = other18.enable_cstr;
+  validate_cstr = other18.validate_cstr;
+  rely_cstr = other18.rely_cstr;
+  __isset = other18.__isset;
 }
-SQLUniqueConstraint& SQLUniqueConstraint::operator=(const SQLUniqueConstraint& other9) {
-  catName = other9.catName;
-  table_db = other9.table_db;
-  table_name = other9.table_name;
-  column_name = other9.column_name;
-  key_seq = other9.key_seq;
-  uk_name = other9.uk_name;
-  enable_cstr = other9.enable_cstr;
-  validate_cstr = other9.validate_cstr;
-  rely_cstr = other9.rely_cstr;
-  __isset = other9.__isset;
+SQLUniqueConstraint& SQLUniqueConstraint::operator=(const SQLUniqueConstraint& other19) {
+  catName = other19.catName;
+  table_db = other19.table_db;
+  table_name = other19.table_name;
+  column_name = other19.column_name;
+  key_seq = other19.key_seq;
+  uk_name = other19.uk_name;
+  enable_cstr = other19.enable_cstr;
+  validate_cstr = other19.validate_cstr;
+  rely_cstr = other19.rely_cstr;
+  __isset = other19.__isset;
   return *this;
 }
 void SQLUniqueConstraint::printTo(std::ostream& out) const {
@@ -2210,27 +2326,27 @@ void swap(SQLNotNullConstraint &a, SQLNotNullConstraint &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLNotNullConstraint::SQLNotNullConstraint(const SQLNotNullConstraint& other10) {
-  catName = other10.catName;
-  table_db = other10.table_db;
-  table_name = other10.table_name;
-  column_name = other10.column_name;
-  nn_name = other10.nn_name;
-  enable_cstr = other10.enable_cstr;
-  validate_cstr = other10.validate_cstr;
-  rely_cstr = other10.rely_cstr;
-  __isset = other10.__isset;
+SQLNotNullConstraint::SQLNotNullConstraint(const SQLNotNullConstraint& other20) {
+  catName = other20.catName;
+  table_db = other20.table_db;
+  table_name = other20.table_name;
+  column_name = other20.column_name;
+  nn_name = other20.nn_name;
+  enable_cstr = other20.enable_cstr;
+  validate_cstr = other20.validate_cstr;
+  rely_cstr = other20.rely_cstr;
+  __isset = other20.__isset;
 }
-SQLNotNullConstraint& SQLNotNullConstraint::operator=(const SQLNotNullConstraint& other11) {
-  catName = other11.catName;
-  table_db = other11.table_db;
-  table_name = other11.table_name;
-  column_name = other11.column_name;
-  nn_name = other11.nn_name;
-  enable_cstr = other11.enable_cstr;
-  validate_cstr = other11.validate_cstr;
-  rely_cstr = other11.rely_cstr;
-  __isset = other11.__isset;
+SQLNotNullConstraint& SQLNotNullConstraint::operator=(const SQLNotNullConstraint& other21) {
+  catName = other21.catName;
+  table_db = other21.table_db;
+  table_name = other21.table_name;
+  column_name = other21.column_name;
+  nn_name = other21.nn_name;
+  enable_cstr = other21.enable_cstr;
+  validate_cstr = other21.validate_cstr;
+  rely_cstr = other21.rely_cstr;
+  __isset = other21.__isset;
   return *this;
 }
 void SQLNotNullConstraint::printTo(std::ostream& out) const {
@@ -2459,29 +2575,29 @@ void swap(SQLDefaultConstraint &a, SQLDefaultConstraint &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLDefaultConstraint::SQLDefaultConstraint(const SQLDefaultConstraint& other12) {
-  catName = other12.catName;
-  table_db = other12.table_db;
-  table_name = other12.table_name;
-  column_name = other12.column_name;
-  default_value = other12.default_value;
-  dc_name = other12.dc_name;
-  enable_cstr = other12.enable_cstr;
-  validate_cstr = other12.validate_cstr;
-  rely_cstr = other12.rely_cstr;
-  __isset = other12.__isset;
+SQLDefaultConstraint::SQLDefaultConstraint(const SQLDefaultConstraint& other22) {
+  catName = other22.catName;
+  table_db = other22.table_db;
+  table_name = other22.table_name;
+  column_name = other22.column_name;
+  default_value = other22.default_value;
+  dc_name = other22.dc_name;
+  enable_cstr = other22.enable_cstr;
+  validate_cstr = other22.validate_cstr;
+  rely_cstr = other22.rely_cstr;
+  __isset = other22.__isset;
 }
-SQLDefaultConstraint& SQLDefaultConstraint::operator=(const SQLDefaultConstraint& other13) {
-  catName = other13.catName;
-  table_db = other13.table_db;
-  table_name = other13.table_name;
-  column_name = other13.column_name;
-  default_value = other13.default_value;
-  dc_name = other13.dc_name;
-  enable_cstr = other13.enable_cstr;
-  validate_cstr = other13.validate_cstr;
-  rely_cstr = other13.rely_cstr;
-  __isset = other13.__isset;
+SQLDefaultConstraint& SQLDefaultConstraint::operator=(const SQLDefaultConstraint& other23) {
+  catName = other23.catName;
+  table_db = other23.table_db;
+  table_name = other23.table_name;
+  column_name = other23.column_name;
+  default_value = other23.default_value;
+  dc_name = other23.dc_name;
+  enable_cstr = other23.enable_cstr;
+  validate_cstr = other23.validate_cstr;
+  rely_cstr = other23.rely_cstr;
+  __isset = other23.__isset;
   return *this;
 }
 void SQLDefaultConstraint::printTo(std::ostream& out) const {
@@ -2711,29 +2827,29 @@ void swap(SQLCheckConstraint &a, SQLCheckConstraint &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLCheckConstraint::SQLCheckConstraint(const SQLCheckConstraint& other14) {
-  catName = other14.catName;
-  table_db = other14.table_db;
-  table_name = other14.table_name;
-  column_name = other14.column_name;
-  check_expression = other14.check_expression;
-  dc_name = other14.dc_name;
-  enable_cstr = other14.enable_cstr;
-  validate_cstr = other14.validate_cstr;
-  rely_cstr = other14.rely_cstr;
-  __isset = other14.__isset;
+SQLCheckConstraint::SQLCheckConstraint(const SQLCheckConstraint& other24) {
+  catName = other24.catName;
+  table_db = other24.table_db;
+  table_name = other24.table_name;
+  column_name = other24.column_name;
+  check_expression = other24.check_expression;
+  dc_name = other24.dc_name;
+  enable_cstr = other24.enable_cstr;
+  validate_cstr = other24.validate_cstr;
+  rely_cstr = other24.rely_cstr;
+  __isset = other24.__isset;
 }
-SQLCheckConstraint& SQLCheckConstraint::operator=(const SQLCheckConstraint& other15) {
-  catName = other15.catName;
-  table_db = other15.table_db;
-  table_name = other15.table_name;
-  column_name = other15.column_name;
-  check_expression = other15.check_expression;
-  dc_name = other15.dc_name;
-  enable_cstr = other15.enable_cstr;
-  validate_cstr = other15.validate_cstr;
-  rely_cstr = other15.rely_cstr;
-  __isset = other15.__isset;
+SQLCheckConstraint& SQLCheckConstraint::operator=(const SQLCheckConstraint& other25) {
+  catName = other25.catName;
+  table_db = other25.table_db;
+  table_name = other25.table_name;
+  column_name = other25.column_name;
+  check_expression = other25.check_expression;
+  dc_name = other25.dc_name;
+  enable_cstr = other25.enable_cstr;
+  validate_cstr = other25.validate_cstr;
+  rely_cstr = other25.rely_cstr;
+  __isset = other25.__isset;
   return *this;
 }
 void SQLCheckConstraint::printTo(std::ostream& out) const {
@@ -2817,14 +2933,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size16;
-            ::apache::thrift::protocol::TType _etype19;
-            xfer += iprot->readListBegin(_etype19, _size16);
-            this->primaryKeys.resize(_size16);
-            uint32_t _i20;
-            for (_i20 = 0; _i20 < _size16; ++_i20)
+            uint32_t _size26;
+            ::apache::thrift::protocol::TType _etype29;
+            xfer += iprot->readListBegin(_etype29, _size26);
+            this->primaryKeys.resize(_size26);
+            uint32_t _i30;
+            for (_i30 = 0; _i30 < _size26; ++_i30)
             {
-              xfer += this->primaryKeys[_i20].read(iprot);
+              xfer += this->primaryKeys[_i30].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2837,14 +2953,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size21;
-            ::apache::thrift::protocol::TType _etype24;
-            xfer += iprot->readListBegin(_etype24, _size21);
-            this->foreignKeys.resize(_size21);
-            uint32_t _i25;
-            for (_i25 = 0; _i25 < _size21; ++_i25)
+            uint32_t _size31;
+            ::apache::thrift::protocol::TType _etype34;
+            xfer += iprot->readListBegin(_etype34, _size31);
+            this->foreignKeys.resize(_size31);
+            uint32_t _i35;
+            for (_i35 = 0; _i35 < _size31; ++_i35)
             {
-              xfer += this->foreignKeys[_i25].read(iprot);
+              xfer += this->foreignKeys[_i35].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2857,14 +2973,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size26;
-            ::apache::thrift::protocol::TType _etype29;
-            xfer += iprot->readListBegin(_etype29, _size26);
-            this->uniqueConstraints.resize(_size26);
-            uint32_t _i30;
-            for (_i30 = 0; _i30 < _size26; ++_i30)
+            uint32_t _size36;
+            ::apache::thrift::protocol::TType _etype39;
+            xfer += iprot->readListBegin(_etype39, _size36);
+            this->uniqueConstraints.resize(_size36);
+            uint32_t _i40;
+            for (_i40 = 0; _i40 < _size36; ++_i40)
             {
-              xfer += this->uniqueConstraints[_i30].read(iprot);
+              xfer += this->uniqueConstraints[_i40].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2877,14 +2993,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size31;
-            ::apache::thrift::protocol::TType _etype34;
-            xfer += iprot->readListBegin(_etype34, _size31);
-            this->notNullConstraints.resize(_size31);
-            uint32_t _i35;
-            for (_i35 = 0; _i35 < _size31; ++_i35)
+            uint32_t _size41;
+            ::apache::thrift::protocol::TType _etype44;
+            xfer += iprot->readListBegin(_etype44, _size41);
+            this->notNullConstraints.resize(_size41);
+            uint32_t _i45;
+            for (_i45 = 0; _i45 < _size41; ++_i45)
             {
-              xfer += this->notNullConstraints[_i35].read(iprot);
+              xfer += this->notNullConstraints[_i45].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2897,14 +3013,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size36;
-            ::apache::thrift::protocol::TType _etype39;
-            xfer += iprot->readListBegin(_etype39, _size36);
-            this->defaultConstraints.resize(_size36);
-            uint32_t _i40;
-            for (_i40 = 0; _i40 < _size36; ++_i40)
+            uint32_t _size46;
+            ::apache::thrift::protocol::TType _etype49;
+            xfer += iprot->readListBegin(_etype49, _size46);
+            this->defaultConstraints.resize(_size46);
+            uint32_t _i50;
+            for (_i50 = 0; _i50 < _size46; ++_i50)
             {
-              xfer += this->defaultConstraints[_i40].read(iprot);
+              xfer += this->defaultConstraints[_i50].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2917,14 +3033,14 @@ uint32_t SQLAllTableConstraints::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size41;
-            ::apache::thrift::protocol::TType _etype44;
-            xfer += iprot->readListBegin(_etype44, _size41);
-            this->checkConstraints.resize(_size41);
-            uint32_t _i45;
-            for (_i45 = 0; _i45 < _size41; ++_i45)
+            uint32_t _size51;
+            ::apache::thrift::protocol::TType _etype54;
+            xfer += iprot->readListBegin(_etype54, _size51);
+            this->checkConstraints.resize(_size51);
+            uint32_t _i55;
+            for (_i55 = 0; _i55 < _size51; ++_i55)
             {
-              xfer += this->checkConstraints[_i45].read(iprot);
+              xfer += this->checkConstraints[_i55].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -2954,10 +3070,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-      std::vector<SQLPrimaryKey> ::const_iterator _iter46;
-      for (_iter46 = this->primaryKeys.begin(); _iter46 != this->primaryKeys.end(); ++_iter46)
+      std::vector<SQLPrimaryKey> ::const_iterator _iter56;
+      for (_iter56 = this->primaryKeys.begin(); _iter56 != this->primaryKeys.end(); ++_iter56)
       {
-        xfer += (*_iter46).write(oprot);
+        xfer += (*_iter56).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2967,10 +3083,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-      std::vector<SQLForeignKey> ::const_iterator _iter47;
-      for (_iter47 = this->foreignKeys.begin(); _iter47 != this->foreignKeys.end(); ++_iter47)
+      std::vector<SQLForeignKey> ::const_iterator _iter57;
+      for (_iter57 = this->foreignKeys.begin(); _iter57 != this->foreignKeys.end(); ++_iter57)
       {
-        xfer += (*_iter47).write(oprot);
+        xfer += (*_iter57).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2980,10 +3096,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-      std::vector<SQLUniqueConstraint> ::const_iterator _iter48;
-      for (_iter48 = this->uniqueConstraints.begin(); _iter48 != this->uniqueConstraints.end(); ++_iter48)
+      std::vector<SQLUniqueConstraint> ::const_iterator _iter58;
+      for (_iter58 = this->uniqueConstraints.begin(); _iter58 != this->uniqueConstraints.end(); ++_iter58)
       {
-        xfer += (*_iter48).write(oprot);
+        xfer += (*_iter58).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2993,10 +3109,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-      std::vector<SQLNotNullConstraint> ::const_iterator _iter49;
-      for (_iter49 = this->notNullConstraints.begin(); _iter49 != this->notNullConstraints.end(); ++_iter49)
+      std::vector<SQLNotNullConstraint> ::const_iterator _iter59;
+      for (_iter59 = this->notNullConstraints.begin(); _iter59 != this->notNullConstraints.end(); ++_iter59)
       {
-        xfer += (*_iter49).write(oprot);
+        xfer += (*_iter59).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3006,10 +3122,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-      std::vector<SQLDefaultConstraint> ::const_iterator _iter50;
-      for (_iter50 = this->defaultConstraints.begin(); _iter50 != this->defaultConstraints.end(); ++_iter50)
+      std::vector<SQLDefaultConstraint> ::const_iterator _iter60;
+      for (_iter60 = this->defaultConstraints.begin(); _iter60 != this->defaultConstraints.end(); ++_iter60)
       {
-        xfer += (*_iter50).write(oprot);
+        xfer += (*_iter60).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3019,10 +3135,10 @@ uint32_t SQLAllTableConstraints::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-      std::vector<SQLCheckConstraint> ::const_iterator _iter51;
-      for (_iter51 = this->checkConstraints.begin(); _iter51 != this->checkConstraints.end(); ++_iter51)
+      std::vector<SQLCheckConstraint> ::const_iterator _iter61;
+      for (_iter61 = this->checkConstraints.begin(); _iter61 != this->checkConstraints.end(); ++_iter61)
       {
-        xfer += (*_iter51).write(oprot);
+        xfer += (*_iter61).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3044,23 +3160,23 @@ void swap(SQLAllTableConstraints &a, SQLAllTableConstraints &b) {
   swap(a.__isset, b.__isset);
 }
 
-SQLAllTableConstraints::SQLAllTableConstraints(const SQLAllTableConstraints& other52) {
-  primaryKeys = other52.primaryKeys;
-  foreignKeys = other52.foreignKeys;
-  uniqueConstraints = other52.uniqueConstraints;
-  notNullConstraints = other52.notNullConstraints;
-  defaultConstraints = other52.defaultConstraints;
-  checkConstraints = other52.checkConstraints;
-  __isset = other52.__isset;
+SQLAllTableConstraints::SQLAllTableConstraints(const SQLAllTableConstraints& other62) {
+  primaryKeys = other62.primaryKeys;
+  foreignKeys = other62.foreignKeys;
+  uniqueConstraints = other62.uniqueConstraints;
+  notNullConstraints = other62.notNullConstraints;
+  defaultConstraints = other62.defaultConstraints;
+  checkConstraints = other62.checkConstraints;
+  __isset = other62.__isset;
 }
-SQLAllTableConstraints& SQLAllTableConstraints::operator=(const SQLAllTableConstraints& other53) {
-  primaryKeys = other53.primaryKeys;
-  foreignKeys = other53.foreignKeys;
-  uniqueConstraints = other53.uniqueConstraints;
-  notNullConstraints = other53.notNullConstraints;
-  defaultConstraints = other53.defaultConstraints;
-  checkConstraints = other53.checkConstraints;
-  __isset = other53.__isset;
+SQLAllTableConstraints& SQLAllTableConstraints::operator=(const SQLAllTableConstraints& other63) {
+  primaryKeys = other63.primaryKeys;
+  foreignKeys = other63.foreignKeys;
+  uniqueConstraints = other63.uniqueConstraints;
+  notNullConstraints = other63.notNullConstraints;
+  defaultConstraints = other63.defaultConstraints;
+  checkConstraints = other63.checkConstraints;
+  __isset = other63.__isset;
   return *this;
 }
 void SQLAllTableConstraints::printTo(std::ostream& out) const {
@@ -3154,14 +3270,14 @@ uint32_t Type::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size54;
-            ::apache::thrift::protocol::TType _etype57;
-            xfer += iprot->readListBegin(_etype57, _size54);
-            this->fields.resize(_size54);
-            uint32_t _i58;
-            for (_i58 = 0; _i58 < _size54; ++_i58)
+            uint32_t _size64;
+            ::apache::thrift::protocol::TType _etype67;
+            xfer += iprot->readListBegin(_etype67, _size64);
+            this->fields.resize(_size64);
+            uint32_t _i68;
+            for (_i68 = 0; _i68 < _size64; ++_i68)
             {
-              xfer += this->fields[_i58].read(iprot);
+              xfer += this->fields[_i68].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3205,10 +3321,10 @@ uint32_t Type::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-      std::vector<FieldSchema> ::const_iterator _iter59;
-      for (_iter59 = this->fields.begin(); _iter59 != this->fields.end(); ++_iter59)
+      std::vector<FieldSchema> ::const_iterator _iter69;
+      for (_iter69 = this->fields.begin(); _iter69 != this->fields.end(); ++_iter69)
       {
-        xfer += (*_iter59).write(oprot);
+        xfer += (*_iter69).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3228,19 +3344,19 @@ void swap(Type &a, Type &b) {
   swap(a.__isset, b.__isset);
 }
 
-Type::Type(const Type& other60) {
-  name = other60.name;
-  type1 = other60.type1;
-  type2 = other60.type2;
-  fields = other60.fields;
-  __isset = other60.__isset;
+Type::Type(const Type& other70) {
+  name = other70.name;
+  type1 = other70.type1;
+  type2 = other70.type2;
+  fields = other70.fields;
+  __isset = other70.__isset;
 }
-Type& Type::operator=(const Type& other61) {
-  name = other61.name;
-  type1 = other61.type1;
-  type2 = other61.type2;
-  fields = other61.fields;
-  __isset = other61.__isset;
+Type& Type::operator=(const Type& other71) {
+  name = other71.name;
+  type1 = other71.type1;
+  type2 = other71.type2;
+  fields = other71.fields;
+  __isset = other71.__isset;
   return *this;
 }
 void Type::printTo(std::ostream& out) const {
@@ -3312,9 +3428,9 @@ uint32_t HiveObjectRef::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast62;
-          xfer += iprot->readI32(ecast62);
-          this->objectType = (HiveObjectType::type)ecast62;
+          int32_t ecast72;
+          xfer += iprot->readI32(ecast72);
+          this->objectType = (HiveObjectType::type)ecast72;
           this->__isset.objectType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3340,14 +3456,14 @@ uint32_t HiveObjectRef::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partValues.clear();
-            uint32_t _size63;
-            ::apache::thrift::protocol::TType _etype66;
-            xfer += iprot->readListBegin(_etype66, _size63);
-            this->partValues.resize(_size63);
-            uint32_t _i67;
-            for (_i67 = 0; _i67 < _size63; ++_i67)
+            uint32_t _size73;
+            ::apache::thrift::protocol::TType _etype76;
+            xfer += iprot->readListBegin(_etype76, _size73);
+            this->partValues.resize(_size73);
+            uint32_t _i77;
+            for (_i77 = 0; _i77 < _size73; ++_i77)
             {
-              xfer += iprot->readString(this->partValues[_i67]);
+              xfer += iprot->readString(this->partValues[_i77]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3404,10 +3520,10 @@ uint32_t HiveObjectRef::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("partValues", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partValues.size()));
-    std::vector<std::string> ::const_iterator _iter68;
-    for (_iter68 = this->partValues.begin(); _iter68 != this->partValues.end(); ++_iter68)
+    std::vector<std::string> ::const_iterator _iter78;
+    for (_iter78 = this->partValues.begin(); _iter78 != this->partValues.end(); ++_iter78)
     {
-      xfer += oprot->writeString((*_iter68));
+      xfer += oprot->writeString((*_iter78));
     }
     xfer += oprot->writeListEnd();
   }
@@ -3438,23 +3554,23 @@ void swap(HiveObjectRef &a, HiveObjectRef &b) {
   swap(a.__isset, b.__isset);
 }
 
-HiveObjectRef::HiveObjectRef(const HiveObjectRef& other69) {
-  objectType = other69.objectType;
-  dbName = other69.dbName;
-  objectName = other69.objectName;
-  partValues = other69.partValues;
-  columnName = other69.columnName;
-  catName = other69.catName;
-  __isset = other69.__isset;
+HiveObjectRef::HiveObjectRef(const HiveObjectRef& other79) {
+  objectType = other79.objectType;
+  dbName = other79.dbName;
+  objectName = other79.objectName;
+  partValues = other79.partValues;
+  columnName = other79.columnName;
+  catName = other79.catName;
+  __isset = other79.__isset;
 }
-HiveObjectRef& HiveObjectRef::operator=(const HiveObjectRef& other70) {
-  objectType = other70.objectType;
-  dbName = other70.dbName;
-  objectName = other70.objectName;
-  partValues = other70.partValues;
-  columnName = other70.columnName;
-  catName = other70.catName;
-  __isset = other70.__isset;
+HiveObjectRef& HiveObjectRef::operator=(const HiveObjectRef& other80) {
+  objectType = other80.objectType;
+  dbName = other80.dbName;
+  objectName = other80.objectName;
+  partValues = other80.partValues;
+  columnName = other80.columnName;
+  catName = other80.catName;
+  __isset = other80.__isset;
   return *this;
 }
 void HiveObjectRef::printTo(std::ostream& out) const {
@@ -3547,9 +3663,9 @@ uint32_t PrivilegeGrantInfo::read(::apache::thrift::protocol::TProtocol* iprot) 
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast71;
-          xfer += iprot->readI32(ecast71);
-          this->grantorType = (PrincipalType::type)ecast71;
+          int32_t ecast81;
+          xfer += iprot->readI32(ecast81);
+          this->grantorType = (PrincipalType::type)ecast81;
           this->__isset.grantorType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3615,21 +3731,21 @@ void swap(PrivilegeGrantInfo &a, PrivilegeGrantInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-PrivilegeGrantInfo::PrivilegeGrantInfo(const PrivilegeGrantInfo& other72) {
-  privilege = other72.privilege;
-  createTime = other72.createTime;
-  grantor = other72.grantor;
-  grantorType = other72.grantorType;
-  grantOption = other72.grantOption;
-  __isset = other72.__isset;
+PrivilegeGrantInfo::PrivilegeGrantInfo(const PrivilegeGrantInfo& other82) {
+  privilege = other82.privilege;
+  createTime = other82.createTime;
+  grantor = other82.grantor;
+  grantorType = other82.grantorType;
+  grantOption = other82.grantOption;
+  __isset = other82.__isset;
 }
-PrivilegeGrantInfo& PrivilegeGrantInfo::operator=(const PrivilegeGrantInfo& other73) {
-  privilege = other73.privilege;
-  createTime = other73.createTime;
-  grantor = other73.grantor;
-  grantorType = other73.grantorType;
-  grantOption = other73.grantOption;
-  __isset = other73.__isset;
+PrivilegeGrantInfo& PrivilegeGrantInfo::operator=(const PrivilegeGrantInfo& other83) {
+  privilege = other83.privilege;
+  createTime = other83.createTime;
+  grantor = other83.grantor;
+  grantorType = other83.grantorType;
+  grantOption = other83.grantOption;
+  __isset = other83.__isset;
   return *this;
 }
 void PrivilegeGrantInfo::printTo(std::ostream& out) const {
@@ -3713,9 +3829,9 @@ uint32_t HiveObjectPrivilege::read(::apache::thrift::protocol::TProtocol* iprot)
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast74;
-          xfer += iprot->readI32(ecast74);
-          this->principalType = (PrincipalType::type)ecast74;
+          int32_t ecast84;
+          xfer += iprot->readI32(ecast84);
+          this->principalType = (PrincipalType::type)ecast84;
           this->__isset.principalType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3789,21 +3905,21 @@ void swap(HiveObjectPrivilege &a, HiveObjectPrivilege &b) {
   swap(a.__isset, b.__isset);
 }
 
-HiveObjectPrivilege::HiveObjectPrivilege(const HiveObjectPrivilege& other75) {
-  hiveObject = other75.hiveObject;
-  principalName = other75.principalName;
-  principalType = other75.principalType;
-  grantInfo = other75.grantInfo;
-  authorizer = other75.authorizer;
-  __isset = other75.__isset;
+HiveObjectPrivilege::HiveObjectPrivilege(const HiveObjectPrivilege& other85) {
+  hiveObject = other85.hiveObject;
+  principalName = other85.principalName;
+  principalType = other85.principalType;
+  grantInfo = other85.grantInfo;
+  authorizer = other85.authorizer;
+  __isset = other85.__isset;
 }
-HiveObjectPrivilege& HiveObjectPrivilege::operator=(const HiveObjectPrivilege& other76) {
-  hiveObject = other76.hiveObject;
-  principalName = other76.principalName;
-  principalType = other76.principalType;
-  grantInfo = other76.grantInfo;
-  authorizer = other76.authorizer;
-  __isset = other76.__isset;
+HiveObjectPrivilege& HiveObjectPrivilege::operator=(const HiveObjectPrivilege& other86) {
+  hiveObject = other86.hiveObject;
+  principalName = other86.principalName;
+  principalType = other86.principalType;
+  grantInfo = other86.grantInfo;
+  authorizer = other86.authorizer;
+  __isset = other86.__isset;
   return *this;
 }
 void HiveObjectPrivilege::printTo(std::ostream& out) const {
@@ -3857,14 +3973,14 @@ uint32_t PrivilegeBag::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->privileges.clear();
-            uint32_t _size77;
-            ::apache::thrift::protocol::TType _etype80;
-            xfer += iprot->readListBegin(_etype80, _size77);
-            this->privileges.resize(_size77);
-            uint32_t _i81;
-            for (_i81 = 0; _i81 < _size77; ++_i81)
+            uint32_t _size87;
+            ::apache::thrift::protocol::TType _etype90;
+            xfer += iprot->readListBegin(_etype90, _size87);
+            this->privileges.resize(_size87);
+            uint32_t _i91;
+            for (_i91 = 0; _i91 < _size87; ++_i91)
             {
-              xfer += this->privileges[_i81].read(iprot);
+              xfer += this->privileges[_i91].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -3893,10 +4009,10 @@ uint32_t PrivilegeBag::write(::apache::thrift::protocol::TProtocol* oprot) const
   xfer += oprot->writeFieldBegin("privileges", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->privileges.size()));
-    std::vector<HiveObjectPrivilege> ::const_iterator _iter82;
-    for (_iter82 = this->privileges.begin(); _iter82 != this->privileges.end(); ++_iter82)
+    std::vector<HiveObjectPrivilege> ::const_iterator _iter92;
+    for (_iter92 = this->privileges.begin(); _iter92 != this->privileges.end(); ++_iter92)
     {
-      xfer += (*_iter82).write(oprot);
+      xfer += (*_iter92).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -3913,13 +4029,13 @@ void swap(PrivilegeBag &a, PrivilegeBag &b) {
   swap(a.__isset, b.__isset);
 }
 
-PrivilegeBag::PrivilegeBag(const PrivilegeBag& other83) {
-  privileges = other83.privileges;
-  __isset = other83.__isset;
+PrivilegeBag::PrivilegeBag(const PrivilegeBag& other93) {
+  privileges = other93.privileges;
+  __isset = other93.__isset;
 }
-PrivilegeBag& PrivilegeBag::operator=(const PrivilegeBag& other84) {
-  privileges = other84.privileges;
-  __isset = other84.__isset;
+PrivilegeBag& PrivilegeBag::operator=(const PrivilegeBag& other94) {
+  privileges = other94.privileges;
+  __isset = other94.__isset;
   return *this;
 }
 void PrivilegeBag::printTo(std::ostream& out) const {
@@ -3977,26 +4093,26 @@ uint32_t PrincipalPrivilegeSet::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->userPrivileges.clear();
-            uint32_t _size85;
-            ::apache::thrift::protocol::TType _ktype86;
-            ::apache::thrift::protocol::TType _vtype87;
-            xfer += iprot->readMapBegin(_ktype86, _vtype87, _size85);
-            uint32_t _i89;
-            for (_i89 = 0; _i89 < _size85; ++_i89)
+            uint32_t _size95;
+            ::apache::thrift::protocol::TType _ktype96;
+            ::apache::thrift::protocol::TType _vtype97;
+            xfer += iprot->readMapBegin(_ktype96, _vtype97, _size95);
+            uint32_t _i99;
+            for (_i99 = 0; _i99 < _size95; ++_i99)
             {
-              std::string _key90;
-              xfer += iprot->readString(_key90);
-              std::vector<PrivilegeGrantInfo> & _val91 = this->userPrivileges[_key90];
+              std::string _key100;
+              xfer += iprot->readString(_key100);
+              std::vector<PrivilegeGrantInfo> & _val101 = this->userPrivileges[_key100];
               {
-                _val91.clear();
-                uint32_t _size92;
-                ::apache::thrift::protocol::TType _etype95;
-                xfer += iprot->readListBegin(_etype95, _size92);
-                _val91.resize(_size92);
-                uint32_t _i96;
-                for (_i96 = 0; _i96 < _size92; ++_i96)
+                _val101.clear();
+                uint32_t _size102;
+                ::apache::thrift::protocol::TType _etype105;
+                xfer += iprot->readListBegin(_etype105, _size102);
+                _val101.resize(_size102);
+                uint32_t _i106;
+                for (_i106 = 0; _i106 < _size102; ++_i106)
                 {
-                  xfer += _val91[_i96].read(iprot);
+                  xfer += _val101[_i106].read(iprot);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -4012,26 +4128,26 @@ uint32_t PrincipalPrivilegeSet::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->groupPrivileges.clear();
-            uint32_t _size97;
-            ::apache::thrift::protocol::TType _ktype98;
-            ::apache::thrift::protocol::TType _vtype99;
-            xfer += iprot->readMapBegin(_ktype98, _vtype99, _size97);
-            uint32_t _i101;
-            for (_i101 = 0; _i101 < _size97; ++_i101)
+            uint32_t _size107;
+            ::apache::thrift::protocol::TType _ktype108;
+            ::apache::thrift::protocol::TType _vtype109;
+            xfer += iprot->readMapBegin(_ktype108, _vtype109, _size107);
+            uint32_t _i111;
+            for (_i111 = 0; _i111 < _size107; ++_i111)
             {
-              std::string _key102;
-              xfer += iprot->readString(_key102);
-              std::vector<PrivilegeGrantInfo> & _val103 = this->groupPrivileges[_key102];
+              std::string _key112;
+              xfer += iprot->readString(_key112);
+              std::vector<PrivilegeGrantInfo> & _val113 = this->groupPrivileges[_key112];
               {
-                _val103.clear();
-                uint32_t _size104;
-                ::apache::thrift::protocol::TType _etype107;
-                xfer += iprot->readListBegin(_etype107, _size104);
-                _val103.resize(_size104);
-                uint32_t _i108;
-                for (_i108 = 0; _i108 < _size104; ++_i108)
+                _val113.clear();
+                uint32_t _size114;
+                ::apache::thrift::protocol::TType _etype117;
+                xfer += iprot->readListBegin(_etype117, _size114);
+                _val113.resize(_size114);
+                uint32_t _i118;
+                for (_i118 = 0; _i118 < _size114; ++_i118)
                 {
-                  xfer += _val103[_i108].read(iprot);
+                  xfer += _val113[_i118].read(iprot);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -4047,26 +4163,26 @@ uint32_t PrincipalPrivilegeSet::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->rolePrivileges.clear();
-            uint32_t _size109;
-            ::apache::thrift::protocol::TType _ktype110;
-            ::apache::thrift::protocol::TType _vtype111;
-            xfer += iprot->readMapBegin(_ktype110, _vtype111, _size109);
-            uint32_t _i113;
-            for (_i113 = 0; _i113 < _size109; ++_i113)
+            uint32_t _size119;
+            ::apache::thrift::protocol::TType _ktype120;
+            ::apache::thrift::protocol::TType _vtype121;
+            xfer += iprot->readMapBegin(_ktype120, _vtype121, _size119);
+            uint32_t _i123;
+            for (_i123 = 0; _i123 < _size119; ++_i123)
             {
-              std::string _key114;
-              xfer += iprot->readString(_key114);
-              std::vector<PrivilegeGrantInfo> & _val115 = this->rolePrivileges[_key114];
+              std::string _key124;
+              xfer += iprot->readString(_key124);
+              std::vector<PrivilegeGrantInfo> & _val125 = this->rolePrivileges[_key124];
               {
-                _val115.clear();
-                uint32_t _size116;
-                ::apache::thrift::protocol::TType _etype119;
-                xfer += iprot->readListBegin(_etype119, _size116);
-                _val115.resize(_size116);
-                uint32_t _i120;
-                for (_i120 = 0; _i120 < _size116; ++_i120)
+                _val125.clear();
+                uint32_t _size126;
+                ::apache::thrift::protocol::TType _etype129;
+                xfer += iprot->readListBegin(_etype129, _size126);
+                _val125.resize(_size126);
+                uint32_t _i130;
+                for (_i130 = 0; _i130 < _size126; ++_i130)
                 {
-                  xfer += _val115[_i120].read(iprot);
+                  xfer += _val125[_i130].read(iprot);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -4098,16 +4214,16 @@ uint32_t PrincipalPrivilegeSet::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("userPrivileges", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->userPrivileges.size()));
-    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter121;
-    for (_iter121 = this->userPrivileges.begin(); _iter121 != this->userPrivileges.end(); ++_iter121)
+    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter131;
+    for (_iter131 = this->userPrivileges.begin(); _iter131 != this->userPrivileges.end(); ++_iter131)
     {
-      xfer += oprot->writeString(_iter121->first);
+      xfer += oprot->writeString(_iter131->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter121->second.size()));
-        std::vector<PrivilegeGrantInfo> ::const_iterator _iter122;
-        for (_iter122 = _iter121->second.begin(); _iter122 != _iter121->second.end(); ++_iter122)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter131->second.size()));
+        std::vector<PrivilegeGrantInfo> ::const_iterator _iter132;
+        for (_iter132 = _iter131->second.begin(); _iter132 != _iter131->second.end(); ++_iter132)
         {
-          xfer += (*_iter122).write(oprot);
+          xfer += (*_iter132).write(oprot);
         }
         xfer += oprot->writeListEnd();
       }
@@ -4119,16 +4235,16 @@ uint32_t PrincipalPrivilegeSet::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("groupPrivileges", ::apache::thrift::protocol::T_MAP, 2);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->groupPrivileges.size()));
-    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter123;
-    for (_iter123 = this->groupPrivileges.begin(); _iter123 != this->groupPrivileges.end(); ++_iter123)
+    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter133;
+    for (_iter133 = this->groupPrivileges.begin(); _iter133 != this->groupPrivileges.end(); ++_iter133)
     {
-      xfer += oprot->writeString(_iter123->first);
+      xfer += oprot->writeString(_iter133->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter123->second.size()));
-        std::vector<PrivilegeGrantInfo> ::const_iterator _iter124;
-        for (_iter124 = _iter123->second.begin(); _iter124 != _iter123->second.end(); ++_iter124)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter133->second.size()));
+        std::vector<PrivilegeGrantInfo> ::const_iterator _iter134;
+        for (_iter134 = _iter133->second.begin(); _iter134 != _iter133->second.end(); ++_iter134)
         {
-          xfer += (*_iter124).write(oprot);
+          xfer += (*_iter134).write(oprot);
         }
         xfer += oprot->writeListEnd();
       }
@@ -4140,16 +4256,16 @@ uint32_t PrincipalPrivilegeSet::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("rolePrivileges", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->rolePrivileges.size()));
-    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter125;
-    for (_iter125 = this->rolePrivileges.begin(); _iter125 != this->rolePrivileges.end(); ++_iter125)
+    std::map<std::string, std::vector<PrivilegeGrantInfo> > ::const_iterator _iter135;
+    for (_iter135 = this->rolePrivileges.begin(); _iter135 != this->rolePrivileges.end(); ++_iter135)
     {
-      xfer += oprot->writeString(_iter125->first);
+      xfer += oprot->writeString(_iter135->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter125->second.size()));
-        std::vector<PrivilegeGrantInfo> ::const_iterator _iter126;
-        for (_iter126 = _iter125->second.begin(); _iter126 != _iter125->second.end(); ++_iter126)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter135->second.size()));
+        std::vector<PrivilegeGrantInfo> ::const_iterator _iter136;
+        for (_iter136 = _iter135->second.begin(); _iter136 != _iter135->second.end(); ++_iter136)
         {
-          xfer += (*_iter126).write(oprot);
+          xfer += (*_iter136).write(oprot);
         }
         xfer += oprot->writeListEnd();
       }
@@ -4171,17 +4287,17 @@ void swap(PrincipalPrivilegeSet &a, PrincipalPrivilegeSet &b) {
   swap(a.__isset, b.__isset);
 }
 
-PrincipalPrivilegeSet::PrincipalPrivilegeSet(const PrincipalPrivilegeSet& other127) {
-  userPrivileges = other127.userPrivileges;
-  groupPrivileges = other127.groupPrivileges;
-  rolePrivileges = other127.rolePrivileges;
-  __isset = other127.__isset;
+PrincipalPrivilegeSet::PrincipalPrivilegeSet(const PrincipalPrivilegeSet& other137) {
+  userPrivileges = other137.userPrivileges;
+  groupPrivileges = other137.groupPrivileges;
+  rolePrivileges = other137.rolePrivileges;
+  __isset = other137.__isset;
 }
-PrincipalPrivilegeSet& PrincipalPrivilegeSet::operator=(const PrincipalPrivilegeSet& other128) {
-  userPrivileges = other128.userPrivileges;
-  groupPrivileges = other128.groupPrivileges;
-  rolePrivileges = other128.rolePrivileges;
-  __isset = other128.__isset;
+PrincipalPrivilegeSet& PrincipalPrivilegeSet::operator=(const PrincipalPrivilegeSet& other138) {
+  userPrivileges = other138.userPrivileges;
+  groupPrivileges = other138.groupPrivileges;
+  rolePrivileges = other138.rolePrivileges;
+  __isset = other138.__isset;
   return *this;
 }
 void PrincipalPrivilegeSet::printTo(std::ostream& out) const {
@@ -4240,9 +4356,9 @@ uint32_t GrantRevokePrivilegeRequest::read(::apache::thrift::protocol::TProtocol
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast129;
-          xfer += iprot->readI32(ecast129);
-          this->requestType = (GrantRevokeType::type)ecast129;
+          int32_t ecast139;
+          xfer += iprot->readI32(ecast139);
+          this->requestType = (GrantRevokeType::type)ecast139;
           this->__isset.requestType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4307,17 +4423,17 @@ void swap(GrantRevokePrivilegeRequest &a, GrantRevokePrivilegeRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GrantRevokePrivilegeRequest::GrantRevokePrivilegeRequest(const GrantRevokePrivilegeRequest& other130) {
-  requestType = other130.requestType;
-  privileges = other130.privileges;
-  revokeGrantOption = other130.revokeGrantOption;
-  __isset = other130.__isset;
+GrantRevokePrivilegeRequest::GrantRevokePrivilegeRequest(const GrantRevokePrivilegeRequest& other140) {
+  requestType = other140.requestType;
+  privileges = other140.privileges;
+  revokeGrantOption = other140.revokeGrantOption;
+  __isset = other140.__isset;
 }
-GrantRevokePrivilegeRequest& GrantRevokePrivilegeRequest::operator=(const GrantRevokePrivilegeRequest& other131) {
-  requestType = other131.requestType;
-  privileges = other131.privileges;
-  revokeGrantOption = other131.revokeGrantOption;
-  __isset = other131.__isset;
+GrantRevokePrivilegeRequest& GrantRevokePrivilegeRequest::operator=(const GrantRevokePrivilegeRequest& other141) {
+  requestType = other141.requestType;
+  privileges = other141.privileges;
+  revokeGrantOption = other141.revokeGrantOption;
+  __isset = other141.__isset;
   return *this;
 }
 void GrantRevokePrivilegeRequest::printTo(std::ostream& out) const {
@@ -4407,13 +4523,13 @@ void swap(GrantRevokePrivilegeResponse &a, GrantRevokePrivilegeResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GrantRevokePrivilegeResponse::GrantRevokePrivilegeResponse(const GrantRevokePrivilegeResponse& other132) {
-  success = other132.success;
-  __isset = other132.__isset;
+GrantRevokePrivilegeResponse::GrantRevokePrivilegeResponse(const GrantRevokePrivilegeResponse& other142) {
+  success = other142.success;
+  __isset = other142.__isset;
 }
-GrantRevokePrivilegeResponse& GrantRevokePrivilegeResponse::operator=(const GrantRevokePrivilegeResponse& other133) {
-  success = other133.success;
-  __isset = other133.__isset;
+GrantRevokePrivilegeResponse& GrantRevokePrivilegeResponse::operator=(const GrantRevokePrivilegeResponse& other143) {
+  success = other143.success;
+  __isset = other143.__isset;
   return *this;
 }
 void GrantRevokePrivilegeResponse::printTo(std::ostream& out) const {
@@ -4505,14 +4621,14 @@ uint32_t TruncateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size134;
-            ::apache::thrift::protocol::TType _etype137;
-            xfer += iprot->readListBegin(_etype137, _size134);
-            this->partNames.resize(_size134);
-            uint32_t _i138;
-            for (_i138 = 0; _i138 < _size134; ++_i138)
+            uint32_t _size144;
+            ::apache::thrift::protocol::TType _etype147;
+            xfer += iprot->readListBegin(_etype147, _size144);
+            this->partNames.resize(_size144);
+            uint32_t _i148;
+            for (_i148 = 0; _i148 < _size144; ++_i148)
             {
-              xfer += iprot->readString(this->partNames[_i138]);
+              xfer += iprot->readString(this->partNames[_i148]);
             }
             xfer += iprot->readListEnd();
           }
@@ -4578,10 +4694,10 @@ uint32_t TruncateTableRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-      std::vector<std::string> ::const_iterator _iter139;
-      for (_iter139 = this->partNames.begin(); _iter139 != this->partNames.end(); ++_iter139)
+      std::vector<std::string> ::const_iterator _iter149;
+      for (_iter149 = this->partNames.begin(); _iter149 != this->partNames.end(); ++_iter149)
       {
-        xfer += oprot->writeString((*_iter139));
+        xfer += oprot->writeString((*_iter149));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4618,23 +4734,23 @@ void swap(TruncateTableRequest &a, TruncateTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-TruncateTableRequest::TruncateTableRequest(const TruncateTableRequest& other140) {
-  dbName = other140.dbName;
-  tableName = other140.tableName;
-  partNames = other140.partNames;
-  writeId = other140.writeId;
-  validWriteIdList = other140.validWriteIdList;
-  environmentContext = other140.environmentContext;
-  __isset = other140.__isset;
+TruncateTableRequest::TruncateTableRequest(const TruncateTableRequest& other150) {
+  dbName = other150.dbName;
+  tableName = other150.tableName;
+  partNames = other150.partNames;
+  writeId = other150.writeId;
+  validWriteIdList = other150.validWriteIdList;
+  environmentContext = other150.environmentContext;
+  __isset = other150.__isset;
 }
-TruncateTableRequest& TruncateTableRequest::operator=(const TruncateTableRequest& other141) {
-  dbName = other141.dbName;
-  tableName = other141.tableName;
-  partNames = other141.partNames;
-  writeId = other141.writeId;
-  validWriteIdList = other141.validWriteIdList;
-  environmentContext = other141.environmentContext;
-  __isset = other141.__isset;
+TruncateTableRequest& TruncateTableRequest::operator=(const TruncateTableRequest& other151) {
+  dbName = other151.dbName;
+  tableName = other151.tableName;
+  partNames = other151.partNames;
+  writeId = other151.writeId;
+  validWriteIdList = other151.validWriteIdList;
+  environmentContext = other151.environmentContext;
+  __isset = other151.__isset;
   return *this;
 }
 void TruncateTableRequest::printTo(std::ostream& out) const {
@@ -4704,11 +4820,11 @@ void swap(TruncateTableResponse &a, TruncateTableResponse &b) {
   (void) b;
 }
 
-TruncateTableResponse::TruncateTableResponse(const TruncateTableResponse& other142) {
-  (void) other142;
+TruncateTableResponse::TruncateTableResponse(const TruncateTableResponse& other152) {
+  (void) other152;
 }
-TruncateTableResponse& TruncateTableResponse::operator=(const TruncateTableResponse& other143) {
-  (void) other143;
+TruncateTableResponse& TruncateTableResponse::operator=(const TruncateTableResponse& other153) {
+  (void) other153;
   return *this;
 }
 void TruncateTableResponse::printTo(std::ostream& out) const {
@@ -4827,17 +4943,17 @@ void swap(Role &a, Role &b) {
   swap(a.__isset, b.__isset);
 }
 
-Role::Role(const Role& other144) {
-  roleName = other144.roleName;
-  createTime = other144.createTime;
-  ownerName = other144.ownerName;
-  __isset = other144.__isset;
+Role::Role(const Role& other154) {
+  roleName = other154.roleName;
+  createTime = other154.createTime;
+  ownerName = other154.ownerName;
+  __isset = other154.__isset;
 }
-Role& Role::operator=(const Role& other145) {
-  roleName = other145.roleName;
-  createTime = other145.createTime;
-  ownerName = other145.ownerName;
-  __isset = other145.__isset;
+Role& Role::operator=(const Role& other155) {
+  roleName = other155.roleName;
+  createTime = other155.createTime;
+  ownerName = other155.ownerName;
+  __isset = other155.__isset;
   return *this;
 }
 void Role::printTo(std::ostream& out) const {
@@ -4927,9 +5043,9 @@ uint32_t RolePrincipalGrant::read(::apache::thrift::protocol::TProtocol* iprot) 
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast146;
-          xfer += iprot->readI32(ecast146);
-          this->principalType = (PrincipalType::type)ecast146;
+          int32_t ecast156;
+          xfer += iprot->readI32(ecast156);
+          this->principalType = (PrincipalType::type)ecast156;
           this->__isset.principalType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4961,9 +5077,9 @@ uint32_t RolePrincipalGrant::read(::apache::thrift::protocol::TProtocol* iprot) 
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast147;
-          xfer += iprot->readI32(ecast147);
-          this->grantorPrincipalType = (PrincipalType::type)ecast147;
+          int32_t ecast157;
+          xfer += iprot->readI32(ecast157);
+          this->grantorPrincipalType = (PrincipalType::type)ecast157;
           this->__isset.grantorPrincipalType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5031,25 +5147,25 @@ void swap(RolePrincipalGrant &a, RolePrincipalGrant &b) {
   swap(a.__isset, b.__isset);
 }
 
-RolePrincipalGrant::RolePrincipalGrant(const RolePrincipalGrant& other148) {
-  roleName = other148.roleName;
-  principalName = other148.principalName;
-  principalType = other148.principalType;
-  grantOption = other148.grantOption;
-  grantTime = other148.grantTime;
-  grantorName = other148.grantorName;
-  grantorPrincipalType = other148.grantorPrincipalType;
-  __isset = other148.__isset;
+RolePrincipalGrant::RolePrincipalGrant(const RolePrincipalGrant& other158) {
+  roleName = other158.roleName;
+  principalName = other158.principalName;
+  principalType = other158.principalType;
+  grantOption = other158.grantOption;
+  grantTime = other158.grantTime;
+  grantorName = other158.grantorName;
+  grantorPrincipalType = other158.grantorPrincipalType;
+  __isset = other158.__isset;
 }
-RolePrincipalGrant& RolePrincipalGrant::operator=(const RolePrincipalGrant& other149) {
-  roleName = other149.roleName;
-  principalName = other149.principalName;
-  principalType = other149.principalType;
-  grantOption = other149.grantOption;
-  grantTime = other149.grantTime;
-  grantorName = other149.grantorName;
-  grantorPrincipalType = other149.grantorPrincipalType;
-  __isset = other149.__isset;
+RolePrincipalGrant& RolePrincipalGrant::operator=(const RolePrincipalGrant& other159) {
+  roleName = other159.roleName;
+  principalName = other159.principalName;
+  principalType = other159.principalType;
+  grantOption = other159.grantOption;
+  grantTime = other159.grantTime;
+  grantorName = other159.grantorName;
+  grantorPrincipalType = other159.grantorPrincipalType;
+  __isset = other159.__isset;
   return *this;
 }
 void RolePrincipalGrant::printTo(std::ostream& out) const {
@@ -5117,9 +5233,9 @@ uint32_t GetRoleGrantsForPrincipalRequest::read(::apache::thrift::protocol::TPro
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast150;
-          xfer += iprot->readI32(ecast150);
-          this->principal_type = (PrincipalType::type)ecast150;
+          int32_t ecast160;
+          xfer += iprot->readI32(ecast160);
+          this->principal_type = (PrincipalType::type)ecast160;
           isset_principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5165,13 +5281,13 @@ void swap(GetRoleGrantsForPrincipalRequest &a, GetRoleGrantsForPrincipalRequest 
   swap(a.principal_type, b.principal_type);
 }
 
-GetRoleGrantsForPrincipalRequest::GetRoleGrantsForPrincipalRequest(const GetRoleGrantsForPrincipalRequest& other151) {
-  principal_name = other151.principal_name;
-  principal_type = other151.principal_type;
+GetRoleGrantsForPrincipalRequest::GetRoleGrantsForPrincipalRequest(const GetRoleGrantsForPrincipalRequest& other161) {
+  principal_name = other161.principal_name;
+  principal_type = other161.principal_type;
 }
-GetRoleGrantsForPrincipalRequest& GetRoleGrantsForPrincipalRequest::operator=(const GetRoleGrantsForPrincipalRequest& other152) {
-  principal_name = other152.principal_name;
-  principal_type = other152.principal_type;
+GetRoleGrantsForPrincipalRequest& GetRoleGrantsForPrincipalRequest::operator=(const GetRoleGrantsForPrincipalRequest& other162) {
+  principal_name = other162.principal_name;
+  principal_type = other162.principal_type;
   return *this;
 }
 void GetRoleGrantsForPrincipalRequest::printTo(std::ostream& out) const {
@@ -5223,14 +5339,14 @@ uint32_t GetRoleGrantsForPrincipalResponse::read(::apache::thrift::protocol::TPr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->principalGrants.clear();
-            uint32_t _size153;
-            ::apache::thrift::protocol::TType _etype156;
-            xfer += iprot->readListBegin(_etype156, _size153);
-            this->principalGrants.resize(_size153);
-            uint32_t _i157;
-            for (_i157 = 0; _i157 < _size153; ++_i157)
+            uint32_t _size163;
+            ::apache::thrift::protocol::TType _etype166;
+            xfer += iprot->readListBegin(_etype166, _size163);
+            this->principalGrants.resize(_size163);
+            uint32_t _i167;
+            for (_i167 = 0; _i167 < _size163; ++_i167)
             {
-              xfer += this->principalGrants[_i157].read(iprot);
+              xfer += this->principalGrants[_i167].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5261,10 +5377,10 @@ uint32_t GetRoleGrantsForPrincipalResponse::write(::apache::thrift::protocol::TP
   xfer += oprot->writeFieldBegin("principalGrants", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->principalGrants.size()));
-    std::vector<RolePrincipalGrant> ::const_iterator _iter158;
-    for (_iter158 = this->principalGrants.begin(); _iter158 != this->principalGrants.end(); ++_iter158)
+    std::vector<RolePrincipalGrant> ::const_iterator _iter168;
+    for (_iter168 = this->principalGrants.begin(); _iter168 != this->principalGrants.end(); ++_iter168)
     {
-      xfer += (*_iter158).write(oprot);
+      xfer += (*_iter168).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5280,11 +5396,11 @@ void swap(GetRoleGrantsForPrincipalResponse &a, GetRoleGrantsForPrincipalRespons
   swap(a.principalGrants, b.principalGrants);
 }
 
-GetRoleGrantsForPrincipalResponse::GetRoleGrantsForPrincipalResponse(const GetRoleGrantsForPrincipalResponse& other159) {
-  principalGrants = other159.principalGrants;
+GetRoleGrantsForPrincipalResponse::GetRoleGrantsForPrincipalResponse(const GetRoleGrantsForPrincipalResponse& other169) {
+  principalGrants = other169.principalGrants;
 }
-GetRoleGrantsForPrincipalResponse& GetRoleGrantsForPrincipalResponse::operator=(const GetRoleGrantsForPrincipalResponse& other160) {
-  principalGrants = other160.principalGrants;
+GetRoleGrantsForPrincipalResponse& GetRoleGrantsForPrincipalResponse::operator=(const GetRoleGrantsForPrincipalResponse& other170) {
+  principalGrants = other170.principalGrants;
   return *this;
 }
 void GetRoleGrantsForPrincipalResponse::printTo(std::ostream& out) const {
@@ -5372,11 +5488,11 @@ void swap(GetPrincipalsInRoleRequest &a, GetPrincipalsInRoleRequest &b) {
   swap(a.roleName, b.roleName);
 }
 
-GetPrincipalsInRoleRequest::GetPrincipalsInRoleRequest(const GetPrincipalsInRoleRequest& other161) {
-  roleName = other161.roleName;
+GetPrincipalsInRoleRequest::GetPrincipalsInRoleRequest(const GetPrincipalsInRoleRequest& other171) {
+  roleName = other171.roleName;
 }
-GetPrincipalsInRoleRequest& GetPrincipalsInRoleRequest::operator=(const GetPrincipalsInRoleRequest& other162) {
-  roleName = other162.roleName;
+GetPrincipalsInRoleRequest& GetPrincipalsInRoleRequest::operator=(const GetPrincipalsInRoleRequest& other172) {
+  roleName = other172.roleName;
   return *this;
 }
 void GetPrincipalsInRoleRequest::printTo(std::ostream& out) const {
@@ -5427,14 +5543,14 @@ uint32_t GetPrincipalsInRoleResponse::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->principalGrants.clear();
-            uint32_t _size163;
-            ::apache::thrift::protocol::TType _etype166;
-            xfer += iprot->readListBegin(_etype166, _size163);
-            this->principalGrants.resize(_size163);
-            uint32_t _i167;
-            for (_i167 = 0; _i167 < _size163; ++_i167)
+            uint32_t _size173;
+            ::apache::thrift::protocol::TType _etype176;
+            xfer += iprot->readListBegin(_etype176, _size173);
+            this->principalGrants.resize(_size173);
+            uint32_t _i177;
+            for (_i177 = 0; _i177 < _size173; ++_i177)
             {
-              xfer += this->principalGrants[_i167].read(iprot);
+              xfer += this->principalGrants[_i177].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5465,10 +5581,10 @@ uint32_t GetPrincipalsInRoleResponse::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("principalGrants", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->principalGrants.size()));
-    std::vector<RolePrincipalGrant> ::const_iterator _iter168;
-    for (_iter168 = this->principalGrants.begin(); _iter168 != this->principalGrants.end(); ++_iter168)
+    std::vector<RolePrincipalGrant> ::const_iterator _iter178;
+    for (_iter178 = this->principalGrants.begin(); _iter178 != this->principalGrants.end(); ++_iter178)
     {
-      xfer += (*_iter168).write(oprot);
+      xfer += (*_iter178).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -5484,11 +5600,11 @@ void swap(GetPrincipalsInRoleResponse &a, GetPrincipalsInRoleResponse &b) {
   swap(a.principalGrants, b.principalGrants);
 }
 
-GetPrincipalsInRoleResponse::GetPrincipalsInRoleResponse(const GetPrincipalsInRoleResponse& other169) {
-  principalGrants = other169.principalGrants;
+GetPrincipalsInRoleResponse::GetPrincipalsInRoleResponse(const GetPrincipalsInRoleResponse& other179) {
+  principalGrants = other179.principalGrants;
 }
-GetPrincipalsInRoleResponse& GetPrincipalsInRoleResponse::operator=(const GetPrincipalsInRoleResponse& other170) {
-  principalGrants = other170.principalGrants;
+GetPrincipalsInRoleResponse& GetPrincipalsInRoleResponse::operator=(const GetPrincipalsInRoleResponse& other180) {
+  principalGrants = other180.principalGrants;
   return *this;
 }
 void GetPrincipalsInRoleResponse::printTo(std::ostream& out) const {
@@ -5563,9 +5679,9 @@ uint32_t GrantRevokeRoleRequest::read(::apache::thrift::protocol::TProtocol* ipr
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast171;
-          xfer += iprot->readI32(ecast171);
-          this->requestType = (GrantRevokeType::type)ecast171;
+          int32_t ecast181;
+          xfer += iprot->readI32(ecast181);
+          this->requestType = (GrantRevokeType::type)ecast181;
           this->__isset.requestType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5589,9 +5705,9 @@ uint32_t GrantRevokeRoleRequest::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast172;
-          xfer += iprot->readI32(ecast172);
-          this->principalType = (PrincipalType::type)ecast172;
+          int32_t ecast182;
+          xfer += iprot->readI32(ecast182);
+          this->principalType = (PrincipalType::type)ecast182;
           this->__isset.principalType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5607,9 +5723,9 @@ uint32_t GrantRevokeRoleRequest::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast173;
-          xfer += iprot->readI32(ecast173);
-          this->grantorType = (PrincipalType::type)ecast173;
+          int32_t ecast183;
+          xfer += iprot->readI32(ecast183);
+          this->grantorType = (PrincipalType::type)ecast183;
           this->__isset.grantorType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5688,25 +5804,25 @@ void swap(GrantRevokeRoleRequest &a, GrantRevokeRoleRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GrantRevokeRoleRequest::GrantRevokeRoleRequest(const GrantRevokeRoleRequest& other174) {
-  requestType = other174.requestType;
-  roleName = other174.roleName;
-  principalName = other174.principalName;
-  principalType = other174.principalType;
-  grantor = other174.grantor;
-  grantorType = other174.grantorType;
-  grantOption = other174.grantOption;
-  __isset = other174.__isset;
+GrantRevokeRoleRequest::GrantRevokeRoleRequest(const GrantRevokeRoleRequest& other184) {
+  requestType = other184.requestType;
+  roleName = other184.roleName;
+  principalName = other184.principalName;
+  principalType = other184.principalType;
+  grantor = other184.grantor;
+  grantorType = other184.grantorType;
+  grantOption = other184.grantOption;
+  __isset = other184.__isset;
 }
-GrantRevokeRoleRequest& GrantRevokeRoleRequest::operator=(const GrantRevokeRoleRequest& other175) {
-  requestType = other175.requestType;
-  roleName = other175.roleName;
-  principalName = other175.principalName;
-  principalType = other175.principalType;
-  grantor = other175.grantor;
-  grantorType = other175.grantorType;
-  grantOption = other175.grantOption;
-  __isset = other175.__isset;
+GrantRevokeRoleRequest& GrantRevokeRoleRequest::operator=(const GrantRevokeRoleRequest& other185) {
+  requestType = other185.requestType;
+  roleName = other185.roleName;
+  principalName = other185.principalName;
+  principalType = other185.principalType;
+  grantor = other185.grantor;
+  grantorType = other185.grantorType;
+  grantOption = other185.grantOption;
+  __isset = other185.__isset;
   return *this;
 }
 void GrantRevokeRoleRequest::printTo(std::ostream& out) const {
@@ -5800,13 +5916,13 @@ void swap(GrantRevokeRoleResponse &a, GrantRevokeRoleResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GrantRevokeRoleResponse::GrantRevokeRoleResponse(const GrantRevokeRoleResponse& other176) {
-  success = other176.success;
-  __isset = other176.__isset;
+GrantRevokeRoleResponse::GrantRevokeRoleResponse(const GrantRevokeRoleResponse& other186) {
+  success = other186.success;
+  __isset = other186.__isset;
 }
-GrantRevokeRoleResponse& GrantRevokeRoleResponse::operator=(const GrantRevokeRoleResponse& other177) {
-  success = other177.success;
-  __isset = other177.__isset;
+GrantRevokeRoleResponse& GrantRevokeRoleResponse::operator=(const GrantRevokeRoleResponse& other187) {
+  success = other187.success;
+  __isset = other187.__isset;
   return *this;
 }
 void GrantRevokeRoleResponse::printTo(std::ostream& out) const {
@@ -5947,19 +6063,19 @@ void swap(Catalog &a, Catalog &b) {
   swap(a.__isset, b.__isset);
 }
 
-Catalog::Catalog(const Catalog& other178) {
-  name = other178.name;
-  description = other178.description;
-  locationUri = other178.locationUri;
-  createTime = other178.createTime;
-  __isset = other178.__isset;
+Catalog::Catalog(const Catalog& other188) {
+  name = other188.name;
+  description = other188.description;
+  locationUri = other188.locationUri;
+  createTime = other188.createTime;
+  __isset = other188.__isset;
 }
-Catalog& Catalog::operator=(const Catalog& other179) {
-  name = other179.name;
-  description = other179.description;
-  locationUri = other179.locationUri;
-  createTime = other179.createTime;
-  __isset = other179.__isset;
+Catalog& Catalog::operator=(const Catalog& other189) {
+  name = other189.name;
+  description = other189.description;
+  locationUri = other189.locationUri;
+  createTime = other189.createTime;
+  __isset = other189.__isset;
   return *this;
 }
 void Catalog::printTo(std::ostream& out) const {
@@ -6048,13 +6164,13 @@ void swap(CreateCatalogRequest &a, CreateCatalogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateCatalogRequest::CreateCatalogRequest(const CreateCatalogRequest& other180) {
-  catalog = other180.catalog;
-  __isset = other180.__isset;
+CreateCatalogRequest::CreateCatalogRequest(const CreateCatalogRequest& other190) {
+  catalog = other190.catalog;
+  __isset = other190.__isset;
 }
-CreateCatalogRequest& CreateCatalogRequest::operator=(const CreateCatalogRequest& other181) {
-  catalog = other181.catalog;
-  __isset = other181.__isset;
+CreateCatalogRequest& CreateCatalogRequest::operator=(const CreateCatalogRequest& other191) {
+  catalog = other191.catalog;
+  __isset = other191.__isset;
   return *this;
 }
 void CreateCatalogRequest::printTo(std::ostream& out) const {
@@ -6157,15 +6273,15 @@ void swap(AlterCatalogRequest &a, AlterCatalogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterCatalogRequest::AlterCatalogRequest(const AlterCatalogRequest& other182) {
-  name = other182.name;
-  newCat = other182.newCat;
-  __isset = other182.__isset;
+AlterCatalogRequest::AlterCatalogRequest(const AlterCatalogRequest& other192) {
+  name = other192.name;
+  newCat = other192.newCat;
+  __isset = other192.__isset;
 }
-AlterCatalogRequest& AlterCatalogRequest::operator=(const AlterCatalogRequest& other183) {
-  name = other183.name;
-  newCat = other183.newCat;
-  __isset = other183.__isset;
+AlterCatalogRequest& AlterCatalogRequest::operator=(const AlterCatalogRequest& other193) {
+  name = other193.name;
+  newCat = other193.newCat;
+  __isset = other193.__isset;
   return *this;
 }
 void AlterCatalogRequest::printTo(std::ostream& out) const {
@@ -6252,13 +6368,13 @@ void swap(GetCatalogRequest &a, GetCatalogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetCatalogRequest::GetCatalogRequest(const GetCatalogRequest& other184) {
-  name = other184.name;
-  __isset = other184.__isset;
+GetCatalogRequest::GetCatalogRequest(const GetCatalogRequest& other194) {
+  name = other194.name;
+  __isset = other194.__isset;
 }
-GetCatalogRequest& GetCatalogRequest::operator=(const GetCatalogRequest& other185) {
-  name = other185.name;
-  __isset = other185.__isset;
+GetCatalogRequest& GetCatalogRequest::operator=(const GetCatalogRequest& other195) {
+  name = other195.name;
+  __isset = other195.__isset;
   return *this;
 }
 void GetCatalogRequest::printTo(std::ostream& out) const {
@@ -6344,13 +6460,13 @@ void swap(GetCatalogResponse &a, GetCatalogResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetCatalogResponse::GetCatalogResponse(const GetCatalogResponse& other186) {
-  catalog = other186.catalog;
-  __isset = other186.__isset;
+GetCatalogResponse::GetCatalogResponse(const GetCatalogResponse& other196) {
+  catalog = other196.catalog;
+  __isset = other196.__isset;
 }
-GetCatalogResponse& GetCatalogResponse::operator=(const GetCatalogResponse& other187) {
-  catalog = other187.catalog;
-  __isset = other187.__isset;
+GetCatalogResponse& GetCatalogResponse::operator=(const GetCatalogResponse& other197) {
+  catalog = other197.catalog;
+  __isset = other197.__isset;
   return *this;
 }
 void GetCatalogResponse::printTo(std::ostream& out) const {
@@ -6400,14 +6516,14 @@ uint32_t GetCatalogsResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size188;
-            ::apache::thrift::protocol::TType _etype191;
-            xfer += iprot->readListBegin(_etype191, _size188);
-            this->names.resize(_size188);
-            uint32_t _i192;
-            for (_i192 = 0; _i192 < _size188; ++_i192)
+            uint32_t _size198;
+            ::apache::thrift::protocol::TType _etype201;
+            xfer += iprot->readListBegin(_etype201, _size198);
+            this->names.resize(_size198);
+            uint32_t _i202;
+            for (_i202 = 0; _i202 < _size198; ++_i202)
             {
-              xfer += iprot->readString(this->names[_i192]);
+              xfer += iprot->readString(this->names[_i202]);
             }
             xfer += iprot->readListEnd();
           }
@@ -6436,10 +6552,10 @@ uint32_t GetCatalogsResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-    std::vector<std::string> ::const_iterator _iter193;
-    for (_iter193 = this->names.begin(); _iter193 != this->names.end(); ++_iter193)
+    std::vector<std::string> ::const_iterator _iter203;
+    for (_iter203 = this->names.begin(); _iter203 != this->names.end(); ++_iter203)
     {
-      xfer += oprot->writeString((*_iter193));
+      xfer += oprot->writeString((*_iter203));
     }
     xfer += oprot->writeListEnd();
   }
@@ -6456,13 +6572,13 @@ void swap(GetCatalogsResponse &a, GetCatalogsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetCatalogsResponse::GetCatalogsResponse(const GetCatalogsResponse& other194) {
-  names = other194.names;
-  __isset = other194.__isset;
+GetCatalogsResponse::GetCatalogsResponse(const GetCatalogsResponse& other204) {
+  names = other204.names;
+  __isset = other204.__isset;
 }
-GetCatalogsResponse& GetCatalogsResponse::operator=(const GetCatalogsResponse& other195) {
-  names = other195.names;
-  __isset = other195.__isset;
+GetCatalogsResponse& GetCatalogsResponse::operator=(const GetCatalogsResponse& other205) {
+  names = other205.names;
+  __isset = other205.__isset;
   return *this;
 }
 void GetCatalogsResponse::printTo(std::ostream& out) const {
@@ -6548,13 +6664,13 @@ void swap(DropCatalogRequest &a, DropCatalogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropCatalogRequest::DropCatalogRequest(const DropCatalogRequest& other196) {
-  name = other196.name;
-  __isset = other196.__isset;
+DropCatalogRequest::DropCatalogRequest(const DropCatalogRequest& other206) {
+  name = other206.name;
+  __isset = other206.__isset;
 }
-DropCatalogRequest& DropCatalogRequest::operator=(const DropCatalogRequest& other197) {
-  name = other197.name;
-  __isset = other197.__isset;
+DropCatalogRequest& DropCatalogRequest::operator=(const DropCatalogRequest& other207) {
+  name = other207.name;
+  __isset = other207.__isset;
   return *this;
 }
 void DropCatalogRequest::printTo(std::ostream& out) const {
@@ -6685,17 +6801,17 @@ uint32_t Database::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size198;
-            ::apache::thrift::protocol::TType _ktype199;
-            ::apache::thrift::protocol::TType _vtype200;
-            xfer += iprot->readMapBegin(_ktype199, _vtype200, _size198);
-            uint32_t _i202;
-            for (_i202 = 0; _i202 < _size198; ++_i202)
+            uint32_t _size208;
+            ::apache::thrift::protocol::TType _ktype209;
+            ::apache::thrift::protocol::TType _vtype210;
+            xfer += iprot->readMapBegin(_ktype209, _vtype210, _size208);
+            uint32_t _i212;
+            for (_i212 = 0; _i212 < _size208; ++_i212)
             {
-              std::string _key203;
-              xfer += iprot->readString(_key203);
-              std::string& _val204 = this->parameters[_key203];
-              xfer += iprot->readString(_val204);
+              std::string _key213;
+              xfer += iprot->readString(_key213);
+              std::string& _val214 = this->parameters[_key213];
+              xfer += iprot->readString(_val214);
             }
             xfer += iprot->readMapEnd();
           }
@@ -6722,9 +6838,9 @@ uint32_t Database::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast205;
-          xfer += iprot->readI32(ecast205);
-          this->ownerType = (PrincipalType::type)ecast205;
+          int32_t ecast215;
+          xfer += iprot->readI32(ecast215);
+          this->ownerType = (PrincipalType::type)ecast215;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -6756,9 +6872,9 @@ uint32_t Database::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 11:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast206;
-          xfer += iprot->readI32(ecast206);
-          this->type = (DatabaseType::type)ecast206;
+          int32_t ecast216;
+          xfer += iprot->readI32(ecast216);
+          this->type = (DatabaseType::type)ecast216;
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -6812,11 +6928,11 @@ uint32_t Database::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 4);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter207;
-    for (_iter207 = this->parameters.begin(); _iter207 != this->parameters.end(); ++_iter207)
+    std::map<std::string, std::string> ::const_iterator _iter217;
+    for (_iter217 = this->parameters.begin(); _iter217 != this->parameters.end(); ++_iter217)
     {
-      xfer += oprot->writeString(_iter207->first);
-      xfer += oprot->writeString(_iter207->second);
+      xfer += oprot->writeString(_iter217->first);
+      xfer += oprot->writeString(_iter217->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -6890,37 +7006,37 @@ void swap(Database &a, Database &b) {
   swap(a.__isset, b.__isset);
 }
 
-Database::Database(const Database& other208) {
-  name = other208.name;
-  description = other208.description;
-  locationUri = other208.locationUri;
-  parameters = other208.parameters;
-  privileges = other208.privileges;
-  ownerName = other208.ownerName;
-  ownerType = other208.ownerType;
-  catalogName = other208.catalogName;
-  createTime = other208.createTime;
-  managedLocationUri = other208.managedLocationUri;
-  type = other208.type;
-  connector_name = other208.connector_name;
-  remote_dbname = other208.remote_dbname;
-  __isset = other208.__isset;
+Database::Database(const Database& other218) {
+  name = other218.name;
+  description = other218.description;
+  locationUri = other218.locationUri;
+  parameters = other218.parameters;
+  privileges = other218.privileges;
+  ownerName = other218.ownerName;
+  ownerType = other218.ownerType;
+  catalogName = other218.catalogName;
+  createTime = other218.createTime;
+  managedLocationUri = other218.managedLocationUri;
+  type = other218.type;
+  connector_name = other218.connector_name;
+  remote_dbname = other218.remote_dbname;
+  __isset = other218.__isset;
 }
-Database& Database::operator=(const Database& other209) {
-  name = other209.name;
-  description = other209.description;
-  locationUri = other209.locationUri;
-  parameters = other209.parameters;
-  privileges = other209.privileges;
-  ownerName = other209.ownerName;
-  ownerType = other209.ownerType;
-  catalogName = other209.catalogName;
-  createTime = other209.createTime;
-  managedLocationUri = other209.managedLocationUri;
-  type = other209.type;
-  connector_name = other209.connector_name;
-  remote_dbname = other209.remote_dbname;
-  __isset = other209.__isset;
+Database& Database::operator=(const Database& other219) {
+  name = other219.name;
+  description = other219.description;
+  locationUri = other219.locationUri;
+  parameters = other219.parameters;
+  privileges = other219.privileges;
+  ownerName = other219.ownerName;
+  ownerType = other219.ownerType;
+  catalogName = other219.catalogName;
+  createTime = other219.createTime;
+  managedLocationUri = other219.managedLocationUri;
+  type = other219.type;
+  connector_name = other219.connector_name;
+  remote_dbname = other219.remote_dbname;
+  __isset = other219.__isset;
   return *this;
 }
 void Database::printTo(std::ostream& out) const {
@@ -7026,17 +7142,17 @@ uint32_t SerDeInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size210;
-            ::apache::thrift::protocol::TType _ktype211;
-            ::apache::thrift::protocol::TType _vtype212;
-            xfer += iprot->readMapBegin(_ktype211, _vtype212, _size210);
-            uint32_t _i214;
-            for (_i214 = 0; _i214 < _size210; ++_i214)
+            uint32_t _size220;
+            ::apache::thrift::protocol::TType _ktype221;
+            ::apache::thrift::protocol::TType _vtype222;
+            xfer += iprot->readMapBegin(_ktype221, _vtype222, _size220);
+            uint32_t _i224;
+            for (_i224 = 0; _i224 < _size220; ++_i224)
             {
-              std::string _key215;
-              xfer += iprot->readString(_key215);
-              std::string& _val216 = this->parameters[_key215];
-              xfer += iprot->readString(_val216);
+              std::string _key225;
+              xfer += iprot->readString(_key225);
+              std::string& _val226 = this->parameters[_key225];
+              xfer += iprot->readString(_val226);
             }
             xfer += iprot->readMapEnd();
           }
@@ -7071,9 +7187,9 @@ uint32_t SerDeInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast217;
-          xfer += iprot->readI32(ecast217);
-          this->serdeType = (SerdeType::type)ecast217;
+          int32_t ecast227;
+          xfer += iprot->readI32(ecast227);
+          this->serdeType = (SerdeType::type)ecast227;
           this->__isset.serdeType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -7107,11 +7223,11 @@ uint32_t SerDeInfo::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter218;
-    for (_iter218 = this->parameters.begin(); _iter218 != this->parameters.end(); ++_iter218)
+    std::map<std::string, std::string> ::const_iterator _iter228;
+    for (_iter228 = this->parameters.begin(); _iter228 != this->parameters.end(); ++_iter228)
     {
-      xfer += oprot->writeString(_iter218->first);
-      xfer += oprot->writeString(_iter218->second);
+      xfer += oprot->writeString(_iter228->first);
+      xfer += oprot->writeString(_iter228->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -7154,25 +7270,25 @@ void swap(SerDeInfo &a, SerDeInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-SerDeInfo::SerDeInfo(const SerDeInfo& other219) {
-  name = other219.name;
-  serializationLib = other219.serializationLib;
-  parameters = other219.parameters;
-  description = other219.description;
-  serializerClass = other219.serializerClass;
-  deserializerClass = other219.deserializerClass;
-  serdeType = other219.serdeType;
-  __isset = other219.__isset;
+SerDeInfo::SerDeInfo(const SerDeInfo& other229) {
+  name = other229.name;
+  serializationLib = other229.serializationLib;
+  parameters = other229.parameters;
+  description = other229.description;
+  serializerClass = other229.serializerClass;
+  deserializerClass = other229.deserializerClass;
+  serdeType = other229.serdeType;
+  __isset = other229.__isset;
 }
-SerDeInfo& SerDeInfo::operator=(const SerDeInfo& other220) {
-  name = other220.name;
-  serializationLib = other220.serializationLib;
-  parameters = other220.parameters;
-  description = other220.description;
-  serializerClass = other220.serializerClass;
-  deserializerClass = other220.deserializerClass;
-  serdeType = other220.serdeType;
-  __isset = other220.__isset;
+SerDeInfo& SerDeInfo::operator=(const SerDeInfo& other230) {
+  name = other230.name;
+  serializationLib = other230.serializationLib;
+  parameters = other230.parameters;
+  description = other230.description;
+  serializerClass = other230.serializerClass;
+  deserializerClass = other230.deserializerClass;
+  serdeType = other230.serdeType;
+  __isset = other230.__isset;
   return *this;
 }
 void SerDeInfo::printTo(std::ostream& out) const {
@@ -7281,15 +7397,15 @@ void swap(Order &a, Order &b) {
   swap(a.__isset, b.__isset);
 }
 
-Order::Order(const Order& other221) {
-  col = other221.col;
-  order = other221.order;
-  __isset = other221.__isset;
+Order::Order(const Order& other231) {
+  col = other231.col;
+  order = other231.order;
+  __isset = other231.__isset;
 }
-Order& Order::operator=(const Order& other222) {
-  col = other222.col;
-  order = other222.order;
-  __isset = other222.__isset;
+Order& Order::operator=(const Order& other232) {
+  col = other232.col;
+  order = other232.order;
+  __isset = other232.__isset;
   return *this;
 }
 void Order::printTo(std::ostream& out) const {
@@ -7348,14 +7464,14 @@ uint32_t SkewedInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->skewedColNames.clear();
-            uint32_t _size223;
-            ::apache::thrift::protocol::TType _etype226;
-            xfer += iprot->readListBegin(_etype226, _size223);
-            this->skewedColNames.resize(_size223);
-            uint32_t _i227;
-            for (_i227 = 0; _i227 < _size223; ++_i227)
+            uint32_t _size233;
+            ::apache::thrift::protocol::TType _etype236;
+            xfer += iprot->readListBegin(_etype236, _size233);
+            this->skewedColNames.resize(_size233);
+            uint32_t _i237;
+            for (_i237 = 0; _i237 < _size233; ++_i237)
             {
-              xfer += iprot->readString(this->skewedColNames[_i227]);
+              xfer += iprot->readString(this->skewedColNames[_i237]);
             }
             xfer += iprot->readListEnd();
           }
@@ -7368,23 +7484,23 @@ uint32_t SkewedInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->skewedColValues.clear();
-            uint32_t _size228;
-            ::apache::thrift::protocol::TType _etype231;
-            xfer += iprot->readListBegin(_etype231, _size228);
-            this->skewedColValues.resize(_size228);
-            uint32_t _i232;
-            for (_i232 = 0; _i232 < _size228; ++_i232)
+            uint32_t _size238;
+            ::apache::thrift::protocol::TType _etype241;
+            xfer += iprot->readListBegin(_etype241, _size238);
+            this->skewedColValues.resize(_size238);
+            uint32_t _i242;
+            for (_i242 = 0; _i242 < _size238; ++_i242)
             {
               {
-                this->skewedColValues[_i232].clear();
-                uint32_t _size233;
-                ::apache::thrift::protocol::TType _etype236;
-                xfer += iprot->readListBegin(_etype236, _size233);
-                this->skewedColValues[_i232].resize(_size233);
-                uint32_t _i237;
-                for (_i237 = 0; _i237 < _size233; ++_i237)
+                this->skewedColValues[_i242].clear();
+                uint32_t _size243;
+                ::apache::thrift::protocol::TType _etype246;
+                xfer += iprot->readListBegin(_etype246, _size243);
+                this->skewedColValues[_i242].resize(_size243);
+                uint32_t _i247;
+                for (_i247 = 0; _i247 < _size243; ++_i247)
                 {
-                  xfer += iprot->readString(this->skewedColValues[_i232][_i237]);
+                  xfer += iprot->readString(this->skewedColValues[_i242][_i247]);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -7400,29 +7516,29 @@ uint32_t SkewedInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->skewedColValueLocationMaps.clear();
-            uint32_t _size238;
-            ::apache::thrift::protocol::TType _ktype239;
-            ::apache::thrift::protocol::TType _vtype240;
-            xfer += iprot->readMapBegin(_ktype239, _vtype240, _size238);
-            uint32_t _i242;
-            for (_i242 = 0; _i242 < _size238; ++_i242)
+            uint32_t _size248;
+            ::apache::thrift::protocol::TType _ktype249;
+            ::apache::thrift::protocol::TType _vtype250;
+            xfer += iprot->readMapBegin(_ktype249, _vtype250, _size248);
+            uint32_t _i252;
+            for (_i252 = 0; _i252 < _size248; ++_i252)
             {
-              std::vector<std::string>  _key243;
+              std::vector<std::string>  _key253;
               {
-                _key243.clear();
-                uint32_t _size245;
-                ::apache::thrift::protocol::TType _etype248;
-                xfer += iprot->readListBegin(_etype248, _size245);
-                _key243.resize(_size245);
-                uint32_t _i249;
-                for (_i249 = 0; _i249 < _size245; ++_i249)
+                _key253.clear();
+                uint32_t _size255;
+                ::apache::thrift::protocol::TType _etype258;
+                xfer += iprot->readListBegin(_etype258, _size255);
+                _key253.resize(_size255);
+                uint32_t _i259;
+                for (_i259 = 0; _i259 < _size255; ++_i259)
                 {
-                  xfer += iprot->readString(_key243[_i249]);
+                  xfer += iprot->readString(_key253[_i259]);
                 }
                 xfer += iprot->readListEnd();
               }
-              std::string& _val244 = this->skewedColValueLocationMaps[_key243];
-              xfer += iprot->readString(_val244);
+              std::string& _val254 = this->skewedColValueLocationMaps[_key253];
+              xfer += iprot->readString(_val254);
             }
             xfer += iprot->readMapEnd();
           }
@@ -7451,10 +7567,10 @@ uint32_t SkewedInfo::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("skewedColNames", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->skewedColNames.size()));
-    std::vector<std::string> ::const_iterator _iter250;
-    for (_iter250 = this->skewedColNames.begin(); _iter250 != this->skewedColNames.end(); ++_iter250)
+    std::vector<std::string> ::const_iterator _iter260;
+    for (_iter260 = this->skewedColNames.begin(); _iter260 != this->skewedColNames.end(); ++_iter260)
     {
-      xfer += oprot->writeString((*_iter250));
+      xfer += oprot->writeString((*_iter260));
     }
     xfer += oprot->writeListEnd();
   }
@@ -7463,15 +7579,15 @@ uint32_t SkewedInfo::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("skewedColValues", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->skewedColValues.size()));
-    std::vector<std::vector<std::string> > ::const_iterator _iter251;
-    for (_iter251 = this->skewedColValues.begin(); _iter251 != this->skewedColValues.end(); ++_iter251)
+    std::vector<std::vector<std::string> > ::const_iterator _iter261;
+    for (_iter261 = this->skewedColValues.begin(); _iter261 != this->skewedColValues.end(); ++_iter261)
     {
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*_iter251).size()));
-        std::vector<std::string> ::const_iterator _iter252;
-        for (_iter252 = (*_iter251).begin(); _iter252 != (*_iter251).end(); ++_iter252)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*_iter261).size()));
+        std::vector<std::string> ::const_iterator _iter262;
+        for (_iter262 = (*_iter261).begin(); _iter262 != (*_iter261).end(); ++_iter262)
         {
-          xfer += oprot->writeString((*_iter252));
+          xfer += oprot->writeString((*_iter262));
         }
         xfer += oprot->writeListEnd();
       }
@@ -7483,19 +7599,19 @@ uint32_t SkewedInfo::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("skewedColValueLocationMaps", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_LIST, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->skewedColValueLocationMaps.size()));
-    std::map<std::vector<std::string> , std::string> ::const_iterator _iter253;
-    for (_iter253 = this->skewedColValueLocationMaps.begin(); _iter253 != this->skewedColValueLocationMaps.end(); ++_iter253)
+    std::map<std::vector<std::string> , std::string> ::const_iterator _iter263;
+    for (_iter263 = this->skewedColValueLocationMaps.begin(); _iter263 != this->skewedColValueLocationMaps.end(); ++_iter263)
     {
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter253->first.size()));
-        std::vector<std::string> ::const_iterator _iter254;
-        for (_iter254 = _iter253->first.begin(); _iter254 != _iter253->first.end(); ++_iter254)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter263->first.size()));
+        std::vector<std::string> ::const_iterator _iter264;
+        for (_iter264 = _iter263->first.begin(); _iter264 != _iter263->first.end(); ++_iter264)
         {
-          xfer += oprot->writeString((*_iter254));
+          xfer += oprot->writeString((*_iter264));
         }
         xfer += oprot->writeListEnd();
       }
-      xfer += oprot->writeString(_iter253->second);
+      xfer += oprot->writeString(_iter263->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -7514,17 +7630,17 @@ void swap(SkewedInfo &a, SkewedInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-SkewedInfo::SkewedInfo(const SkewedInfo& other255) {
-  skewedColNames = other255.skewedColNames;
-  skewedColValues = other255.skewedColValues;
-  skewedColValueLocationMaps = other255.skewedColValueLocationMaps;
-  __isset = other255.__isset;
+SkewedInfo::SkewedInfo(const SkewedInfo& other265) {
+  skewedColNames = other265.skewedColNames;
+  skewedColValues = other265.skewedColValues;
+  skewedColValueLocationMaps = other265.skewedColValueLocationMaps;
+  __isset = other265.__isset;
 }
-SkewedInfo& SkewedInfo::operator=(const SkewedInfo& other256) {
-  skewedColNames = other256.skewedColNames;
-  skewedColValues = other256.skewedColValues;
-  skewedColValueLocationMaps = other256.skewedColValueLocationMaps;
-  __isset = other256.__isset;
+SkewedInfo& SkewedInfo::operator=(const SkewedInfo& other266) {
+  skewedColNames = other266.skewedColNames;
+  skewedColValues = other266.skewedColValues;
+  skewedColValueLocationMaps = other266.skewedColValueLocationMaps;
+  __isset = other266.__isset;
   return *this;
 }
 void SkewedInfo::printTo(std::ostream& out) const {
@@ -7622,14 +7738,14 @@ uint32_t StorageDescriptor::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->cols.clear();
-            uint32_t _size257;
-            ::apache::thrift::protocol::TType _etype260;
-            xfer += iprot->readListBegin(_etype260, _size257);
-            this->cols.resize(_size257);
-            uint32_t _i261;
-            for (_i261 = 0; _i261 < _size257; ++_i261)
+            uint32_t _size267;
+            ::apache::thrift::protocol::TType _etype270;
+            xfer += iprot->readListBegin(_etype270, _size267);
+            this->cols.resize(_size267);
+            uint32_t _i271;
+            for (_i271 = 0; _i271 < _size267; ++_i271)
             {
-              xfer += this->cols[_i261].read(iprot);
+              xfer += this->cols[_i271].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7690,14 +7806,14 @@ uint32_t StorageDescriptor::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->bucketCols.clear();
-            uint32_t _size262;
-            ::apache::thrift::protocol::TType _etype265;
-            xfer += iprot->readListBegin(_etype265, _size262);
-            this->bucketCols.resize(_size262);
-            uint32_t _i266;
-            for (_i266 = 0; _i266 < _size262; ++_i266)
+            uint32_t _size272;
+            ::apache::thrift::protocol::TType _etype275;
+            xfer += iprot->readListBegin(_etype275, _size272);
+            this->bucketCols.resize(_size272);
+            uint32_t _i276;
+            for (_i276 = 0; _i276 < _size272; ++_i276)
             {
-              xfer += iprot->readString(this->bucketCols[_i266]);
+              xfer += iprot->readString(this->bucketCols[_i276]);
             }
             xfer += iprot->readListEnd();
           }
@@ -7710,14 +7826,14 @@ uint32_t StorageDescriptor::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->sortCols.clear();
-            uint32_t _size267;
-            ::apache::thrift::protocol::TType _etype270;
-            xfer += iprot->readListBegin(_etype270, _size267);
-            this->sortCols.resize(_size267);
-            uint32_t _i271;
-            for (_i271 = 0; _i271 < _size267; ++_i271)
+            uint32_t _size277;
+            ::apache::thrift::protocol::TType _etype280;
+            xfer += iprot->readListBegin(_etype280, _size277);
+            this->sortCols.resize(_size277);
+            uint32_t _i281;
+            for (_i281 = 0; _i281 < _size277; ++_i281)
             {
-              xfer += this->sortCols[_i271].read(iprot);
+              xfer += this->sortCols[_i281].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7730,17 +7846,17 @@ uint32_t StorageDescriptor::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size272;
-            ::apache::thrift::protocol::TType _ktype273;
-            ::apache::thrift::protocol::TType _vtype274;
-            xfer += iprot->readMapBegin(_ktype273, _vtype274, _size272);
-            uint32_t _i276;
-            for (_i276 = 0; _i276 < _size272; ++_i276)
+            uint32_t _size282;
+            ::apache::thrift::protocol::TType _ktype283;
+            ::apache::thrift::protocol::TType _vtype284;
+            xfer += iprot->readMapBegin(_ktype283, _vtype284, _size282);
+            uint32_t _i286;
+            for (_i286 = 0; _i286 < _size282; ++_i286)
             {
-              std::string _key277;
-              xfer += iprot->readString(_key277);
-              std::string& _val278 = this->parameters[_key277];
-              xfer += iprot->readString(_val278);
+              std::string _key287;
+              xfer += iprot->readString(_key287);
+              std::string& _val288 = this->parameters[_key287];
+              xfer += iprot->readString(_val288);
             }
             xfer += iprot->readMapEnd();
           }
@@ -7785,10 +7901,10 @@ uint32_t StorageDescriptor::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("cols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->cols.size()));
-    std::vector<FieldSchema> ::const_iterator _iter279;
-    for (_iter279 = this->cols.begin(); _iter279 != this->cols.end(); ++_iter279)
+    std::vector<FieldSchema> ::const_iterator _iter289;
+    for (_iter289 = this->cols.begin(); _iter289 != this->cols.end(); ++_iter289)
     {
-      xfer += (*_iter279).write(oprot);
+      xfer += (*_iter289).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7821,10 +7937,10 @@ uint32_t StorageDescriptor::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("bucketCols", ::apache::thrift::protocol::T_LIST, 8);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->bucketCols.size()));
-    std::vector<std::string> ::const_iterator _iter280;
-    for (_iter280 = this->bucketCols.begin(); _iter280 != this->bucketCols.end(); ++_iter280)
+    std::vector<std::string> ::const_iterator _iter290;
+    for (_iter290 = this->bucketCols.begin(); _iter290 != this->bucketCols.end(); ++_iter290)
     {
-      xfer += oprot->writeString((*_iter280));
+      xfer += oprot->writeString((*_iter290));
     }
     xfer += oprot->writeListEnd();
   }
@@ -7833,10 +7949,10 @@ uint32_t StorageDescriptor::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("sortCols", ::apache::thrift::protocol::T_LIST, 9);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sortCols.size()));
-    std::vector<Order> ::const_iterator _iter281;
-    for (_iter281 = this->sortCols.begin(); _iter281 != this->sortCols.end(); ++_iter281)
+    std::vector<Order> ::const_iterator _iter291;
+    for (_iter291 = this->sortCols.begin(); _iter291 != this->sortCols.end(); ++_iter291)
     {
-      xfer += (*_iter281).write(oprot);
+      xfer += (*_iter291).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7845,11 +7961,11 @@ uint32_t StorageDescriptor::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 10);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter282;
-    for (_iter282 = this->parameters.begin(); _iter282 != this->parameters.end(); ++_iter282)
+    std::map<std::string, std::string> ::const_iterator _iter292;
+    for (_iter292 = this->parameters.begin(); _iter292 != this->parameters.end(); ++_iter292)
     {
-      xfer += oprot->writeString(_iter282->first);
-      xfer += oprot->writeString(_iter282->second);
+      xfer += oprot->writeString(_iter292->first);
+      xfer += oprot->writeString(_iter292->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -7887,35 +8003,35 @@ void swap(StorageDescriptor &a, StorageDescriptor &b) {
   swap(a.__isset, b.__isset);
 }
 
-StorageDescriptor::StorageDescriptor(const StorageDescriptor& other283) {
-  cols = other283.cols;
-  location = other283.location;
-  inputFormat = other283.inputFormat;
-  outputFormat = other283.outputFormat;
-  compressed = other283.compressed;
-  numBuckets = other283.numBuckets;
-  serdeInfo = other283.serdeInfo;
-  bucketCols = other283.bucketCols;
-  sortCols = other283.sortCols;
-  parameters = other283.parameters;
-  skewedInfo = other283.skewedInfo;
-  storedAsSubDirectories = other283.storedAsSubDirectories;
-  __isset = other283.__isset;
+StorageDescriptor::StorageDescriptor(const StorageDescriptor& other293) {
+  cols = other293.cols;
+  location = other293.location;
+  inputFormat = other293.inputFormat;
+  outputFormat = other293.outputFormat;
+  compressed = other293.compressed;
+  numBuckets = other293.numBuckets;
+  serdeInfo = other293.serdeInfo;
+  bucketCols = other293.bucketCols;
+  sortCols = other293.sortCols;
+  parameters = other293.parameters;
+  skewedInfo = other293.skewedInfo;
+  storedAsSubDirectories = other293.storedAsSubDirectories;
+  __isset = other293.__isset;
 }
-StorageDescriptor& StorageDescriptor::operator=(const StorageDescriptor& other284) {
-  cols = other284.cols;
-  location = other284.location;
-  inputFormat = other284.inputFormat;
-  outputFormat = other284.outputFormat;
-  compressed = other284.compressed;
-  numBuckets = other284.numBuckets;
-  serdeInfo = other284.serdeInfo;
-  bucketCols = other284.bucketCols;
-  sortCols = other284.sortCols;
-  parameters = other284.parameters;
-  skewedInfo = other284.skewedInfo;
-  storedAsSubDirectories = other284.storedAsSubDirectories;
-  __isset = other284.__isset;
+StorageDescriptor& StorageDescriptor::operator=(const StorageDescriptor& other294) {
+  cols = other294.cols;
+  location = other294.location;
+  inputFormat = other294.inputFormat;
+  outputFormat = other294.outputFormat;
+  compressed = other294.compressed;
+  numBuckets = other294.numBuckets;
+  serdeInfo = other294.serdeInfo;
+  bucketCols = other294.bucketCols;
+  sortCols = other294.sortCols;
+  parameters = other294.parameters;
+  skewedInfo = other294.skewedInfo;
+  storedAsSubDirectories = other294.storedAsSubDirectories;
+  __isset = other294.__isset;
   return *this;
 }
 void StorageDescriptor::printTo(std::ostream& out) const {
@@ -8026,15 +8142,15 @@ uint32_t CreationMetadata::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_SET) {
           {
             this->tablesUsed.clear();
-            uint32_t _size285;
-            ::apache::thrift::protocol::TType _etype288;
-            xfer += iprot->readSetBegin(_etype288, _size285);
-            uint32_t _i289;
-            for (_i289 = 0; _i289 < _size285; ++_i289)
+            uint32_t _size295;
+            ::apache::thrift::protocol::TType _etype298;
+            xfer += iprot->readSetBegin(_etype298, _size295);
+            uint32_t _i299;
+            for (_i299 = 0; _i299 < _size295; ++_i299)
             {
-              std::string _elem290;
-              xfer += iprot->readString(_elem290);
-              this->tablesUsed.insert(_elem290);
+              std::string _elem300;
+              xfer += iprot->readString(_elem300);
+              this->tablesUsed.insert(_elem300);
             }
             xfer += iprot->readSetEnd();
           }
@@ -8099,10 +8215,10 @@ uint32_t CreationMetadata::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("tablesUsed", ::apache::thrift::protocol::T_SET, 4);
   {
     xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tablesUsed.size()));
-    std::set<std::string> ::const_iterator _iter291;
-    for (_iter291 = this->tablesUsed.begin(); _iter291 != this->tablesUsed.end(); ++_iter291)
+    std::set<std::string> ::const_iterator _iter301;
+    for (_iter301 = this->tablesUsed.begin(); _iter301 != this->tablesUsed.end(); ++_iter301)
     {
-      xfer += oprot->writeString((*_iter291));
+      xfer += oprot->writeString((*_iter301));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -8134,23 +8250,23 @@ void swap(CreationMetadata &a, CreationMetadata &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreationMetadata::CreationMetadata(const CreationMetadata& other292) {
-  catName = other292.catName;
-  dbName = other292.dbName;
-  tblName = other292.tblName;
-  tablesUsed = other292.tablesUsed;
-  validTxnList = other292.validTxnList;
-  materializationTime = other292.materializationTime;
-  __isset = other292.__isset;
+CreationMetadata::CreationMetadata(const CreationMetadata& other302) {
+  catName = other302.catName;
+  dbName = other302.dbName;
+  tblName = other302.tblName;
+  tablesUsed = other302.tablesUsed;
+  validTxnList = other302.validTxnList;
+  materializationTime = other302.materializationTime;
+  __isset = other302.__isset;
 }
-CreationMetadata& CreationMetadata::operator=(const CreationMetadata& other293) {
-  catName = other293.catName;
-  dbName = other293.dbName;
-  tblName = other293.tblName;
-  tablesUsed = other293.tablesUsed;
-  validTxnList = other293.validTxnList;
-  materializationTime = other293.materializationTime;
-  __isset = other293.__isset;
+CreationMetadata& CreationMetadata::operator=(const CreationMetadata& other303) {
+  catName = other303.catName;
+  dbName = other303.dbName;
+  tblName = other303.tblName;
+  tablesUsed = other303.tablesUsed;
+  validTxnList = other303.validTxnList;
+  materializationTime = other303.materializationTime;
+  __isset = other303.__isset;
   return *this;
 }
 void CreationMetadata::printTo(std::ostream& out) const {
@@ -8303,19 +8419,19 @@ void swap(BooleanColumnStatsData &a, BooleanColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-BooleanColumnStatsData::BooleanColumnStatsData(const BooleanColumnStatsData& other294) {
-  numTrues = other294.numTrues;
-  numFalses = other294.numFalses;
-  numNulls = other294.numNulls;
-  bitVectors = other294.bitVectors;
-  __isset = other294.__isset;
+BooleanColumnStatsData::BooleanColumnStatsData(const BooleanColumnStatsData& other304) {
+  numTrues = other304.numTrues;
+  numFalses = other304.numFalses;
+  numNulls = other304.numNulls;
+  bitVectors = other304.bitVectors;
+  __isset = other304.__isset;
 }
-BooleanColumnStatsData& BooleanColumnStatsData::operator=(const BooleanColumnStatsData& other295) {
-  numTrues = other295.numTrues;
-  numFalses = other295.numFalses;
-  numNulls = other295.numNulls;
-  bitVectors = other295.bitVectors;
-  __isset = other295.__isset;
+BooleanColumnStatsData& BooleanColumnStatsData::operator=(const BooleanColumnStatsData& other305) {
+  numTrues = other305.numTrues;
+  numFalses = other305.numFalses;
+  numNulls = other305.numNulls;
+  bitVectors = other305.bitVectors;
+  __isset = other305.__isset;
   return *this;
 }
 void BooleanColumnStatsData::printTo(std::ostream& out) const {
@@ -8484,21 +8600,21 @@ void swap(DoubleColumnStatsData &a, DoubleColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DoubleColumnStatsData::DoubleColumnStatsData(const DoubleColumnStatsData& other296) {
-  lowValue = other296.lowValue;
-  highValue = other296.highValue;
-  numNulls = other296.numNulls;
-  numDVs = other296.numDVs;
-  bitVectors = other296.bitVectors;
-  __isset = other296.__isset;
+DoubleColumnStatsData::DoubleColumnStatsData(const DoubleColumnStatsData& other306) {
+  lowValue = other306.lowValue;
+  highValue = other306.highValue;
+  numNulls = other306.numNulls;
+  numDVs = other306.numDVs;
+  bitVectors = other306.bitVectors;
+  __isset = other306.__isset;
 }
-DoubleColumnStatsData& DoubleColumnStatsData::operator=(const DoubleColumnStatsData& other297) {
-  lowValue = other297.lowValue;
-  highValue = other297.highValue;
-  numNulls = other297.numNulls;
-  numDVs = other297.numDVs;
-  bitVectors = other297.bitVectors;
-  __isset = other297.__isset;
+DoubleColumnStatsData& DoubleColumnStatsData::operator=(const DoubleColumnStatsData& other307) {
+  lowValue = other307.lowValue;
+  highValue = other307.highValue;
+  numNulls = other307.numNulls;
+  numDVs = other307.numDVs;
+  bitVectors = other307.bitVectors;
+  __isset = other307.__isset;
   return *this;
 }
 void DoubleColumnStatsData::printTo(std::ostream& out) const {
@@ -8668,21 +8784,21 @@ void swap(LongColumnStatsData &a, LongColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-LongColumnStatsData::LongColumnStatsData(const LongColumnStatsData& other298) {
-  lowValue = other298.lowValue;
-  highValue = other298.highValue;
-  numNulls = other298.numNulls;
-  numDVs = other298.numDVs;
-  bitVectors = other298.bitVectors;
-  __isset = other298.__isset;
+LongColumnStatsData::LongColumnStatsData(const LongColumnStatsData& other308) {
+  lowValue = other308.lowValue;
+  highValue = other308.highValue;
+  numNulls = other308.numNulls;
+  numDVs = other308.numDVs;
+  bitVectors = other308.bitVectors;
+  __isset = other308.__isset;
 }
-LongColumnStatsData& LongColumnStatsData::operator=(const LongColumnStatsData& other299) {
-  lowValue = other299.lowValue;
-  highValue = other299.highValue;
-  numNulls = other299.numNulls;
-  numDVs = other299.numDVs;
-  bitVectors = other299.bitVectors;
-  __isset = other299.__isset;
+LongColumnStatsData& LongColumnStatsData::operator=(const LongColumnStatsData& other309) {
+  lowValue = other309.lowValue;
+  highValue = other309.highValue;
+  numNulls = other309.numNulls;
+  numDVs = other309.numDVs;
+  bitVectors = other309.bitVectors;
+  __isset = other309.__isset;
   return *this;
 }
 void LongColumnStatsData::printTo(std::ostream& out) const {
@@ -8854,21 +8970,21 @@ void swap(StringColumnStatsData &a, StringColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-StringColumnStatsData::StringColumnStatsData(const StringColumnStatsData& other300) {
-  maxColLen = other300.maxColLen;
-  avgColLen = other300.avgColLen;
-  numNulls = other300.numNulls;
-  numDVs = other300.numDVs;
-  bitVectors = other300.bitVectors;
-  __isset = other300.__isset;
+StringColumnStatsData::StringColumnStatsData(const StringColumnStatsData& other310) {
+  maxColLen = other310.maxColLen;
+  avgColLen = other310.avgColLen;
+  numNulls = other310.numNulls;
+  numDVs = other310.numDVs;
+  bitVectors = other310.bitVectors;
+  __isset = other310.__isset;
 }
-StringColumnStatsData& StringColumnStatsData::operator=(const StringColumnStatsData& other301) {
-  maxColLen = other301.maxColLen;
-  avgColLen = other301.avgColLen;
-  numNulls = other301.numNulls;
-  numDVs = other301.numDVs;
-  bitVectors = other301.bitVectors;
-  __isset = other301.__isset;
+StringColumnStatsData& StringColumnStatsData::operator=(const StringColumnStatsData& other311) {
+  maxColLen = other311.maxColLen;
+  avgColLen = other311.avgColLen;
+  numNulls = other311.numNulls;
+  numDVs = other311.numDVs;
+  bitVectors = other311.bitVectors;
+  __isset = other311.__isset;
   return *this;
 }
 void StringColumnStatsData::printTo(std::ostream& out) const {
@@ -9020,19 +9136,19 @@ void swap(BinaryColumnStatsData &a, BinaryColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-BinaryColumnStatsData::BinaryColumnStatsData(const BinaryColumnStatsData& other302) {
-  maxColLen = other302.maxColLen;
-  avgColLen = other302.avgColLen;
-  numNulls = other302.numNulls;
-  bitVectors = other302.bitVectors;
-  __isset = other302.__isset;
+BinaryColumnStatsData::BinaryColumnStatsData(const BinaryColumnStatsData& other312) {
+  maxColLen = other312.maxColLen;
+  avgColLen = other312.avgColLen;
+  numNulls = other312.numNulls;
+  bitVectors = other312.bitVectors;
+  __isset = other312.__isset;
 }
-BinaryColumnStatsData& BinaryColumnStatsData::operator=(const BinaryColumnStatsData& other303) {
-  maxColLen = other303.maxColLen;
-  avgColLen = other303.avgColLen;
-  numNulls = other303.numNulls;
-  bitVectors = other303.bitVectors;
-  __isset = other303.__isset;
+BinaryColumnStatsData& BinaryColumnStatsData::operator=(const BinaryColumnStatsData& other313) {
+  maxColLen = other313.maxColLen;
+  avgColLen = other313.avgColLen;
+  numNulls = other313.numNulls;
+  bitVectors = other313.bitVectors;
+  __isset = other313.__isset;
   return *this;
 }
 void BinaryColumnStatsData::printTo(std::ostream& out) const {
@@ -9143,13 +9259,13 @@ void swap(Decimal &a, Decimal &b) {
   swap(a.unscaled, b.unscaled);
 }
 
-Decimal::Decimal(const Decimal& other304) {
-  scale = other304.scale;
-  unscaled = other304.unscaled;
+Decimal::Decimal(const Decimal& other314) {
+  scale = other314.scale;
+  unscaled = other314.unscaled;
 }
-Decimal& Decimal::operator=(const Decimal& other305) {
-  scale = other305.scale;
-  unscaled = other305.unscaled;
+Decimal& Decimal::operator=(const Decimal& other315) {
+  scale = other315.scale;
+  unscaled = other315.unscaled;
   return *this;
 }
 void Decimal::printTo(std::ostream& out) const {
@@ -9316,21 +9432,21 @@ void swap(DecimalColumnStatsData &a, DecimalColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DecimalColumnStatsData::DecimalColumnStatsData(const DecimalColumnStatsData& other306) {
-  lowValue = other306.lowValue;
-  highValue = other306.highValue;
-  numNulls = other306.numNulls;
-  numDVs = other306.numDVs;
-  bitVectors = other306.bitVectors;
-  __isset = other306.__isset;
+DecimalColumnStatsData::DecimalColumnStatsData(const DecimalColumnStatsData& other316) {
+  lowValue = other316.lowValue;
+  highValue = other316.highValue;
+  numNulls = other316.numNulls;
+  numDVs = other316.numDVs;
+  bitVectors = other316.bitVectors;
+  __isset = other316.__isset;
 }
-DecimalColumnStatsData& DecimalColumnStatsData::operator=(const DecimalColumnStatsData& other307) {
-  lowValue = other307.lowValue;
-  highValue = other307.highValue;
-  numNulls = other307.numNulls;
-  numDVs = other307.numDVs;
-  bitVectors = other307.bitVectors;
-  __isset = other307.__isset;
+DecimalColumnStatsData& DecimalColumnStatsData::operator=(const DecimalColumnStatsData& other317) {
+  lowValue = other317.lowValue;
+  highValue = other317.highValue;
+  numNulls = other317.numNulls;
+  numDVs = other317.numDVs;
+  bitVectors = other317.bitVectors;
+  __isset = other317.__isset;
   return *this;
 }
 void DecimalColumnStatsData::printTo(std::ostream& out) const {
@@ -9422,11 +9538,11 @@ void swap(Date &a, Date &b) {
   swap(a.daysSinceEpoch, b.daysSinceEpoch);
 }
 
-Date::Date(const Date& other308) {
-  daysSinceEpoch = other308.daysSinceEpoch;
+Date::Date(const Date& other318) {
+  daysSinceEpoch = other318.daysSinceEpoch;
 }
-Date& Date::operator=(const Date& other309) {
-  daysSinceEpoch = other309.daysSinceEpoch;
+Date& Date::operator=(const Date& other319) {
+  daysSinceEpoch = other319.daysSinceEpoch;
   return *this;
 }
 void Date::printTo(std::ostream& out) const {
@@ -9592,21 +9708,21 @@ void swap(DateColumnStatsData &a, DateColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DateColumnStatsData::DateColumnStatsData(const DateColumnStatsData& other310) {
-  lowValue = other310.lowValue;
-  highValue = other310.highValue;
-  numNulls = other310.numNulls;
-  numDVs = other310.numDVs;
-  bitVectors = other310.bitVectors;
-  __isset = other310.__isset;
+DateColumnStatsData::DateColumnStatsData(const DateColumnStatsData& other320) {
+  lowValue = other320.lowValue;
+  highValue = other320.highValue;
+  numNulls = other320.numNulls;
+  numDVs = other320.numDVs;
+  bitVectors = other320.bitVectors;
+  __isset = other320.__isset;
 }
-DateColumnStatsData& DateColumnStatsData::operator=(const DateColumnStatsData& other311) {
-  lowValue = other311.lowValue;
-  highValue = other311.highValue;
-  numNulls = other311.numNulls;
-  numDVs = other311.numDVs;
-  bitVectors = other311.bitVectors;
-  __isset = other311.__isset;
+DateColumnStatsData& DateColumnStatsData::operator=(const DateColumnStatsData& other321) {
+  lowValue = other321.lowValue;
+  highValue = other321.highValue;
+  numNulls = other321.numNulls;
+  numDVs = other321.numDVs;
+  bitVectors = other321.bitVectors;
+  __isset = other321.__isset;
   return *this;
 }
 void DateColumnStatsData::printTo(std::ostream& out) const {
@@ -9698,11 +9814,11 @@ void swap(Timestamp &a, Timestamp &b) {
   swap(a.secondsSinceEpoch, b.secondsSinceEpoch);
 }
 
-Timestamp::Timestamp(const Timestamp& other312) {
-  secondsSinceEpoch = other312.secondsSinceEpoch;
+Timestamp::Timestamp(const Timestamp& other322) {
+  secondsSinceEpoch = other322.secondsSinceEpoch;
 }
-Timestamp& Timestamp::operator=(const Timestamp& other313) {
-  secondsSinceEpoch = other313.secondsSinceEpoch;
+Timestamp& Timestamp::operator=(const Timestamp& other323) {
+  secondsSinceEpoch = other323.secondsSinceEpoch;
   return *this;
 }
 void Timestamp::printTo(std::ostream& out) const {
@@ -9868,21 +9984,21 @@ void swap(TimestampColumnStatsData &a, TimestampColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-TimestampColumnStatsData::TimestampColumnStatsData(const TimestampColumnStatsData& other314) {
-  lowValue = other314.lowValue;
-  highValue = other314.highValue;
-  numNulls = other314.numNulls;
-  numDVs = other314.numDVs;
-  bitVectors = other314.bitVectors;
-  __isset = other314.__isset;
+TimestampColumnStatsData::TimestampColumnStatsData(const TimestampColumnStatsData& other324) {
+  lowValue = other324.lowValue;
+  highValue = other324.highValue;
+  numNulls = other324.numNulls;
+  numDVs = other324.numDVs;
+  bitVectors = other324.bitVectors;
+  __isset = other324.__isset;
 }
-TimestampColumnStatsData& TimestampColumnStatsData::operator=(const TimestampColumnStatsData& other315) {
-  lowValue = other315.lowValue;
-  highValue = other315.highValue;
-  numNulls = other315.numNulls;
-  numDVs = other315.numDVs;
-  bitVectors = other315.bitVectors;
-  __isset = other315.__isset;
+TimestampColumnStatsData& TimestampColumnStatsData::operator=(const TimestampColumnStatsData& other325) {
+  lowValue = other325.lowValue;
+  highValue = other325.highValue;
+  numNulls = other325.numNulls;
+  numDVs = other325.numDVs;
+  bitVectors = other325.bitVectors;
+  __isset = other325.__isset;
   return *this;
 }
 void TimestampColumnStatsData::printTo(std::ostream& out) const {
@@ -10107,27 +10223,27 @@ void swap(ColumnStatisticsData &a, ColumnStatisticsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatisticsData::ColumnStatisticsData(const ColumnStatisticsData& other316) {
-  booleanStats = other316.booleanStats;
-  longStats = other316.longStats;
-  doubleStats = other316.doubleStats;
-  stringStats = other316.stringStats;
-  binaryStats = other316.binaryStats;
-  decimalStats = other316.decimalStats;
-  dateStats = other316.dateStats;
-  timestampStats = other316.timestampStats;
-  __isset = other316.__isset;
+ColumnStatisticsData::ColumnStatisticsData(const ColumnStatisticsData& other326) {
+  booleanStats = other326.booleanStats;
+  longStats = other326.longStats;
+  doubleStats = other326.doubleStats;
+  stringStats = other326.stringStats;
+  binaryStats = other326.binaryStats;
+  decimalStats = other326.decimalStats;
+  dateStats = other326.dateStats;
+  timestampStats = other326.timestampStats;
+  __isset = other326.__isset;
 }
-ColumnStatisticsData& ColumnStatisticsData::operator=(const ColumnStatisticsData& other317) {
-  booleanStats = other317.booleanStats;
-  longStats = other317.longStats;
-  doubleStats = other317.doubleStats;
-  stringStats = other317.stringStats;
-  binaryStats = other317.binaryStats;
-  decimalStats = other317.decimalStats;
-  dateStats = other317.dateStats;
-  timestampStats = other317.timestampStats;
-  __isset = other317.__isset;
+ColumnStatisticsData& ColumnStatisticsData::operator=(const ColumnStatisticsData& other327) {
+  booleanStats = other327.booleanStats;
+  longStats = other327.longStats;
+  doubleStats = other327.doubleStats;
+  stringStats = other327.stringStats;
+  binaryStats = other327.binaryStats;
+  decimalStats = other327.decimalStats;
+  dateStats = other327.dateStats;
+  timestampStats = other327.timestampStats;
+  __isset = other327.__isset;
   return *this;
 }
 void ColumnStatisticsData::printTo(std::ostream& out) const {
@@ -10262,15 +10378,15 @@ void swap(ColumnStatisticsObj &a, ColumnStatisticsObj &b) {
   swap(a.statsData, b.statsData);
 }
 
-ColumnStatisticsObj::ColumnStatisticsObj(const ColumnStatisticsObj& other318) {
-  colName = other318.colName;
-  colType = other318.colType;
-  statsData = other318.statsData;
+ColumnStatisticsObj::ColumnStatisticsObj(const ColumnStatisticsObj& other328) {
+  colName = other328.colName;
+  colType = other328.colType;
+  statsData = other328.statsData;
 }
-ColumnStatisticsObj& ColumnStatisticsObj::operator=(const ColumnStatisticsObj& other319) {
-  colName = other319.colName;
-  colType = other319.colType;
-  statsData = other319.statsData;
+ColumnStatisticsObj& ColumnStatisticsObj::operator=(const ColumnStatisticsObj& other329) {
+  colName = other329.colName;
+  colType = other329.colType;
+  statsData = other329.statsData;
   return *this;
 }
 void ColumnStatisticsObj::printTo(std::ostream& out) const {
@@ -10458,23 +10574,23 @@ void swap(ColumnStatisticsDesc &a, ColumnStatisticsDesc &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatisticsDesc::ColumnStatisticsDesc(const ColumnStatisticsDesc& other320) {
-  isTblLevel = other320.isTblLevel;
-  dbName = other320.dbName;
-  tableName = other320.tableName;
-  partName = other320.partName;
-  lastAnalyzed = other320.lastAnalyzed;
-  catName = other320.catName;
-  __isset = other320.__isset;
+ColumnStatisticsDesc::ColumnStatisticsDesc(const ColumnStatisticsDesc& other330) {
+  isTblLevel = other330.isTblLevel;
+  dbName = other330.dbName;
+  tableName = other330.tableName;
+  partName = other330.partName;
+  lastAnalyzed = other330.lastAnalyzed;
+  catName = other330.catName;
+  __isset = other330.__isset;
 }
-ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc& other321) {
-  isTblLevel = other321.isTblLevel;
-  dbName = other321.dbName;
-  tableName = other321.tableName;
-  partName = other321.partName;
-  lastAnalyzed = other321.lastAnalyzed;
-  catName = other321.catName;
-  __isset = other321.__isset;
+ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc& other331) {
+  isTblLevel = other331.isTblLevel;
+  dbName = other331.dbName;
+  tableName = other331.tableName;
+  partName = other331.partName;
+  lastAnalyzed = other331.lastAnalyzed;
+  catName = other331.catName;
+  __isset = other331.__isset;
   return *this;
 }
 void ColumnStatisticsDesc::printTo(std::ostream& out) const {
@@ -10553,14 +10669,14 @@ uint32_t ColumnStatistics::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->statsObj.clear();
-            uint32_t _size322;
-            ::apache::thrift::protocol::TType _etype325;
-            xfer += iprot->readListBegin(_etype325, _size322);
-            this->statsObj.resize(_size322);
-            uint32_t _i326;
-            for (_i326 = 0; _i326 < _size322; ++_i326)
+            uint32_t _size332;
+            ::apache::thrift::protocol::TType _etype335;
+            xfer += iprot->readListBegin(_etype335, _size332);
+            this->statsObj.resize(_size332);
+            uint32_t _i336;
+            for (_i336 = 0; _i336 < _size332; ++_i336)
             {
-              xfer += this->statsObj[_i326].read(iprot);
+              xfer += this->statsObj[_i336].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -10613,10 +10729,10 @@ uint32_t ColumnStatistics::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("statsObj", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->statsObj.size()));
-    std::vector<ColumnStatisticsObj> ::const_iterator _iter327;
-    for (_iter327 = this->statsObj.begin(); _iter327 != this->statsObj.end(); ++_iter327)
+    std::vector<ColumnStatisticsObj> ::const_iterator _iter337;
+    for (_iter337 = this->statsObj.begin(); _iter337 != this->statsObj.end(); ++_iter337)
     {
-      xfer += (*_iter327).write(oprot);
+      xfer += (*_iter337).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -10646,19 +10762,19 @@ void swap(ColumnStatistics &a, ColumnStatistics &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatistics::ColumnStatistics(const ColumnStatistics& other328) {
-  statsDesc = other328.statsDesc;
-  statsObj = other328.statsObj;
-  isStatsCompliant = other328.isStatsCompliant;
-  engine = other328.engine;
-  __isset = other328.__isset;
+ColumnStatistics::ColumnStatistics(const ColumnStatistics& other338) {
+  statsDesc = other338.statsDesc;
+  statsObj = other338.statsObj;
+  isStatsCompliant = other338.isStatsCompliant;
+  engine = other338.engine;
+  __isset = other338.__isset;
 }
-ColumnStatistics& ColumnStatistics::operator=(const ColumnStatistics& other329) {
-  statsDesc = other329.statsDesc;
-  statsObj = other329.statsObj;
-  isStatsCompliant = other329.isStatsCompliant;
-  engine = other329.engine;
-  __isset = other329.__isset;
+ColumnStatistics& ColumnStatistics::operator=(const ColumnStatistics& other339) {
+  statsDesc = other339.statsDesc;
+  statsObj = other339.statsObj;
+  isStatsCompliant = other339.isStatsCompliant;
+  engine = other339.engine;
+  __isset = other339.__isset;
   return *this;
 }
 void ColumnStatistics::printTo(std::ostream& out) const {
@@ -10735,14 +10851,14 @@ uint32_t FileMetadata::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->data.clear();
-            uint32_t _size330;
-            ::apache::thrift::protocol::TType _etype333;
-            xfer += iprot->readListBegin(_etype333, _size330);
-            this->data.resize(_size330);
-            uint32_t _i334;
-            for (_i334 = 0; _i334 < _size330; ++_i334)
+            uint32_t _size340;
+            ::apache::thrift::protocol::TType _etype343;
+            xfer += iprot->readListBegin(_etype343, _size340);
+            this->data.resize(_size340);
+            uint32_t _i344;
+            for (_i344 = 0; _i344 < _size340; ++_i344)
             {
-              xfer += iprot->readBinary(this->data[_i334]);
+              xfer += iprot->readBinary(this->data[_i344]);
             }
             xfer += iprot->readListEnd();
           }
@@ -10779,10 +10895,10 @@ uint32_t FileMetadata::write(::apache::thrift::protocol::TProtocol* oprot) const
   xfer += oprot->writeFieldBegin("data", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->data.size()));
-    std::vector<std::string> ::const_iterator _iter335;
-    for (_iter335 = this->data.begin(); _iter335 != this->data.end(); ++_iter335)
+    std::vector<std::string> ::const_iterator _iter345;
+    for (_iter345 = this->data.begin(); _iter345 != this->data.end(); ++_iter345)
     {
-      xfer += oprot->writeBinary((*_iter335));
+      xfer += oprot->writeBinary((*_iter345));
     }
     xfer += oprot->writeListEnd();
   }
@@ -10801,17 +10917,17 @@ void swap(FileMetadata &a, FileMetadata &b) {
   swap(a.__isset, b.__isset);
 }
 
-FileMetadata::FileMetadata(const FileMetadata& other336) {
-  type = other336.type;
-  version = other336.version;
-  data = other336.data;
-  __isset = other336.__isset;
+FileMetadata::FileMetadata(const FileMetadata& other346) {
+  type = other346.type;
+  version = other346.version;
+  data = other346.data;
+  __isset = other346.__isset;
 }
-FileMetadata& FileMetadata::operator=(const FileMetadata& other337) {
-  type = other337.type;
-  version = other337.version;
-  data = other337.data;
-  __isset = other337.__isset;
+FileMetadata& FileMetadata::operator=(const FileMetadata& other347) {
+  type = other347.type;
+  version = other347.version;
+  data = other347.data;
+  __isset = other347.__isset;
   return *this;
 }
 void FileMetadata::printTo(std::ostream& out) const {
@@ -10864,26 +10980,26 @@ uint32_t ObjectDictionary::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->values.clear();
-            uint32_t _size338;
-            ::apache::thrift::protocol::TType _ktype339;
-            ::apache::thrift::protocol::TType _vtype340;
-            xfer += iprot->readMapBegin(_ktype339, _vtype340, _size338);
-            uint32_t _i342;
-            for (_i342 = 0; _i342 < _size338; ++_i342)
+            uint32_t _size348;
+            ::apache::thrift::protocol::TType _ktype349;
+            ::apache::thrift::protocol::TType _vtype350;
+            xfer += iprot->readMapBegin(_ktype349, _vtype350, _size348);
+            uint32_t _i352;
+            for (_i352 = 0; _i352 < _size348; ++_i352)
             {
-              std::string _key343;
-              xfer += iprot->readString(_key343);
-              std::vector<std::string> & _val344 = this->values[_key343];
+              std::string _key353;
+              xfer += iprot->readString(_key353);
+              std::vector<std::string> & _val354 = this->values[_key353];
               {
-                _val344.clear();
-                uint32_t _size345;
-                ::apache::thrift::protocol::TType _etype348;
-                xfer += iprot->readListBegin(_etype348, _size345);
-                _val344.resize(_size345);
-                uint32_t _i349;
-                for (_i349 = 0; _i349 < _size345; ++_i349)
+                _val354.clear();
+                uint32_t _size355;
+                ::apache::thrift::protocol::TType _etype358;
+                xfer += iprot->readListBegin(_etype358, _size355);
+                _val354.resize(_size355);
+                uint32_t _i359;
+                for (_i359 = 0; _i359 < _size355; ++_i359)
                 {
-                  xfer += iprot->readBinary(_val344[_i349]);
+                  xfer += iprot->readBinary(_val354[_i359]);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -10917,16 +11033,16 @@ uint32_t ObjectDictionary::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->values.size()));
-    std::map<std::string, std::vector<std::string> > ::const_iterator _iter350;
-    for (_iter350 = this->values.begin(); _iter350 != this->values.end(); ++_iter350)
+    std::map<std::string, std::vector<std::string> > ::const_iterator _iter360;
+    for (_iter360 = this->values.begin(); _iter360 != this->values.end(); ++_iter360)
     {
-      xfer += oprot->writeString(_iter350->first);
+      xfer += oprot->writeString(_iter360->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter350->second.size()));
-        std::vector<std::string> ::const_iterator _iter351;
-        for (_iter351 = _iter350->second.begin(); _iter351 != _iter350->second.end(); ++_iter351)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter360->second.size()));
+        std::vector<std::string> ::const_iterator _iter361;
+        for (_iter361 = _iter360->second.begin(); _iter361 != _iter360->second.end(); ++_iter361)
         {
-          xfer += oprot->writeBinary((*_iter351));
+          xfer += oprot->writeBinary((*_iter361));
         }
         xfer += oprot->writeListEnd();
       }
@@ -10945,11 +11061,11 @@ void swap(ObjectDictionary &a, ObjectDictionary &b) {
   swap(a.values, b.values);
 }
 
-ObjectDictionary::ObjectDictionary(const ObjectDictionary& other352) {
-  values = other352.values;
+ObjectDictionary::ObjectDictionary(const ObjectDictionary& other362) {
+  values = other362.values;
 }
-ObjectDictionary& ObjectDictionary::operator=(const ObjectDictionary& other353) {
-  values = other353.values;
+ObjectDictionary& ObjectDictionary::operator=(const ObjectDictionary& other363) {
+  values = other363.values;
   return *this;
 }
 void ObjectDictionary::printTo(std::ostream& out) const {
@@ -11174,14 +11290,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionKeys.clear();
-            uint32_t _size354;
-            ::apache::thrift::protocol::TType _etype357;
-            xfer += iprot->readListBegin(_etype357, _size354);
-            this->partitionKeys.resize(_size354);
-            uint32_t _i358;
-            for (_i358 = 0; _i358 < _size354; ++_i358)
+            uint32_t _size364;
+            ::apache::thrift::protocol::TType _etype367;
+            xfer += iprot->readListBegin(_etype367, _size364);
+            this->partitionKeys.resize(_size364);
+            uint32_t _i368;
+            for (_i368 = 0; _i368 < _size364; ++_i368)
             {
-              xfer += this->partitionKeys[_i358].read(iprot);
+              xfer += this->partitionKeys[_i368].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11194,17 +11310,17 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size359;
-            ::apache::thrift::protocol::TType _ktype360;
-            ::apache::thrift::protocol::TType _vtype361;
-            xfer += iprot->readMapBegin(_ktype360, _vtype361, _size359);
-            uint32_t _i363;
-            for (_i363 = 0; _i363 < _size359; ++_i363)
+            uint32_t _size369;
+            ::apache::thrift::protocol::TType _ktype370;
+            ::apache::thrift::protocol::TType _vtype371;
+            xfer += iprot->readMapBegin(_ktype370, _vtype371, _size369);
+            uint32_t _i373;
+            for (_i373 = 0; _i373 < _size369; ++_i373)
             {
-              std::string _key364;
-              xfer += iprot->readString(_key364);
-              std::string& _val365 = this->parameters[_key364];
-              xfer += iprot->readString(_val365);
+              std::string _key374;
+              xfer += iprot->readString(_key374);
+              std::string& _val375 = this->parameters[_key374];
+              xfer += iprot->readString(_val375);
             }
             xfer += iprot->readMapEnd();
           }
@@ -11279,9 +11395,9 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 18:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast366;
-          xfer += iprot->readI32(ecast366);
-          this->ownerType = (PrincipalType::type)ecast366;
+          int32_t ecast376;
+          xfer += iprot->readI32(ecast376);
+          this->ownerType = (PrincipalType::type)ecast376;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -11323,14 +11439,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredReadCapabilities.clear();
-            uint32_t _size367;
-            ::apache::thrift::protocol::TType _etype370;
-            xfer += iprot->readListBegin(_etype370, _size367);
-            this->requiredReadCapabilities.resize(_size367);
-            uint32_t _i371;
-            for (_i371 = 0; _i371 < _size367; ++_i371)
+            uint32_t _size377;
+            ::apache::thrift::protocol::TType _etype380;
+            xfer += iprot->readListBegin(_etype380, _size377);
+            this->requiredReadCapabilities.resize(_size377);
+            uint32_t _i381;
+            for (_i381 = 0; _i381 < _size377; ++_i381)
             {
-              xfer += iprot->readString(this->requiredReadCapabilities[_i371]);
+              xfer += iprot->readString(this->requiredReadCapabilities[_i381]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11343,14 +11459,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredWriteCapabilities.clear();
-            uint32_t _size372;
-            ::apache::thrift::protocol::TType _etype375;
-            xfer += iprot->readListBegin(_etype375, _size372);
-            this->requiredWriteCapabilities.resize(_size372);
-            uint32_t _i376;
-            for (_i376 = 0; _i376 < _size372; ++_i376)
+            uint32_t _size382;
+            ::apache::thrift::protocol::TType _etype385;
+            xfer += iprot->readListBegin(_etype385, _size382);
+            this->requiredWriteCapabilities.resize(_size382);
+            uint32_t _i386;
+            for (_i386 = 0; _i386 < _size382; ++_i386)
             {
-              xfer += iprot->readString(this->requiredWriteCapabilities[_i376]);
+              xfer += iprot->readString(this->requiredWriteCapabilities[_i386]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11431,10 +11547,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("partitionKeys", ::apache::thrift::protocol::T_LIST, 8);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionKeys.size()));
-    std::vector<FieldSchema> ::const_iterator _iter377;
-    for (_iter377 = this->partitionKeys.begin(); _iter377 != this->partitionKeys.end(); ++_iter377)
+    std::vector<FieldSchema> ::const_iterator _iter387;
+    for (_iter387 = this->partitionKeys.begin(); _iter387 != this->partitionKeys.end(); ++_iter387)
     {
-      xfer += (*_iter377).write(oprot);
+      xfer += (*_iter387).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -11443,11 +11559,11 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 9);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter378;
-    for (_iter378 = this->parameters.begin(); _iter378 != this->parameters.end(); ++_iter378)
+    std::map<std::string, std::string> ::const_iterator _iter388;
+    for (_iter388 = this->parameters.begin(); _iter388 != this->parameters.end(); ++_iter388)
     {
-      xfer += oprot->writeString(_iter378->first);
-      xfer += oprot->writeString(_iter378->second);
+      xfer += oprot->writeString(_iter388->first);
+      xfer += oprot->writeString(_iter388->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -11519,10 +11635,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("requiredReadCapabilities", ::apache::thrift::protocol::T_LIST, 23);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredReadCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter379;
-      for (_iter379 = this->requiredReadCapabilities.begin(); _iter379 != this->requiredReadCapabilities.end(); ++_iter379)
+      std::vector<std::string> ::const_iterator _iter389;
+      for (_iter389 = this->requiredReadCapabilities.begin(); _iter389 != this->requiredReadCapabilities.end(); ++_iter389)
       {
-        xfer += oprot->writeString((*_iter379));
+        xfer += oprot->writeString((*_iter389));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11532,10 +11648,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("requiredWriteCapabilities", ::apache::thrift::protocol::T_LIST, 24);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredWriteCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter380;
-      for (_iter380 = this->requiredWriteCapabilities.begin(); _iter380 != this->requiredWriteCapabilities.end(); ++_iter380)
+      std::vector<std::string> ::const_iterator _iter390;
+      for (_iter390 = this->requiredWriteCapabilities.begin(); _iter390 != this->requiredWriteCapabilities.end(); ++_iter390)
       {
-        xfer += oprot->writeString((*_iter380));
+        xfer += oprot->writeString((*_iter390));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11593,65 +11709,65 @@ void swap(Table &a, Table &b) {
   swap(a.__isset, b.__isset);
 }
 
-Table::Table(const Table& other381) {
-  tableName = other381.tableName;
-  dbName = other381.dbName;
-  owner = other381.owner;
-  createTime = other381.createTime;
-  lastAccessTime = other381.lastAccessTime;
-  retention = other381.retention;
-  sd = other381.sd;
-  partitionKeys = other381.partitionKeys;
-  parameters = other381.parameters;
-  viewOriginalText = other381.viewOriginalText;
-  viewExpandedText = other381.viewExpandedText;
-  tableType = other381.tableType;
-  privileges = other381.privileges;
-  temporary = other381.temporary;
-  rewriteEnabled = other381.rewriteEnabled;
-  creationMetadata = other381.creationMetadata;
-  catName = other381.catName;
-  ownerType = other381.ownerType;
-  writeId = other381.writeId;
-  isStatsCompliant = other381.isStatsCompliant;
-  colStats = other381.colStats;
-  accessType = other381.accessType;
-  requiredReadCapabilities = other381.requiredReadCapabilities;
-  requiredWriteCapabilities = other381.requiredWriteCapabilities;
-  id = other381.id;
-  fileMetadata = other381.fileMetadata;
-  dictionary = other381.dictionary;
-  __isset = other381.__isset;
+Table::Table(const Table& other391) {
+  tableName = other391.tableName;
+  dbName = other391.dbName;
+  owner = other391.owner;
+  createTime = other391.createTime;
+  lastAccessTime = other391.lastAccessTime;
+  retention = other391.retention;
+  sd = other391.sd;
+  partitionKeys = other391.partitionKeys;
+  parameters = other391.parameters;
+  viewOriginalText = other391.viewOriginalText;
+  viewExpandedText = other391.viewExpandedText;
+  tableType = other391.tableType;
+  privileges = other391.privileges;
+  temporary = other391.temporary;
+  rewriteEnabled = other391.rewriteEnabled;
+  creationMetadata = other391.creationMetadata;
+  catName = other391.catName;
+  ownerType = other391.ownerType;
+  writeId = other391.writeId;
+  isStatsCompliant = other391.isStatsCompliant;
+  colStats = other391.colStats;
+  accessType = other391.accessType;
+  requiredReadCapabilities = other391.requiredReadCapabilities;
+  requiredWriteCapabilities = other391.requiredWriteCapabilities;
+  id = other391.id;
+  fileMetadata = other391.fileMetadata;
+  dictionary = other391.dictionary;
+  __isset = other391.__isset;
 }
-Table& Table::operator=(const Table& other382) {
-  tableName = other382.tableName;
-  dbName = other382.dbName;
-  owner = other382.owner;
-  createTime = other382.createTime;
-  lastAccessTime = other382.lastAccessTime;
-  retention = other382.retention;
-  sd = other382.sd;
-  partitionKeys = other382.partitionKeys;
-  parameters = other382.parameters;
-  viewOriginalText = other382.viewOriginalText;
-  viewExpandedText = other382.viewExpandedText;
-  tableType = other382.tableType;
-  privileges = other382.privileges;
-  temporary = other382.temporary;
-  rewriteEnabled = other382.rewriteEnabled;
-  creationMetadata = other382.creationMetadata;
-  catName = other382.catName;
-  ownerType = other382.ownerType;
-  writeId = other382.writeId;
-  isStatsCompliant = other382.isStatsCompliant;
-  colStats = other382.colStats;
-  accessType = other382.accessType;
-  requiredReadCapabilities = other382.requiredReadCapabilities;
-  requiredWriteCapabilities = other382.requiredWriteCapabilities;
-  id = other382.id;
-  fileMetadata = other382.fileMetadata;
-  dictionary = other382.dictionary;
-  __isset = other382.__isset;
+Table& Table::operator=(const Table& other392) {
+  tableName = other392.tableName;
+  dbName = other392.dbName;
+  owner = other392.owner;
+  createTime = other392.createTime;
+  lastAccessTime = other392.lastAccessTime;
+  retention = other392.retention;
+  sd = other392.sd;
+  partitionKeys = other392.partitionKeys;
+  parameters = other392.parameters;
+  viewOriginalText = other392.viewOriginalText;
+  viewExpandedText = other392.viewExpandedText;
+  tableType = other392.tableType;
+  privileges = other392.privileges;
+  temporary = other392.temporary;
+  rewriteEnabled = other392.rewriteEnabled;
+  creationMetadata = other392.creationMetadata;
+  catName = other392.catName;
+  ownerType = other392.ownerType;
+  writeId = other392.writeId;
+  isStatsCompliant = other392.isStatsCompliant;
+  colStats = other392.colStats;
+  accessType = other392.accessType;
+  requiredReadCapabilities = other392.requiredReadCapabilities;
+  requiredWriteCapabilities = other392.requiredWriteCapabilities;
+  id = other392.id;
+  fileMetadata = other392.fileMetadata;
+  dictionary = other392.dictionary;
+  __isset = other392.__isset;
   return *this;
 }
 void Table::printTo(std::ostream& out) const {
@@ -11781,14 +11897,14 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size383;
-            ::apache::thrift::protocol::TType _etype386;
-            xfer += iprot->readListBegin(_etype386, _size383);
-            this->values.resize(_size383);
-            uint32_t _i387;
-            for (_i387 = 0; _i387 < _size383; ++_i387)
+            uint32_t _size393;
+            ::apache::thrift::protocol::TType _etype396;
+            xfer += iprot->readListBegin(_etype396, _size393);
+            this->values.resize(_size393);
+            uint32_t _i397;
+            for (_i397 = 0; _i397 < _size393; ++_i397)
             {
-              xfer += iprot->readString(this->values[_i387]);
+              xfer += iprot->readString(this->values[_i397]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11841,17 +11957,17 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size388;
-            ::apache::thrift::protocol::TType _ktype389;
-            ::apache::thrift::protocol::TType _vtype390;
-            xfer += iprot->readMapBegin(_ktype389, _vtype390, _size388);
-            uint32_t _i392;
-            for (_i392 = 0; _i392 < _size388; ++_i392)
+            uint32_t _size398;
+            ::apache::thrift::protocol::TType _ktype399;
+            ::apache::thrift::protocol::TType _vtype400;
+            xfer += iprot->readMapBegin(_ktype399, _vtype400, _size398);
+            uint32_t _i402;
+            for (_i402 = 0; _i402 < _size398; ++_i402)
             {
-              std::string _key393;
-              xfer += iprot->readString(_key393);
-              std::string& _val394 = this->parameters[_key393];
-              xfer += iprot->readString(_val394);
+              std::string _key403;
+              xfer += iprot->readString(_key403);
+              std::string& _val404 = this->parameters[_key403];
+              xfer += iprot->readString(_val404);
             }
             xfer += iprot->readMapEnd();
           }
@@ -11928,10 +12044,10 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->values.size()));
-    std::vector<std::string> ::const_iterator _iter395;
-    for (_iter395 = this->values.begin(); _iter395 != this->values.end(); ++_iter395)
+    std::vector<std::string> ::const_iterator _iter405;
+    for (_iter405 = this->values.begin(); _iter405 != this->values.end(); ++_iter405)
     {
-      xfer += oprot->writeString((*_iter395));
+      xfer += oprot->writeString((*_iter405));
     }
     xfer += oprot->writeListEnd();
   }
@@ -11960,11 +12076,11 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 7);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter396;
-    for (_iter396 = this->parameters.begin(); _iter396 != this->parameters.end(); ++_iter396)
+    std::map<std::string, std::string> ::const_iterator _iter406;
+    for (_iter406 = this->parameters.begin(); _iter406 != this->parameters.end(); ++_iter406)
     {
-      xfer += oprot->writeString(_iter396->first);
-      xfer += oprot->writeString(_iter396->second);
+      xfer += oprot->writeString(_iter406->first);
+      xfer += oprot->writeString(_iter406->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -12023,37 +12139,37 @@ void swap(Partition &a, Partition &b) {
   swap(a.__isset, b.__isset);
 }
 
-Partition::Partition(const Partition& other397) {
-  values = other397.values;
-  dbName = other397.dbName;
-  tableName = other397.tableName;
-  createTime = other397.createTime;
-  lastAccessTime = other397.lastAccessTime;
-  sd = other397.sd;
-  parameters = other397.parameters;
-  privileges = other397.privileges;
-  catName = other397.catName;
-  writeId = other397.writeId;
-  isStatsCompliant = other397.isStatsCompliant;
-  colStats = other397.colStats;
-  fileMetadata = other397.fileMetadata;
-  __isset = other397.__isset;
+Partition::Partition(const Partition& other407) {
+  values = other407.values;
+  dbName = other407.dbName;
+  tableName = other407.tableName;
+  createTime = other407.createTime;
+  lastAccessTime = other407.lastAccessTime;
+  sd = other407.sd;
+  parameters = other407.parameters;
+  privileges = other407.privileges;
+  catName = other407.catName;
+  writeId = other407.writeId;
+  isStatsCompliant = other407.isStatsCompliant;
+  colStats = other407.colStats;
+  fileMetadata = other407.fileMetadata;
+  __isset = other407.__isset;
 }
-Partition& Partition::operator=(const Partition& other398) {
-  values = other398.values;
-  dbName = other398.dbName;
-  tableName = other398.tableName;
-  createTime = other398.createTime;
-  lastAccessTime = other398.lastAccessTime;
-  sd = other398.sd;
-  parameters = other398.parameters;
-  privileges = other398.privileges;
-  catName = other398.catName;
-  writeId = other398.writeId;
-  isStatsCompliant = other398.isStatsCompliant;
-  colStats = other398.colStats;
-  fileMetadata = other398.fileMetadata;
-  __isset = other398.__isset;
+Partition& Partition::operator=(const Partition& other408) {
+  values = other408.values;
+  dbName = other408.dbName;
+  tableName = other408.tableName;
+  createTime = other408.createTime;
+  lastAccessTime = other408.lastAccessTime;
+  sd = other408.sd;
+  parameters = other408.parameters;
+  privileges = other408.privileges;
+  catName = other408.catName;
+  writeId = other408.writeId;
+  isStatsCompliant = other408.isStatsCompliant;
+  colStats = other408.colStats;
+  fileMetadata = other408.fileMetadata;
+  __isset = other408.__isset;
   return *this;
 }
 void Partition::printTo(std::ostream& out) const {
@@ -12136,14 +12252,14 @@ uint32_t PartitionWithoutSD::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size399;
-            ::apache::thrift::protocol::TType _etype402;
-            xfer += iprot->readListBegin(_etype402, _size399);
-            this->values.resize(_size399);
-            uint32_t _i403;
-            for (_i403 = 0; _i403 < _size399; ++_i403)
+            uint32_t _size409;
+            ::apache::thrift::protocol::TType _etype412;
+            xfer += iprot->readListBegin(_etype412, _size409);
+            this->values.resize(_size409);
+            uint32_t _i413;
+            for (_i413 = 0; _i413 < _size409; ++_i413)
             {
-              xfer += iprot->readString(this->values[_i403]);
+              xfer += iprot->readString(this->values[_i413]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12180,17 +12296,17 @@ uint32_t PartitionWithoutSD::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size404;
-            ::apache::thrift::protocol::TType _ktype405;
-            ::apache::thrift::protocol::TType _vtype406;
-            xfer += iprot->readMapBegin(_ktype405, _vtype406, _size404);
-            uint32_t _i408;
-            for (_i408 = 0; _i408 < _size404; ++_i408)
+            uint32_t _size414;
+            ::apache::thrift::protocol::TType _ktype415;
+            ::apache::thrift::protocol::TType _vtype416;
+            xfer += iprot->readMapBegin(_ktype415, _vtype416, _size414);
+            uint32_t _i418;
+            for (_i418 = 0; _i418 < _size414; ++_i418)
             {
-              std::string _key409;
-              xfer += iprot->readString(_key409);
-              std::string& _val410 = this->parameters[_key409];
-              xfer += iprot->readString(_val410);
+              std::string _key419;
+              xfer += iprot->readString(_key419);
+              std::string& _val420 = this->parameters[_key419];
+              xfer += iprot->readString(_val420);
             }
             xfer += iprot->readMapEnd();
           }
@@ -12227,10 +12343,10 @@ uint32_t PartitionWithoutSD::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->values.size()));
-    std::vector<std::string> ::const_iterator _iter411;
-    for (_iter411 = this->values.begin(); _iter411 != this->values.end(); ++_iter411)
+    std::vector<std::string> ::const_iterator _iter421;
+    for (_iter421 = this->values.begin(); _iter421 != this->values.end(); ++_iter421)
     {
-      xfer += oprot->writeString((*_iter411));
+      xfer += oprot->writeString((*_iter421));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12251,11 +12367,11 @@ uint32_t PartitionWithoutSD::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 5);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter412;
-    for (_iter412 = this->parameters.begin(); _iter412 != this->parameters.end(); ++_iter412)
+    std::map<std::string, std::string> ::const_iterator _iter422;
+    for (_iter422 = this->parameters.begin(); _iter422 != this->parameters.end(); ++_iter422)
     {
-      xfer += oprot->writeString(_iter412->first);
-      xfer += oprot->writeString(_iter412->second);
+      xfer += oprot->writeString(_iter422->first);
+      xfer += oprot->writeString(_iter422->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -12282,23 +12398,23 @@ void swap(PartitionWithoutSD &a, PartitionWithoutSD &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionWithoutSD::PartitionWithoutSD(const PartitionWithoutSD& other413) {
-  values = other413.values;
-  createTime = other413.createTime;
-  lastAccessTime = other413.lastAccessTime;
-  relativePath = other413.relativePath;
-  parameters = other413.parameters;
-  privileges = other413.privileges;
-  __isset = other413.__isset;
+PartitionWithoutSD::PartitionWithoutSD(const PartitionWithoutSD& other423) {
+  values = other423.values;
+  createTime = other423.createTime;
+  lastAccessTime = other423.lastAccessTime;
+  relativePath = other423.relativePath;
+  parameters = other423.parameters;
+  privileges = other423.privileges;
+  __isset = other423.__isset;
 }
-PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& other414) {
-  values = other414.values;
-  createTime = other414.createTime;
-  lastAccessTime = other414.lastAccessTime;
-  relativePath = other414.relativePath;
-  parameters = other414.parameters;
-  privileges = other414.privileges;
-  __isset = other414.__isset;
+PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& other424) {
+  values = other424.values;
+  createTime = other424.createTime;
+  lastAccessTime = other424.lastAccessTime;
+  relativePath = other424.relativePath;
+  parameters = other424.parameters;
+  privileges = other424.privileges;
+  __isset = other424.__isset;
   return *this;
 }
 void PartitionWithoutSD::printTo(std::ostream& out) const {
@@ -12357,14 +12473,14 @@ uint32_t PartitionSpecWithSharedSD::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size415;
-            ::apache::thrift::protocol::TType _etype418;
-            xfer += iprot->readListBegin(_etype418, _size415);
-            this->partitions.resize(_size415);
-            uint32_t _i419;
-            for (_i419 = 0; _i419 < _size415; ++_i419)
+            uint32_t _size425;
+            ::apache::thrift::protocol::TType _etype428;
+            xfer += iprot->readListBegin(_etype428, _size425);
+            this->partitions.resize(_size425);
+            uint32_t _i429;
+            for (_i429 = 0; _i429 < _size425; ++_i429)
             {
-              xfer += this->partitions[_i419].read(iprot);
+              xfer += this->partitions[_i429].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12401,10 +12517,10 @@ uint32_t PartitionSpecWithSharedSD::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<PartitionWithoutSD> ::const_iterator _iter420;
-    for (_iter420 = this->partitions.begin(); _iter420 != this->partitions.end(); ++_iter420)
+    std::vector<PartitionWithoutSD> ::const_iterator _iter430;
+    for (_iter430 = this->partitions.begin(); _iter430 != this->partitions.end(); ++_iter430)
     {
-      xfer += (*_iter420).write(oprot);
+      xfer += (*_iter430).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -12426,15 +12542,15 @@ void swap(PartitionSpecWithSharedSD &a, PartitionSpecWithSharedSD &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionSpecWithSharedSD::PartitionSpecWithSharedSD(const PartitionSpecWithSharedSD& other421) {
-  partitions = other421.partitions;
-  sd = other421.sd;
-  __isset = other421.__isset;
+PartitionSpecWithSharedSD::PartitionSpecWithSharedSD(const PartitionSpecWithSharedSD& other431) {
+  partitions = other431.partitions;
+  sd = other431.sd;
+  __isset = other431.__isset;
 }
-PartitionSpecWithSharedSD& PartitionSpecWithSharedSD::operator=(const PartitionSpecWithSharedSD& other422) {
-  partitions = other422.partitions;
-  sd = other422.sd;
-  __isset = other422.__isset;
+PartitionSpecWithSharedSD& PartitionSpecWithSharedSD::operator=(const PartitionSpecWithSharedSD& other432) {
+  partitions = other432.partitions;
+  sd = other432.sd;
+  __isset = other432.__isset;
   return *this;
 }
 void PartitionSpecWithSharedSD::printTo(std::ostream& out) const {
@@ -12485,14 +12601,14 @@ uint32_t PartitionListComposingSpec::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size423;
-            ::apache::thrift::protocol::TType _etype426;
-            xfer += iprot->readListBegin(_etype426, _size423);
-            this->partitions.resize(_size423);
-            uint32_t _i427;
-            for (_i427 = 0; _i427 < _size423; ++_i427)
+            uint32_t _size433;
+            ::apache::thrift::protocol::TType _etype436;
+            xfer += iprot->readListBegin(_etype436, _size433);
+            this->partitions.resize(_size433);
+            uint32_t _i437;
+            for (_i437 = 0; _i437 < _size433; ++_i437)
             {
-              xfer += this->partitions[_i427].read(iprot);
+              xfer += this->partitions[_i437].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12521,10 +12637,10 @@ uint32_t PartitionListComposingSpec::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter428;
-    for (_iter428 = this->partitions.begin(); _iter428 != this->partitions.end(); ++_iter428)
+    std::vector<Partition> ::const_iterator _iter438;
+    for (_iter438 = this->partitions.begin(); _iter438 != this->partitions.end(); ++_iter438)
     {
-      xfer += (*_iter428).write(oprot);
+      xfer += (*_iter438).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -12541,13 +12657,13 @@ void swap(PartitionListComposingSpec &a, PartitionListComposingSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionListComposingSpec::PartitionListComposingSpec(const PartitionListComposingSpec& other429) {
-  partitions = other429.partitions;
-  __isset = other429.__isset;
+PartitionListComposingSpec::PartitionListComposingSpec(const PartitionListComposingSpec& other439) {
+  partitions = other439.partitions;
+  __isset = other439.__isset;
 }
-PartitionListComposingSpec& PartitionListComposingSpec::operator=(const PartitionListComposingSpec& other430) {
-  partitions = other430.partitions;
-  __isset = other430.__isset;
+PartitionListComposingSpec& PartitionListComposingSpec::operator=(const PartitionListComposingSpec& other440) {
+  partitions = other440.partitions;
+  __isset = other440.__isset;
   return *this;
 }
 void PartitionListComposingSpec::printTo(std::ostream& out) const {
@@ -12762,27 +12878,27 @@ void swap(PartitionSpec &a, PartitionSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionSpec::PartitionSpec(const PartitionSpec& other431) {
-  dbName = other431.dbName;
-  tableName = other431.tableName;
-  rootPath = other431.rootPath;
-  sharedSDPartitionSpec = other431.sharedSDPartitionSpec;
-  partitionList = other431.partitionList;
-  catName = other431.catName;
-  writeId = other431.writeId;
-  isStatsCompliant = other431.isStatsCompliant;
-  __isset = other431.__isset;
+PartitionSpec::PartitionSpec(const PartitionSpec& other441) {
+  dbName = other441.dbName;
+  tableName = other441.tableName;
+  rootPath = other441.rootPath;
+  sharedSDPartitionSpec = other441.sharedSDPartitionSpec;
+  partitionList = other441.partitionList;
+  catName = other441.catName;
+  writeId = other441.writeId;
+  isStatsCompliant = other441.isStatsCompliant;
+  __isset = other441.__isset;
 }
-PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other432) {
-  dbName = other432.dbName;
-  tableName = other432.tableName;
-  rootPath = other432.rootPath;
-  sharedSDPartitionSpec = other432.sharedSDPartitionSpec;
-  partitionList = other432.partitionList;
-  catName = other432.catName;
-  writeId = other432.writeId;
-  isStatsCompliant = other432.isStatsCompliant;
-  __isset = other432.__isset;
+PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other442) {
+  dbName = other442.dbName;
+  tableName = other442.tableName;
+  rootPath = other442.rootPath;
+  sharedSDPartitionSpec = other442.sharedSDPartitionSpec;
+  partitionList = other442.partitionList;
+  catName = other442.catName;
+  writeId = other442.writeId;
+  isStatsCompliant = other442.isStatsCompliant;
+  __isset = other442.__isset;
   return *this;
 }
 void PartitionSpec::printTo(std::ostream& out) const {
@@ -12850,14 +12966,14 @@ uint32_t AggrStats::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colStats.clear();
-            uint32_t _size433;
-            ::apache::thrift::protocol::TType _etype436;
-            xfer += iprot->readListBegin(_etype436, _size433);
-            this->colStats.resize(_size433);
-            uint32_t _i437;
-            for (_i437 = 0; _i437 < _size433; ++_i437)
+            uint32_t _size443;
+            ::apache::thrift::protocol::TType _etype446;
+            xfer += iprot->readListBegin(_etype446, _size443);
+            this->colStats.resize(_size443);
+            uint32_t _i447;
+            for (_i447 = 0; _i447 < _size443; ++_i447)
             {
-              xfer += this->colStats[_i437].read(iprot);
+              xfer += this->colStats[_i447].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12906,10 +13022,10 @@ uint32_t AggrStats::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("colStats", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->colStats.size()));
-    std::vector<ColumnStatisticsObj> ::const_iterator _iter438;
-    for (_iter438 = this->colStats.begin(); _iter438 != this->colStats.end(); ++_iter438)
+    std::vector<ColumnStatisticsObj> ::const_iterator _iter448;
+    for (_iter448 = this->colStats.begin(); _iter448 != this->colStats.end(); ++_iter448)
     {
-      xfer += (*_iter438).write(oprot);
+      xfer += (*_iter448).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -12937,17 +13053,17 @@ void swap(AggrStats &a, AggrStats &b) {
   swap(a.__isset, b.__isset);
 }
 
-AggrStats::AggrStats(const AggrStats& other439) {
-  colStats = other439.colStats;
-  partsFound = other439.partsFound;
-  isStatsCompliant = other439.isStatsCompliant;
-  __isset = other439.__isset;
+AggrStats::AggrStats(const AggrStats& other449) {
+  colStats = other449.colStats;
+  partsFound = other449.partsFound;
+  isStatsCompliant = other449.isStatsCompliant;
+  __isset = other449.__isset;
 }
-AggrStats& AggrStats::operator=(const AggrStats& other440) {
-  colStats = other440.colStats;
-  partsFound = other440.partsFound;
-  isStatsCompliant = other440.isStatsCompliant;
-  __isset = other440.__isset;
+AggrStats& AggrStats::operator=(const AggrStats& other450) {
+  colStats = other450.colStats;
+  partsFound = other450.partsFound;
+  isStatsCompliant = other450.isStatsCompliant;
+  __isset = other450.__isset;
   return *this;
 }
 void AggrStats::printTo(std::ostream& out) const {
@@ -13020,14 +13136,14 @@ uint32_t SetPartitionsStatsRequest::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colStats.clear();
-            uint32_t _size441;
-            ::apache::thrift::protocol::TType _etype444;
-            xfer += iprot->readListBegin(_etype444, _size441);
-            this->colStats.resize(_size441);
-            uint32_t _i445;
-            for (_i445 = 0; _i445 < _size441; ++_i445)
+            uint32_t _size451;
+            ::apache::thrift::protocol::TType _etype454;
+            xfer += iprot->readListBegin(_etype454, _size451);
+            this->colStats.resize(_size451);
+            uint32_t _i455;
+            for (_i455 = 0; _i455 < _size451; ++_i455)
             {
-              xfer += this->colStats[_i445].read(iprot);
+              xfer += this->colStats[_i455].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13092,10 +13208,10 @@ uint32_t SetPartitionsStatsRequest::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("colStats", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->colStats.size()));
-    std::vector<ColumnStatistics> ::const_iterator _iter446;
-    for (_iter446 = this->colStats.begin(); _iter446 != this->colStats.end(); ++_iter446)
+    std::vector<ColumnStatistics> ::const_iterator _iter456;
+    for (_iter456 = this->colStats.begin(); _iter456 != this->colStats.end(); ++_iter456)
     {
-      xfer += (*_iter446).write(oprot);
+      xfer += (*_iter456).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -13135,21 +13251,21 @@ void swap(SetPartitionsStatsRequest &a, SetPartitionsStatsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-SetPartitionsStatsRequest::SetPartitionsStatsRequest(const SetPartitionsStatsRequest& other447) {
-  colStats = other447.colStats;
-  needMerge = other447.needMerge;
-  writeId = other447.writeId;
-  validWriteIdList = other447.validWriteIdList;
-  engine = other447.engine;
-  __isset = other447.__isset;
+SetPartitionsStatsRequest::SetPartitionsStatsRequest(const SetPartitionsStatsRequest& other457) {
+  colStats = other457.colStats;
+  needMerge = other457.needMerge;
+  writeId = other457.writeId;
+  validWriteIdList = other457.validWriteIdList;
+  engine = other457.engine;
+  __isset = other457.__isset;
 }
-SetPartitionsStatsRequest& SetPartitionsStatsRequest::operator=(const SetPartitionsStatsRequest& other448) {
-  colStats = other448.colStats;
-  needMerge = other448.needMerge;
-  writeId = other448.writeId;
-  validWriteIdList = other448.validWriteIdList;
-  engine = other448.engine;
-  __isset = other448.__isset;
+SetPartitionsStatsRequest& SetPartitionsStatsRequest::operator=(const SetPartitionsStatsRequest& other458) {
+  colStats = other458.colStats;
+  needMerge = other458.needMerge;
+  writeId = other458.writeId;
+  validWriteIdList = other458.validWriteIdList;
+  engine = other458.engine;
+  __isset = other458.__isset;
   return *this;
 }
 void SetPartitionsStatsRequest::printTo(std::ostream& out) const {
@@ -13241,11 +13357,11 @@ void swap(SetPartitionsStatsResponse &a, SetPartitionsStatsResponse &b) {
   swap(a.result, b.result);
 }
 
-SetPartitionsStatsResponse::SetPartitionsStatsResponse(const SetPartitionsStatsResponse& other449) {
-  result = other449.result;
+SetPartitionsStatsResponse::SetPartitionsStatsResponse(const SetPartitionsStatsResponse& other459) {
+  result = other459.result;
 }
-SetPartitionsStatsResponse& SetPartitionsStatsResponse::operator=(const SetPartitionsStatsResponse& other450) {
-  result = other450.result;
+SetPartitionsStatsResponse& SetPartitionsStatsResponse::operator=(const SetPartitionsStatsResponse& other460) {
+  result = other460.result;
   return *this;
 }
 void SetPartitionsStatsResponse::printTo(std::ostream& out) const {
@@ -13299,14 +13415,14 @@ uint32_t Schema::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fieldSchemas.clear();
-            uint32_t _size451;
-            ::apache::thrift::protocol::TType _etype454;
-            xfer += iprot->readListBegin(_etype454, _size451);
-            this->fieldSchemas.resize(_size451);
-            uint32_t _i455;
-            for (_i455 = 0; _i455 < _size451; ++_i455)
+            uint32_t _size461;
+            ::apache::thrift::protocol::TType _etype464;
+            xfer += iprot->readListBegin(_etype464, _size461);
+            this->fieldSchemas.resize(_size461);
+            uint32_t _i465;
+            for (_i465 = 0; _i465 < _size461; ++_i465)
             {
-              xfer += this->fieldSchemas[_i455].read(iprot);
+              xfer += this->fieldSchemas[_i465].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13319,17 +13435,17 @@ uint32_t Schema::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->properties.clear();
-            uint32_t _size456;
-            ::apache::thrift::protocol::TType _ktype457;
-            ::apache::thrift::protocol::TType _vtype458;
-            xfer += iprot->readMapBegin(_ktype457, _vtype458, _size456);
-            uint32_t _i460;
-            for (_i460 = 0; _i460 < _size456; ++_i460)
+            uint32_t _size466;
+            ::apache::thrift::protocol::TType _ktype467;
+            ::apache::thrift::protocol::TType _vtype468;
+            xfer += iprot->readMapBegin(_ktype467, _vtype468, _size466);
+            uint32_t _i470;
+            for (_i470 = 0; _i470 < _size466; ++_i470)
             {
-              std::string _key461;
-              xfer += iprot->readString(_key461);
-              std::string& _val462 = this->properties[_key461];
-              xfer += iprot->readString(_val462);
+              std::string _key471;
+              xfer += iprot->readString(_key471);
+              std::string& _val472 = this->properties[_key471];
+              xfer += iprot->readString(_val472);
             }
             xfer += iprot->readMapEnd();
           }
@@ -13358,136 +13474,16 @@ uint32_t Schema::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("fieldSchemas", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fieldSchemas.size()));
-    std::vector<FieldSchema> ::const_iterator _iter463;
-    for (_iter463 = this->fieldSchemas.begin(); _iter463 != this->fieldSchemas.end(); ++_iter463)
+    std::vector<FieldSchema> ::const_iterator _iter473;
+    for (_iter473 = this->fieldSchemas.begin(); _iter473 != this->fieldSchemas.end(); ++_iter473)
     {
-      xfer += (*_iter463).write(oprot);
+      xfer += (*_iter473).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 2);
-  {
-    xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
-    std::map<std::string, std::string> ::const_iterator _iter464;
-    for (_iter464 = this->properties.begin(); _iter464 != this->properties.end(); ++_iter464)
-    {
-      xfer += oprot->writeString(_iter464->first);
-      xfer += oprot->writeString(_iter464->second);
-    }
-    xfer += oprot->writeMapEnd();
-  }
-  xfer += oprot->writeFieldEnd();
-
-  xfer += oprot->writeFieldStop();
-  xfer += oprot->writeStructEnd();
-  return xfer;
-}
-
-void swap(Schema &a, Schema &b) {
-  using ::std::swap;
-  swap(a.fieldSchemas, b.fieldSchemas);
-  swap(a.properties, b.properties);
-  swap(a.__isset, b.__isset);
-}
-
-Schema::Schema(const Schema& other465) {
-  fieldSchemas = other465.fieldSchemas;
-  properties = other465.properties;
-  __isset = other465.__isset;
-}
-Schema& Schema::operator=(const Schema& other466) {
-  fieldSchemas = other466.fieldSchemas;
-  properties = other466.properties;
-  __isset = other466.__isset;
-  return *this;
-}
-void Schema::printTo(std::ostream& out) const {
-  using ::apache::thrift::to_string;
-  out << "Schema(";
-  out << "fieldSchemas=" << to_string(fieldSchemas);
-  out << ", " << "properties=" << to_string(properties);
-  out << ")";
-}
-
-
-EnvironmentContext::~EnvironmentContext() noexcept {
-}
-
-
-void EnvironmentContext::__set_properties(const std::map<std::string, std::string> & val) {
-  this->properties = val;
-}
-std::ostream& operator<<(std::ostream& out, const EnvironmentContext& obj)
-{
-  obj.printTo(out);
-  return out;
-}
-
-
-uint32_t EnvironmentContext::read(::apache::thrift::protocol::TProtocol* iprot) {
-
-  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-  uint32_t xfer = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TType ftype;
-  int16_t fid;
-
-  xfer += iprot->readStructBegin(fname);
-
-  using ::apache::thrift::protocol::TProtocolException;
-
-
-  while (true)
-  {
-    xfer += iprot->readFieldBegin(fname, ftype, fid);
-    if (ftype == ::apache::thrift::protocol::T_STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-        if (ftype == ::apache::thrift::protocol::T_MAP) {
-          {
-            this->properties.clear();
-            uint32_t _size467;
-            ::apache::thrift::protocol::TType _ktype468;
-            ::apache::thrift::protocol::TType _vtype469;
-            xfer += iprot->readMapBegin(_ktype468, _vtype469, _size467);
-            uint32_t _i471;
-            for (_i471 = 0; _i471 < _size467; ++_i471)
-            {
-              std::string _key472;
-              xfer += iprot->readString(_key472);
-              std::string& _val473 = this->properties[_key472];
-              xfer += iprot->readString(_val473);
-            }
-            xfer += iprot->readMapEnd();
-          }
-          this->__isset.properties = true;
-        } else {
-          xfer += iprot->skip(ftype);
-        }
-        break;
-      default:
-        xfer += iprot->skip(ftype);
-        break;
-    }
-    xfer += iprot->readFieldEnd();
-  }
-
-  xfer += iprot->readStructEnd();
-
-  return xfer;
-}
-
-uint32_t EnvironmentContext::write(::apache::thrift::protocol::TProtocol* oprot) const {
-  uint32_t xfer = 0;
-  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-  xfer += oprot->writeStructBegin("EnvironmentContext");
-
-  xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
     std::map<std::string, std::string> ::const_iterator _iter474;
@@ -13505,25 +13501,29 @@ uint32_t EnvironmentContext::write(::apache::thrift::protocol::TProtocol* oprot)
   return xfer;
 }
 
-void swap(EnvironmentContext &a, EnvironmentContext &b) {
+void swap(Schema &a, Schema &b) {
   using ::std::swap;
+  swap(a.fieldSchemas, b.fieldSchemas);
   swap(a.properties, b.properties);
   swap(a.__isset, b.__isset);
 }
 
-EnvironmentContext::EnvironmentContext(const EnvironmentContext& other475) {
+Schema::Schema(const Schema& other475) {
+  fieldSchemas = other475.fieldSchemas;
   properties = other475.properties;
   __isset = other475.__isset;
 }
-EnvironmentContext& EnvironmentContext::operator=(const EnvironmentContext& other476) {
+Schema& Schema::operator=(const Schema& other476) {
+  fieldSchemas = other476.fieldSchemas;
   properties = other476.properties;
   __isset = other476.__isset;
   return *this;
 }
-void EnvironmentContext::printTo(std::ostream& out) const {
+void Schema::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
-  out << "EnvironmentContext(";
-  out << "properties=" << to_string(properties);
+  out << "Schema(";
+  out << "fieldSchemas=" << to_string(fieldSchemas);
+  out << ", " << "properties=" << to_string(properties);
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -423,6 +423,8 @@ class Version;
 
 class FieldSchema;
 
+class EnvironmentContext;
+
 class SQLPrimaryKey;
 
 class SQLForeignKey;
@@ -552,8 +554,6 @@ class SetPartitionsStatsRequest;
 class SetPartitionsStatsResponse;
 
 class Schema;
-
-class EnvironmentContext;
 
 class PrimaryKeysRequest;
 
@@ -1134,6 +1134,48 @@ class FieldSchema : public virtual ::apache::thrift::TBase {
 void swap(FieldSchema &a, FieldSchema &b);
 
 std::ostream& operator<<(std::ostream& out, const FieldSchema& obj);
+
+typedef struct _EnvironmentContext__isset {
+  _EnvironmentContext__isset() : properties(false) {}
+  bool properties :1;
+} _EnvironmentContext__isset;
+
+class EnvironmentContext : public virtual ::apache::thrift::TBase {
+ public:
+
+  EnvironmentContext(const EnvironmentContext&);
+  EnvironmentContext& operator=(const EnvironmentContext&);
+  EnvironmentContext() {
+  }
+
+  virtual ~EnvironmentContext() noexcept;
+  std::map<std::string, std::string>  properties;
+
+  _EnvironmentContext__isset __isset;
+
+  void __set_properties(const std::map<std::string, std::string> & val);
+
+  bool operator == (const EnvironmentContext & rhs) const
+  {
+    if (!(properties == rhs.properties))
+      return false;
+    return true;
+  }
+  bool operator != (const EnvironmentContext &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const EnvironmentContext & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
+};
+
+void swap(EnvironmentContext &a, EnvironmentContext &b);
+
+std::ostream& operator<<(std::ostream& out, const EnvironmentContext& obj);
 
 typedef struct _SQLPrimaryKey__isset {
   _SQLPrimaryKey__isset() : table_db(false), table_name(false), column_name(false), key_seq(false), pk_name(false), enable_cstr(false), validate_cstr(false), rely_cstr(false), catName(false) {}
@@ -5500,48 +5542,6 @@ class Schema : public virtual ::apache::thrift::TBase {
 void swap(Schema &a, Schema &b);
 
 std::ostream& operator<<(std::ostream& out, const Schema& obj);
-
-typedef struct _EnvironmentContext__isset {
-  _EnvironmentContext__isset() : properties(false) {}
-  bool properties :1;
-} _EnvironmentContext__isset;
-
-class EnvironmentContext : public virtual ::apache::thrift::TBase {
- public:
-
-  EnvironmentContext(const EnvironmentContext&);
-  EnvironmentContext& operator=(const EnvironmentContext&);
-  EnvironmentContext() {
-  }
-
-  virtual ~EnvironmentContext() noexcept;
-  std::map<std::string, std::string>  properties;
-
-  _EnvironmentContext__isset __isset;
-
-  void __set_properties(const std::map<std::string, std::string> & val);
-
-  bool operator == (const EnvironmentContext & rhs) const
-  {
-    if (!(properties == rhs.properties))
-      return false;
-    return true;
-  }
-  bool operator != (const EnvironmentContext &rhs) const {
-    return !(*this == rhs);
-  }
-
-  bool operator < (const EnvironmentContext & ) const;
-
-  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
-  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
-
-  virtual void printTo(std::ostream& out) const;
-};
-
-void swap(EnvironmentContext &a, EnvironmentContext &b);
-
-std::ostream& operator<<(std::ostream& out, const EnvironmentContext& obj);
 
 typedef struct _PrimaryKeysRequest__isset {
   _PrimaryKeysRequest__isset() : catName(false), validWriteIdList(false), tableId(true) {}

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AggrStats.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AggrStats.java
@@ -487,14 +487,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COL_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list382 = iprot.readListBegin();
-                struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list382.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem383;
-                for (int _i384 = 0; _i384 < _list382.size; ++_i384)
+                org.apache.thrift.protocol.TList _list392 = iprot.readListBegin();
+                struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list392.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem393;
+                for (int _i394 = 0; _i394 < _list392.size; ++_i394)
                 {
-                  _elem383 = new ColumnStatisticsObj();
-                  _elem383.read(iprot);
-                  struct.colStats.add(_elem383);
+                  _elem393 = new ColumnStatisticsObj();
+                  _elem393.read(iprot);
+                  struct.colStats.add(_elem393);
                 }
                 iprot.readListEnd();
               }
@@ -536,9 +536,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_STATS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.colStats.size()));
-          for (ColumnStatisticsObj _iter385 : struct.colStats)
+          for (ColumnStatisticsObj _iter395 : struct.colStats)
           {
-            _iter385.write(oprot);
+            _iter395.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -571,9 +571,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.colStats.size());
-        for (ColumnStatisticsObj _iter386 : struct.colStats)
+        for (ColumnStatisticsObj _iter396 : struct.colStats)
         {
-          _iter386.write(oprot);
+          _iter396.write(oprot);
         }
       }
       oprot.writeI64(struct.partsFound);
@@ -591,14 +591,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AggrStats struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list387 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list387.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem388;
-        for (int _i389 = 0; _i389 < _list387.size; ++_i389)
+        org.apache.thrift.protocol.TList _list397 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list397.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem398;
+        for (int _i399 = 0; _i399 < _list397.size; ++_i399)
         {
-          _elem388 = new ColumnStatisticsObj();
-          _elem388.read(iprot);
-          struct.colStats.add(_elem388);
+          _elem398 = new ColumnStatisticsObj();
+          _elem398.read(iprot);
+          struct.colStats.add(_elem398);
         }
       }
       struct.setColStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatistics.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatistics.java
@@ -587,14 +587,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // STATS_OBJ
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list262 = iprot.readListBegin();
-                struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list262.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem263;
-                for (int _i264 = 0; _i264 < _list262.size; ++_i264)
+                org.apache.thrift.protocol.TList _list272 = iprot.readListBegin();
+                struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list272.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem273;
+                for (int _i274 = 0; _i274 < _list272.size; ++_i274)
                 {
-                  _elem263 = new ColumnStatisticsObj();
-                  _elem263.read(iprot);
-                  struct.statsObj.add(_elem263);
+                  _elem273 = new ColumnStatisticsObj();
+                  _elem273.read(iprot);
+                  struct.statsObj.add(_elem273);
                 }
                 iprot.readListEnd();
               }
@@ -641,9 +641,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(STATS_OBJ_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.statsObj.size()));
-          for (ColumnStatisticsObj _iter265 : struct.statsObj)
+          for (ColumnStatisticsObj _iter275 : struct.statsObj)
           {
-            _iter265.write(oprot);
+            _iter275.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -681,9 +681,9 @@ package org.apache.hadoop.hive.metastore.api;
       struct.statsDesc.write(oprot);
       {
         oprot.writeI32(struct.statsObj.size());
-        for (ColumnStatisticsObj _iter266 : struct.statsObj)
+        for (ColumnStatisticsObj _iter276 : struct.statsObj)
         {
-          _iter266.write(oprot);
+          _iter276.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -709,14 +709,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.statsDesc.read(iprot);
       struct.setStatsDescIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list267 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list267.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem268;
-        for (int _i269 = 0; _i269 < _list267.size; ++_i269)
+        org.apache.thrift.protocol.TList _list277 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list277.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem278;
+        for (int _i279 = 0; _i279 < _list277.size; ++_i279)
         {
-          _elem268 = new ColumnStatisticsObj();
-          _elem268.read(iprot);
-          struct.statsObj.add(_elem268);
+          _elem278 = new ColumnStatisticsObj();
+          _elem278.read(iprot);
+          struct.statsObj.add(_elem278);
         }
       }
       struct.setStatsObjIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreationMetadata.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreationMetadata.java
@@ -766,13 +766,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // TABLES_USED
             if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
               {
-                org.apache.thrift.protocol.TSet _set254 = iprot.readSetBegin();
-                struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set254.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem255;
-                for (int _i256 = 0; _i256 < _set254.size; ++_i256)
+                org.apache.thrift.protocol.TSet _set264 = iprot.readSetBegin();
+                struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set264.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem265;
+                for (int _i266 = 0; _i266 < _set264.size; ++_i266)
                 {
-                  _elem255 = iprot.readString();
-                  struct.tablesUsed.add(_elem255);
+                  _elem265 = iprot.readString();
+                  struct.tablesUsed.add(_elem265);
                 }
                 iprot.readSetEnd();
               }
@@ -829,9 +829,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TABLES_USED_FIELD_DESC);
         {
           oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRING, struct.tablesUsed.size()));
-          for (java.lang.String _iter257 : struct.tablesUsed)
+          for (java.lang.String _iter267 : struct.tablesUsed)
           {
-            oprot.writeString(_iter257);
+            oprot.writeString(_iter267);
           }
           oprot.writeSetEnd();
         }
@@ -871,9 +871,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.tablesUsed.size());
-        for (java.lang.String _iter258 : struct.tablesUsed)
+        for (java.lang.String _iter268 : struct.tablesUsed)
         {
-          oprot.writeString(_iter258);
+          oprot.writeString(_iter268);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -902,13 +902,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TSet _set259 = iprot.readSetBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set259.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem260;
-        for (int _i261 = 0; _i261 < _set259.size; ++_i261)
+        org.apache.thrift.protocol.TSet _set269 = iprot.readSetBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set269.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem270;
+        for (int _i271 = 0; _i271 < _set269.size; ++_i271)
         {
-          _elem260 = iprot.readString();
-          struct.tablesUsed.add(_elem260);
+          _elem270 = iprot.readString();
+          struct.tablesUsed.add(_elem270);
         }
       }
       struct.setTablesUsedIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
@@ -1340,15 +1340,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map158 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map158.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key159;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val160;
-                for (int _i161 = 0; _i161 < _map158.size; ++_i161)
+                org.apache.thrift.protocol.TMap _map168 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map168.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key169;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val170;
+                for (int _i171 = 0; _i171 < _map168.size; ++_i171)
                 {
-                  _key159 = iprot.readString();
-                  _val160 = iprot.readString();
-                  struct.parameters.put(_key159, _val160);
+                  _key169 = iprot.readString();
+                  _val170 = iprot.readString();
+                  struct.parameters.put(_key169, _val170);
                 }
                 iprot.readMapEnd();
               }
@@ -1462,10 +1462,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter162 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter172 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter162.getKey());
-            oprot.writeString(_iter162.getValue());
+            oprot.writeString(_iter172.getKey());
+            oprot.writeString(_iter172.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -1602,10 +1602,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter163 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter173 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter163.getKey());
-            oprot.writeString(_iter163.getValue());
+            oprot.writeString(_iter173.getKey());
+            oprot.writeString(_iter173.getValue());
           }
         }
       }
@@ -1656,15 +1656,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TMap _map164 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map164.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key165;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val166;
-          for (int _i167 = 0; _i167 < _map164.size; ++_i167)
+          org.apache.thrift.protocol.TMap _map174 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map174.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key175;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val176;
+          for (int _i177 = 0; _i177 < _map174.size; ++_i177)
           {
-            _key165 = iprot.readString();
-            _val166 = iprot.readString();
-            struct.parameters.put(_key165, _val166);
+            _key175 = iprot.readString();
+            _val176 = iprot.readString();
+            struct.parameters.put(_key175, _val176);
           }
         }
         struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/EnvironmentContext.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/EnvironmentContext.java
@@ -318,15 +318,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PROPERTIES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map416 = iprot.readMapBegin();
-                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map416.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key417;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val418;
-                for (int _i419 = 0; _i419 < _map416.size; ++_i419)
+                org.apache.thrift.protocol.TMap _map0 = iprot.readMapBegin();
+                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map0.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key1;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val2;
+                for (int _i3 = 0; _i3 < _map0.size; ++_i3)
                 {
-                  _key417 = iprot.readString();
-                  _val418 = iprot.readString();
-                  struct.properties.put(_key417, _val418);
+                  _key1 = iprot.readString();
+                  _val2 = iprot.readString();
+                  struct.properties.put(_key1, _val2);
                 }
                 iprot.readMapEnd();
               }
@@ -352,10 +352,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PROPERTIES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.properties.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter420 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter4 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter420.getKey());
-            oprot.writeString(_iter420.getValue());
+            oprot.writeString(_iter4.getKey());
+            oprot.writeString(_iter4.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -386,10 +386,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProperties()) {
         {
           oprot.writeI32(struct.properties.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter421 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter5 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter421.getKey());
-            oprot.writeString(_iter421.getValue());
+            oprot.writeString(_iter5.getKey());
+            oprot.writeString(_iter5.getValue());
           }
         }
       }
@@ -401,15 +401,15 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map422 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map422.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key423;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val424;
-          for (int _i425 = 0; _i425 < _map422.size; ++_i425)
+          org.apache.thrift.protocol.TMap _map6 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map6.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key7;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val8;
+          for (int _i9 = 0; _i9 < _map6.size; ++_i9)
           {
-            _key423 = iprot.readString();
-            _val424 = iprot.readString();
-            struct.properties.put(_key423, _val424);
+            _key7 = iprot.readString();
+            _val8 = iprot.readString();
+            struct.properties.put(_key7, _val8);
           }
         }
         struct.setPropertiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FileMetadata.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FileMetadata.java
@@ -494,13 +494,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // DATA
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list270 = iprot.readListBegin();
-                struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list270.size);
-                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem271;
-                for (int _i272 = 0; _i272 < _list270.size; ++_i272)
+                org.apache.thrift.protocol.TList _list280 = iprot.readListBegin();
+                struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list280.size);
+                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem281;
+                for (int _i282 = 0; _i282 < _list280.size; ++_i282)
                 {
-                  _elem271 = iprot.readBinary();
-                  struct.data.add(_elem271);
+                  _elem281 = iprot.readBinary();
+                  struct.data.add(_elem281);
                 }
                 iprot.readListEnd();
               }
@@ -532,9 +532,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(DATA_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.data.size()));
-          for (java.nio.ByteBuffer _iter273 : struct.data)
+          for (java.nio.ByteBuffer _iter283 : struct.data)
           {
-            oprot.writeBinary(_iter273);
+            oprot.writeBinary(_iter283);
           }
           oprot.writeListEnd();
         }
@@ -577,9 +577,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetData()) {
         {
           oprot.writeI32(struct.data.size());
-          for (java.nio.ByteBuffer _iter274 : struct.data)
+          for (java.nio.ByteBuffer _iter284 : struct.data)
           {
-            oprot.writeBinary(_iter274);
+            oprot.writeBinary(_iter284);
           }
         }
       }
@@ -599,13 +599,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list275 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list275.size);
-          @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem276;
-          for (int _i277 = 0; _i277 < _list275.size; ++_i277)
+          org.apache.thrift.protocol.TList _list285 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list285.size);
+          @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem286;
+          for (int _i287 = 0; _i287 < _list285.size; ++_i287)
           {
-            _elem276 = iprot.readBinary();
-            struct.data.add(_elem276);
+            _elem286 = iprot.readBinary();
+            struct.data.add(_elem286);
           }
         }
         struct.setDataIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetCatalogsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetCatalogsResponse.java
@@ -322,13 +322,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list150 = iprot.readListBegin();
-                struct.names = new java.util.ArrayList<java.lang.String>(_list150.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem151;
-                for (int _i152 = 0; _i152 < _list150.size; ++_i152)
+                org.apache.thrift.protocol.TList _list160 = iprot.readListBegin();
+                struct.names = new java.util.ArrayList<java.lang.String>(_list160.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem161;
+                for (int _i162 = 0; _i162 < _list160.size; ++_i162)
                 {
-                  _elem151 = iprot.readString();
-                  struct.names.add(_elem151);
+                  _elem161 = iprot.readString();
+                  struct.names.add(_elem161);
                 }
                 iprot.readListEnd();
               }
@@ -354,9 +354,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.names.size()));
-          for (java.lang.String _iter153 : struct.names)
+          for (java.lang.String _iter163 : struct.names)
           {
-            oprot.writeString(_iter153);
+            oprot.writeString(_iter163);
           }
           oprot.writeListEnd();
         }
@@ -387,9 +387,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetNames()) {
         {
           oprot.writeI32(struct.names.size());
-          for (java.lang.String _iter154 : struct.names)
+          for (java.lang.String _iter164 : struct.names)
           {
-            oprot.writeString(_iter154);
+            oprot.writeString(_iter164);
           }
         }
       }
@@ -401,13 +401,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list155 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.names = new java.util.ArrayList<java.lang.String>(_list155.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem156;
-          for (int _i157 = 0; _i157 < _list155.size; ++_i157)
+          org.apache.thrift.protocol.TList _list165 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.names = new java.util.ArrayList<java.lang.String>(_list165.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem166;
+          for (int _i167 = 0; _i167 < _list165.size; ++_i167)
           {
-            _elem156 = iprot.readString();
-            struct.names.add(_elem156);
+            _elem166 = iprot.readString();
+            struct.names.add(_elem166);
           }
         }
         struct.setNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPrincipalsInRoleResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPrincipalsInRoleResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRINCIPAL_GRANTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list142 = iprot.readListBegin();
-                struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list142.size);
-                @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem143;
-                for (int _i144 = 0; _i144 < _list142.size; ++_i144)
+                org.apache.thrift.protocol.TList _list152 = iprot.readListBegin();
+                struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list152.size);
+                @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem153;
+                for (int _i154 = 0; _i154 < _list152.size; ++_i154)
                 {
-                  _elem143 = new RolePrincipalGrant();
-                  _elem143.read(iprot);
-                  struct.principalGrants.add(_elem143);
+                  _elem153 = new RolePrincipalGrant();
+                  _elem153.read(iprot);
+                  struct.principalGrants.add(_elem153);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PRINCIPAL_GRANTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.principalGrants.size()));
-          for (RolePrincipalGrant _iter145 : struct.principalGrants)
+          for (RolePrincipalGrant _iter155 : struct.principalGrants)
           {
-            _iter145.write(oprot);
+            _iter155.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.principalGrants.size());
-        for (RolePrincipalGrant _iter146 : struct.principalGrants)
+        for (RolePrincipalGrant _iter156 : struct.principalGrants)
         {
-          _iter146.write(oprot);
+          _iter156.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetPrincipalsInRoleResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list147 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list147.size);
-        @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem148;
-        for (int _i149 = 0; _i149 < _list147.size; ++_i149)
+        org.apache.thrift.protocol.TList _list157 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list157.size);
+        @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem158;
+        for (int _i159 = 0; _i159 < _list157.size; ++_i159)
         {
-          _elem148 = new RolePrincipalGrant();
-          _elem148.read(iprot);
-          struct.principalGrants.add(_elem148);
+          _elem158 = new RolePrincipalGrant();
+          _elem158.read(iprot);
+          struct.principalGrants.add(_elem158);
         }
       }
       struct.setPrincipalGrantsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetRoleGrantsForPrincipalResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetRoleGrantsForPrincipalResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRINCIPAL_GRANTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list134 = iprot.readListBegin();
-                struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list134.size);
-                @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem135;
-                for (int _i136 = 0; _i136 < _list134.size; ++_i136)
+                org.apache.thrift.protocol.TList _list144 = iprot.readListBegin();
+                struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list144.size);
+                @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem145;
+                for (int _i146 = 0; _i146 < _list144.size; ++_i146)
                 {
-                  _elem135 = new RolePrincipalGrant();
-                  _elem135.read(iprot);
-                  struct.principalGrants.add(_elem135);
+                  _elem145 = new RolePrincipalGrant();
+                  _elem145.read(iprot);
+                  struct.principalGrants.add(_elem145);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PRINCIPAL_GRANTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.principalGrants.size()));
-          for (RolePrincipalGrant _iter137 : struct.principalGrants)
+          for (RolePrincipalGrant _iter147 : struct.principalGrants)
           {
-            _iter137.write(oprot);
+            _iter147.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.principalGrants.size());
-        for (RolePrincipalGrant _iter138 : struct.principalGrants)
+        for (RolePrincipalGrant _iter148 : struct.principalGrants)
         {
-          _iter138.write(oprot);
+          _iter148.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetRoleGrantsForPrincipalResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list139 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list139.size);
-        @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem140;
-        for (int _i141 = 0; _i141 < _list139.size; ++_i141)
+        org.apache.thrift.protocol.TList _list149 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.principalGrants = new java.util.ArrayList<RolePrincipalGrant>(_list149.size);
+        @org.apache.thrift.annotation.Nullable RolePrincipalGrant _elem150;
+        for (int _i151 = 0; _i151 < _list149.size; ++_i151)
         {
-          _elem140 = new RolePrincipalGrant();
-          _elem140.read(iprot);
-          struct.principalGrants.add(_elem140);
+          _elem150 = new RolePrincipalGrant();
+          _elem150.read(iprot);
+          struct.principalGrants.add(_elem150);
         }
       }
       struct.setPrincipalGrantsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HiveObjectRef.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HiveObjectRef.java
@@ -764,13 +764,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list56 = iprot.readListBegin();
-                struct.partValues = new java.util.ArrayList<java.lang.String>(_list56.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem57;
-                for (int _i58 = 0; _i58 < _list56.size; ++_i58)
+                org.apache.thrift.protocol.TList _list66 = iprot.readListBegin();
+                struct.partValues = new java.util.ArrayList<java.lang.String>(_list66.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem67;
+                for (int _i68 = 0; _i68 < _list66.size; ++_i68)
                 {
-                  _elem57 = iprot.readString();
-                  struct.partValues.add(_elem57);
+                  _elem67 = iprot.readString();
+                  struct.partValues.add(_elem67);
                 }
                 iprot.readListEnd();
               }
@@ -827,9 +827,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PART_VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partValues.size()));
-          for (java.lang.String _iter59 : struct.partValues)
+          for (java.lang.String _iter69 : struct.partValues)
           {
-            oprot.writeString(_iter59);
+            oprot.writeString(_iter69);
           }
           oprot.writeListEnd();
         }
@@ -896,9 +896,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartValues()) {
         {
           oprot.writeI32(struct.partValues.size());
-          for (java.lang.String _iter60 : struct.partValues)
+          for (java.lang.String _iter70 : struct.partValues)
           {
-            oprot.writeString(_iter60);
+            oprot.writeString(_iter70);
           }
         }
       }
@@ -928,13 +928,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list61 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partValues = new java.util.ArrayList<java.lang.String>(_list61.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem62;
-          for (int _i63 = 0; _i63 < _list61.size; ++_i63)
+          org.apache.thrift.protocol.TList _list71 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partValues = new java.util.ArrayList<java.lang.String>(_list71.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem72;
+          for (int _i73 = 0; _i73 < _list71.size; ++_i73)
           {
-            _elem62 = iprot.readString();
-            struct.partValues.add(_elem62);
+            _elem72 = iprot.readString();
+            struct.partValues.add(_elem72);
           }
         }
         struct.setPartValuesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ObjectDictionary.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ObjectDictionary.java
@@ -334,25 +334,25 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map278 = iprot.readMapBegin();
-                struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map278.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key279;
-                @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val280;
-                for (int _i281 = 0; _i281 < _map278.size; ++_i281)
+                org.apache.thrift.protocol.TMap _map288 = iprot.readMapBegin();
+                struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map288.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key289;
+                @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val290;
+                for (int _i291 = 0; _i291 < _map288.size; ++_i291)
                 {
-                  _key279 = iprot.readString();
+                  _key289 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list282 = iprot.readListBegin();
-                    _val280 = new java.util.ArrayList<java.nio.ByteBuffer>(_list282.size);
-                    @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem283;
-                    for (int _i284 = 0; _i284 < _list282.size; ++_i284)
+                    org.apache.thrift.protocol.TList _list292 = iprot.readListBegin();
+                    _val290 = new java.util.ArrayList<java.nio.ByteBuffer>(_list292.size);
+                    @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem293;
+                    for (int _i294 = 0; _i294 < _list292.size; ++_i294)
                     {
-                      _elem283 = iprot.readBinary();
-                      _val280.add(_elem283);
+                      _elem293 = iprot.readBinary();
+                      _val290.add(_elem293);
                     }
                     iprot.readListEnd();
                   }
-                  struct.values.put(_key279, _val280);
+                  struct.values.put(_key289, _val290);
                 }
                 iprot.readMapEnd();
               }
@@ -378,14 +378,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.values.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter285 : struct.values.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter295 : struct.values.entrySet())
           {
-            oprot.writeString(_iter285.getKey());
+            oprot.writeString(_iter295.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter285.getValue().size()));
-              for (java.nio.ByteBuffer _iter286 : _iter285.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter295.getValue().size()));
+              for (java.nio.ByteBuffer _iter296 : _iter295.getValue())
               {
-                oprot.writeBinary(_iter286);
+                oprot.writeBinary(_iter296);
               }
               oprot.writeListEnd();
             }
@@ -413,14 +413,14 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.values.size());
-        for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter287 : struct.values.entrySet())
+        for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter297 : struct.values.entrySet())
         {
-          oprot.writeString(_iter287.getKey());
+          oprot.writeString(_iter297.getKey());
           {
-            oprot.writeI32(_iter287.getValue().size());
-            for (java.nio.ByteBuffer _iter288 : _iter287.getValue())
+            oprot.writeI32(_iter297.getValue().size());
+            for (java.nio.ByteBuffer _iter298 : _iter297.getValue())
             {
-              oprot.writeBinary(_iter288);
+              oprot.writeBinary(_iter298);
             }
           }
         }
@@ -431,24 +431,24 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ObjectDictionary struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map289 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-        struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map289.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _key290;
-        @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val291;
-        for (int _i292 = 0; _i292 < _map289.size; ++_i292)
+        org.apache.thrift.protocol.TMap _map299 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+        struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map299.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _key300;
+        @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val301;
+        for (int _i302 = 0; _i302 < _map299.size; ++_i302)
         {
-          _key290 = iprot.readString();
+          _key300 = iprot.readString();
           {
-            org.apache.thrift.protocol.TList _list293 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-            _val291 = new java.util.ArrayList<java.nio.ByteBuffer>(_list293.size);
-            @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem294;
-            for (int _i295 = 0; _i295 < _list293.size; ++_i295)
+            org.apache.thrift.protocol.TList _list303 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+            _val301 = new java.util.ArrayList<java.nio.ByteBuffer>(_list303.size);
+            @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem304;
+            for (int _i305 = 0; _i305 < _list303.size; ++_i305)
             {
-              _elem294 = iprot.readBinary();
-              _val291.add(_elem294);
+              _elem304 = iprot.readBinary();
+              _val301.add(_elem304);
             }
           }
-          struct.values.put(_key290, _val291);
+          struct.values.put(_key300, _val301);
         }
       }
       struct.setValuesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
@@ -1301,13 +1301,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list330 = iprot.readListBegin();
-                struct.values = new java.util.ArrayList<java.lang.String>(_list330.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem331;
-                for (int _i332 = 0; _i332 < _list330.size; ++_i332)
+                org.apache.thrift.protocol.TList _list340 = iprot.readListBegin();
+                struct.values = new java.util.ArrayList<java.lang.String>(_list340.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem341;
+                for (int _i342 = 0; _i342 < _list340.size; ++_i342)
                 {
-                  _elem331 = iprot.readString();
-                  struct.values.add(_elem331);
+                  _elem341 = iprot.readString();
+                  struct.values.add(_elem341);
                 }
                 iprot.readListEnd();
               }
@@ -1360,15 +1360,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 7: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map333 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map333.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key334;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val335;
-                for (int _i336 = 0; _i336 < _map333.size; ++_i336)
+                org.apache.thrift.protocol.TMap _map343 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map343.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key344;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val345;
+                for (int _i346 = 0; _i346 < _map343.size; ++_i346)
                 {
-                  _key334 = iprot.readString();
-                  _val335 = iprot.readString();
-                  struct.parameters.put(_key334, _val335);
+                  _key344 = iprot.readString();
+                  _val345 = iprot.readString();
+                  struct.parameters.put(_key344, _val345);
                 }
                 iprot.readMapEnd();
               }
@@ -1445,9 +1445,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.values.size()));
-          for (java.lang.String _iter337 : struct.values)
+          for (java.lang.String _iter347 : struct.values)
           {
-            oprot.writeString(_iter337);
+            oprot.writeString(_iter347);
           }
           oprot.writeListEnd();
         }
@@ -1478,10 +1478,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter338 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter348 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter338.getKey());
-            oprot.writeString(_iter338.getValue());
+            oprot.writeString(_iter348.getKey());
+            oprot.writeString(_iter348.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -1586,9 +1586,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
-          for (java.lang.String _iter339 : struct.values)
+          for (java.lang.String _iter349 : struct.values)
           {
-            oprot.writeString(_iter339);
+            oprot.writeString(_iter349);
           }
         }
       }
@@ -1610,10 +1610,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter340 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter350 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter340.getKey());
-            oprot.writeString(_iter340.getValue());
+            oprot.writeString(_iter350.getKey());
+            oprot.writeString(_iter350.getValue());
           }
         }
       }
@@ -1643,13 +1643,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(13);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list341 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.values = new java.util.ArrayList<java.lang.String>(_list341.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem342;
-          for (int _i343 = 0; _i343 < _list341.size; ++_i343)
+          org.apache.thrift.protocol.TList _list351 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.values = new java.util.ArrayList<java.lang.String>(_list351.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem352;
+          for (int _i353 = 0; _i353 < _list351.size; ++_i353)
           {
-            _elem342 = iprot.readString();
-            struct.values.add(_elem342);
+            _elem352 = iprot.readString();
+            struct.values.add(_elem352);
           }
         }
         struct.setValuesIsSet(true);
@@ -1677,15 +1677,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TMap _map344 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map344.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key345;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val346;
-          for (int _i347 = 0; _i347 < _map344.size; ++_i347)
+          org.apache.thrift.protocol.TMap _map354 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map354.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key355;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val356;
+          for (int _i357 = 0; _i357 < _map354.size; ++_i357)
           {
-            _key345 = iprot.readString();
-            _val346 = iprot.readString();
-            struct.parameters.put(_key345, _val346);
+            _key355 = iprot.readString();
+            _val356 = iprot.readString();
+            struct.parameters.put(_key355, _val356);
           }
         }
         struct.parameters = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.parameters); struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionListComposingSpec.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionListComposingSpec.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list374 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list374.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem375;
-                for (int _i376 = 0; _i376 < _list374.size; ++_i376)
+                org.apache.thrift.protocol.TList _list384 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list384.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem385;
+                for (int _i386 = 0; _i386 < _list384.size; ++_i386)
                 {
-                  _elem375 = new Partition();
-                  _elem375.read(iprot);
-                  struct.partitions.add(_elem375);
+                  _elem385 = new Partition();
+                  _elem385.read(iprot);
+                  struct.partitions.add(_elem385);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter377 : struct.partitions)
+          for (Partition _iter387 : struct.partitions)
           {
-            _iter377.write(oprot);
+            _iter387.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (Partition _iter378 : struct.partitions)
+          for (Partition _iter388 : struct.partitions)
           {
-            _iter378.write(oprot);
+            _iter388.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list379 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<Partition>(_list379.size);
-          @org.apache.thrift.annotation.Nullable Partition _elem380;
-          for (int _i381 = 0; _i381 < _list379.size; ++_i381)
+          org.apache.thrift.protocol.TList _list389 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<Partition>(_list389.size);
+          @org.apache.thrift.annotation.Nullable Partition _elem390;
+          for (int _i391 = 0; _i391 < _list389.size; ++_i391)
           {
-            _elem380 = new Partition();
-            _elem380.read(iprot);
-            struct.partitions.add(_elem380);
+            _elem390 = new Partition();
+            _elem390.read(iprot);
+            struct.partitions.add(_elem390);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpecWithSharedSD.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpecWithSharedSD.java
@@ -409,14 +409,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list366 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list366.size);
-                @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem367;
-                for (int _i368 = 0; _i368 < _list366.size; ++_i368)
+                org.apache.thrift.protocol.TList _list376 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list376.size);
+                @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem377;
+                for (int _i378 = 0; _i378 < _list376.size; ++_i378)
                 {
-                  _elem367 = new PartitionWithoutSD();
-                  _elem367.read(iprot);
-                  struct.partitions.add(_elem367);
+                  _elem377 = new PartitionWithoutSD();
+                  _elem377.read(iprot);
+                  struct.partitions.add(_elem377);
                 }
                 iprot.readListEnd();
               }
@@ -451,9 +451,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (PartitionWithoutSD _iter369 : struct.partitions)
+          for (PartitionWithoutSD _iter379 : struct.partitions)
           {
-            _iter369.write(oprot);
+            _iter379.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -492,9 +492,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (PartitionWithoutSD _iter370 : struct.partitions)
+          for (PartitionWithoutSD _iter380 : struct.partitions)
           {
-            _iter370.write(oprot);
+            _iter380.write(oprot);
           }
         }
       }
@@ -509,14 +509,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list371 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list371.size);
-          @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem372;
-          for (int _i373 = 0; _i373 < _list371.size; ++_i373)
+          org.apache.thrift.protocol.TList _list381 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list381.size);
+          @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem382;
+          for (int _i383 = 0; _i383 < _list381.size; ++_i383)
           {
-            _elem372 = new PartitionWithoutSD();
-            _elem372.read(iprot);
-            struct.partitions.add(_elem372);
+            _elem382 = new PartitionWithoutSD();
+            _elem382.read(iprot);
+            struct.partitions.add(_elem382);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
@@ -735,13 +735,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list348 = iprot.readListBegin();
-                struct.values = new java.util.ArrayList<java.lang.String>(_list348.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem349;
-                for (int _i350 = 0; _i350 < _list348.size; ++_i350)
+                org.apache.thrift.protocol.TList _list358 = iprot.readListBegin();
+                struct.values = new java.util.ArrayList<java.lang.String>(_list358.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem359;
+                for (int _i360 = 0; _i360 < _list358.size; ++_i360)
                 {
-                  _elem349 = iprot.readString();
-                  struct.values.add(_elem349);
+                  _elem359 = iprot.readString();
+                  struct.values.add(_elem359);
                 }
                 iprot.readListEnd();
               }
@@ -777,15 +777,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map351 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map351.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key352;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val353;
-                for (int _i354 = 0; _i354 < _map351.size; ++_i354)
+                org.apache.thrift.protocol.TMap _map361 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map361.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key362;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val363;
+                for (int _i364 = 0; _i364 < _map361.size; ++_i364)
                 {
-                  _key352 = iprot.readString();
-                  _val353 = iprot.readString();
-                  struct.parameters.put(_key352, _val353);
+                  _key362 = iprot.readString();
+                  _val363 = iprot.readString();
+                  struct.parameters.put(_key362, _val363);
                 }
                 iprot.readMapEnd();
               }
@@ -820,9 +820,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.values.size()));
-          for (java.lang.String _iter355 : struct.values)
+          for (java.lang.String _iter365 : struct.values)
           {
-            oprot.writeString(_iter355);
+            oprot.writeString(_iter365);
           }
           oprot.writeListEnd();
         }
@@ -843,10 +843,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter356 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter366 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter356.getKey());
-            oprot.writeString(_iter356.getValue());
+            oprot.writeString(_iter366.getKey());
+            oprot.writeString(_iter366.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -899,9 +899,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
-          for (java.lang.String _iter357 : struct.values)
+          for (java.lang.String _iter367 : struct.values)
           {
-            oprot.writeString(_iter357);
+            oprot.writeString(_iter367);
           }
         }
       }
@@ -917,10 +917,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter358 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter368 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter358.getKey());
-            oprot.writeString(_iter358.getValue());
+            oprot.writeString(_iter368.getKey());
+            oprot.writeString(_iter368.getValue());
           }
         }
       }
@@ -935,13 +935,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list359 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.values = new java.util.ArrayList<java.lang.String>(_list359.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem360;
-          for (int _i361 = 0; _i361 < _list359.size; ++_i361)
+          org.apache.thrift.protocol.TList _list369 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.values = new java.util.ArrayList<java.lang.String>(_list369.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem370;
+          for (int _i371 = 0; _i371 < _list369.size; ++_i371)
           {
-            _elem360 = iprot.readString();
-            struct.values.add(_elem360);
+            _elem370 = iprot.readString();
+            struct.values.add(_elem370);
           }
         }
         struct.setValuesIsSet(true);
@@ -960,15 +960,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TMap _map362 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map362.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key363;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val364;
-          for (int _i365 = 0; _i365 < _map362.size; ++_i365)
+          org.apache.thrift.protocol.TMap _map372 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map372.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key373;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val374;
+          for (int _i375 = 0; _i375 < _map372.size; ++_i375)
           {
-            _key363 = iprot.readString();
-            _val364 = iprot.readString();
-            struct.parameters.put(_key363, _val364);
+            _key373 = iprot.readString();
+            _val374 = iprot.readString();
+            struct.parameters.put(_key373, _val374);
           }
         }
         struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrincipalPrivilegeSet.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrincipalPrivilegeSet.java
@@ -553,26 +553,26 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // USER_PRIVILEGES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map72 = iprot.readMapBegin();
-                struct.userPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map72.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key73;
-                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val74;
-                for (int _i75 = 0; _i75 < _map72.size; ++_i75)
+                org.apache.thrift.protocol.TMap _map82 = iprot.readMapBegin();
+                struct.userPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map82.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key83;
+                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val84;
+                for (int _i85 = 0; _i85 < _map82.size; ++_i85)
                 {
-                  _key73 = iprot.readString();
+                  _key83 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list76 = iprot.readListBegin();
-                    _val74 = new java.util.ArrayList<PrivilegeGrantInfo>(_list76.size);
-                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem77;
-                    for (int _i78 = 0; _i78 < _list76.size; ++_i78)
+                    org.apache.thrift.protocol.TList _list86 = iprot.readListBegin();
+                    _val84 = new java.util.ArrayList<PrivilegeGrantInfo>(_list86.size);
+                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem87;
+                    for (int _i88 = 0; _i88 < _list86.size; ++_i88)
                     {
-                      _elem77 = new PrivilegeGrantInfo();
-                      _elem77.read(iprot);
-                      _val74.add(_elem77);
+                      _elem87 = new PrivilegeGrantInfo();
+                      _elem87.read(iprot);
+                      _val84.add(_elem87);
                     }
                     iprot.readListEnd();
                   }
-                  struct.userPrivileges.put(_key73, _val74);
+                  struct.userPrivileges.put(_key83, _val84);
                 }
                 iprot.readMapEnd();
               }
@@ -584,26 +584,26 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // GROUP_PRIVILEGES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map79 = iprot.readMapBegin();
-                struct.groupPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map79.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key80;
-                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val81;
-                for (int _i82 = 0; _i82 < _map79.size; ++_i82)
+                org.apache.thrift.protocol.TMap _map89 = iprot.readMapBegin();
+                struct.groupPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map89.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key90;
+                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val91;
+                for (int _i92 = 0; _i92 < _map89.size; ++_i92)
                 {
-                  _key80 = iprot.readString();
+                  _key90 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list83 = iprot.readListBegin();
-                    _val81 = new java.util.ArrayList<PrivilegeGrantInfo>(_list83.size);
-                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem84;
-                    for (int _i85 = 0; _i85 < _list83.size; ++_i85)
+                    org.apache.thrift.protocol.TList _list93 = iprot.readListBegin();
+                    _val91 = new java.util.ArrayList<PrivilegeGrantInfo>(_list93.size);
+                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem94;
+                    for (int _i95 = 0; _i95 < _list93.size; ++_i95)
                     {
-                      _elem84 = new PrivilegeGrantInfo();
-                      _elem84.read(iprot);
-                      _val81.add(_elem84);
+                      _elem94 = new PrivilegeGrantInfo();
+                      _elem94.read(iprot);
+                      _val91.add(_elem94);
                     }
                     iprot.readListEnd();
                   }
-                  struct.groupPrivileges.put(_key80, _val81);
+                  struct.groupPrivileges.put(_key90, _val91);
                 }
                 iprot.readMapEnd();
               }
@@ -615,26 +615,26 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // ROLE_PRIVILEGES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map86 = iprot.readMapBegin();
-                struct.rolePrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map86.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key87;
-                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val88;
-                for (int _i89 = 0; _i89 < _map86.size; ++_i89)
+                org.apache.thrift.protocol.TMap _map96 = iprot.readMapBegin();
+                struct.rolePrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map96.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key97;
+                @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val98;
+                for (int _i99 = 0; _i99 < _map96.size; ++_i99)
                 {
-                  _key87 = iprot.readString();
+                  _key97 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list90 = iprot.readListBegin();
-                    _val88 = new java.util.ArrayList<PrivilegeGrantInfo>(_list90.size);
-                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem91;
-                    for (int _i92 = 0; _i92 < _list90.size; ++_i92)
+                    org.apache.thrift.protocol.TList _list100 = iprot.readListBegin();
+                    _val98 = new java.util.ArrayList<PrivilegeGrantInfo>(_list100.size);
+                    @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem101;
+                    for (int _i102 = 0; _i102 < _list100.size; ++_i102)
                     {
-                      _elem91 = new PrivilegeGrantInfo();
-                      _elem91.read(iprot);
-                      _val88.add(_elem91);
+                      _elem101 = new PrivilegeGrantInfo();
+                      _elem101.read(iprot);
+                      _val98.add(_elem101);
                     }
                     iprot.readListEnd();
                   }
-                  struct.rolePrivileges.put(_key87, _val88);
+                  struct.rolePrivileges.put(_key97, _val98);
                 }
                 iprot.readMapEnd();
               }
@@ -660,14 +660,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(USER_PRIVILEGES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.userPrivileges.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter93 : struct.userPrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter103 : struct.userPrivileges.entrySet())
           {
-            oprot.writeString(_iter93.getKey());
+            oprot.writeString(_iter103.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter93.getValue().size()));
-              for (PrivilegeGrantInfo _iter94 : _iter93.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter103.getValue().size()));
+              for (PrivilegeGrantInfo _iter104 : _iter103.getValue())
               {
-                _iter94.write(oprot);
+                _iter104.write(oprot);
               }
               oprot.writeListEnd();
             }
@@ -680,14 +680,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(GROUP_PRIVILEGES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.groupPrivileges.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter95 : struct.groupPrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter105 : struct.groupPrivileges.entrySet())
           {
-            oprot.writeString(_iter95.getKey());
+            oprot.writeString(_iter105.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter95.getValue().size()));
-              for (PrivilegeGrantInfo _iter96 : _iter95.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter105.getValue().size()));
+              for (PrivilegeGrantInfo _iter106 : _iter105.getValue())
               {
-                _iter96.write(oprot);
+                _iter106.write(oprot);
               }
               oprot.writeListEnd();
             }
@@ -700,14 +700,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(ROLE_PRIVILEGES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.rolePrivileges.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter97 : struct.rolePrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter107 : struct.rolePrivileges.entrySet())
           {
-            oprot.writeString(_iter97.getKey());
+            oprot.writeString(_iter107.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter97.getValue().size()));
-              for (PrivilegeGrantInfo _iter98 : _iter97.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter107.getValue().size()));
+              for (PrivilegeGrantInfo _iter108 : _iter107.getValue())
               {
-                _iter98.write(oprot);
+                _iter108.write(oprot);
               }
               oprot.writeListEnd();
             }
@@ -747,14 +747,14 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetUserPrivileges()) {
         {
           oprot.writeI32(struct.userPrivileges.size());
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter99 : struct.userPrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter109 : struct.userPrivileges.entrySet())
           {
-            oprot.writeString(_iter99.getKey());
+            oprot.writeString(_iter109.getKey());
             {
-              oprot.writeI32(_iter99.getValue().size());
-              for (PrivilegeGrantInfo _iter100 : _iter99.getValue())
+              oprot.writeI32(_iter109.getValue().size());
+              for (PrivilegeGrantInfo _iter110 : _iter109.getValue())
               {
-                _iter100.write(oprot);
+                _iter110.write(oprot);
               }
             }
           }
@@ -763,14 +763,14 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetGroupPrivileges()) {
         {
           oprot.writeI32(struct.groupPrivileges.size());
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter101 : struct.groupPrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter111 : struct.groupPrivileges.entrySet())
           {
-            oprot.writeString(_iter101.getKey());
+            oprot.writeString(_iter111.getKey());
             {
-              oprot.writeI32(_iter101.getValue().size());
-              for (PrivilegeGrantInfo _iter102 : _iter101.getValue())
+              oprot.writeI32(_iter111.getValue().size());
+              for (PrivilegeGrantInfo _iter112 : _iter111.getValue())
               {
-                _iter102.write(oprot);
+                _iter112.write(oprot);
               }
             }
           }
@@ -779,14 +779,14 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetRolePrivileges()) {
         {
           oprot.writeI32(struct.rolePrivileges.size());
-          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter103 : struct.rolePrivileges.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<PrivilegeGrantInfo>> _iter113 : struct.rolePrivileges.entrySet())
           {
-            oprot.writeString(_iter103.getKey());
+            oprot.writeString(_iter113.getKey());
             {
-              oprot.writeI32(_iter103.getValue().size());
-              for (PrivilegeGrantInfo _iter104 : _iter103.getValue())
+              oprot.writeI32(_iter113.getValue().size());
+              for (PrivilegeGrantInfo _iter114 : _iter113.getValue())
               {
-                _iter104.write(oprot);
+                _iter114.write(oprot);
               }
             }
           }
@@ -800,75 +800,75 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map105 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-          struct.userPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map105.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key106;
-          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val107;
-          for (int _i108 = 0; _i108 < _map105.size; ++_i108)
+          org.apache.thrift.protocol.TMap _map115 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+          struct.userPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map115.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key116;
+          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val117;
+          for (int _i118 = 0; _i118 < _map115.size; ++_i118)
           {
-            _key106 = iprot.readString();
+            _key116 = iprot.readString();
             {
-              org.apache.thrift.protocol.TList _list109 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-              _val107 = new java.util.ArrayList<PrivilegeGrantInfo>(_list109.size);
-              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem110;
-              for (int _i111 = 0; _i111 < _list109.size; ++_i111)
+              org.apache.thrift.protocol.TList _list119 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+              _val117 = new java.util.ArrayList<PrivilegeGrantInfo>(_list119.size);
+              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem120;
+              for (int _i121 = 0; _i121 < _list119.size; ++_i121)
               {
-                _elem110 = new PrivilegeGrantInfo();
-                _elem110.read(iprot);
-                _val107.add(_elem110);
+                _elem120 = new PrivilegeGrantInfo();
+                _elem120.read(iprot);
+                _val117.add(_elem120);
               }
             }
-            struct.userPrivileges.put(_key106, _val107);
+            struct.userPrivileges.put(_key116, _val117);
           }
         }
         struct.setUserPrivilegesIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TMap _map112 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-          struct.groupPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map112.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key113;
-          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val114;
-          for (int _i115 = 0; _i115 < _map112.size; ++_i115)
+          org.apache.thrift.protocol.TMap _map122 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+          struct.groupPrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map122.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key123;
+          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val124;
+          for (int _i125 = 0; _i125 < _map122.size; ++_i125)
           {
-            _key113 = iprot.readString();
+            _key123 = iprot.readString();
             {
-              org.apache.thrift.protocol.TList _list116 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-              _val114 = new java.util.ArrayList<PrivilegeGrantInfo>(_list116.size);
-              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem117;
-              for (int _i118 = 0; _i118 < _list116.size; ++_i118)
+              org.apache.thrift.protocol.TList _list126 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+              _val124 = new java.util.ArrayList<PrivilegeGrantInfo>(_list126.size);
+              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem127;
+              for (int _i128 = 0; _i128 < _list126.size; ++_i128)
               {
-                _elem117 = new PrivilegeGrantInfo();
-                _elem117.read(iprot);
-                _val114.add(_elem117);
+                _elem127 = new PrivilegeGrantInfo();
+                _elem127.read(iprot);
+                _val124.add(_elem127);
               }
             }
-            struct.groupPrivileges.put(_key113, _val114);
+            struct.groupPrivileges.put(_key123, _val124);
           }
         }
         struct.setGroupPrivilegesIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map119 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-          struct.rolePrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map119.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key120;
-          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val121;
-          for (int _i122 = 0; _i122 < _map119.size; ++_i122)
+          org.apache.thrift.protocol.TMap _map129 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+          struct.rolePrivileges = new java.util.HashMap<java.lang.String,java.util.List<PrivilegeGrantInfo>>(2*_map129.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key130;
+          @org.apache.thrift.annotation.Nullable java.util.List<PrivilegeGrantInfo> _val131;
+          for (int _i132 = 0; _i132 < _map129.size; ++_i132)
           {
-            _key120 = iprot.readString();
+            _key130 = iprot.readString();
             {
-              org.apache.thrift.protocol.TList _list123 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-              _val121 = new java.util.ArrayList<PrivilegeGrantInfo>(_list123.size);
-              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem124;
-              for (int _i125 = 0; _i125 < _list123.size; ++_i125)
+              org.apache.thrift.protocol.TList _list133 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+              _val131 = new java.util.ArrayList<PrivilegeGrantInfo>(_list133.size);
+              @org.apache.thrift.annotation.Nullable PrivilegeGrantInfo _elem134;
+              for (int _i135 = 0; _i135 < _list133.size; ++_i135)
               {
-                _elem124 = new PrivilegeGrantInfo();
-                _elem124.read(iprot);
-                _val121.add(_elem124);
+                _elem134 = new PrivilegeGrantInfo();
+                _elem134.read(iprot);
+                _val131.add(_elem134);
               }
             }
-            struct.rolePrivileges.put(_key120, _val121);
+            struct.rolePrivileges.put(_key130, _val131);
           }
         }
         struct.setRolePrivilegesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrivilegeBag.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrivilegeBag.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRIVILEGES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list64 = iprot.readListBegin();
-                struct.privileges = new java.util.ArrayList<HiveObjectPrivilege>(_list64.size);
-                @org.apache.thrift.annotation.Nullable HiveObjectPrivilege _elem65;
-                for (int _i66 = 0; _i66 < _list64.size; ++_i66)
+                org.apache.thrift.protocol.TList _list74 = iprot.readListBegin();
+                struct.privileges = new java.util.ArrayList<HiveObjectPrivilege>(_list74.size);
+                @org.apache.thrift.annotation.Nullable HiveObjectPrivilege _elem75;
+                for (int _i76 = 0; _i76 < _list74.size; ++_i76)
                 {
-                  _elem65 = new HiveObjectPrivilege();
-                  _elem65.read(iprot);
-                  struct.privileges.add(_elem65);
+                  _elem75 = new HiveObjectPrivilege();
+                  _elem75.read(iprot);
+                  struct.privileges.add(_elem75);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PRIVILEGES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.privileges.size()));
-          for (HiveObjectPrivilege _iter67 : struct.privileges)
+          for (HiveObjectPrivilege _iter77 : struct.privileges)
           {
-            _iter67.write(oprot);
+            _iter77.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPrivileges()) {
         {
           oprot.writeI32(struct.privileges.size());
-          for (HiveObjectPrivilege _iter68 : struct.privileges)
+          for (HiveObjectPrivilege _iter78 : struct.privileges)
           {
-            _iter68.write(oprot);
+            _iter78.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list69 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.privileges = new java.util.ArrayList<HiveObjectPrivilege>(_list69.size);
-          @org.apache.thrift.annotation.Nullable HiveObjectPrivilege _elem70;
-          for (int _i71 = 0; _i71 < _list69.size; ++_i71)
+          org.apache.thrift.protocol.TList _list79 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.privileges = new java.util.ArrayList<HiveObjectPrivilege>(_list79.size);
+          @org.apache.thrift.annotation.Nullable HiveObjectPrivilege _elem80;
+          for (int _i81 = 0; _i81 < _list79.size; ++_i81)
           {
-            _elem70 = new HiveObjectPrivilege();
-            _elem70.read(iprot);
-            struct.privileges.add(_elem70);
+            _elem80 = new HiveObjectPrivilege();
+            _elem80.read(iprot);
+            struct.privileges.add(_elem80);
           }
         }
         struct.setPrivilegesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SQLAllTableConstraints.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SQLAllTableConstraints.java
@@ -831,14 +831,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRIMARY_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list0 = iprot.readListBegin();
-                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list0.size);
-                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem1;
-                for (int _i2 = 0; _i2 < _list0.size; ++_i2)
+                org.apache.thrift.protocol.TList _list10 = iprot.readListBegin();
+                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list10.size);
+                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem11;
+                for (int _i12 = 0; _i12 < _list10.size; ++_i12)
                 {
-                  _elem1 = new SQLPrimaryKey();
-                  _elem1.read(iprot);
-                  struct.primaryKeys.add(_elem1);
+                  _elem11 = new SQLPrimaryKey();
+                  _elem11.read(iprot);
+                  struct.primaryKeys.add(_elem11);
                 }
                 iprot.readListEnd();
               }
@@ -850,14 +850,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // FOREIGN_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list3 = iprot.readListBegin();
-                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list3.size);
-                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem4;
-                for (int _i5 = 0; _i5 < _list3.size; ++_i5)
+                org.apache.thrift.protocol.TList _list13 = iprot.readListBegin();
+                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list13.size);
+                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem14;
+                for (int _i15 = 0; _i15 < _list13.size; ++_i15)
                 {
-                  _elem4 = new SQLForeignKey();
-                  _elem4.read(iprot);
-                  struct.foreignKeys.add(_elem4);
+                  _elem14 = new SQLForeignKey();
+                  _elem14.read(iprot);
+                  struct.foreignKeys.add(_elem14);
                 }
                 iprot.readListEnd();
               }
@@ -869,14 +869,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // UNIQUE_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list6 = iprot.readListBegin();
-                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list6.size);
-                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem7;
-                for (int _i8 = 0; _i8 < _list6.size; ++_i8)
+                org.apache.thrift.protocol.TList _list16 = iprot.readListBegin();
+                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list16.size);
+                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem17;
+                for (int _i18 = 0; _i18 < _list16.size; ++_i18)
                 {
-                  _elem7 = new SQLUniqueConstraint();
-                  _elem7.read(iprot);
-                  struct.uniqueConstraints.add(_elem7);
+                  _elem17 = new SQLUniqueConstraint();
+                  _elem17.read(iprot);
+                  struct.uniqueConstraints.add(_elem17);
                 }
                 iprot.readListEnd();
               }
@@ -888,14 +888,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // NOT_NULL_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list9 = iprot.readListBegin();
-                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list9.size);
-                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem10;
-                for (int _i11 = 0; _i11 < _list9.size; ++_i11)
+                org.apache.thrift.protocol.TList _list19 = iprot.readListBegin();
+                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list19.size);
+                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem20;
+                for (int _i21 = 0; _i21 < _list19.size; ++_i21)
                 {
-                  _elem10 = new SQLNotNullConstraint();
-                  _elem10.read(iprot);
-                  struct.notNullConstraints.add(_elem10);
+                  _elem20 = new SQLNotNullConstraint();
+                  _elem20.read(iprot);
+                  struct.notNullConstraints.add(_elem20);
                 }
                 iprot.readListEnd();
               }
@@ -907,14 +907,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // DEFAULT_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list12 = iprot.readListBegin();
-                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list12.size);
-                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem13;
-                for (int _i14 = 0; _i14 < _list12.size; ++_i14)
+                org.apache.thrift.protocol.TList _list22 = iprot.readListBegin();
+                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list22.size);
+                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem23;
+                for (int _i24 = 0; _i24 < _list22.size; ++_i24)
                 {
-                  _elem13 = new SQLDefaultConstraint();
-                  _elem13.read(iprot);
-                  struct.defaultConstraints.add(_elem13);
+                  _elem23 = new SQLDefaultConstraint();
+                  _elem23.read(iprot);
+                  struct.defaultConstraints.add(_elem23);
                 }
                 iprot.readListEnd();
               }
@@ -926,14 +926,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // CHECK_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list15 = iprot.readListBegin();
-                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list15.size);
-                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem16;
-                for (int _i17 = 0; _i17 < _list15.size; ++_i17)
+                org.apache.thrift.protocol.TList _list25 = iprot.readListBegin();
+                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list25.size);
+                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem26;
+                for (int _i27 = 0; _i27 < _list25.size; ++_i27)
                 {
-                  _elem16 = new SQLCheckConstraint();
-                  _elem16.read(iprot);
-                  struct.checkConstraints.add(_elem16);
+                  _elem26 = new SQLCheckConstraint();
+                  _elem26.read(iprot);
+                  struct.checkConstraints.add(_elem26);
                 }
                 iprot.readListEnd();
               }
@@ -960,9 +960,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PRIMARY_KEYS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.primaryKeys.size()));
-            for (SQLPrimaryKey _iter18 : struct.primaryKeys)
+            for (SQLPrimaryKey _iter28 : struct.primaryKeys)
             {
-              _iter18.write(oprot);
+              _iter28.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -974,9 +974,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FOREIGN_KEYS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.foreignKeys.size()));
-            for (SQLForeignKey _iter19 : struct.foreignKeys)
+            for (SQLForeignKey _iter29 : struct.foreignKeys)
             {
-              _iter19.write(oprot);
+              _iter29.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -988,9 +988,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(UNIQUE_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.uniqueConstraints.size()));
-            for (SQLUniqueConstraint _iter20 : struct.uniqueConstraints)
+            for (SQLUniqueConstraint _iter30 : struct.uniqueConstraints)
             {
-              _iter20.write(oprot);
+              _iter30.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1002,9 +1002,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(NOT_NULL_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.notNullConstraints.size()));
-            for (SQLNotNullConstraint _iter21 : struct.notNullConstraints)
+            for (SQLNotNullConstraint _iter31 : struct.notNullConstraints)
             {
-              _iter21.write(oprot);
+              _iter31.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1016,9 +1016,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(DEFAULT_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.defaultConstraints.size()));
-            for (SQLDefaultConstraint _iter22 : struct.defaultConstraints)
+            for (SQLDefaultConstraint _iter32 : struct.defaultConstraints)
             {
-              _iter22.write(oprot);
+              _iter32.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1030,9 +1030,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(CHECK_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.checkConstraints.size()));
-            for (SQLCheckConstraint _iter23 : struct.checkConstraints)
+            for (SQLCheckConstraint _iter33 : struct.checkConstraints)
             {
-              _iter23.write(oprot);
+              _iter33.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1079,54 +1079,54 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPrimaryKeys()) {
         {
           oprot.writeI32(struct.primaryKeys.size());
-          for (SQLPrimaryKey _iter24 : struct.primaryKeys)
+          for (SQLPrimaryKey _iter34 : struct.primaryKeys)
           {
-            _iter24.write(oprot);
+            _iter34.write(oprot);
           }
         }
       }
       if (struct.isSetForeignKeys()) {
         {
           oprot.writeI32(struct.foreignKeys.size());
-          for (SQLForeignKey _iter25 : struct.foreignKeys)
+          for (SQLForeignKey _iter35 : struct.foreignKeys)
           {
-            _iter25.write(oprot);
+            _iter35.write(oprot);
           }
         }
       }
       if (struct.isSetUniqueConstraints()) {
         {
           oprot.writeI32(struct.uniqueConstraints.size());
-          for (SQLUniqueConstraint _iter26 : struct.uniqueConstraints)
+          for (SQLUniqueConstraint _iter36 : struct.uniqueConstraints)
           {
-            _iter26.write(oprot);
+            _iter36.write(oprot);
           }
         }
       }
       if (struct.isSetNotNullConstraints()) {
         {
           oprot.writeI32(struct.notNullConstraints.size());
-          for (SQLNotNullConstraint _iter27 : struct.notNullConstraints)
+          for (SQLNotNullConstraint _iter37 : struct.notNullConstraints)
           {
-            _iter27.write(oprot);
+            _iter37.write(oprot);
           }
         }
       }
       if (struct.isSetDefaultConstraints()) {
         {
           oprot.writeI32(struct.defaultConstraints.size());
-          for (SQLDefaultConstraint _iter28 : struct.defaultConstraints)
+          for (SQLDefaultConstraint _iter38 : struct.defaultConstraints)
           {
-            _iter28.write(oprot);
+            _iter38.write(oprot);
           }
         }
       }
       if (struct.isSetCheckConstraints()) {
         {
           oprot.writeI32(struct.checkConstraints.size());
-          for (SQLCheckConstraint _iter29 : struct.checkConstraints)
+          for (SQLCheckConstraint _iter39 : struct.checkConstraints)
           {
-            _iter29.write(oprot);
+            _iter39.write(oprot);
           }
         }
       }
@@ -1138,84 +1138,84 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list30 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list30.size);
-          @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem31;
-          for (int _i32 = 0; _i32 < _list30.size; ++_i32)
+          org.apache.thrift.protocol.TList _list40 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list40.size);
+          @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem41;
+          for (int _i42 = 0; _i42 < _list40.size; ++_i42)
           {
-            _elem31 = new SQLPrimaryKey();
-            _elem31.read(iprot);
-            struct.primaryKeys.add(_elem31);
+            _elem41 = new SQLPrimaryKey();
+            _elem41.read(iprot);
+            struct.primaryKeys.add(_elem41);
           }
         }
         struct.setPrimaryKeysIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list33 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list33.size);
-          @org.apache.thrift.annotation.Nullable SQLForeignKey _elem34;
-          for (int _i35 = 0; _i35 < _list33.size; ++_i35)
+          org.apache.thrift.protocol.TList _list43 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list43.size);
+          @org.apache.thrift.annotation.Nullable SQLForeignKey _elem44;
+          for (int _i45 = 0; _i45 < _list43.size; ++_i45)
           {
-            _elem34 = new SQLForeignKey();
-            _elem34.read(iprot);
-            struct.foreignKeys.add(_elem34);
+            _elem44 = new SQLForeignKey();
+            _elem44.read(iprot);
+            struct.foreignKeys.add(_elem44);
           }
         }
         struct.setForeignKeysIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list36 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list36.size);
-          @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem37;
-          for (int _i38 = 0; _i38 < _list36.size; ++_i38)
+          org.apache.thrift.protocol.TList _list46 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list46.size);
+          @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem47;
+          for (int _i48 = 0; _i48 < _list46.size; ++_i48)
           {
-            _elem37 = new SQLUniqueConstraint();
-            _elem37.read(iprot);
-            struct.uniqueConstraints.add(_elem37);
+            _elem47 = new SQLUniqueConstraint();
+            _elem47.read(iprot);
+            struct.uniqueConstraints.add(_elem47);
           }
         }
         struct.setUniqueConstraintsIsSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list39 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list39.size);
-          @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem40;
-          for (int _i41 = 0; _i41 < _list39.size; ++_i41)
+          org.apache.thrift.protocol.TList _list49 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list49.size);
+          @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem50;
+          for (int _i51 = 0; _i51 < _list49.size; ++_i51)
           {
-            _elem40 = new SQLNotNullConstraint();
-            _elem40.read(iprot);
-            struct.notNullConstraints.add(_elem40);
+            _elem50 = new SQLNotNullConstraint();
+            _elem50.read(iprot);
+            struct.notNullConstraints.add(_elem50);
           }
         }
         struct.setNotNullConstraintsIsSet(true);
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TList _list42 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list42.size);
-          @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem43;
-          for (int _i44 = 0; _i44 < _list42.size; ++_i44)
+          org.apache.thrift.protocol.TList _list52 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list52.size);
+          @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem53;
+          for (int _i54 = 0; _i54 < _list52.size; ++_i54)
           {
-            _elem43 = new SQLDefaultConstraint();
-            _elem43.read(iprot);
-            struct.defaultConstraints.add(_elem43);
+            _elem53 = new SQLDefaultConstraint();
+            _elem53.read(iprot);
+            struct.defaultConstraints.add(_elem53);
           }
         }
         struct.setDefaultConstraintsIsSet(true);
       }
       if (incoming.get(5)) {
         {
-          org.apache.thrift.protocol.TList _list45 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list45.size);
-          @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem46;
-          for (int _i47 = 0; _i47 < _list45.size; ++_i47)
+          org.apache.thrift.protocol.TList _list55 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list55.size);
+          @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem56;
+          for (int _i57 = 0; _i57 < _list55.size; ++_i57)
           {
-            _elem46 = new SQLCheckConstraint();
-            _elem46.read(iprot);
-            struct.checkConstraints.add(_elem46);
+            _elem56 = new SQLCheckConstraint();
+            _elem56.read(iprot);
+            struct.checkConstraints.add(_elem56);
           }
         }
         struct.setCheckConstraintsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Schema.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Schema.java
@@ -420,14 +420,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FIELD_SCHEMAS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list398 = iprot.readListBegin();
-                struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list398.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem399;
-                for (int _i400 = 0; _i400 < _list398.size; ++_i400)
+                org.apache.thrift.protocol.TList _list408 = iprot.readListBegin();
+                struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list408.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem409;
+                for (int _i410 = 0; _i410 < _list408.size; ++_i410)
                 {
-                  _elem399 = new FieldSchema();
-                  _elem399.read(iprot);
-                  struct.fieldSchemas.add(_elem399);
+                  _elem409 = new FieldSchema();
+                  _elem409.read(iprot);
+                  struct.fieldSchemas.add(_elem409);
                 }
                 iprot.readListEnd();
               }
@@ -439,15 +439,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // PROPERTIES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map401 = iprot.readMapBegin();
-                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map401.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key402;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val403;
-                for (int _i404 = 0; _i404 < _map401.size; ++_i404)
+                org.apache.thrift.protocol.TMap _map411 = iprot.readMapBegin();
+                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map411.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key412;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val413;
+                for (int _i414 = 0; _i414 < _map411.size; ++_i414)
                 {
-                  _key402 = iprot.readString();
-                  _val403 = iprot.readString();
-                  struct.properties.put(_key402, _val403);
+                  _key412 = iprot.readString();
+                  _val413 = iprot.readString();
+                  struct.properties.put(_key412, _val413);
                 }
                 iprot.readMapEnd();
               }
@@ -473,9 +473,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FIELD_SCHEMAS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.fieldSchemas.size()));
-          for (FieldSchema _iter405 : struct.fieldSchemas)
+          for (FieldSchema _iter415 : struct.fieldSchemas)
           {
-            _iter405.write(oprot);
+            _iter415.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -485,10 +485,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PROPERTIES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.properties.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter406 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter416 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter406.getKey());
-            oprot.writeString(_iter406.getValue());
+            oprot.writeString(_iter416.getKey());
+            oprot.writeString(_iter416.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -522,19 +522,19 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFieldSchemas()) {
         {
           oprot.writeI32(struct.fieldSchemas.size());
-          for (FieldSchema _iter407 : struct.fieldSchemas)
+          for (FieldSchema _iter417 : struct.fieldSchemas)
           {
-            _iter407.write(oprot);
+            _iter417.write(oprot);
           }
         }
       }
       if (struct.isSetProperties()) {
         {
           oprot.writeI32(struct.properties.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter408 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter418 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter408.getKey());
-            oprot.writeString(_iter408.getValue());
+            oprot.writeString(_iter418.getKey());
+            oprot.writeString(_iter418.getValue());
           }
         }
       }
@@ -546,29 +546,29 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list409 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list409.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem410;
-          for (int _i411 = 0; _i411 < _list409.size; ++_i411)
+          org.apache.thrift.protocol.TList _list419 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list419.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem420;
+          for (int _i421 = 0; _i421 < _list419.size; ++_i421)
           {
-            _elem410 = new FieldSchema();
-            _elem410.read(iprot);
-            struct.fieldSchemas.add(_elem410);
+            _elem420 = new FieldSchema();
+            _elem420.read(iprot);
+            struct.fieldSchemas.add(_elem420);
           }
         }
         struct.setFieldSchemasIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TMap _map412 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map412.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key413;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val414;
-          for (int _i415 = 0; _i415 < _map412.size; ++_i415)
+          org.apache.thrift.protocol.TMap _map422 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map422.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key423;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val424;
+          for (int _i425 = 0; _i425 < _map422.size; ++_i425)
           {
-            _key413 = iprot.readString();
-            _val414 = iprot.readString();
-            struct.properties.put(_key413, _val414);
+            _key423 = iprot.readString();
+            _val424 = iprot.readString();
+            struct.properties.put(_key423, _val424);
           }
         }
         struct.setPropertiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SerDeInfo.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SerDeInfo.java
@@ -833,15 +833,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map168 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map168.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key169;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val170;
-                for (int _i171 = 0; _i171 < _map168.size; ++_i171)
+                org.apache.thrift.protocol.TMap _map178 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map178.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key179;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val180;
+                for (int _i181 = 0; _i181 < _map178.size; ++_i181)
                 {
-                  _key169 = iprot.readString();
-                  _val170 = iprot.readString();
-                  struct.parameters.put(_key169, _val170);
+                  _key179 = iprot.readString();
+                  _val180 = iprot.readString();
+                  struct.parameters.put(_key179, _val180);
                 }
                 iprot.readMapEnd();
               }
@@ -909,10 +909,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter172 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter182 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter172.getKey());
-            oprot.writeString(_iter172.getValue());
+            oprot.writeString(_iter182.getKey());
+            oprot.writeString(_iter182.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -995,10 +995,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter173 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter183 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter173.getKey());
-            oprot.writeString(_iter173.getValue());
+            oprot.writeString(_iter183.getKey());
+            oprot.writeString(_iter183.getValue());
           }
         }
       }
@@ -1030,15 +1030,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map174 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map174.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key175;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val176;
-          for (int _i177 = 0; _i177 < _map174.size; ++_i177)
+          org.apache.thrift.protocol.TMap _map184 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map184.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key185;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val186;
+          for (int _i187 = 0; _i187 < _map184.size; ++_i187)
           {
-            _key175 = iprot.readString();
-            _val176 = iprot.readString();
-            struct.parameters.put(_key175, _val176);
+            _key185 = iprot.readString();
+            _val186 = iprot.readString();
+            struct.parameters.put(_key185, _val186);
           }
         }
         struct.parameters = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.parameters); struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SetPartitionsStatsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SetPartitionsStatsRequest.java
@@ -652,14 +652,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COL_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list390 = iprot.readListBegin();
-                struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list390.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatistics _elem391;
-                for (int _i392 = 0; _i392 < _list390.size; ++_i392)
+                org.apache.thrift.protocol.TList _list400 = iprot.readListBegin();
+                struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list400.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatistics _elem401;
+                for (int _i402 = 0; _i402 < _list400.size; ++_i402)
                 {
-                  _elem391 = new ColumnStatistics();
-                  _elem391.read(iprot);
-                  struct.colStats.add(_elem391);
+                  _elem401 = new ColumnStatistics();
+                  _elem401.read(iprot);
+                  struct.colStats.add(_elem401);
                 }
                 iprot.readListEnd();
               }
@@ -717,9 +717,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_STATS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.colStats.size()));
-          for (ColumnStatistics _iter393 : struct.colStats)
+          for (ColumnStatistics _iter403 : struct.colStats)
           {
-            _iter393.write(oprot);
+            _iter403.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -766,9 +766,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.colStats.size());
-        for (ColumnStatistics _iter394 : struct.colStats)
+        for (ColumnStatistics _iter404 : struct.colStats)
         {
-          _iter394.write(oprot);
+          _iter404.write(oprot);
         }
       }
       oprot.writeString(struct.engine);
@@ -798,14 +798,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, SetPartitionsStatsRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list395 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list395.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatistics _elem396;
-        for (int _i397 = 0; _i397 < _list395.size; ++_i397)
+        org.apache.thrift.protocol.TList _list405 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list405.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatistics _elem406;
+        for (int _i407 = 0; _i407 < _list405.size; ++_i407)
         {
-          _elem396 = new ColumnStatistics();
-          _elem396.read(iprot);
-          struct.colStats.add(_elem396);
+          _elem406 = new ColumnStatistics();
+          _elem406.read(iprot);
+          struct.colStats.add(_elem406);
         }
       }
       struct.setColStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SkewedInfo.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SkewedInfo.java
@@ -533,13 +533,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // SKEWED_COL_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list178 = iprot.readListBegin();
-                struct.skewedColNames = new java.util.ArrayList<java.lang.String>(_list178.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem179;
-                for (int _i180 = 0; _i180 < _list178.size; ++_i180)
+                org.apache.thrift.protocol.TList _list188 = iprot.readListBegin();
+                struct.skewedColNames = new java.util.ArrayList<java.lang.String>(_list188.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem189;
+                for (int _i190 = 0; _i190 < _list188.size; ++_i190)
                 {
-                  _elem179 = iprot.readString();
-                  struct.skewedColNames.add(_elem179);
+                  _elem189 = iprot.readString();
+                  struct.skewedColNames.add(_elem189);
                 }
                 iprot.readListEnd();
               }
@@ -551,23 +551,23 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // SKEWED_COL_VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list181 = iprot.readListBegin();
-                struct.skewedColValues = new java.util.ArrayList<java.util.List<java.lang.String>>(_list181.size);
-                @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _elem182;
-                for (int _i183 = 0; _i183 < _list181.size; ++_i183)
+                org.apache.thrift.protocol.TList _list191 = iprot.readListBegin();
+                struct.skewedColValues = new java.util.ArrayList<java.util.List<java.lang.String>>(_list191.size);
+                @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _elem192;
+                for (int _i193 = 0; _i193 < _list191.size; ++_i193)
                 {
                   {
-                    org.apache.thrift.protocol.TList _list184 = iprot.readListBegin();
-                    _elem182 = new java.util.ArrayList<java.lang.String>(_list184.size);
-                    @org.apache.thrift.annotation.Nullable java.lang.String _elem185;
-                    for (int _i186 = 0; _i186 < _list184.size; ++_i186)
+                    org.apache.thrift.protocol.TList _list194 = iprot.readListBegin();
+                    _elem192 = new java.util.ArrayList<java.lang.String>(_list194.size);
+                    @org.apache.thrift.annotation.Nullable java.lang.String _elem195;
+                    for (int _i196 = 0; _i196 < _list194.size; ++_i196)
                     {
-                      _elem185 = iprot.readString();
-                      _elem182.add(_elem185);
+                      _elem195 = iprot.readString();
+                      _elem192.add(_elem195);
                     }
                     iprot.readListEnd();
                   }
-                  struct.skewedColValues.add(_elem182);
+                  struct.skewedColValues.add(_elem192);
                 }
                 iprot.readListEnd();
               }
@@ -579,25 +579,25 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // SKEWED_COL_VALUE_LOCATION_MAPS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map187 = iprot.readMapBegin();
-                struct.skewedColValueLocationMaps = new java.util.HashMap<java.util.List<java.lang.String>,java.lang.String>(2*_map187.size);
-                @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _key188;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val189;
-                for (int _i190 = 0; _i190 < _map187.size; ++_i190)
+                org.apache.thrift.protocol.TMap _map197 = iprot.readMapBegin();
+                struct.skewedColValueLocationMaps = new java.util.HashMap<java.util.List<java.lang.String>,java.lang.String>(2*_map197.size);
+                @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _key198;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val199;
+                for (int _i200 = 0; _i200 < _map197.size; ++_i200)
                 {
                   {
-                    org.apache.thrift.protocol.TList _list191 = iprot.readListBegin();
-                    _key188 = new java.util.ArrayList<java.lang.String>(_list191.size);
-                    @org.apache.thrift.annotation.Nullable java.lang.String _elem192;
-                    for (int _i193 = 0; _i193 < _list191.size; ++_i193)
+                    org.apache.thrift.protocol.TList _list201 = iprot.readListBegin();
+                    _key198 = new java.util.ArrayList<java.lang.String>(_list201.size);
+                    @org.apache.thrift.annotation.Nullable java.lang.String _elem202;
+                    for (int _i203 = 0; _i203 < _list201.size; ++_i203)
                     {
-                      _elem192 = iprot.readString();
-                      _key188.add(_elem192);
+                      _elem202 = iprot.readString();
+                      _key198.add(_elem202);
                     }
                     iprot.readListEnd();
                   }
-                  _val189 = iprot.readString();
-                  struct.skewedColValueLocationMaps.put(_key188, _val189);
+                  _val199 = iprot.readString();
+                  struct.skewedColValueLocationMaps.put(_key198, _val199);
                 }
                 iprot.readMapEnd();
               }
@@ -623,9 +623,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(SKEWED_COL_NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.skewedColNames.size()));
-          for (java.lang.String _iter194 : struct.skewedColNames)
+          for (java.lang.String _iter204 : struct.skewedColNames)
           {
-            oprot.writeString(_iter194);
+            oprot.writeString(_iter204);
           }
           oprot.writeListEnd();
         }
@@ -635,13 +635,13 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(SKEWED_COL_VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, struct.skewedColValues.size()));
-          for (java.util.List<java.lang.String> _iter195 : struct.skewedColValues)
+          for (java.util.List<java.lang.String> _iter205 : struct.skewedColValues)
           {
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter195.size()));
-              for (java.lang.String _iter196 : _iter195)
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter205.size()));
+              for (java.lang.String _iter206 : _iter205)
               {
-                oprot.writeString(_iter196);
+                oprot.writeString(_iter206);
               }
               oprot.writeListEnd();
             }
@@ -654,17 +654,17 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(SKEWED_COL_VALUE_LOCATION_MAPS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRING, struct.skewedColValueLocationMaps.size()));
-          for (java.util.Map.Entry<java.util.List<java.lang.String>, java.lang.String> _iter197 : struct.skewedColValueLocationMaps.entrySet())
+          for (java.util.Map.Entry<java.util.List<java.lang.String>, java.lang.String> _iter207 : struct.skewedColValueLocationMaps.entrySet())
           {
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter197.getKey().size()));
-              for (java.lang.String _iter198 : _iter197.getKey())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter207.getKey().size()));
+              for (java.lang.String _iter208 : _iter207.getKey())
               {
-                oprot.writeString(_iter198);
+                oprot.writeString(_iter208);
               }
               oprot.writeListEnd();
             }
-            oprot.writeString(_iter197.getValue());
+            oprot.writeString(_iter207.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -701,22 +701,22 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetSkewedColNames()) {
         {
           oprot.writeI32(struct.skewedColNames.size());
-          for (java.lang.String _iter199 : struct.skewedColNames)
+          for (java.lang.String _iter209 : struct.skewedColNames)
           {
-            oprot.writeString(_iter199);
+            oprot.writeString(_iter209);
           }
         }
       }
       if (struct.isSetSkewedColValues()) {
         {
           oprot.writeI32(struct.skewedColValues.size());
-          for (java.util.List<java.lang.String> _iter200 : struct.skewedColValues)
+          for (java.util.List<java.lang.String> _iter210 : struct.skewedColValues)
           {
             {
-              oprot.writeI32(_iter200.size());
-              for (java.lang.String _iter201 : _iter200)
+              oprot.writeI32(_iter210.size());
+              for (java.lang.String _iter211 : _iter210)
               {
-                oprot.writeString(_iter201);
+                oprot.writeString(_iter211);
               }
             }
           }
@@ -725,16 +725,16 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetSkewedColValueLocationMaps()) {
         {
           oprot.writeI32(struct.skewedColValueLocationMaps.size());
-          for (java.util.Map.Entry<java.util.List<java.lang.String>, java.lang.String> _iter202 : struct.skewedColValueLocationMaps.entrySet())
+          for (java.util.Map.Entry<java.util.List<java.lang.String>, java.lang.String> _iter212 : struct.skewedColValueLocationMaps.entrySet())
           {
             {
-              oprot.writeI32(_iter202.getKey().size());
-              for (java.lang.String _iter203 : _iter202.getKey())
+              oprot.writeI32(_iter212.getKey().size());
+              for (java.lang.String _iter213 : _iter212.getKey())
               {
-                oprot.writeString(_iter203);
+                oprot.writeString(_iter213);
               }
             }
-            oprot.writeString(_iter202.getValue());
+            oprot.writeString(_iter212.getValue());
           }
         }
       }
@@ -746,59 +746,59 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list204 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.skewedColNames = new java.util.ArrayList<java.lang.String>(_list204.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem205;
-          for (int _i206 = 0; _i206 < _list204.size; ++_i206)
+          org.apache.thrift.protocol.TList _list214 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.skewedColNames = new java.util.ArrayList<java.lang.String>(_list214.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem215;
+          for (int _i216 = 0; _i216 < _list214.size; ++_i216)
           {
-            _elem205 = iprot.readString();
-            struct.skewedColNames.add(_elem205);
+            _elem215 = iprot.readString();
+            struct.skewedColNames.add(_elem215);
           }
         }
         struct.setSkewedColNamesIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list207 = iprot.readListBegin(org.apache.thrift.protocol.TType.LIST);
-          struct.skewedColValues = new java.util.ArrayList<java.util.List<java.lang.String>>(_list207.size);
-          @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _elem208;
-          for (int _i209 = 0; _i209 < _list207.size; ++_i209)
+          org.apache.thrift.protocol.TList _list217 = iprot.readListBegin(org.apache.thrift.protocol.TType.LIST);
+          struct.skewedColValues = new java.util.ArrayList<java.util.List<java.lang.String>>(_list217.size);
+          @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _elem218;
+          for (int _i219 = 0; _i219 < _list217.size; ++_i219)
           {
             {
-              org.apache.thrift.protocol.TList _list210 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-              _elem208 = new java.util.ArrayList<java.lang.String>(_list210.size);
-              @org.apache.thrift.annotation.Nullable java.lang.String _elem211;
-              for (int _i212 = 0; _i212 < _list210.size; ++_i212)
+              org.apache.thrift.protocol.TList _list220 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+              _elem218 = new java.util.ArrayList<java.lang.String>(_list220.size);
+              @org.apache.thrift.annotation.Nullable java.lang.String _elem221;
+              for (int _i222 = 0; _i222 < _list220.size; ++_i222)
               {
-                _elem211 = iprot.readString();
-                _elem208.add(_elem211);
+                _elem221 = iprot.readString();
+                _elem218.add(_elem221);
               }
             }
-            struct.skewedColValues.add(_elem208);
+            struct.skewedColValues.add(_elem218);
           }
         }
         struct.setSkewedColValuesIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map213 = iprot.readMapBegin(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRING); 
-          struct.skewedColValueLocationMaps = new java.util.HashMap<java.util.List<java.lang.String>,java.lang.String>(2*_map213.size);
-          @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _key214;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val215;
-          for (int _i216 = 0; _i216 < _map213.size; ++_i216)
+          org.apache.thrift.protocol.TMap _map223 = iprot.readMapBegin(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRING); 
+          struct.skewedColValueLocationMaps = new java.util.HashMap<java.util.List<java.lang.String>,java.lang.String>(2*_map223.size);
+          @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> _key224;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val225;
+          for (int _i226 = 0; _i226 < _map223.size; ++_i226)
           {
             {
-              org.apache.thrift.protocol.TList _list217 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-              _key214 = new java.util.ArrayList<java.lang.String>(_list217.size);
-              @org.apache.thrift.annotation.Nullable java.lang.String _elem218;
-              for (int _i219 = 0; _i219 < _list217.size; ++_i219)
+              org.apache.thrift.protocol.TList _list227 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+              _key224 = new java.util.ArrayList<java.lang.String>(_list227.size);
+              @org.apache.thrift.annotation.Nullable java.lang.String _elem228;
+              for (int _i229 = 0; _i229 < _list227.size; ++_i229)
               {
-                _elem218 = iprot.readString();
-                _key214.add(_elem218);
+                _elem228 = iprot.readString();
+                _key224.add(_elem228);
               }
             }
-            _val215 = iprot.readString();
-            struct.skewedColValueLocationMaps.put(_key214, _val215);
+            _val225 = iprot.readString();
+            struct.skewedColValueLocationMaps.put(_key224, _val225);
           }
         }
         struct.setSkewedColValueLocationMapsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
@@ -1260,14 +1260,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list220 = iprot.readListBegin();
-                struct.cols = new java.util.ArrayList<FieldSchema>(_list220.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem221;
-                for (int _i222 = 0; _i222 < _list220.size; ++_i222)
+                org.apache.thrift.protocol.TList _list230 = iprot.readListBegin();
+                struct.cols = new java.util.ArrayList<FieldSchema>(_list230.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem231;
+                for (int _i232 = 0; _i232 < _list230.size; ++_i232)
                 {
-                  _elem221 = new FieldSchema();
-                  _elem221.read(iprot);
-                  struct.cols.add(_elem221);
+                  _elem231 = new FieldSchema();
+                  _elem231.read(iprot);
+                  struct.cols.add(_elem231);
                 }
                 iprot.readListEnd();
               }
@@ -1328,13 +1328,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // BUCKET_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list223 = iprot.readListBegin();
-                struct.bucketCols = new java.util.ArrayList<java.lang.String>(_list223.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem224;
-                for (int _i225 = 0; _i225 < _list223.size; ++_i225)
+                org.apache.thrift.protocol.TList _list233 = iprot.readListBegin();
+                struct.bucketCols = new java.util.ArrayList<java.lang.String>(_list233.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem234;
+                for (int _i235 = 0; _i235 < _list233.size; ++_i235)
                 {
-                  _elem224 = iprot.readString();
-                  struct.bucketCols.add(_elem224);
+                  _elem234 = iprot.readString();
+                  struct.bucketCols.add(_elem234);
                 }
                 iprot.readListEnd();
               }
@@ -1346,14 +1346,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 9: // SORT_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list226 = iprot.readListBegin();
-                struct.sortCols = new java.util.ArrayList<Order>(_list226.size);
-                @org.apache.thrift.annotation.Nullable Order _elem227;
-                for (int _i228 = 0; _i228 < _list226.size; ++_i228)
+                org.apache.thrift.protocol.TList _list236 = iprot.readListBegin();
+                struct.sortCols = new java.util.ArrayList<Order>(_list236.size);
+                @org.apache.thrift.annotation.Nullable Order _elem237;
+                for (int _i238 = 0; _i238 < _list236.size; ++_i238)
                 {
-                  _elem227 = new Order();
-                  _elem227.read(iprot);
-                  struct.sortCols.add(_elem227);
+                  _elem237 = new Order();
+                  _elem237.read(iprot);
+                  struct.sortCols.add(_elem237);
                 }
                 iprot.readListEnd();
               }
@@ -1365,15 +1365,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 10: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map229 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map229.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key230;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val231;
-                for (int _i232 = 0; _i232 < _map229.size; ++_i232)
+                org.apache.thrift.protocol.TMap _map239 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map239.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key240;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val241;
+                for (int _i242 = 0; _i242 < _map239.size; ++_i242)
                 {
-                  _key230 = iprot.readString();
-                  _val231 = iprot.readString();
-                  struct.parameters.put(_key230, _val231);
+                  _key240 = iprot.readString();
+                  _val241 = iprot.readString();
+                  struct.parameters.put(_key240, _val241);
                 }
                 iprot.readMapEnd();
               }
@@ -1416,9 +1416,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.cols.size()));
-          for (FieldSchema _iter233 : struct.cols)
+          for (FieldSchema _iter243 : struct.cols)
           {
-            _iter233.write(oprot);
+            _iter243.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -1454,9 +1454,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(BUCKET_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.bucketCols.size()));
-          for (java.lang.String _iter234 : struct.bucketCols)
+          for (java.lang.String _iter244 : struct.bucketCols)
           {
-            oprot.writeString(_iter234);
+            oprot.writeString(_iter244);
           }
           oprot.writeListEnd();
         }
@@ -1466,9 +1466,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(SORT_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.sortCols.size()));
-          for (Order _iter235 : struct.sortCols)
+          for (Order _iter245 : struct.sortCols)
           {
-            _iter235.write(oprot);
+            _iter245.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -1478,10 +1478,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter236 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter246 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter236.getKey());
-            oprot.writeString(_iter236.getValue());
+            oprot.writeString(_iter246.getKey());
+            oprot.writeString(_iter246.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -1557,9 +1557,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetCols()) {
         {
           oprot.writeI32(struct.cols.size());
-          for (FieldSchema _iter237 : struct.cols)
+          for (FieldSchema _iter247 : struct.cols)
           {
-            _iter237.write(oprot);
+            _iter247.write(oprot);
           }
         }
       }
@@ -1584,28 +1584,28 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetBucketCols()) {
         {
           oprot.writeI32(struct.bucketCols.size());
-          for (java.lang.String _iter238 : struct.bucketCols)
+          for (java.lang.String _iter248 : struct.bucketCols)
           {
-            oprot.writeString(_iter238);
+            oprot.writeString(_iter248);
           }
         }
       }
       if (struct.isSetSortCols()) {
         {
           oprot.writeI32(struct.sortCols.size());
-          for (Order _iter239 : struct.sortCols)
+          for (Order _iter249 : struct.sortCols)
           {
-            _iter239.write(oprot);
+            _iter249.write(oprot);
           }
         }
       }
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter240 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter250 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter240.getKey());
-            oprot.writeString(_iter240.getValue());
+            oprot.writeString(_iter250.getKey());
+            oprot.writeString(_iter250.getValue());
           }
         }
       }
@@ -1623,14 +1623,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(12);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list241 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.cols = new java.util.ArrayList<FieldSchema>(_list241.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem242;
-          for (int _i243 = 0; _i243 < _list241.size; ++_i243)
+          org.apache.thrift.protocol.TList _list251 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.cols = new java.util.ArrayList<FieldSchema>(_list251.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem252;
+          for (int _i253 = 0; _i253 < _list251.size; ++_i253)
           {
-            _elem242 = new FieldSchema();
-            _elem242.read(iprot);
-            struct.cols.add(_elem242);
+            _elem252 = new FieldSchema();
+            _elem252.read(iprot);
+            struct.cols.add(_elem252);
           }
         }
         struct.setColsIsSet(true);
@@ -1662,42 +1662,42 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list244 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.bucketCols = new java.util.ArrayList<java.lang.String>(_list244.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem245;
-          for (int _i246 = 0; _i246 < _list244.size; ++_i246)
+          org.apache.thrift.protocol.TList _list254 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.bucketCols = new java.util.ArrayList<java.lang.String>(_list254.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem255;
+          for (int _i256 = 0; _i256 < _list254.size; ++_i256)
           {
-            _elem245 = iprot.readString();
-            struct.bucketCols.add(_elem245);
+            _elem255 = iprot.readString();
+            struct.bucketCols.add(_elem255);
           }
         }
         struct.bucketCols = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.bucketCols); struct.setBucketColsIsSet(true);
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TList _list247 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.sortCols = new java.util.ArrayList<Order>(_list247.size);
-          @org.apache.thrift.annotation.Nullable Order _elem248;
-          for (int _i249 = 0; _i249 < _list247.size; ++_i249)
+          org.apache.thrift.protocol.TList _list257 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.sortCols = new java.util.ArrayList<Order>(_list257.size);
+          @org.apache.thrift.annotation.Nullable Order _elem258;
+          for (int _i259 = 0; _i259 < _list257.size; ++_i259)
           {
-            _elem248 = new Order();
-            _elem248.read(iprot);
-            struct.sortCols.add(_elem248);
+            _elem258 = new Order();
+            _elem258.read(iprot);
+            struct.sortCols.add(_elem258);
           }
         }
         struct.setSortColsIsSet(true);
       }
       if (incoming.get(9)) {
         {
-          org.apache.thrift.protocol.TMap _map250 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map250.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key251;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val252;
-          for (int _i253 = 0; _i253 < _map250.size; ++_i253)
+          org.apache.thrift.protocol.TMap _map260 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map260.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key261;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val262;
+          for (int _i263 = 0; _i263 < _map260.size; ++_i263)
           {
-            _key251 = iprot.readString();
-            _val252 = iprot.readString();
-            struct.parameters.put(_key251, _val252);
+            _key261 = iprot.readString();
+            _val262 = iprot.readString();
+            struct.parameters.put(_key261, _val262);
           }
         }
         struct.parameters = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.parameters); struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
@@ -2523,14 +2523,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // PARTITION_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list296 = iprot.readListBegin();
-                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list296.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem297;
-                for (int _i298 = 0; _i298 < _list296.size; ++_i298)
+                org.apache.thrift.protocol.TList _list306 = iprot.readListBegin();
+                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list306.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem307;
+                for (int _i308 = 0; _i308 < _list306.size; ++_i308)
                 {
-                  _elem297 = new FieldSchema();
-                  _elem297.read(iprot);
-                  struct.partitionKeys.add(_elem297);
+                  _elem307 = new FieldSchema();
+                  _elem307.read(iprot);
+                  struct.partitionKeys.add(_elem307);
                 }
                 iprot.readListEnd();
               }
@@ -2542,15 +2542,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 9: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map299 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map299.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key300;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val301;
-                for (int _i302 = 0; _i302 < _map299.size; ++_i302)
+                org.apache.thrift.protocol.TMap _map309 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map309.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key310;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val311;
+                for (int _i312 = 0; _i312 < _map309.size; ++_i312)
                 {
-                  _key300 = iprot.readString();
-                  _val301 = iprot.readString();
-                  struct.parameters.put(_key300, _val301);
+                  _key310 = iprot.readString();
+                  _val311 = iprot.readString();
+                  struct.parameters.put(_key310, _val311);
                 }
                 iprot.readMapEnd();
               }
@@ -2669,13 +2669,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 23: // REQUIRED_READ_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list303 = iprot.readListBegin();
-                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list303.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem304;
-                for (int _i305 = 0; _i305 < _list303.size; ++_i305)
+                org.apache.thrift.protocol.TList _list313 = iprot.readListBegin();
+                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list313.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem314;
+                for (int _i315 = 0; _i315 < _list313.size; ++_i315)
                 {
-                  _elem304 = iprot.readString();
-                  struct.requiredReadCapabilities.add(_elem304);
+                  _elem314 = iprot.readString();
+                  struct.requiredReadCapabilities.add(_elem314);
                 }
                 iprot.readListEnd();
               }
@@ -2687,13 +2687,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 24: // REQUIRED_WRITE_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list306 = iprot.readListBegin();
-                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list306.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem307;
-                for (int _i308 = 0; _i308 < _list306.size; ++_i308)
+                org.apache.thrift.protocol.TList _list316 = iprot.readListBegin();
+                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list316.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem317;
+                for (int _i318 = 0; _i318 < _list316.size; ++_i318)
                 {
-                  _elem307 = iprot.readString();
-                  struct.requiredWriteCapabilities.add(_elem307);
+                  _elem317 = iprot.readString();
+                  struct.requiredWriteCapabilities.add(_elem317);
                 }
                 iprot.readListEnd();
               }
@@ -2774,9 +2774,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITION_KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionKeys.size()));
-          for (FieldSchema _iter309 : struct.partitionKeys)
+          for (FieldSchema _iter319 : struct.partitionKeys)
           {
-            _iter309.write(oprot);
+            _iter319.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -2786,10 +2786,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter310 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter320 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter310.getKey());
-            oprot.writeString(_iter310.getValue());
+            oprot.writeString(_iter320.getKey());
+            oprot.writeString(_iter320.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -2875,9 +2875,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_READ_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredReadCapabilities.size()));
-            for (java.lang.String _iter311 : struct.requiredReadCapabilities)
+            for (java.lang.String _iter321 : struct.requiredReadCapabilities)
             {
-              oprot.writeString(_iter311);
+              oprot.writeString(_iter321);
             }
             oprot.writeListEnd();
           }
@@ -2889,9 +2889,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_WRITE_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredWriteCapabilities.size()));
-            for (java.lang.String _iter312 : struct.requiredWriteCapabilities)
+            for (java.lang.String _iter322 : struct.requiredWriteCapabilities)
             {
-              oprot.writeString(_iter312);
+              oprot.writeString(_iter322);
             }
             oprot.writeListEnd();
           }
@@ -3041,19 +3041,19 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionKeys()) {
         {
           oprot.writeI32(struct.partitionKeys.size());
-          for (FieldSchema _iter313 : struct.partitionKeys)
+          for (FieldSchema _iter323 : struct.partitionKeys)
           {
-            _iter313.write(oprot);
+            _iter323.write(oprot);
           }
         }
       }
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter314 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter324 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter314.getKey());
-            oprot.writeString(_iter314.getValue());
+            oprot.writeString(_iter324.getKey());
+            oprot.writeString(_iter324.getValue());
           }
         }
       }
@@ -3099,18 +3099,18 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetRequiredReadCapabilities()) {
         {
           oprot.writeI32(struct.requiredReadCapabilities.size());
-          for (java.lang.String _iter315 : struct.requiredReadCapabilities)
+          for (java.lang.String _iter325 : struct.requiredReadCapabilities)
           {
-            oprot.writeString(_iter315);
+            oprot.writeString(_iter325);
           }
         }
       }
       if (struct.isSetRequiredWriteCapabilities()) {
         {
           oprot.writeI32(struct.requiredWriteCapabilities.size());
-          for (java.lang.String _iter316 : struct.requiredWriteCapabilities)
+          for (java.lang.String _iter326 : struct.requiredWriteCapabilities)
           {
-            oprot.writeString(_iter316);
+            oprot.writeString(_iter326);
           }
         }
       }
@@ -3160,29 +3160,29 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list317 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list317.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem318;
-          for (int _i319 = 0; _i319 < _list317.size; ++_i319)
+          org.apache.thrift.protocol.TList _list327 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list327.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem328;
+          for (int _i329 = 0; _i329 < _list327.size; ++_i329)
           {
-            _elem318 = new FieldSchema();
-            _elem318.read(iprot);
-            struct.partitionKeys.add(_elem318);
+            _elem328 = new FieldSchema();
+            _elem328.read(iprot);
+            struct.partitionKeys.add(_elem328);
           }
         }
         struct.setPartitionKeysIsSet(true);
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TMap _map320 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map320.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key321;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val322;
-          for (int _i323 = 0; _i323 < _map320.size; ++_i323)
+          org.apache.thrift.protocol.TMap _map330 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map330.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key331;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val332;
+          for (int _i333 = 0; _i333 < _map330.size; ++_i333)
           {
-            _key321 = iprot.readString();
-            _val322 = iprot.readString();
-            struct.parameters.put(_key321, _val322);
+            _key331 = iprot.readString();
+            _val332 = iprot.readString();
+            struct.parameters.put(_key331, _val332);
           }
         }
         struct.setParametersIsSet(true);
@@ -3244,26 +3244,26 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(22)) {
         {
-          org.apache.thrift.protocol.TList _list324 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list324.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem325;
-          for (int _i326 = 0; _i326 < _list324.size; ++_i326)
+          org.apache.thrift.protocol.TList _list334 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list334.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem335;
+          for (int _i336 = 0; _i336 < _list334.size; ++_i336)
           {
-            _elem325 = iprot.readString();
-            struct.requiredReadCapabilities.add(_elem325);
+            _elem335 = iprot.readString();
+            struct.requiredReadCapabilities.add(_elem335);
           }
         }
         struct.setRequiredReadCapabilitiesIsSet(true);
       }
       if (incoming.get(23)) {
         {
-          org.apache.thrift.protocol.TList _list327 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list327.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem328;
-          for (int _i329 = 0; _i329 < _list327.size; ++_i329)
+          org.apache.thrift.protocol.TList _list337 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list337.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem338;
+          for (int _i339 = 0; _i339 < _list337.size; ++_i339)
           {
-            _elem328 = iprot.readString();
-            struct.requiredWriteCapabilities.add(_elem328);
+            _elem338 = iprot.readString();
+            struct.requiredWriteCapabilities.add(_elem338);
           }
         }
         struct.setRequiredWriteCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TruncateTableRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TruncateTableRequest.java
@@ -122,7 +122,7 @@ package org.apache.hadoop.hive.metastore.api;
     tmpMap.put(_Fields.VALID_WRITE_ID_LIST, new org.apache.thrift.meta_data.FieldMetaData("validWriteIdList", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.ENVIRONMENT_CONTEXT, new org.apache.thrift.meta_data.FieldMetaData("environmentContext", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
-        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT        , "EnvironmentContext")));
+        new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, EnvironmentContext.class)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TruncateTableRequest.class, metaDataMap);
   }
@@ -695,6 +695,9 @@ package org.apache.hadoop.hive.metastore.api;
     }
 
     // check for sub-struct validity
+    if (environmentContext != null) {
+      environmentContext.validate();
+    }
   }
 
   private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
@@ -752,13 +755,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PART_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list126 = iprot.readListBegin();
-                struct.partNames = new java.util.ArrayList<java.lang.String>(_list126.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem127;
-                for (int _i128 = 0; _i128 < _list126.size; ++_i128)
+                org.apache.thrift.protocol.TList _list136 = iprot.readListBegin();
+                struct.partNames = new java.util.ArrayList<java.lang.String>(_list136.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem137;
+                for (int _i138 = 0; _i138 < _list136.size; ++_i138)
                 {
-                  _elem127 = iprot.readString();
-                  struct.partNames.add(_elem127);
+                  _elem137 = iprot.readString();
+                  struct.partNames.add(_elem137);
                 }
                 iprot.readListEnd();
               }
@@ -820,9 +823,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PART_NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partNames.size()));
-            for (java.lang.String _iter129 : struct.partNames)
+            for (java.lang.String _iter139 : struct.partNames)
             {
-              oprot.writeString(_iter129);
+              oprot.writeString(_iter139);
             }
             oprot.writeListEnd();
           }
@@ -884,9 +887,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartNames()) {
         {
           oprot.writeI32(struct.partNames.size());
-          for (java.lang.String _iter130 : struct.partNames)
+          for (java.lang.String _iter140 : struct.partNames)
           {
-            oprot.writeString(_iter130);
+            oprot.writeString(_iter140);
           }
         }
       }
@@ -911,13 +914,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(4);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list131 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partNames = new java.util.ArrayList<java.lang.String>(_list131.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem132;
-          for (int _i133 = 0; _i133 < _list131.size; ++_i133)
+          org.apache.thrift.protocol.TList _list141 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partNames = new java.util.ArrayList<java.lang.String>(_list141.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem142;
+          for (int _i143 = 0; _i143 < _list141.size; ++_i143)
           {
-            _elem132 = iprot.readString();
-            struct.partNames.add(_elem132);
+            _elem142 = iprot.readString();
+            struct.partNames.add(_elem142);
           }
         }
         struct.setPartNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Type.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Type.java
@@ -593,14 +593,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // FIELDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list48 = iprot.readListBegin();
-                struct.fields = new java.util.ArrayList<FieldSchema>(_list48.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem49;
-                for (int _i50 = 0; _i50 < _list48.size; ++_i50)
+                org.apache.thrift.protocol.TList _list58 = iprot.readListBegin();
+                struct.fields = new java.util.ArrayList<FieldSchema>(_list58.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem59;
+                for (int _i60 = 0; _i60 < _list58.size; ++_i60)
                 {
-                  _elem49 = new FieldSchema();
-                  _elem49.read(iprot);
-                  struct.fields.add(_elem49);
+                  _elem59 = new FieldSchema();
+                  _elem59.read(iprot);
+                  struct.fields.add(_elem59);
                 }
                 iprot.readListEnd();
               }
@@ -646,9 +646,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FIELDS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.fields.size()));
-            for (FieldSchema _iter51 : struct.fields)
+            for (FieldSchema _iter61 : struct.fields)
             {
-              _iter51.write(oprot);
+              _iter61.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -698,9 +698,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFields()) {
         {
           oprot.writeI32(struct.fields.size());
-          for (FieldSchema _iter52 : struct.fields)
+          for (FieldSchema _iter62 : struct.fields)
           {
-            _iter52.write(oprot);
+            _iter62.write(oprot);
           }
         }
       }
@@ -724,14 +724,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list53 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.fields = new java.util.ArrayList<FieldSchema>(_list53.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem54;
-          for (int _i55 = 0; _i55 < _list53.size; ++_i55)
+          org.apache.thrift.protocol.TList _list63 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.fields = new java.util.ArrayList<FieldSchema>(_list63.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem64;
+          for (int _i65 = 0; _i65 < _list63.size; ++_i65)
           {
-            _elem54 = new FieldSchema();
-            _elem54.read(iprot);
-            struct.fields.add(_elem54);
+            _elem64 = new FieldSchema();
+            _elem64.read(iprot);
+            struct.fields.add(_elem64);
           }
         }
         struct.setFieldsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AggrStats.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AggrStats.php
@@ -93,14 +93,14 @@ class AggrStats
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->colStats = array();
-                        $_size338 = 0;
-                        $_etype341 = 0;
-                        $xfer += $input->readListBegin($_etype341, $_size338);
-                        for ($_i342 = 0; $_i342 < $_size338; ++$_i342) {
-                            $elem343 = null;
-                            $elem343 = new \metastore\ColumnStatisticsObj();
-                            $xfer += $elem343->read($input);
-                            $this->colStats []= $elem343;
+                        $_size347 = 0;
+                        $_etype350 = 0;
+                        $xfer += $input->readListBegin($_etype350, $_size347);
+                        for ($_i351 = 0; $_i351 < $_size347; ++$_i351) {
+                            $elem352 = null;
+                            $elem352 = new \metastore\ColumnStatisticsObj();
+                            $xfer += $elem352->read($input);
+                            $this->colStats []= $elem352;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -141,8 +141,8 @@ class AggrStats
             }
             $xfer += $output->writeFieldBegin('colStats', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->colStats));
-            foreach ($this->colStats as $iter344) {
-                $xfer += $iter344->write($output);
+            foreach ($this->colStats as $iter353) {
+                $xfer += $iter353->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ColumnStatistics.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ColumnStatistics.php
@@ -114,14 +114,14 @@ class ColumnStatistics
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->statsObj = array();
-                        $_size232 = 0;
-                        $_etype235 = 0;
-                        $xfer += $input->readListBegin($_etype235, $_size232);
-                        for ($_i236 = 0; $_i236 < $_size232; ++$_i236) {
-                            $elem237 = null;
-                            $elem237 = new \metastore\ColumnStatisticsObj();
-                            $xfer += $elem237->read($input);
-                            $this->statsObj []= $elem237;
+                        $_size241 = 0;
+                        $_etype244 = 0;
+                        $xfer += $input->readListBegin($_etype244, $_size241);
+                        for ($_i245 = 0; $_i245 < $_size241; ++$_i245) {
+                            $elem246 = null;
+                            $elem246 = new \metastore\ColumnStatisticsObj();
+                            $xfer += $elem246->read($input);
+                            $this->statsObj []= $elem246;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -170,8 +170,8 @@ class ColumnStatistics
             }
             $xfer += $output->writeFieldBegin('statsObj', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->statsObj));
-            foreach ($this->statsObj as $iter238) {
-                $xfer += $iter238->write($output);
+            foreach ($this->statsObj as $iter247) {
+                $xfer += $iter247->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreationMetadata.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreationMetadata.php
@@ -149,13 +149,13 @@ class CreationMetadata
                 case 4:
                     if ($ftype == TType::SET) {
                         $this->tablesUsed = array();
-                        $_size224 = 0;
-                        $_etype227 = 0;
-                        $xfer += $input->readSetBegin($_etype227, $_size224);
-                        for ($_i228 = 0; $_i228 < $_size224; ++$_i228) {
-                            $elem229 = null;
-                            $xfer += $input->readString($elem229);
-                            $this->tablesUsed[$elem229] = true;
+                        $_size233 = 0;
+                        $_etype236 = 0;
+                        $xfer += $input->readSetBegin($_etype236, $_size233);
+                        for ($_i237 = 0; $_i237 < $_size233; ++$_i237) {
+                            $elem238 = null;
+                            $xfer += $input->readString($elem238);
+                            $this->tablesUsed[$elem238] = true;
                         }
                         $xfer += $input->readSetEnd();
                     } else {
@@ -211,8 +211,8 @@ class CreationMetadata
             }
             $xfer += $output->writeFieldBegin('tablesUsed', TType::SET, 4);
             $output->writeSetBegin(TType::STRING, count($this->tablesUsed));
-            foreach ($this->tablesUsed as $iter230 => $iter231) {
-                $xfer += $output->writeString($iter230);
+            foreach ($this->tablesUsed as $iter239 => $iter240) {
+                $xfer += $output->writeString($iter239);
             }
             $output->writeSetEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Database.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Database.php
@@ -240,16 +240,16 @@ class Database
                 case 4:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size139 = 0;
-                        $_ktype140 = 0;
-                        $_vtype141 = 0;
-                        $xfer += $input->readMapBegin($_ktype140, $_vtype141, $_size139);
-                        for ($_i143 = 0; $_i143 < $_size139; ++$_i143) {
-                            $key144 = '';
-                            $val145 = '';
-                            $xfer += $input->readString($key144);
-                            $xfer += $input->readString($val145);
-                            $this->parameters[$key144] = $val145;
+                        $_size148 = 0;
+                        $_ktype149 = 0;
+                        $_vtype150 = 0;
+                        $xfer += $input->readMapBegin($_ktype149, $_vtype150, $_size148);
+                        for ($_i152 = 0; $_i152 < $_size148; ++$_i152) {
+                            $key153 = '';
+                            $val154 = '';
+                            $xfer += $input->readString($key153);
+                            $xfer += $input->readString($val154);
+                            $this->parameters[$key153] = $val154;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -355,9 +355,9 @@ class Database
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 4);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter146 => $viter147) {
-                $xfer += $output->writeString($kiter146);
-                $xfer += $output->writeString($viter147);
+            foreach ($this->parameters as $kiter155 => $viter156) {
+                $xfer += $output->writeString($kiter155);
+                $xfer += $output->writeString($viter156);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/EnvironmentContext.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/EnvironmentContext.php
@@ -72,16 +72,16 @@ class EnvironmentContext
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->properties = array();
-                        $_size368 = 0;
-                        $_ktype369 = 0;
-                        $_vtype370 = 0;
-                        $xfer += $input->readMapBegin($_ktype369, $_vtype370, $_size368);
-                        for ($_i372 = 0; $_i372 < $_size368; ++$_i372) {
-                            $key373 = '';
-                            $val374 = '';
-                            $xfer += $input->readString($key373);
-                            $xfer += $input->readString($val374);
-                            $this->properties[$key373] = $val374;
+                        $_size0 = 0;
+                        $_ktype1 = 0;
+                        $_vtype2 = 0;
+                        $xfer += $input->readMapBegin($_ktype1, $_vtype2, $_size0);
+                        for ($_i4 = 0; $_i4 < $_size0; ++$_i4) {
+                            $key5 = '';
+                            $val6 = '';
+                            $xfer += $input->readString($key5);
+                            $xfer += $input->readString($val6);
+                            $this->properties[$key5] = $val6;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -108,9 +108,9 @@ class EnvironmentContext
             }
             $xfer += $output->writeFieldBegin('properties', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->properties));
-            foreach ($this->properties as $kiter375 => $viter376) {
-                $xfer += $output->writeString($kiter375);
-                $xfer += $output->writeString($viter376);
+            foreach ($this->properties as $kiter7 => $viter8) {
+                $xfer += $output->writeString($kiter7);
+                $xfer += $output->writeString($viter8);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FileMetadata.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FileMetadata.php
@@ -106,13 +106,13 @@ class FileMetadata
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->data = array();
-                        $_size239 = 0;
-                        $_etype242 = 0;
-                        $xfer += $input->readListBegin($_etype242, $_size239);
-                        for ($_i243 = 0; $_i243 < $_size239; ++$_i243) {
-                            $elem244 = null;
-                            $xfer += $input->readString($elem244);
-                            $this->data []= $elem244;
+                        $_size248 = 0;
+                        $_etype251 = 0;
+                        $xfer += $input->readListBegin($_etype251, $_size248);
+                        for ($_i252 = 0; $_i252 < $_size248; ++$_i252) {
+                            $elem253 = null;
+                            $xfer += $input->readString($elem253);
+                            $this->data []= $elem253;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class FileMetadata
             }
             $xfer += $output->writeFieldBegin('data', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->data));
-            foreach ($this->data as $iter245) {
-                $xfer += $output->writeString($iter245);
+            foreach ($this->data as $iter254) {
+                $xfer += $output->writeString($iter254);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetCatalogsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetCatalogsResponse.php
@@ -68,13 +68,13 @@ class GetCatalogsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->names = array();
-                        $_size132 = 0;
-                        $_etype135 = 0;
-                        $xfer += $input->readListBegin($_etype135, $_size132);
-                        for ($_i136 = 0; $_i136 < $_size132; ++$_i136) {
-                            $elem137 = null;
-                            $xfer += $input->readString($elem137);
-                            $this->names []= $elem137;
+                        $_size141 = 0;
+                        $_etype144 = 0;
+                        $xfer += $input->readListBegin($_etype144, $_size141);
+                        for ($_i145 = 0; $_i145 < $_size141; ++$_i145) {
+                            $elem146 = null;
+                            $xfer += $input->readString($elem146);
+                            $this->names []= $elem146;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class GetCatalogsResponse
             }
             $xfer += $output->writeFieldBegin('names', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->names));
-            foreach ($this->names as $iter138) {
-                $xfer += $output->writeString($iter138);
+            foreach ($this->names as $iter147) {
+                $xfer += $output->writeString($iter147);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPrincipalsInRoleResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPrincipalsInRoleResponse.php
@@ -69,14 +69,14 @@ class GetPrincipalsInRoleResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->principalGrants = array();
-                        $_size125 = 0;
-                        $_etype128 = 0;
-                        $xfer += $input->readListBegin($_etype128, $_size125);
-                        for ($_i129 = 0; $_i129 < $_size125; ++$_i129) {
-                            $elem130 = null;
-                            $elem130 = new \metastore\RolePrincipalGrant();
-                            $xfer += $elem130->read($input);
-                            $this->principalGrants []= $elem130;
+                        $_size134 = 0;
+                        $_etype137 = 0;
+                        $xfer += $input->readListBegin($_etype137, $_size134);
+                        for ($_i138 = 0; $_i138 < $_size134; ++$_i138) {
+                            $elem139 = null;
+                            $elem139 = new \metastore\RolePrincipalGrant();
+                            $xfer += $elem139->read($input);
+                            $this->principalGrants []= $elem139;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetPrincipalsInRoleResponse
             }
             $xfer += $output->writeFieldBegin('principalGrants', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->principalGrants));
-            foreach ($this->principalGrants as $iter131) {
-                $xfer += $iter131->write($output);
+            foreach ($this->principalGrants as $iter140) {
+                $xfer += $iter140->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetRoleGrantsForPrincipalResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetRoleGrantsForPrincipalResponse.php
@@ -69,14 +69,14 @@ class GetRoleGrantsForPrincipalResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->principalGrants = array();
-                        $_size118 = 0;
-                        $_etype121 = 0;
-                        $xfer += $input->readListBegin($_etype121, $_size118);
-                        for ($_i122 = 0; $_i122 < $_size118; ++$_i122) {
-                            $elem123 = null;
-                            $elem123 = new \metastore\RolePrincipalGrant();
-                            $xfer += $elem123->read($input);
-                            $this->principalGrants []= $elem123;
+                        $_size127 = 0;
+                        $_etype130 = 0;
+                        $xfer += $input->readListBegin($_etype130, $_size127);
+                        for ($_i131 = 0; $_i131 < $_size127; ++$_i131) {
+                            $elem132 = null;
+                            $elem132 = new \metastore\RolePrincipalGrant();
+                            $xfer += $elem132->read($input);
+                            $this->principalGrants []= $elem132;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetRoleGrantsForPrincipalResponse
             }
             $xfer += $output->writeFieldBegin('principalGrants', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->principalGrants));
-            foreach ($this->principalGrants as $iter124) {
-                $xfer += $iter124->write($output);
+            foreach ($this->principalGrants as $iter133) {
+                $xfer += $iter133->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/HiveObjectRef.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/HiveObjectRef.php
@@ -150,13 +150,13 @@ class HiveObjectRef
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partValues = array();
-                        $_size49 = 0;
-                        $_etype52 = 0;
-                        $xfer += $input->readListBegin($_etype52, $_size49);
-                        for ($_i53 = 0; $_i53 < $_size49; ++$_i53) {
-                            $elem54 = null;
-                            $xfer += $input->readString($elem54);
-                            $this->partValues []= $elem54;
+                        $_size58 = 0;
+                        $_etype61 = 0;
+                        $xfer += $input->readListBegin($_etype61, $_size58);
+                        for ($_i62 = 0; $_i62 < $_size58; ++$_i62) {
+                            $elem63 = null;
+                            $xfer += $input->readString($elem63);
+                            $this->partValues []= $elem63;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -212,8 +212,8 @@ class HiveObjectRef
             }
             $xfer += $output->writeFieldBegin('partValues', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partValues));
-            foreach ($this->partValues as $iter55) {
-                $xfer += $output->writeString($iter55);
+            foreach ($this->partValues as $iter64) {
+                $xfer += $output->writeString($iter64);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ObjectDictionary.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ObjectDictionary.php
@@ -76,25 +76,25 @@ class ObjectDictionary
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->values = array();
-                        $_size246 = 0;
-                        $_ktype247 = 0;
-                        $_vtype248 = 0;
-                        $xfer += $input->readMapBegin($_ktype247, $_vtype248, $_size246);
-                        for ($_i250 = 0; $_i250 < $_size246; ++$_i250) {
-                            $key251 = '';
-                            $val252 = array();
-                            $xfer += $input->readString($key251);
-                            $val252 = array();
-                            $_size253 = 0;
-                            $_etype256 = 0;
-                            $xfer += $input->readListBegin($_etype256, $_size253);
-                            for ($_i257 = 0; $_i257 < $_size253; ++$_i257) {
-                                $elem258 = null;
-                                $xfer += $input->readString($elem258);
-                                $val252 []= $elem258;
+                        $_size255 = 0;
+                        $_ktype256 = 0;
+                        $_vtype257 = 0;
+                        $xfer += $input->readMapBegin($_ktype256, $_vtype257, $_size255);
+                        for ($_i259 = 0; $_i259 < $_size255; ++$_i259) {
+                            $key260 = '';
+                            $val261 = array();
+                            $xfer += $input->readString($key260);
+                            $val261 = array();
+                            $_size262 = 0;
+                            $_etype265 = 0;
+                            $xfer += $input->readListBegin($_etype265, $_size262);
+                            for ($_i266 = 0; $_i266 < $_size262; ++$_i266) {
+                                $elem267 = null;
+                                $xfer += $input->readString($elem267);
+                                $val261 []= $elem267;
                             }
                             $xfer += $input->readListEnd();
-                            $this->values[$key251] = $val252;
+                            $this->values[$key260] = $val261;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -121,11 +121,11 @@ class ObjectDictionary
             }
             $xfer += $output->writeFieldBegin('values', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->values));
-            foreach ($this->values as $kiter259 => $viter260) {
-                $xfer += $output->writeString($kiter259);
-                $output->writeListBegin(TType::STRING, count($viter260));
-                foreach ($viter260 as $iter261) {
-                    $xfer += $output->writeString($iter261);
+            foreach ($this->values as $kiter268 => $viter269) {
+                $xfer += $output->writeString($kiter268);
+                $output->writeListBegin(TType::STRING, count($viter269));
+                foreach ($viter269 as $iter270) {
+                    $xfer += $output->writeString($iter270);
                 }
                 $output->writeListEnd();
             }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
@@ -224,13 +224,13 @@ class Partition
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->values = array();
-                        $_size292 = 0;
-                        $_etype295 = 0;
-                        $xfer += $input->readListBegin($_etype295, $_size292);
-                        for ($_i296 = 0; $_i296 < $_size292; ++$_i296) {
-                            $elem297 = null;
-                            $xfer += $input->readString($elem297);
-                            $this->values []= $elem297;
+                        $_size301 = 0;
+                        $_etype304 = 0;
+                        $xfer += $input->readListBegin($_etype304, $_size301);
+                        for ($_i305 = 0; $_i305 < $_size301; ++$_i305) {
+                            $elem306 = null;
+                            $xfer += $input->readString($elem306);
+                            $this->values []= $elem306;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -276,16 +276,16 @@ class Partition
                 case 7:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size298 = 0;
-                        $_ktype299 = 0;
-                        $_vtype300 = 0;
-                        $xfer += $input->readMapBegin($_ktype299, $_vtype300, $_size298);
-                        for ($_i302 = 0; $_i302 < $_size298; ++$_i302) {
-                            $key303 = '';
-                            $val304 = '';
-                            $xfer += $input->readString($key303);
-                            $xfer += $input->readString($val304);
-                            $this->parameters[$key303] = $val304;
+                        $_size307 = 0;
+                        $_ktype308 = 0;
+                        $_vtype309 = 0;
+                        $xfer += $input->readMapBegin($_ktype308, $_vtype309, $_size307);
+                        for ($_i311 = 0; $_i311 < $_size307; ++$_i311) {
+                            $key312 = '';
+                            $val313 = '';
+                            $xfer += $input->readString($key312);
+                            $xfer += $input->readString($val313);
+                            $this->parameters[$key312] = $val313;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -357,8 +357,8 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('values', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->values));
-            foreach ($this->values as $iter305) {
-                $xfer += $output->writeString($iter305);
+            foreach ($this->values as $iter314) {
+                $xfer += $output->writeString($iter314);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -397,9 +397,9 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 7);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter306 => $viter307) {
-                $xfer += $output->writeString($kiter306);
-                $xfer += $output->writeString($viter307);
+            foreach ($this->parameters as $kiter315 => $viter316) {
+                $xfer += $output->writeString($kiter315);
+                $xfer += $output->writeString($viter316);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionListComposingSpec.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionListComposingSpec.php
@@ -69,14 +69,14 @@ class PartitionListComposingSpec
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size331 = 0;
-                        $_etype334 = 0;
-                        $xfer += $input->readListBegin($_etype334, $_size331);
-                        for ($_i335 = 0; $_i335 < $_size331; ++$_i335) {
-                            $elem336 = null;
-                            $elem336 = new \metastore\Partition();
-                            $xfer += $elem336->read($input);
-                            $this->partitions []= $elem336;
+                        $_size340 = 0;
+                        $_etype343 = 0;
+                        $xfer += $input->readListBegin($_etype343, $_size340);
+                        for ($_i344 = 0; $_i344 < $_size340; ++$_i344) {
+                            $elem345 = null;
+                            $elem345 = new \metastore\Partition();
+                            $xfer += $elem345->read($input);
+                            $this->partitions []= $elem345;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PartitionListComposingSpec
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter337) {
-                $xfer += $iter337->write($output);
+            foreach ($this->partitions as $iter346) {
+                $xfer += $iter346->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionSpecWithSharedSD.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionSpecWithSharedSD.php
@@ -82,14 +82,14 @@ class PartitionSpecWithSharedSD
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size324 = 0;
-                        $_etype327 = 0;
-                        $xfer += $input->readListBegin($_etype327, $_size324);
-                        for ($_i328 = 0; $_i328 < $_size324; ++$_i328) {
-                            $elem329 = null;
-                            $elem329 = new \metastore\PartitionWithoutSD();
-                            $xfer += $elem329->read($input);
-                            $this->partitions []= $elem329;
+                        $_size333 = 0;
+                        $_etype336 = 0;
+                        $xfer += $input->readListBegin($_etype336, $_size333);
+                        for ($_i337 = 0; $_i337 < $_size333; ++$_i337) {
+                            $elem338 = null;
+                            $elem338 = new \metastore\PartitionWithoutSD();
+                            $xfer += $elem338->read($input);
+                            $this->partitions []= $elem338;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class PartitionSpecWithSharedSD
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter330) {
-                $xfer += $iter330->write($output);
+            foreach ($this->partitions as $iter339) {
+                $xfer += $iter339->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
@@ -137,13 +137,13 @@ class PartitionWithoutSD
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->values = array();
-                        $_size308 = 0;
-                        $_etype311 = 0;
-                        $xfer += $input->readListBegin($_etype311, $_size308);
-                        for ($_i312 = 0; $_i312 < $_size308; ++$_i312) {
-                            $elem313 = null;
-                            $xfer += $input->readString($elem313);
-                            $this->values []= $elem313;
+                        $_size317 = 0;
+                        $_etype320 = 0;
+                        $xfer += $input->readListBegin($_etype320, $_size317);
+                        for ($_i321 = 0; $_i321 < $_size317; ++$_i321) {
+                            $elem322 = null;
+                            $xfer += $input->readString($elem322);
+                            $this->values []= $elem322;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -174,16 +174,16 @@ class PartitionWithoutSD
                 case 5:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size314 = 0;
-                        $_ktype315 = 0;
-                        $_vtype316 = 0;
-                        $xfer += $input->readMapBegin($_ktype315, $_vtype316, $_size314);
-                        for ($_i318 = 0; $_i318 < $_size314; ++$_i318) {
-                            $key319 = '';
-                            $val320 = '';
-                            $xfer += $input->readString($key319);
-                            $xfer += $input->readString($val320);
-                            $this->parameters[$key319] = $val320;
+                        $_size323 = 0;
+                        $_ktype324 = 0;
+                        $_vtype325 = 0;
+                        $xfer += $input->readMapBegin($_ktype324, $_vtype325, $_size323);
+                        for ($_i327 = 0; $_i327 < $_size323; ++$_i327) {
+                            $key328 = '';
+                            $val329 = '';
+                            $xfer += $input->readString($key328);
+                            $xfer += $input->readString($val329);
+                            $this->parameters[$key328] = $val329;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -218,8 +218,8 @@ class PartitionWithoutSD
             }
             $xfer += $output->writeFieldBegin('values', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->values));
-            foreach ($this->values as $iter321) {
-                $xfer += $output->writeString($iter321);
+            foreach ($this->values as $iter330) {
+                $xfer += $output->writeString($iter330);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -245,9 +245,9 @@ class PartitionWithoutSD
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 5);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter322 => $viter323) {
-                $xfer += $output->writeString($kiter322);
-                $xfer += $output->writeString($viter323);
+            foreach ($this->parameters as $kiter331 => $viter332) {
+                $xfer += $output->writeString($kiter331);
+                $xfer += $output->writeString($viter332);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrincipalPrivilegeSet.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrincipalPrivilegeSet.php
@@ -127,26 +127,26 @@ class PrincipalPrivilegeSet
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->userPrivileges = array();
-                        $_size63 = 0;
-                        $_ktype64 = 0;
-                        $_vtype65 = 0;
-                        $xfer += $input->readMapBegin($_ktype64, $_vtype65, $_size63);
-                        for ($_i67 = 0; $_i67 < $_size63; ++$_i67) {
-                            $key68 = '';
-                            $val69 = array();
-                            $xfer += $input->readString($key68);
-                            $val69 = array();
-                            $_size70 = 0;
-                            $_etype73 = 0;
-                            $xfer += $input->readListBegin($_etype73, $_size70);
-                            for ($_i74 = 0; $_i74 < $_size70; ++$_i74) {
-                                $elem75 = null;
-                                $elem75 = new \metastore\PrivilegeGrantInfo();
-                                $xfer += $elem75->read($input);
-                                $val69 []= $elem75;
+                        $_size72 = 0;
+                        $_ktype73 = 0;
+                        $_vtype74 = 0;
+                        $xfer += $input->readMapBegin($_ktype73, $_vtype74, $_size72);
+                        for ($_i76 = 0; $_i76 < $_size72; ++$_i76) {
+                            $key77 = '';
+                            $val78 = array();
+                            $xfer += $input->readString($key77);
+                            $val78 = array();
+                            $_size79 = 0;
+                            $_etype82 = 0;
+                            $xfer += $input->readListBegin($_etype82, $_size79);
+                            for ($_i83 = 0; $_i83 < $_size79; ++$_i83) {
+                                $elem84 = null;
+                                $elem84 = new \metastore\PrivilegeGrantInfo();
+                                $xfer += $elem84->read($input);
+                                $val78 []= $elem84;
                             }
                             $xfer += $input->readListEnd();
-                            $this->userPrivileges[$key68] = $val69;
+                            $this->userPrivileges[$key77] = $val78;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -156,26 +156,26 @@ class PrincipalPrivilegeSet
                 case 2:
                     if ($ftype == TType::MAP) {
                         $this->groupPrivileges = array();
-                        $_size76 = 0;
-                        $_ktype77 = 0;
-                        $_vtype78 = 0;
-                        $xfer += $input->readMapBegin($_ktype77, $_vtype78, $_size76);
-                        for ($_i80 = 0; $_i80 < $_size76; ++$_i80) {
-                            $key81 = '';
-                            $val82 = array();
-                            $xfer += $input->readString($key81);
-                            $val82 = array();
-                            $_size83 = 0;
-                            $_etype86 = 0;
-                            $xfer += $input->readListBegin($_etype86, $_size83);
-                            for ($_i87 = 0; $_i87 < $_size83; ++$_i87) {
-                                $elem88 = null;
-                                $elem88 = new \metastore\PrivilegeGrantInfo();
-                                $xfer += $elem88->read($input);
-                                $val82 []= $elem88;
+                        $_size85 = 0;
+                        $_ktype86 = 0;
+                        $_vtype87 = 0;
+                        $xfer += $input->readMapBegin($_ktype86, $_vtype87, $_size85);
+                        for ($_i89 = 0; $_i89 < $_size85; ++$_i89) {
+                            $key90 = '';
+                            $val91 = array();
+                            $xfer += $input->readString($key90);
+                            $val91 = array();
+                            $_size92 = 0;
+                            $_etype95 = 0;
+                            $xfer += $input->readListBegin($_etype95, $_size92);
+                            for ($_i96 = 0; $_i96 < $_size92; ++$_i96) {
+                                $elem97 = null;
+                                $elem97 = new \metastore\PrivilegeGrantInfo();
+                                $xfer += $elem97->read($input);
+                                $val91 []= $elem97;
                             }
                             $xfer += $input->readListEnd();
-                            $this->groupPrivileges[$key81] = $val82;
+                            $this->groupPrivileges[$key90] = $val91;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -185,26 +185,26 @@ class PrincipalPrivilegeSet
                 case 3:
                     if ($ftype == TType::MAP) {
                         $this->rolePrivileges = array();
-                        $_size89 = 0;
-                        $_ktype90 = 0;
-                        $_vtype91 = 0;
-                        $xfer += $input->readMapBegin($_ktype90, $_vtype91, $_size89);
-                        for ($_i93 = 0; $_i93 < $_size89; ++$_i93) {
-                            $key94 = '';
-                            $val95 = array();
-                            $xfer += $input->readString($key94);
-                            $val95 = array();
-                            $_size96 = 0;
-                            $_etype99 = 0;
-                            $xfer += $input->readListBegin($_etype99, $_size96);
-                            for ($_i100 = 0; $_i100 < $_size96; ++$_i100) {
-                                $elem101 = null;
-                                $elem101 = new \metastore\PrivilegeGrantInfo();
-                                $xfer += $elem101->read($input);
-                                $val95 []= $elem101;
+                        $_size98 = 0;
+                        $_ktype99 = 0;
+                        $_vtype100 = 0;
+                        $xfer += $input->readMapBegin($_ktype99, $_vtype100, $_size98);
+                        for ($_i102 = 0; $_i102 < $_size98; ++$_i102) {
+                            $key103 = '';
+                            $val104 = array();
+                            $xfer += $input->readString($key103);
+                            $val104 = array();
+                            $_size105 = 0;
+                            $_etype108 = 0;
+                            $xfer += $input->readListBegin($_etype108, $_size105);
+                            for ($_i109 = 0; $_i109 < $_size105; ++$_i109) {
+                                $elem110 = null;
+                                $elem110 = new \metastore\PrivilegeGrantInfo();
+                                $xfer += $elem110->read($input);
+                                $val104 []= $elem110;
                             }
                             $xfer += $input->readListEnd();
-                            $this->rolePrivileges[$key94] = $val95;
+                            $this->rolePrivileges[$key103] = $val104;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -231,11 +231,11 @@ class PrincipalPrivilegeSet
             }
             $xfer += $output->writeFieldBegin('userPrivileges', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->userPrivileges));
-            foreach ($this->userPrivileges as $kiter102 => $viter103) {
-                $xfer += $output->writeString($kiter102);
-                $output->writeListBegin(TType::STRUCT, count($viter103));
-                foreach ($viter103 as $iter104) {
-                    $xfer += $iter104->write($output);
+            foreach ($this->userPrivileges as $kiter111 => $viter112) {
+                $xfer += $output->writeString($kiter111);
+                $output->writeListBegin(TType::STRUCT, count($viter112));
+                foreach ($viter112 as $iter113) {
+                    $xfer += $iter113->write($output);
                 }
                 $output->writeListEnd();
             }
@@ -248,11 +248,11 @@ class PrincipalPrivilegeSet
             }
             $xfer += $output->writeFieldBegin('groupPrivileges', TType::MAP, 2);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->groupPrivileges));
-            foreach ($this->groupPrivileges as $kiter105 => $viter106) {
-                $xfer += $output->writeString($kiter105);
-                $output->writeListBegin(TType::STRUCT, count($viter106));
-                foreach ($viter106 as $iter107) {
-                    $xfer += $iter107->write($output);
+            foreach ($this->groupPrivileges as $kiter114 => $viter115) {
+                $xfer += $output->writeString($kiter114);
+                $output->writeListBegin(TType::STRUCT, count($viter115));
+                foreach ($viter115 as $iter116) {
+                    $xfer += $iter116->write($output);
                 }
                 $output->writeListEnd();
             }
@@ -265,11 +265,11 @@ class PrincipalPrivilegeSet
             }
             $xfer += $output->writeFieldBegin('rolePrivileges', TType::MAP, 3);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->rolePrivileges));
-            foreach ($this->rolePrivileges as $kiter108 => $viter109) {
-                $xfer += $output->writeString($kiter108);
-                $output->writeListBegin(TType::STRUCT, count($viter109));
-                foreach ($viter109 as $iter110) {
-                    $xfer += $iter110->write($output);
+            foreach ($this->rolePrivileges as $kiter117 => $viter118) {
+                $xfer += $output->writeString($kiter117);
+                $output->writeListBegin(TType::STRUCT, count($viter118));
+                foreach ($viter118 as $iter119) {
+                    $xfer += $iter119->write($output);
                 }
                 $output->writeListEnd();
             }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrivilegeBag.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrivilegeBag.php
@@ -69,14 +69,14 @@ class PrivilegeBag
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->privileges = array();
-                        $_size56 = 0;
-                        $_etype59 = 0;
-                        $xfer += $input->readListBegin($_etype59, $_size56);
-                        for ($_i60 = 0; $_i60 < $_size56; ++$_i60) {
-                            $elem61 = null;
-                            $elem61 = new \metastore\HiveObjectPrivilege();
-                            $xfer += $elem61->read($input);
-                            $this->privileges []= $elem61;
+                        $_size65 = 0;
+                        $_etype68 = 0;
+                        $xfer += $input->readListBegin($_etype68, $_size65);
+                        for ($_i69 = 0; $_i69 < $_size65; ++$_i69) {
+                            $elem70 = null;
+                            $elem70 = new \metastore\HiveObjectPrivilege();
+                            $xfer += $elem70->read($input);
+                            $this->privileges []= $elem70;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PrivilegeBag
             }
             $xfer += $output->writeFieldBegin('privileges', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->privileges));
-            foreach ($this->privileges as $iter62) {
-                $xfer += $iter62->write($output);
+            foreach ($this->privileges as $iter71) {
+                $xfer += $iter71->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SQLAllTableConstraints.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SQLAllTableConstraints.php
@@ -154,14 +154,14 @@ class SQLAllTableConstraints
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->primaryKeys = array();
-                        $_size0 = 0;
-                        $_etype3 = 0;
-                        $xfer += $input->readListBegin($_etype3, $_size0);
-                        for ($_i4 = 0; $_i4 < $_size0; ++$_i4) {
-                            $elem5 = null;
-                            $elem5 = new \metastore\SQLPrimaryKey();
-                            $xfer += $elem5->read($input);
-                            $this->primaryKeys []= $elem5;
+                        $_size9 = 0;
+                        $_etype12 = 0;
+                        $xfer += $input->readListBegin($_etype12, $_size9);
+                        for ($_i13 = 0; $_i13 < $_size9; ++$_i13) {
+                            $elem14 = null;
+                            $elem14 = new \metastore\SQLPrimaryKey();
+                            $xfer += $elem14->read($input);
+                            $this->primaryKeys []= $elem14;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -171,14 +171,14 @@ class SQLAllTableConstraints
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->foreignKeys = array();
-                        $_size6 = 0;
-                        $_etype9 = 0;
-                        $xfer += $input->readListBegin($_etype9, $_size6);
-                        for ($_i10 = 0; $_i10 < $_size6; ++$_i10) {
-                            $elem11 = null;
-                            $elem11 = new \metastore\SQLForeignKey();
-                            $xfer += $elem11->read($input);
-                            $this->foreignKeys []= $elem11;
+                        $_size15 = 0;
+                        $_etype18 = 0;
+                        $xfer += $input->readListBegin($_etype18, $_size15);
+                        for ($_i19 = 0; $_i19 < $_size15; ++$_i19) {
+                            $elem20 = null;
+                            $elem20 = new \metastore\SQLForeignKey();
+                            $xfer += $elem20->read($input);
+                            $this->foreignKeys []= $elem20;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -188,14 +188,14 @@ class SQLAllTableConstraints
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->uniqueConstraints = array();
-                        $_size12 = 0;
-                        $_etype15 = 0;
-                        $xfer += $input->readListBegin($_etype15, $_size12);
-                        for ($_i16 = 0; $_i16 < $_size12; ++$_i16) {
-                            $elem17 = null;
-                            $elem17 = new \metastore\SQLUniqueConstraint();
-                            $xfer += $elem17->read($input);
-                            $this->uniqueConstraints []= $elem17;
+                        $_size21 = 0;
+                        $_etype24 = 0;
+                        $xfer += $input->readListBegin($_etype24, $_size21);
+                        for ($_i25 = 0; $_i25 < $_size21; ++$_i25) {
+                            $elem26 = null;
+                            $elem26 = new \metastore\SQLUniqueConstraint();
+                            $xfer += $elem26->read($input);
+                            $this->uniqueConstraints []= $elem26;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -205,14 +205,14 @@ class SQLAllTableConstraints
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->notNullConstraints = array();
-                        $_size18 = 0;
-                        $_etype21 = 0;
-                        $xfer += $input->readListBegin($_etype21, $_size18);
-                        for ($_i22 = 0; $_i22 < $_size18; ++$_i22) {
-                            $elem23 = null;
-                            $elem23 = new \metastore\SQLNotNullConstraint();
-                            $xfer += $elem23->read($input);
-                            $this->notNullConstraints []= $elem23;
+                        $_size27 = 0;
+                        $_etype30 = 0;
+                        $xfer += $input->readListBegin($_etype30, $_size27);
+                        for ($_i31 = 0; $_i31 < $_size27; ++$_i31) {
+                            $elem32 = null;
+                            $elem32 = new \metastore\SQLNotNullConstraint();
+                            $xfer += $elem32->read($input);
+                            $this->notNullConstraints []= $elem32;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -222,14 +222,14 @@ class SQLAllTableConstraints
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->defaultConstraints = array();
-                        $_size24 = 0;
-                        $_etype27 = 0;
-                        $xfer += $input->readListBegin($_etype27, $_size24);
-                        for ($_i28 = 0; $_i28 < $_size24; ++$_i28) {
-                            $elem29 = null;
-                            $elem29 = new \metastore\SQLDefaultConstraint();
-                            $xfer += $elem29->read($input);
-                            $this->defaultConstraints []= $elem29;
+                        $_size33 = 0;
+                        $_etype36 = 0;
+                        $xfer += $input->readListBegin($_etype36, $_size33);
+                        for ($_i37 = 0; $_i37 < $_size33; ++$_i37) {
+                            $elem38 = null;
+                            $elem38 = new \metastore\SQLDefaultConstraint();
+                            $xfer += $elem38->read($input);
+                            $this->defaultConstraints []= $elem38;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -239,14 +239,14 @@ class SQLAllTableConstraints
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->checkConstraints = array();
-                        $_size30 = 0;
-                        $_etype33 = 0;
-                        $xfer += $input->readListBegin($_etype33, $_size30);
-                        for ($_i34 = 0; $_i34 < $_size30; ++$_i34) {
-                            $elem35 = null;
-                            $elem35 = new \metastore\SQLCheckConstraint();
-                            $xfer += $elem35->read($input);
-                            $this->checkConstraints []= $elem35;
+                        $_size39 = 0;
+                        $_etype42 = 0;
+                        $xfer += $input->readListBegin($_etype42, $_size39);
+                        for ($_i43 = 0; $_i43 < $_size39; ++$_i43) {
+                            $elem44 = null;
+                            $elem44 = new \metastore\SQLCheckConstraint();
+                            $xfer += $elem44->read($input);
+                            $this->checkConstraints []= $elem44;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -273,8 +273,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('primaryKeys', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->primaryKeys));
-            foreach ($this->primaryKeys as $iter36) {
-                $xfer += $iter36->write($output);
+            foreach ($this->primaryKeys as $iter45) {
+                $xfer += $iter45->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -285,8 +285,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('foreignKeys', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->foreignKeys));
-            foreach ($this->foreignKeys as $iter37) {
-                $xfer += $iter37->write($output);
+            foreach ($this->foreignKeys as $iter46) {
+                $xfer += $iter46->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -297,8 +297,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('uniqueConstraints', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->uniqueConstraints));
-            foreach ($this->uniqueConstraints as $iter38) {
-                $xfer += $iter38->write($output);
+            foreach ($this->uniqueConstraints as $iter47) {
+                $xfer += $iter47->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -309,8 +309,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('notNullConstraints', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->notNullConstraints));
-            foreach ($this->notNullConstraints as $iter39) {
-                $xfer += $iter39->write($output);
+            foreach ($this->notNullConstraints as $iter48) {
+                $xfer += $iter48->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -321,8 +321,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('defaultConstraints', TType::LST, 5);
             $output->writeListBegin(TType::STRUCT, count($this->defaultConstraints));
-            foreach ($this->defaultConstraints as $iter40) {
-                $xfer += $iter40->write($output);
+            foreach ($this->defaultConstraints as $iter49) {
+                $xfer += $iter49->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -333,8 +333,8 @@ class SQLAllTableConstraints
             }
             $xfer += $output->writeFieldBegin('checkConstraints', TType::LST, 6);
             $output->writeListBegin(TType::STRUCT, count($this->checkConstraints));
-            foreach ($this->checkConstraints as $iter41) {
-                $xfer += $iter41->write($output);
+            foreach ($this->checkConstraints as $iter50) {
+                $xfer += $iter50->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Schema.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Schema.php
@@ -89,14 +89,14 @@ class Schema
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fieldSchemas = array();
-                        $_size352 = 0;
-                        $_etype355 = 0;
-                        $xfer += $input->readListBegin($_etype355, $_size352);
-                        for ($_i356 = 0; $_i356 < $_size352; ++$_i356) {
-                            $elem357 = null;
-                            $elem357 = new \metastore\FieldSchema();
-                            $xfer += $elem357->read($input);
-                            $this->fieldSchemas []= $elem357;
+                        $_size361 = 0;
+                        $_etype364 = 0;
+                        $xfer += $input->readListBegin($_etype364, $_size361);
+                        for ($_i365 = 0; $_i365 < $_size361; ++$_i365) {
+                            $elem366 = null;
+                            $elem366 = new \metastore\FieldSchema();
+                            $xfer += $elem366->read($input);
+                            $this->fieldSchemas []= $elem366;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -106,16 +106,16 @@ class Schema
                 case 2:
                     if ($ftype == TType::MAP) {
                         $this->properties = array();
-                        $_size358 = 0;
-                        $_ktype359 = 0;
-                        $_vtype360 = 0;
-                        $xfer += $input->readMapBegin($_ktype359, $_vtype360, $_size358);
-                        for ($_i362 = 0; $_i362 < $_size358; ++$_i362) {
-                            $key363 = '';
-                            $val364 = '';
-                            $xfer += $input->readString($key363);
-                            $xfer += $input->readString($val364);
-                            $this->properties[$key363] = $val364;
+                        $_size367 = 0;
+                        $_ktype368 = 0;
+                        $_vtype369 = 0;
+                        $xfer += $input->readMapBegin($_ktype368, $_vtype369, $_size367);
+                        for ($_i371 = 0; $_i371 < $_size367; ++$_i371) {
+                            $key372 = '';
+                            $val373 = '';
+                            $xfer += $input->readString($key372);
+                            $xfer += $input->readString($val373);
+                            $this->properties[$key372] = $val373;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -142,8 +142,8 @@ class Schema
             }
             $xfer += $output->writeFieldBegin('fieldSchemas', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->fieldSchemas));
-            foreach ($this->fieldSchemas as $iter365) {
-                $xfer += $iter365->write($output);
+            foreach ($this->fieldSchemas as $iter374) {
+                $xfer += $iter374->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -154,9 +154,9 @@ class Schema
             }
             $xfer += $output->writeFieldBegin('properties', TType::MAP, 2);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->properties));
-            foreach ($this->properties as $kiter366 => $viter367) {
-                $xfer += $output->writeString($kiter366);
-                $xfer += $output->writeString($viter367);
+            foreach ($this->properties as $kiter375 => $viter376) {
+                $xfer += $output->writeString($kiter375);
+                $xfer += $output->writeString($viter376);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SerDeInfo.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SerDeInfo.php
@@ -159,16 +159,16 @@ class SerDeInfo
                 case 3:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size148 = 0;
-                        $_ktype149 = 0;
-                        $_vtype150 = 0;
-                        $xfer += $input->readMapBegin($_ktype149, $_vtype150, $_size148);
-                        for ($_i152 = 0; $_i152 < $_size148; ++$_i152) {
-                            $key153 = '';
-                            $val154 = '';
-                            $xfer += $input->readString($key153);
-                            $xfer += $input->readString($val154);
-                            $this->parameters[$key153] = $val154;
+                        $_size157 = 0;
+                        $_ktype158 = 0;
+                        $_vtype159 = 0;
+                        $xfer += $input->readMapBegin($_ktype158, $_vtype159, $_size157);
+                        for ($_i161 = 0; $_i161 < $_size157; ++$_i161) {
+                            $key162 = '';
+                            $val163 = '';
+                            $xfer += $input->readString($key162);
+                            $xfer += $input->readString($val163);
+                            $this->parameters[$key162] = $val163;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -233,9 +233,9 @@ class SerDeInfo
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 3);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter155 => $viter156) {
-                $xfer += $output->writeString($kiter155);
-                $xfer += $output->writeString($viter156);
+            foreach ($this->parameters as $kiter164 => $viter165) {
+                $xfer += $output->writeString($kiter164);
+                $xfer += $output->writeString($viter165);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SetPartitionsStatsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SetPartitionsStatsRequest.php
@@ -117,14 +117,14 @@ class SetPartitionsStatsRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->colStats = array();
-                        $_size345 = 0;
-                        $_etype348 = 0;
-                        $xfer += $input->readListBegin($_etype348, $_size345);
-                        for ($_i349 = 0; $_i349 < $_size345; ++$_i349) {
-                            $elem350 = null;
-                            $elem350 = new \metastore\ColumnStatistics();
-                            $xfer += $elem350->read($input);
-                            $this->colStats []= $elem350;
+                        $_size354 = 0;
+                        $_etype357 = 0;
+                        $xfer += $input->readListBegin($_etype357, $_size354);
+                        for ($_i358 = 0; $_i358 < $_size354; ++$_i358) {
+                            $elem359 = null;
+                            $elem359 = new \metastore\ColumnStatistics();
+                            $xfer += $elem359->read($input);
+                            $this->colStats []= $elem359;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -179,8 +179,8 @@ class SetPartitionsStatsRequest
             }
             $xfer += $output->writeFieldBegin('colStats', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->colStats));
-            foreach ($this->colStats as $iter351) {
-                $xfer += $iter351->write($output);
+            foreach ($this->colStats as $iter360) {
+                $xfer += $iter360->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SkewedInfo.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SkewedInfo.php
@@ -112,13 +112,13 @@ class SkewedInfo
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->skewedColNames = array();
-                        $_size157 = 0;
-                        $_etype160 = 0;
-                        $xfer += $input->readListBegin($_etype160, $_size157);
-                        for ($_i161 = 0; $_i161 < $_size157; ++$_i161) {
-                            $elem162 = null;
-                            $xfer += $input->readString($elem162);
-                            $this->skewedColNames []= $elem162;
+                        $_size166 = 0;
+                        $_etype169 = 0;
+                        $xfer += $input->readListBegin($_etype169, $_size166);
+                        for ($_i170 = 0; $_i170 < $_size166; ++$_i170) {
+                            $elem171 = null;
+                            $xfer += $input->readString($elem171);
+                            $this->skewedColNames []= $elem171;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -128,22 +128,22 @@ class SkewedInfo
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->skewedColValues = array();
-                        $_size163 = 0;
-                        $_etype166 = 0;
-                        $xfer += $input->readListBegin($_etype166, $_size163);
-                        for ($_i167 = 0; $_i167 < $_size163; ++$_i167) {
-                            $elem168 = null;
-                            $elem168 = array();
-                            $_size169 = 0;
-                            $_etype172 = 0;
-                            $xfer += $input->readListBegin($_etype172, $_size169);
-                            for ($_i173 = 0; $_i173 < $_size169; ++$_i173) {
-                                $elem174 = null;
-                                $xfer += $input->readString($elem174);
-                                $elem168 []= $elem174;
+                        $_size172 = 0;
+                        $_etype175 = 0;
+                        $xfer += $input->readListBegin($_etype175, $_size172);
+                        for ($_i176 = 0; $_i176 < $_size172; ++$_i176) {
+                            $elem177 = null;
+                            $elem177 = array();
+                            $_size178 = 0;
+                            $_etype181 = 0;
+                            $xfer += $input->readListBegin($_etype181, $_size178);
+                            for ($_i182 = 0; $_i182 < $_size178; ++$_i182) {
+                                $elem183 = null;
+                                $xfer += $input->readString($elem183);
+                                $elem177 []= $elem183;
                             }
                             $xfer += $input->readListEnd();
-                            $this->skewedColValues []= $elem168;
+                            $this->skewedColValues []= $elem177;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -153,25 +153,25 @@ class SkewedInfo
                 case 3:
                     if ($ftype == TType::MAP) {
                         $this->skewedColValueLocationMaps = array();
-                        $_size175 = 0;
-                        $_ktype176 = 0;
-                        $_vtype177 = 0;
-                        $xfer += $input->readMapBegin($_ktype176, $_vtype177, $_size175);
-                        for ($_i179 = 0; $_i179 < $_size175; ++$_i179) {
-                            $key180 = array();
-                            $val181 = '';
-                            $key180 = array();
-                            $_size182 = 0;
-                            $_etype185 = 0;
-                            $xfer += $input->readListBegin($_etype185, $_size182);
-                            for ($_i186 = 0; $_i186 < $_size182; ++$_i186) {
-                                $elem187 = null;
-                                $xfer += $input->readString($elem187);
-                                $key180 []= $elem187;
+                        $_size184 = 0;
+                        $_ktype185 = 0;
+                        $_vtype186 = 0;
+                        $xfer += $input->readMapBegin($_ktype185, $_vtype186, $_size184);
+                        for ($_i188 = 0; $_i188 < $_size184; ++$_i188) {
+                            $key189 = array();
+                            $val190 = '';
+                            $key189 = array();
+                            $_size191 = 0;
+                            $_etype194 = 0;
+                            $xfer += $input->readListBegin($_etype194, $_size191);
+                            for ($_i195 = 0; $_i195 < $_size191; ++$_i195) {
+                                $elem196 = null;
+                                $xfer += $input->readString($elem196);
+                                $key189 []= $elem196;
                             }
                             $xfer += $input->readListEnd();
-                            $xfer += $input->readString($val181);
-                            $this->skewedColValueLocationMaps[$key180] = $val181;
+                            $xfer += $input->readString($val190);
+                            $this->skewedColValueLocationMaps[$key189] = $val190;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -198,8 +198,8 @@ class SkewedInfo
             }
             $xfer += $output->writeFieldBegin('skewedColNames', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->skewedColNames));
-            foreach ($this->skewedColNames as $iter188) {
-                $xfer += $output->writeString($iter188);
+            foreach ($this->skewedColNames as $iter197) {
+                $xfer += $output->writeString($iter197);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -210,10 +210,10 @@ class SkewedInfo
             }
             $xfer += $output->writeFieldBegin('skewedColValues', TType::LST, 2);
             $output->writeListBegin(TType::LST, count($this->skewedColValues));
-            foreach ($this->skewedColValues as $iter189) {
-                $output->writeListBegin(TType::STRING, count($iter189));
-                foreach ($iter189 as $iter190) {
-                    $xfer += $output->writeString($iter190);
+            foreach ($this->skewedColValues as $iter198) {
+                $output->writeListBegin(TType::STRING, count($iter198));
+                foreach ($iter198 as $iter199) {
+                    $xfer += $output->writeString($iter199);
                 }
                 $output->writeListEnd();
             }
@@ -226,13 +226,13 @@ class SkewedInfo
             }
             $xfer += $output->writeFieldBegin('skewedColValueLocationMaps', TType::MAP, 3);
             $output->writeMapBegin(TType::LST, TType::STRING, count($this->skewedColValueLocationMaps));
-            foreach ($this->skewedColValueLocationMaps as $kiter191 => $viter192) {
-                $output->writeListBegin(TType::STRING, count($kiter191));
-                foreach ($kiter191 as $iter193) {
-                    $xfer += $output->writeString($iter193);
+            foreach ($this->skewedColValueLocationMaps as $kiter200 => $viter201) {
+                $output->writeListBegin(TType::STRING, count($kiter200));
+                foreach ($kiter200 as $iter202) {
+                    $xfer += $output->writeString($iter202);
                 }
                 $output->writeListEnd();
-                $xfer += $output->writeString($viter192);
+                $xfer += $output->writeString($viter201);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/StorageDescriptor.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/StorageDescriptor.php
@@ -220,14 +220,14 @@ class StorageDescriptor
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->cols = array();
-                        $_size194 = 0;
-                        $_etype197 = 0;
-                        $xfer += $input->readListBegin($_etype197, $_size194);
-                        for ($_i198 = 0; $_i198 < $_size194; ++$_i198) {
-                            $elem199 = null;
-                            $elem199 = new \metastore\FieldSchema();
-                            $xfer += $elem199->read($input);
-                            $this->cols []= $elem199;
+                        $_size203 = 0;
+                        $_etype206 = 0;
+                        $xfer += $input->readListBegin($_etype206, $_size203);
+                        for ($_i207 = 0; $_i207 < $_size203; ++$_i207) {
+                            $elem208 = null;
+                            $elem208 = new \metastore\FieldSchema();
+                            $xfer += $elem208->read($input);
+                            $this->cols []= $elem208;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -280,13 +280,13 @@ class StorageDescriptor
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->bucketCols = array();
-                        $_size200 = 0;
-                        $_etype203 = 0;
-                        $xfer += $input->readListBegin($_etype203, $_size200);
-                        for ($_i204 = 0; $_i204 < $_size200; ++$_i204) {
-                            $elem205 = null;
-                            $xfer += $input->readString($elem205);
-                            $this->bucketCols []= $elem205;
+                        $_size209 = 0;
+                        $_etype212 = 0;
+                        $xfer += $input->readListBegin($_etype212, $_size209);
+                        for ($_i213 = 0; $_i213 < $_size209; ++$_i213) {
+                            $elem214 = null;
+                            $xfer += $input->readString($elem214);
+                            $this->bucketCols []= $elem214;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -296,14 +296,14 @@ class StorageDescriptor
                 case 9:
                     if ($ftype == TType::LST) {
                         $this->sortCols = array();
-                        $_size206 = 0;
-                        $_etype209 = 0;
-                        $xfer += $input->readListBegin($_etype209, $_size206);
-                        for ($_i210 = 0; $_i210 < $_size206; ++$_i210) {
-                            $elem211 = null;
-                            $elem211 = new \metastore\Order();
-                            $xfer += $elem211->read($input);
-                            $this->sortCols []= $elem211;
+                        $_size215 = 0;
+                        $_etype218 = 0;
+                        $xfer += $input->readListBegin($_etype218, $_size215);
+                        for ($_i219 = 0; $_i219 < $_size215; ++$_i219) {
+                            $elem220 = null;
+                            $elem220 = new \metastore\Order();
+                            $xfer += $elem220->read($input);
+                            $this->sortCols []= $elem220;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -313,16 +313,16 @@ class StorageDescriptor
                 case 10:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size212 = 0;
-                        $_ktype213 = 0;
-                        $_vtype214 = 0;
-                        $xfer += $input->readMapBegin($_ktype213, $_vtype214, $_size212);
-                        for ($_i216 = 0; $_i216 < $_size212; ++$_i216) {
-                            $key217 = '';
-                            $val218 = '';
-                            $xfer += $input->readString($key217);
-                            $xfer += $input->readString($val218);
-                            $this->parameters[$key217] = $val218;
+                        $_size221 = 0;
+                        $_ktype222 = 0;
+                        $_vtype223 = 0;
+                        $xfer += $input->readMapBegin($_ktype222, $_vtype223, $_size221);
+                        for ($_i225 = 0; $_i225 < $_size221; ++$_i225) {
+                            $key226 = '';
+                            $val227 = '';
+                            $xfer += $input->readString($key226);
+                            $xfer += $input->readString($val227);
+                            $this->parameters[$key226] = $val227;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -364,8 +364,8 @@ class StorageDescriptor
             }
             $xfer += $output->writeFieldBegin('cols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->cols));
-            foreach ($this->cols as $iter219) {
-                $xfer += $iter219->write($output);
+            foreach ($this->cols as $iter228) {
+                $xfer += $iter228->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -409,8 +409,8 @@ class StorageDescriptor
             }
             $xfer += $output->writeFieldBegin('bucketCols', TType::LST, 8);
             $output->writeListBegin(TType::STRING, count($this->bucketCols));
-            foreach ($this->bucketCols as $iter220) {
-                $xfer += $output->writeString($iter220);
+            foreach ($this->bucketCols as $iter229) {
+                $xfer += $output->writeString($iter229);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -421,8 +421,8 @@ class StorageDescriptor
             }
             $xfer += $output->writeFieldBegin('sortCols', TType::LST, 9);
             $output->writeListBegin(TType::STRUCT, count($this->sortCols));
-            foreach ($this->sortCols as $iter221) {
-                $xfer += $iter221->write($output);
+            foreach ($this->sortCols as $iter230) {
+                $xfer += $iter230->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -433,9 +433,9 @@ class StorageDescriptor
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 10);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter222 => $viter223) {
-                $xfer += $output->writeString($kiter222);
-                $xfer += $output->writeString($viter223);
+            foreach ($this->parameters as $kiter231 => $viter232) {
+                $xfer += $output->writeString($kiter231);
+                $xfer += $output->writeString($viter232);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Table.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Table.php
@@ -454,14 +454,14 @@ class Table
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->partitionKeys = array();
-                        $_size262 = 0;
-                        $_etype265 = 0;
-                        $xfer += $input->readListBegin($_etype265, $_size262);
-                        for ($_i266 = 0; $_i266 < $_size262; ++$_i266) {
-                            $elem267 = null;
-                            $elem267 = new \metastore\FieldSchema();
-                            $xfer += $elem267->read($input);
-                            $this->partitionKeys []= $elem267;
+                        $_size271 = 0;
+                        $_etype274 = 0;
+                        $xfer += $input->readListBegin($_etype274, $_size271);
+                        for ($_i275 = 0; $_i275 < $_size271; ++$_i275) {
+                            $elem276 = null;
+                            $elem276 = new \metastore\FieldSchema();
+                            $xfer += $elem276->read($input);
+                            $this->partitionKeys []= $elem276;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -471,16 +471,16 @@ class Table
                 case 9:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size268 = 0;
-                        $_ktype269 = 0;
-                        $_vtype270 = 0;
-                        $xfer += $input->readMapBegin($_ktype269, $_vtype270, $_size268);
-                        for ($_i272 = 0; $_i272 < $_size268; ++$_i272) {
-                            $key273 = '';
-                            $val274 = '';
-                            $xfer += $input->readString($key273);
-                            $xfer += $input->readString($val274);
-                            $this->parameters[$key273] = $val274;
+                        $_size277 = 0;
+                        $_ktype278 = 0;
+                        $_vtype279 = 0;
+                        $xfer += $input->readMapBegin($_ktype278, $_vtype279, $_size277);
+                        for ($_i281 = 0; $_i281 < $_size277; ++$_i281) {
+                            $key282 = '';
+                            $val283 = '';
+                            $xfer += $input->readString($key282);
+                            $xfer += $input->readString($val283);
+                            $this->parameters[$key282] = $val283;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -584,13 +584,13 @@ class Table
                 case 23:
                     if ($ftype == TType::LST) {
                         $this->requiredReadCapabilities = array();
-                        $_size275 = 0;
-                        $_etype278 = 0;
-                        $xfer += $input->readListBegin($_etype278, $_size275);
-                        for ($_i279 = 0; $_i279 < $_size275; ++$_i279) {
-                            $elem280 = null;
-                            $xfer += $input->readString($elem280);
-                            $this->requiredReadCapabilities []= $elem280;
+                        $_size284 = 0;
+                        $_etype287 = 0;
+                        $xfer += $input->readListBegin($_etype287, $_size284);
+                        for ($_i288 = 0; $_i288 < $_size284; ++$_i288) {
+                            $elem289 = null;
+                            $xfer += $input->readString($elem289);
+                            $this->requiredReadCapabilities []= $elem289;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -600,13 +600,13 @@ class Table
                 case 24:
                     if ($ftype == TType::LST) {
                         $this->requiredWriteCapabilities = array();
-                        $_size281 = 0;
-                        $_etype284 = 0;
-                        $xfer += $input->readListBegin($_etype284, $_size281);
-                        for ($_i285 = 0; $_i285 < $_size281; ++$_i285) {
-                            $elem286 = null;
-                            $xfer += $input->readString($elem286);
-                            $this->requiredWriteCapabilities []= $elem286;
+                        $_size290 = 0;
+                        $_etype293 = 0;
+                        $xfer += $input->readListBegin($_etype293, $_size290);
+                        for ($_i294 = 0; $_i294 < $_size290; ++$_i294) {
+                            $elem295 = null;
+                            $xfer += $input->readString($elem295);
+                            $this->requiredWriteCapabilities []= $elem295;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -694,8 +694,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('partitionKeys', TType::LST, 8);
             $output->writeListBegin(TType::STRUCT, count($this->partitionKeys));
-            foreach ($this->partitionKeys as $iter287) {
-                $xfer += $iter287->write($output);
+            foreach ($this->partitionKeys as $iter296) {
+                $xfer += $iter296->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -706,9 +706,9 @@ class Table
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 9);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter288 => $viter289) {
-                $xfer += $output->writeString($kiter288);
-                $xfer += $output->writeString($viter289);
+            foreach ($this->parameters as $kiter297 => $viter298) {
+                $xfer += $output->writeString($kiter297);
+                $xfer += $output->writeString($viter298);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();
@@ -793,8 +793,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('requiredReadCapabilities', TType::LST, 23);
             $output->writeListBegin(TType::STRING, count($this->requiredReadCapabilities));
-            foreach ($this->requiredReadCapabilities as $iter290) {
-                $xfer += $output->writeString($iter290);
+            foreach ($this->requiredReadCapabilities as $iter299) {
+                $xfer += $output->writeString($iter299);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -805,8 +805,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('requiredWriteCapabilities', TType::LST, 24);
             $output->writeListBegin(TType::STRING, count($this->requiredWriteCapabilities));
-            foreach ($this->requiredWriteCapabilities as $iter291) {
-                $xfer += $output->writeString($iter291);
+            foreach ($this->requiredWriteCapabilities as $iter300) {
+                $xfer += $output->writeString($iter300);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TruncateTableRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TruncateTableRequest.php
@@ -143,13 +143,13 @@ class TruncateTableRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->partNames = array();
-                        $_size111 = 0;
-                        $_etype114 = 0;
-                        $xfer += $input->readListBegin($_etype114, $_size111);
-                        for ($_i115 = 0; $_i115 < $_size111; ++$_i115) {
-                            $elem116 = null;
-                            $xfer += $input->readString($elem116);
-                            $this->partNames []= $elem116;
+                        $_size120 = 0;
+                        $_etype123 = 0;
+                        $xfer += $input->readListBegin($_etype123, $_size120);
+                        for ($_i124 = 0; $_i124 < $_size120; ++$_i124) {
+                            $elem125 = null;
+                            $xfer += $input->readString($elem125);
+                            $this->partNames []= $elem125;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -208,8 +208,8 @@ class TruncateTableRequest
             }
             $xfer += $output->writeFieldBegin('partNames', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->partNames));
-            foreach ($this->partNames as $iter117) {
-                $xfer += $output->writeString($iter117);
+            foreach ($this->partNames as $iter126) {
+                $xfer += $output->writeString($iter126);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Type.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Type.php
@@ -126,14 +126,14 @@ class Type
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->fields = array();
-                        $_size42 = 0;
-                        $_etype45 = 0;
-                        $xfer += $input->readListBegin($_etype45, $_size42);
-                        for ($_i46 = 0; $_i46 < $_size42; ++$_i46) {
-                            $elem47 = null;
-                            $elem47 = new \metastore\FieldSchema();
-                            $xfer += $elem47->read($input);
-                            $this->fields []= $elem47;
+                        $_size51 = 0;
+                        $_etype54 = 0;
+                        $xfer += $input->readListBegin($_etype54, $_size51);
+                        for ($_i55 = 0; $_i55 < $_size51; ++$_i55) {
+                            $elem56 = null;
+                            $elem56 = new \metastore\FieldSchema();
+                            $xfer += $elem56->read($input);
+                            $this->fields []= $elem56;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -175,8 +175,8 @@ class Type
             }
             $xfer += $output->writeFieldBegin('fields', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->fields));
-            foreach ($this->fields as $iter48) {
-                $xfer += $iter48->write($output);
+            foreach ($this->fields as $iter57) {
+                $xfer += $iter57->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -683,6 +683,73 @@ class FieldSchema(object):
         return not (self == other)
 
 
+class EnvironmentContext(object):
+    """
+    Attributes:
+     - properties
+
+    """
+
+
+    def __init__(self, properties=None,):
+        self.properties = properties
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.MAP:
+                    self.properties = {}
+                    (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
+                    for _i4 in range(_size0):
+                        _key5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val6 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.properties[_key5] = _val6
+                    iprot.readMapEnd()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('EnvironmentContext')
+        if self.properties is not None:
+            oprot.writeFieldBegin('properties', TType.MAP, 1)
+            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
+            for kiter7, viter8 in self.properties.items():
+                oprot.writeString(kiter7.encode('utf-8') if sys.version_info[0] == 2 else kiter7)
+                oprot.writeString(viter8.encode('utf-8') if sys.version_info[0] == 2 else viter8)
+            oprot.writeMapEnd()
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
 class SQLPrimaryKey(object):
     """
     Attributes:
@@ -1641,66 +1708,66 @@ class SQLAllTableConstraints(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.primaryKeys = []
-                    (_etype3, _size0) = iprot.readListBegin()
-                    for _i4 in range(_size0):
-                        _elem5 = SQLPrimaryKey()
-                        _elem5.read(iprot)
-                        self.primaryKeys.append(_elem5)
+                    (_etype12, _size9) = iprot.readListBegin()
+                    for _i13 in range(_size9):
+                        _elem14 = SQLPrimaryKey()
+                        _elem14.read(iprot)
+                        self.primaryKeys.append(_elem14)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.foreignKeys = []
-                    (_etype9, _size6) = iprot.readListBegin()
-                    for _i10 in range(_size6):
-                        _elem11 = SQLForeignKey()
-                        _elem11.read(iprot)
-                        self.foreignKeys.append(_elem11)
+                    (_etype18, _size15) = iprot.readListBegin()
+                    for _i19 in range(_size15):
+                        _elem20 = SQLForeignKey()
+                        _elem20.read(iprot)
+                        self.foreignKeys.append(_elem20)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.uniqueConstraints = []
-                    (_etype15, _size12) = iprot.readListBegin()
-                    for _i16 in range(_size12):
-                        _elem17 = SQLUniqueConstraint()
-                        _elem17.read(iprot)
-                        self.uniqueConstraints.append(_elem17)
+                    (_etype24, _size21) = iprot.readListBegin()
+                    for _i25 in range(_size21):
+                        _elem26 = SQLUniqueConstraint()
+                        _elem26.read(iprot)
+                        self.uniqueConstraints.append(_elem26)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.notNullConstraints = []
-                    (_etype21, _size18) = iprot.readListBegin()
-                    for _i22 in range(_size18):
-                        _elem23 = SQLNotNullConstraint()
-                        _elem23.read(iprot)
-                        self.notNullConstraints.append(_elem23)
+                    (_etype30, _size27) = iprot.readListBegin()
+                    for _i31 in range(_size27):
+                        _elem32 = SQLNotNullConstraint()
+                        _elem32.read(iprot)
+                        self.notNullConstraints.append(_elem32)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.defaultConstraints = []
-                    (_etype27, _size24) = iprot.readListBegin()
-                    for _i28 in range(_size24):
-                        _elem29 = SQLDefaultConstraint()
-                        _elem29.read(iprot)
-                        self.defaultConstraints.append(_elem29)
+                    (_etype36, _size33) = iprot.readListBegin()
+                    for _i37 in range(_size33):
+                        _elem38 = SQLDefaultConstraint()
+                        _elem38.read(iprot)
+                        self.defaultConstraints.append(_elem38)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.checkConstraints = []
-                    (_etype33, _size30) = iprot.readListBegin()
-                    for _i34 in range(_size30):
-                        _elem35 = SQLCheckConstraint()
-                        _elem35.read(iprot)
-                        self.checkConstraints.append(_elem35)
+                    (_etype42, _size39) = iprot.readListBegin()
+                    for _i43 in range(_size39):
+                        _elem44 = SQLCheckConstraint()
+                        _elem44.read(iprot)
+                        self.checkConstraints.append(_elem44)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1717,43 +1784,43 @@ class SQLAllTableConstraints(object):
         if self.primaryKeys is not None:
             oprot.writeFieldBegin('primaryKeys', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.primaryKeys))
-            for iter36 in self.primaryKeys:
-                iter36.write(oprot)
+            for iter45 in self.primaryKeys:
+                iter45.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.foreignKeys is not None:
             oprot.writeFieldBegin('foreignKeys', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.foreignKeys))
-            for iter37 in self.foreignKeys:
-                iter37.write(oprot)
+            for iter46 in self.foreignKeys:
+                iter46.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.uniqueConstraints is not None:
             oprot.writeFieldBegin('uniqueConstraints', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.uniqueConstraints))
-            for iter38 in self.uniqueConstraints:
-                iter38.write(oprot)
+            for iter47 in self.uniqueConstraints:
+                iter47.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.notNullConstraints is not None:
             oprot.writeFieldBegin('notNullConstraints', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.notNullConstraints))
-            for iter39 in self.notNullConstraints:
-                iter39.write(oprot)
+            for iter48 in self.notNullConstraints:
+                iter48.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.defaultConstraints is not None:
             oprot.writeFieldBegin('defaultConstraints', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.defaultConstraints))
-            for iter40 in self.defaultConstraints:
-                iter40.write(oprot)
+            for iter49 in self.defaultConstraints:
+                iter49.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.checkConstraints is not None:
             oprot.writeFieldBegin('checkConstraints', TType.LIST, 6)
             oprot.writeListBegin(TType.STRUCT, len(self.checkConstraints))
-            for iter41 in self.checkConstraints:
-                iter41.write(oprot)
+            for iter50 in self.checkConstraints:
+                iter50.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1818,11 +1885,11 @@ class Type(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.fields = []
-                    (_etype45, _size42) = iprot.readListBegin()
-                    for _i46 in range(_size42):
-                        _elem47 = FieldSchema()
-                        _elem47.read(iprot)
-                        self.fields.append(_elem47)
+                    (_etype54, _size51) = iprot.readListBegin()
+                    for _i55 in range(_size51):
+                        _elem56 = FieldSchema()
+                        _elem56.read(iprot)
+                        self.fields.append(_elem56)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1851,8 +1918,8 @@ class Type(object):
         if self.fields is not None:
             oprot.writeFieldBegin('fields', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.fields))
-            for iter48 in self.fields:
-                iter48.write(oprot)
+            for iter57 in self.fields:
+                iter57.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1921,10 +1988,10 @@ class HiveObjectRef(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partValues = []
-                    (_etype52, _size49) = iprot.readListBegin()
-                    for _i53 in range(_size49):
-                        _elem54 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partValues.append(_elem54)
+                    (_etype61, _size58) = iprot.readListBegin()
+                    for _i62 in range(_size58):
+                        _elem63 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partValues.append(_elem63)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1963,8 +2030,8 @@ class HiveObjectRef(object):
         if self.partValues is not None:
             oprot.writeFieldBegin('partValues', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partValues))
-            for iter55 in self.partValues:
-                oprot.writeString(iter55.encode('utf-8') if sys.version_info[0] == 2 else iter55)
+            for iter64 in self.partValues:
+                oprot.writeString(iter64.encode('utf-8') if sys.version_info[0] == 2 else iter64)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.columnName is not None:
@@ -2220,11 +2287,11 @@ class PrivilegeBag(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.privileges = []
-                    (_etype59, _size56) = iprot.readListBegin()
-                    for _i60 in range(_size56):
-                        _elem61 = HiveObjectPrivilege()
-                        _elem61.read(iprot)
-                        self.privileges.append(_elem61)
+                    (_etype68, _size65) = iprot.readListBegin()
+                    for _i69 in range(_size65):
+                        _elem70 = HiveObjectPrivilege()
+                        _elem70.read(iprot)
+                        self.privileges.append(_elem70)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -2241,8 +2308,8 @@ class PrivilegeBag(object):
         if self.privileges is not None:
             oprot.writeFieldBegin('privileges', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.privileges))
-            for iter62 in self.privileges:
-                iter62.write(oprot)
+            for iter71 in self.privileges:
+                iter71.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -2290,51 +2357,51 @@ class PrincipalPrivilegeSet(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.userPrivileges = {}
-                    (_ktype64, _vtype65, _size63) = iprot.readMapBegin()
-                    for _i67 in range(_size63):
-                        _key68 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val69 = []
-                        (_etype73, _size70) = iprot.readListBegin()
-                        for _i74 in range(_size70):
-                            _elem75 = PrivilegeGrantInfo()
-                            _elem75.read(iprot)
-                            _val69.append(_elem75)
+                    (_ktype73, _vtype74, _size72) = iprot.readMapBegin()
+                    for _i76 in range(_size72):
+                        _key77 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val78 = []
+                        (_etype82, _size79) = iprot.readListBegin()
+                        for _i83 in range(_size79):
+                            _elem84 = PrivilegeGrantInfo()
+                            _elem84.read(iprot)
+                            _val78.append(_elem84)
                         iprot.readListEnd()
-                        self.userPrivileges[_key68] = _val69
+                        self.userPrivileges[_key77] = _val78
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.groupPrivileges = {}
-                    (_ktype77, _vtype78, _size76) = iprot.readMapBegin()
-                    for _i80 in range(_size76):
-                        _key81 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val82 = []
-                        (_etype86, _size83) = iprot.readListBegin()
-                        for _i87 in range(_size83):
-                            _elem88 = PrivilegeGrantInfo()
-                            _elem88.read(iprot)
-                            _val82.append(_elem88)
+                    (_ktype86, _vtype87, _size85) = iprot.readMapBegin()
+                    for _i89 in range(_size85):
+                        _key90 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val91 = []
+                        (_etype95, _size92) = iprot.readListBegin()
+                        for _i96 in range(_size92):
+                            _elem97 = PrivilegeGrantInfo()
+                            _elem97.read(iprot)
+                            _val91.append(_elem97)
                         iprot.readListEnd()
-                        self.groupPrivileges[_key81] = _val82
+                        self.groupPrivileges[_key90] = _val91
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.rolePrivileges = {}
-                    (_ktype90, _vtype91, _size89) = iprot.readMapBegin()
-                    for _i93 in range(_size89):
-                        _key94 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val95 = []
-                        (_etype99, _size96) = iprot.readListBegin()
-                        for _i100 in range(_size96):
-                            _elem101 = PrivilegeGrantInfo()
-                            _elem101.read(iprot)
-                            _val95.append(_elem101)
+                    (_ktype99, _vtype100, _size98) = iprot.readMapBegin()
+                    for _i102 in range(_size98):
+                        _key103 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val104 = []
+                        (_etype108, _size105) = iprot.readListBegin()
+                        for _i109 in range(_size105):
+                            _elem110 = PrivilegeGrantInfo()
+                            _elem110.read(iprot)
+                            _val104.append(_elem110)
                         iprot.readListEnd()
-                        self.rolePrivileges[_key94] = _val95
+                        self.rolePrivileges[_key103] = _val104
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -2351,33 +2418,33 @@ class PrincipalPrivilegeSet(object):
         if self.userPrivileges is not None:
             oprot.writeFieldBegin('userPrivileges', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.userPrivileges))
-            for kiter102, viter103 in self.userPrivileges.items():
-                oprot.writeString(kiter102.encode('utf-8') if sys.version_info[0] == 2 else kiter102)
-                oprot.writeListBegin(TType.STRUCT, len(viter103))
-                for iter104 in viter103:
-                    iter104.write(oprot)
+            for kiter111, viter112 in self.userPrivileges.items():
+                oprot.writeString(kiter111.encode('utf-8') if sys.version_info[0] == 2 else kiter111)
+                oprot.writeListBegin(TType.STRUCT, len(viter112))
+                for iter113 in viter112:
+                    iter113.write(oprot)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.groupPrivileges is not None:
             oprot.writeFieldBegin('groupPrivileges', TType.MAP, 2)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.groupPrivileges))
-            for kiter105, viter106 in self.groupPrivileges.items():
-                oprot.writeString(kiter105.encode('utf-8') if sys.version_info[0] == 2 else kiter105)
-                oprot.writeListBegin(TType.STRUCT, len(viter106))
-                for iter107 in viter106:
-                    iter107.write(oprot)
+            for kiter114, viter115 in self.groupPrivileges.items():
+                oprot.writeString(kiter114.encode('utf-8') if sys.version_info[0] == 2 else kiter114)
+                oprot.writeListBegin(TType.STRUCT, len(viter115))
+                for iter116 in viter115:
+                    iter116.write(oprot)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.rolePrivileges is not None:
             oprot.writeFieldBegin('rolePrivileges', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.rolePrivileges))
-            for kiter108, viter109 in self.rolePrivileges.items():
-                oprot.writeString(kiter108.encode('utf-8') if sys.version_info[0] == 2 else kiter108)
-                oprot.writeListBegin(TType.STRUCT, len(viter109))
-                for iter110 in viter109:
-                    iter110.write(oprot)
+            for kiter117, viter118 in self.rolePrivileges.items():
+                oprot.writeString(kiter117.encode('utf-8') if sys.version_info[0] == 2 else kiter117)
+                oprot.writeListBegin(TType.STRUCT, len(viter118))
+                for iter119 in viter118:
+                    iter119.write(oprot)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -2579,10 +2646,10 @@ class TruncateTableRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.partNames = []
-                    (_etype114, _size111) = iprot.readListBegin()
-                    for _i115 in range(_size111):
-                        _elem116 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partNames.append(_elem116)
+                    (_etype123, _size120) = iprot.readListBegin()
+                    for _i124 in range(_size120):
+                        _elem125 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partNames.append(_elem125)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -2623,8 +2690,8 @@ class TruncateTableRequest(object):
         if self.partNames is not None:
             oprot.writeFieldBegin('partNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.partNames))
-            for iter117 in self.partNames:
-                oprot.writeString(iter117.encode('utf-8') if sys.version_info[0] == 2 else iter117)
+            for iter126 in self.partNames:
+                oprot.writeString(iter126.encode('utf-8') if sys.version_info[0] == 2 else iter126)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.writeId is not None:
@@ -2998,11 +3065,11 @@ class GetRoleGrantsForPrincipalResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.principalGrants = []
-                    (_etype121, _size118) = iprot.readListBegin()
-                    for _i122 in range(_size118):
-                        _elem123 = RolePrincipalGrant()
-                        _elem123.read(iprot)
-                        self.principalGrants.append(_elem123)
+                    (_etype130, _size127) = iprot.readListBegin()
+                    for _i131 in range(_size127):
+                        _elem132 = RolePrincipalGrant()
+                        _elem132.read(iprot)
+                        self.principalGrants.append(_elem132)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3019,8 +3086,8 @@ class GetRoleGrantsForPrincipalResponse(object):
         if self.principalGrants is not None:
             oprot.writeFieldBegin('principalGrants', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.principalGrants))
-            for iter124 in self.principalGrants:
-                iter124.write(oprot)
+            for iter133 in self.principalGrants:
+                iter133.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3125,11 +3192,11 @@ class GetPrincipalsInRoleResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.principalGrants = []
-                    (_etype128, _size125) = iprot.readListBegin()
-                    for _i129 in range(_size125):
-                        _elem130 = RolePrincipalGrant()
-                        _elem130.read(iprot)
-                        self.principalGrants.append(_elem130)
+                    (_etype137, _size134) = iprot.readListBegin()
+                    for _i138 in range(_size134):
+                        _elem139 = RolePrincipalGrant()
+                        _elem139.read(iprot)
+                        self.principalGrants.append(_elem139)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3146,8 +3213,8 @@ class GetPrincipalsInRoleResponse(object):
         if self.principalGrants is not None:
             oprot.writeFieldBegin('principalGrants', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.principalGrants))
-            for iter131 in self.principalGrants:
-                iter131.write(oprot)
+            for iter140 in self.principalGrants:
+                iter140.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3705,10 +3772,10 @@ class GetCatalogsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.names = []
-                    (_etype135, _size132) = iprot.readListBegin()
-                    for _i136 in range(_size132):
-                        _elem137 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.names.append(_elem137)
+                    (_etype144, _size141) = iprot.readListBegin()
+                    for _i145 in range(_size141):
+                        _elem146 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.names.append(_elem146)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3725,8 +3792,8 @@ class GetCatalogsResponse(object):
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.names))
-            for iter138 in self.names:
-                oprot.writeString(iter138.encode('utf-8') if sys.version_info[0] == 2 else iter138)
+            for iter147 in self.names:
+                oprot.writeString(iter147.encode('utf-8') if sys.version_info[0] == 2 else iter147)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3866,11 +3933,11 @@ class Database(object):
             elif fid == 4:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype140, _vtype141, _size139) = iprot.readMapBegin()
-                    for _i143 in range(_size139):
-                        _key144 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val145 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key144] = _val145
+                    (_ktype149, _vtype150, _size148) = iprot.readMapBegin()
+                    for _i152 in range(_size148):
+                        _key153 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val154 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key153] = _val154
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -3945,9 +4012,9 @@ class Database(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter146, viter147 in self.parameters.items():
-                oprot.writeString(kiter146.encode('utf-8') if sys.version_info[0] == 2 else kiter146)
-                oprot.writeString(viter147.encode('utf-8') if sys.version_info[0] == 2 else viter147)
+            for kiter155, viter156 in self.parameters.items():
+                oprot.writeString(kiter155.encode('utf-8') if sys.version_info[0] == 2 else kiter155)
+                oprot.writeString(viter156.encode('utf-8') if sys.version_info[0] == 2 else viter156)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -4049,11 +4116,11 @@ class SerDeInfo(object):
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype149, _vtype150, _size148) = iprot.readMapBegin()
-                    for _i152 in range(_size148):
-                        _key153 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val154 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key153] = _val154
+                    (_ktype158, _vtype159, _size157) = iprot.readMapBegin()
+                    for _i161 in range(_size157):
+                        _key162 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val163 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key162] = _val163
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4098,9 +4165,9 @@ class SerDeInfo(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter155, viter156 in self.parameters.items():
-                oprot.writeString(kiter155.encode('utf-8') if sys.version_info[0] == 2 else kiter155)
-                oprot.writeString(viter156.encode('utf-8') if sys.version_info[0] == 2 else viter156)
+            for kiter164, viter165 in self.parameters.items():
+                oprot.writeString(kiter164.encode('utf-8') if sys.version_info[0] == 2 else kiter164)
+                oprot.writeString(viter165.encode('utf-8') if sys.version_info[0] == 2 else viter165)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.description is not None:
@@ -4232,41 +4299,41 @@ class SkewedInfo(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.skewedColNames = []
-                    (_etype160, _size157) = iprot.readListBegin()
-                    for _i161 in range(_size157):
-                        _elem162 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.skewedColNames.append(_elem162)
+                    (_etype169, _size166) = iprot.readListBegin()
+                    for _i170 in range(_size166):
+                        _elem171 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.skewedColNames.append(_elem171)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.skewedColValues = []
-                    (_etype166, _size163) = iprot.readListBegin()
-                    for _i167 in range(_size163):
-                        _elem168 = []
-                        (_etype172, _size169) = iprot.readListBegin()
-                        for _i173 in range(_size169):
-                            _elem174 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                            _elem168.append(_elem174)
+                    (_etype175, _size172) = iprot.readListBegin()
+                    for _i176 in range(_size172):
+                        _elem177 = []
+                        (_etype181, _size178) = iprot.readListBegin()
+                        for _i182 in range(_size178):
+                            _elem183 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _elem177.append(_elem183)
                         iprot.readListEnd()
-                        self.skewedColValues.append(_elem168)
+                        self.skewedColValues.append(_elem177)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.skewedColValueLocationMaps = {}
-                    (_ktype176, _vtype177, _size175) = iprot.readMapBegin()
-                    for _i179 in range(_size175):
-                        _key180 = []
-                        (_etype185, _size182) = iprot.readListBegin()
-                        for _i186 in range(_size182):
-                            _elem187 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                            _key180.append(_elem187)
+                    (_ktype185, _vtype186, _size184) = iprot.readMapBegin()
+                    for _i188 in range(_size184):
+                        _key189 = []
+                        (_etype194, _size191) = iprot.readListBegin()
+                        for _i195 in range(_size191):
+                            _elem196 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _key189.append(_elem196)
                         iprot.readListEnd()
-                        _val181 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.skewedColValueLocationMaps[_key180] = _val181
+                        _val190 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.skewedColValueLocationMaps[_key189] = _val190
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4283,29 +4350,29 @@ class SkewedInfo(object):
         if self.skewedColNames is not None:
             oprot.writeFieldBegin('skewedColNames', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.skewedColNames))
-            for iter188 in self.skewedColNames:
-                oprot.writeString(iter188.encode('utf-8') if sys.version_info[0] == 2 else iter188)
+            for iter197 in self.skewedColNames:
+                oprot.writeString(iter197.encode('utf-8') if sys.version_info[0] == 2 else iter197)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.skewedColValues is not None:
             oprot.writeFieldBegin('skewedColValues', TType.LIST, 2)
             oprot.writeListBegin(TType.LIST, len(self.skewedColValues))
-            for iter189 in self.skewedColValues:
-                oprot.writeListBegin(TType.STRING, len(iter189))
-                for iter190 in iter189:
-                    oprot.writeString(iter190.encode('utf-8') if sys.version_info[0] == 2 else iter190)
+            for iter198 in self.skewedColValues:
+                oprot.writeListBegin(TType.STRING, len(iter198))
+                for iter199 in iter198:
+                    oprot.writeString(iter199.encode('utf-8') if sys.version_info[0] == 2 else iter199)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.skewedColValueLocationMaps is not None:
             oprot.writeFieldBegin('skewedColValueLocationMaps', TType.MAP, 3)
             oprot.writeMapBegin(TType.LIST, TType.STRING, len(self.skewedColValueLocationMaps))
-            for kiter191, viter192 in self.skewedColValueLocationMaps.items():
-                oprot.writeListBegin(TType.STRING, len(kiter191))
-                for iter193 in kiter191:
-                    oprot.writeString(iter193.encode('utf-8') if sys.version_info[0] == 2 else iter193)
+            for kiter200, viter201 in self.skewedColValueLocationMaps.items():
+                oprot.writeListBegin(TType.STRING, len(kiter200))
+                for iter202 in kiter200:
+                    oprot.writeString(iter202.encode('utf-8') if sys.version_info[0] == 2 else iter202)
                 oprot.writeListEnd()
-                oprot.writeString(viter192.encode('utf-8') if sys.version_info[0] == 2 else viter192)
+                oprot.writeString(viter201.encode('utf-8') if sys.version_info[0] == 2 else viter201)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -4371,11 +4438,11 @@ class StorageDescriptor(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.cols = []
-                    (_etype197, _size194) = iprot.readListBegin()
-                    for _i198 in range(_size194):
-                        _elem199 = FieldSchema()
-                        _elem199.read(iprot)
-                        self.cols.append(_elem199)
+                    (_etype206, _size203) = iprot.readListBegin()
+                    for _i207 in range(_size203):
+                        _elem208 = FieldSchema()
+                        _elem208.read(iprot)
+                        self.cols.append(_elem208)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4413,32 +4480,32 @@ class StorageDescriptor(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.bucketCols = []
-                    (_etype203, _size200) = iprot.readListBegin()
-                    for _i204 in range(_size200):
-                        _elem205 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.bucketCols.append(_elem205)
+                    (_etype212, _size209) = iprot.readListBegin()
+                    for _i213 in range(_size209):
+                        _elem214 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.bucketCols.append(_elem214)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
                 if ftype == TType.LIST:
                     self.sortCols = []
-                    (_etype209, _size206) = iprot.readListBegin()
-                    for _i210 in range(_size206):
-                        _elem211 = Order()
-                        _elem211.read(iprot)
-                        self.sortCols.append(_elem211)
+                    (_etype218, _size215) = iprot.readListBegin()
+                    for _i219 in range(_size215):
+                        _elem220 = Order()
+                        _elem220.read(iprot)
+                        self.sortCols.append(_elem220)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 10:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype213, _vtype214, _size212) = iprot.readMapBegin()
-                    for _i216 in range(_size212):
-                        _key217 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val218 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key217] = _val218
+                    (_ktype222, _vtype223, _size221) = iprot.readMapBegin()
+                    for _i225 in range(_size221):
+                        _key226 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val227 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key226] = _val227
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4466,8 +4533,8 @@ class StorageDescriptor(object):
         if self.cols is not None:
             oprot.writeFieldBegin('cols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.cols))
-            for iter219 in self.cols:
-                iter219.write(oprot)
+            for iter228 in self.cols:
+                iter228.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.location is not None:
@@ -4497,23 +4564,23 @@ class StorageDescriptor(object):
         if self.bucketCols is not None:
             oprot.writeFieldBegin('bucketCols', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.bucketCols))
-            for iter220 in self.bucketCols:
-                oprot.writeString(iter220.encode('utf-8') if sys.version_info[0] == 2 else iter220)
+            for iter229 in self.bucketCols:
+                oprot.writeString(iter229.encode('utf-8') if sys.version_info[0] == 2 else iter229)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sortCols is not None:
             oprot.writeFieldBegin('sortCols', TType.LIST, 9)
             oprot.writeListBegin(TType.STRUCT, len(self.sortCols))
-            for iter221 in self.sortCols:
-                iter221.write(oprot)
+            for iter230 in self.sortCols:
+                iter230.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 10)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter222, viter223 in self.parameters.items():
-                oprot.writeString(kiter222.encode('utf-8') if sys.version_info[0] == 2 else kiter222)
-                oprot.writeString(viter223.encode('utf-8') if sys.version_info[0] == 2 else viter223)
+            for kiter231, viter232 in self.parameters.items():
+                oprot.writeString(kiter231.encode('utf-8') if sys.version_info[0] == 2 else kiter231)
+                oprot.writeString(viter232.encode('utf-8') if sys.version_info[0] == 2 else viter232)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.skewedInfo is not None:
@@ -4590,10 +4657,10 @@ class CreationMetadata(object):
             elif fid == 4:
                 if ftype == TType.SET:
                     self.tablesUsed = set()
-                    (_etype227, _size224) = iprot.readSetBegin()
-                    for _i228 in range(_size224):
-                        _elem229 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tablesUsed.add(_elem229)
+                    (_etype236, _size233) = iprot.readSetBegin()
+                    for _i237 in range(_size233):
+                        _elem238 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.tablesUsed.add(_elem238)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -4632,8 +4699,8 @@ class CreationMetadata(object):
         if self.tablesUsed is not None:
             oprot.writeFieldBegin('tablesUsed', TType.SET, 4)
             oprot.writeSetBegin(TType.STRING, len(self.tablesUsed))
-            for iter230 in self.tablesUsed:
-                oprot.writeString(iter230.encode('utf-8') if sys.version_info[0] == 2 else iter230)
+            for iter239 in self.tablesUsed:
+                oprot.writeString(iter239.encode('utf-8') if sys.version_info[0] == 2 else iter239)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.validTxnList is not None:
@@ -6073,11 +6140,11 @@ class ColumnStatistics(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.statsObj = []
-                    (_etype234, _size231) = iprot.readListBegin()
-                    for _i235 in range(_size231):
-                        _elem236 = ColumnStatisticsObj()
-                        _elem236.read(iprot)
-                        self.statsObj.append(_elem236)
+                    (_etype243, _size240) = iprot.readListBegin()
+                    for _i244 in range(_size240):
+                        _elem245 = ColumnStatisticsObj()
+                        _elem245.read(iprot)
+                        self.statsObj.append(_elem245)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6108,8 +6175,8 @@ class ColumnStatistics(object):
         if self.statsObj is not None:
             oprot.writeFieldBegin('statsObj', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.statsObj))
-            for iter237 in self.statsObj:
-                iter237.write(oprot)
+            for iter246 in self.statsObj:
+                iter246.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.isStatsCompliant is not None:
@@ -6179,10 +6246,10 @@ class FileMetadata(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.data = []
-                    (_etype241, _size238) = iprot.readListBegin()
-                    for _i242 in range(_size238):
-                        _elem243 = iprot.readBinary()
-                        self.data.append(_elem243)
+                    (_etype250, _size247) = iprot.readListBegin()
+                    for _i251 in range(_size247):
+                        _elem252 = iprot.readBinary()
+                        self.data.append(_elem252)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6207,8 +6274,8 @@ class FileMetadata(object):
         if self.data is not None:
             oprot.writeFieldBegin('data', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.data))
-            for iter244 in self.data:
-                oprot.writeBinary(iter244)
+            for iter253 in self.data:
+                oprot.writeBinary(iter253)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -6252,16 +6319,16 @@ class ObjectDictionary(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.values = {}
-                    (_ktype246, _vtype247, _size245) = iprot.readMapBegin()
-                    for _i249 in range(_size245):
-                        _key250 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val251 = []
-                        (_etype255, _size252) = iprot.readListBegin()
-                        for _i256 in range(_size252):
-                            _elem257 = iprot.readBinary()
-                            _val251.append(_elem257)
+                    (_ktype255, _vtype256, _size254) = iprot.readMapBegin()
+                    for _i258 in range(_size254):
+                        _key259 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val260 = []
+                        (_etype264, _size261) = iprot.readListBegin()
+                        for _i265 in range(_size261):
+                            _elem266 = iprot.readBinary()
+                            _val260.append(_elem266)
                         iprot.readListEnd()
-                        self.values[_key250] = _val251
+                        self.values[_key259] = _val260
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6278,11 +6345,11 @@ class ObjectDictionary(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.values))
-            for kiter258, viter259 in self.values.items():
-                oprot.writeString(kiter258.encode('utf-8') if sys.version_info[0] == 2 else kiter258)
-                oprot.writeListBegin(TType.STRING, len(viter259))
-                for iter260 in viter259:
-                    oprot.writeBinary(iter260)
+            for kiter267, viter268 in self.values.items():
+                oprot.writeString(kiter267.encode('utf-8') if sys.version_info[0] == 2 else kiter267)
+                oprot.writeListBegin(TType.STRING, len(viter268))
+                for iter269 in viter268:
+                    oprot.writeBinary(iter269)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -6417,22 +6484,22 @@ class Table(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.partitionKeys = []
-                    (_etype264, _size261) = iprot.readListBegin()
-                    for _i265 in range(_size261):
-                        _elem266 = FieldSchema()
-                        _elem266.read(iprot)
-                        self.partitionKeys.append(_elem266)
+                    (_etype273, _size270) = iprot.readListBegin()
+                    for _i274 in range(_size270):
+                        _elem275 = FieldSchema()
+                        _elem275.read(iprot)
+                        self.partitionKeys.append(_elem275)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype268, _vtype269, _size267) = iprot.readMapBegin()
-                    for _i271 in range(_size267):
-                        _key272 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val273 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key272] = _val273
+                    (_ktype277, _vtype278, _size276) = iprot.readMapBegin()
+                    for _i280 in range(_size276):
+                        _key281 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val282 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key281] = _val282
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6507,20 +6574,20 @@ class Table(object):
             elif fid == 23:
                 if ftype == TType.LIST:
                     self.requiredReadCapabilities = []
-                    (_etype277, _size274) = iprot.readListBegin()
-                    for _i278 in range(_size274):
-                        _elem279 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredReadCapabilities.append(_elem279)
+                    (_etype286, _size283) = iprot.readListBegin()
+                    for _i287 in range(_size283):
+                        _elem288 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredReadCapabilities.append(_elem288)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 24:
                 if ftype == TType.LIST:
                     self.requiredWriteCapabilities = []
-                    (_etype283, _size280) = iprot.readListBegin()
-                    for _i284 in range(_size280):
-                        _elem285 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredWriteCapabilities.append(_elem285)
+                    (_etype292, _size289) = iprot.readListBegin()
+                    for _i293 in range(_size289):
+                        _elem294 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredWriteCapabilities.append(_elem294)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6582,16 +6649,16 @@ class Table(object):
         if self.partitionKeys is not None:
             oprot.writeFieldBegin('partitionKeys', TType.LIST, 8)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionKeys))
-            for iter286 in self.partitionKeys:
-                iter286.write(oprot)
+            for iter295 in self.partitionKeys:
+                iter295.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 9)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter287, viter288 in self.parameters.items():
-                oprot.writeString(kiter287.encode('utf-8') if sys.version_info[0] == 2 else kiter287)
-                oprot.writeString(viter288.encode('utf-8') if sys.version_info[0] == 2 else viter288)
+            for kiter296, viter297 in self.parameters.items():
+                oprot.writeString(kiter296.encode('utf-8') if sys.version_info[0] == 2 else kiter296)
+                oprot.writeString(viter297.encode('utf-8') if sys.version_info[0] == 2 else viter297)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.viewOriginalText is not None:
@@ -6649,15 +6716,15 @@ class Table(object):
         if self.requiredReadCapabilities is not None:
             oprot.writeFieldBegin('requiredReadCapabilities', TType.LIST, 23)
             oprot.writeListBegin(TType.STRING, len(self.requiredReadCapabilities))
-            for iter289 in self.requiredReadCapabilities:
-                oprot.writeString(iter289.encode('utf-8') if sys.version_info[0] == 2 else iter289)
+            for iter298 in self.requiredReadCapabilities:
+                oprot.writeString(iter298.encode('utf-8') if sys.version_info[0] == 2 else iter298)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.requiredWriteCapabilities is not None:
             oprot.writeFieldBegin('requiredWriteCapabilities', TType.LIST, 24)
             oprot.writeListBegin(TType.STRING, len(self.requiredWriteCapabilities))
-            for iter290 in self.requiredWriteCapabilities:
-                oprot.writeString(iter290.encode('utf-8') if sys.version_info[0] == 2 else iter290)
+            for iter299 in self.requiredWriteCapabilities:
+                oprot.writeString(iter299.encode('utf-8') if sys.version_info[0] == 2 else iter299)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.id is not None:
@@ -6737,10 +6804,10 @@ class Partition(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.values = []
-                    (_etype294, _size291) = iprot.readListBegin()
-                    for _i295 in range(_size291):
-                        _elem296 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.values.append(_elem296)
+                    (_etype303, _size300) = iprot.readListBegin()
+                    for _i304 in range(_size300):
+                        _elem305 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.values.append(_elem305)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6773,11 +6840,11 @@ class Partition(object):
             elif fid == 7:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype298, _vtype299, _size297) = iprot.readMapBegin()
-                    for _i301 in range(_size297):
-                        _key302 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val303 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key302] = _val303
+                    (_ktype307, _vtype308, _size306) = iprot.readMapBegin()
+                    for _i310 in range(_size306):
+                        _key311 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val312 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key311] = _val312
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6827,8 +6894,8 @@ class Partition(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter304 in self.values:
-                oprot.writeString(iter304.encode('utf-8') if sys.version_info[0] == 2 else iter304)
+            for iter313 in self.values:
+                oprot.writeString(iter313.encode('utf-8') if sys.version_info[0] == 2 else iter313)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.dbName is not None:
@@ -6854,9 +6921,9 @@ class Partition(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 7)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter305, viter306 in self.parameters.items():
-                oprot.writeString(kiter305.encode('utf-8') if sys.version_info[0] == 2 else kiter305)
-                oprot.writeString(viter306.encode('utf-8') if sys.version_info[0] == 2 else viter306)
+            for kiter314, viter315 in self.parameters.items():
+                oprot.writeString(kiter314.encode('utf-8') if sys.version_info[0] == 2 else kiter314)
+                oprot.writeString(viter315.encode('utf-8') if sys.version_info[0] == 2 else viter315)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -6934,10 +7001,10 @@ class PartitionWithoutSD(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.values = []
-                    (_etype310, _size307) = iprot.readListBegin()
-                    for _i311 in range(_size307):
-                        _elem312 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.values.append(_elem312)
+                    (_etype319, _size316) = iprot.readListBegin()
+                    for _i320 in range(_size316):
+                        _elem321 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.values.append(_elem321)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6959,11 +7026,11 @@ class PartitionWithoutSD(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype314, _vtype315, _size313) = iprot.readMapBegin()
-                    for _i317 in range(_size313):
-                        _key318 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val319 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key318] = _val319
+                    (_ktype323, _vtype324, _size322) = iprot.readMapBegin()
+                    for _i326 in range(_size322):
+                        _key327 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val328 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key327] = _val328
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6986,8 +7053,8 @@ class PartitionWithoutSD(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter320 in self.values:
-                oprot.writeString(iter320.encode('utf-8') if sys.version_info[0] == 2 else iter320)
+            for iter329 in self.values:
+                oprot.writeString(iter329.encode('utf-8') if sys.version_info[0] == 2 else iter329)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.createTime is not None:
@@ -7005,9 +7072,9 @@ class PartitionWithoutSD(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 5)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter321, viter322 in self.parameters.items():
-                oprot.writeString(kiter321.encode('utf-8') if sys.version_info[0] == 2 else kiter321)
-                oprot.writeString(viter322.encode('utf-8') if sys.version_info[0] == 2 else viter322)
+            for kiter330, viter331 in self.parameters.items():
+                oprot.writeString(kiter330.encode('utf-8') if sys.version_info[0] == 2 else kiter330)
+                oprot.writeString(viter331.encode('utf-8') if sys.version_info[0] == 2 else viter331)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -7057,11 +7124,11 @@ class PartitionSpecWithSharedSD(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype326, _size323) = iprot.readListBegin()
-                    for _i327 in range(_size323):
-                        _elem328 = PartitionWithoutSD()
-                        _elem328.read(iprot)
-                        self.partitions.append(_elem328)
+                    (_etype335, _size332) = iprot.readListBegin()
+                    for _i336 in range(_size332):
+                        _elem337 = PartitionWithoutSD()
+                        _elem337.read(iprot)
+                        self.partitions.append(_elem337)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7084,8 +7151,8 @@ class PartitionSpecWithSharedSD(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter329 in self.partitions:
-                iter329.write(oprot)
+            for iter338 in self.partitions:
+                iter338.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sd is not None:
@@ -7133,11 +7200,11 @@ class PartitionListComposingSpec(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype333, _size330) = iprot.readListBegin()
-                    for _i334 in range(_size330):
-                        _elem335 = Partition()
-                        _elem335.read(iprot)
-                        self.partitions.append(_elem335)
+                    (_etype342, _size339) = iprot.readListBegin()
+                    for _i343 in range(_size339):
+                        _elem344 = Partition()
+                        _elem344.read(iprot)
+                        self.partitions.append(_elem344)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7154,8 +7221,8 @@ class PartitionListComposingSpec(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter336 in self.partitions:
-                iter336.write(oprot)
+            for iter345 in self.partitions:
+                iter345.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -7339,11 +7406,11 @@ class AggrStats(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.colStats = []
-                    (_etype340, _size337) = iprot.readListBegin()
-                    for _i341 in range(_size337):
-                        _elem342 = ColumnStatisticsObj()
-                        _elem342.read(iprot)
-                        self.colStats.append(_elem342)
+                    (_etype349, _size346) = iprot.readListBegin()
+                    for _i350 in range(_size346):
+                        _elem351 = ColumnStatisticsObj()
+                        _elem351.read(iprot)
+                        self.colStats.append(_elem351)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7370,8 +7437,8 @@ class AggrStats(object):
         if self.colStats is not None:
             oprot.writeFieldBegin('colStats', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.colStats))
-            for iter343 in self.colStats:
-                iter343.write(oprot)
+            for iter352 in self.colStats:
+                iter352.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.partsFound is not None:
@@ -7435,11 +7502,11 @@ class SetPartitionsStatsRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.colStats = []
-                    (_etype347, _size344) = iprot.readListBegin()
-                    for _i348 in range(_size344):
-                        _elem349 = ColumnStatistics()
-                        _elem349.read(iprot)
-                        self.colStats.append(_elem349)
+                    (_etype356, _size353) = iprot.readListBegin()
+                    for _i357 in range(_size353):
+                        _elem358 = ColumnStatistics()
+                        _elem358.read(iprot)
+                        self.colStats.append(_elem358)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7476,8 +7543,8 @@ class SetPartitionsStatsRequest(object):
         if self.colStats is not None:
             oprot.writeFieldBegin('colStats', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.colStats))
-            for iter350 in self.colStats:
-                iter350.write(oprot)
+            for iter359 in self.colStats:
+                iter359.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.needMerge is not None:
@@ -7602,22 +7669,22 @@ class Schema(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fieldSchemas = []
-                    (_etype354, _size351) = iprot.readListBegin()
-                    for _i355 in range(_size351):
-                        _elem356 = FieldSchema()
-                        _elem356.read(iprot)
-                        self.fieldSchemas.append(_elem356)
+                    (_etype363, _size360) = iprot.readListBegin()
+                    for _i364 in range(_size360):
+                        _elem365 = FieldSchema()
+                        _elem365.read(iprot)
+                        self.fieldSchemas.append(_elem365)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.properties = {}
-                    (_ktype358, _vtype359, _size357) = iprot.readMapBegin()
-                    for _i361 in range(_size357):
-                        _key362 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val363 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.properties[_key362] = _val363
+                    (_ktype367, _vtype368, _size366) = iprot.readMapBegin()
+                    for _i370 in range(_size366):
+                        _key371 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val372 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.properties[_key371] = _val372
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -7634,79 +7701,12 @@ class Schema(object):
         if self.fieldSchemas is not None:
             oprot.writeFieldBegin('fieldSchemas', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.fieldSchemas))
-            for iter364 in self.fieldSchemas:
-                iter364.write(oprot)
+            for iter373 in self.fieldSchemas:
+                iter373.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.properties is not None:
             oprot.writeFieldBegin('properties', TType.MAP, 2)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
-            for kiter365, viter366 in self.properties.items():
-                oprot.writeString(kiter365.encode('utf-8') if sys.version_info[0] == 2 else kiter365)
-                oprot.writeString(viter366.encode('utf-8') if sys.version_info[0] == 2 else viter366)
-            oprot.writeMapEnd()
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
-
-    def validate(self):
-        return
-
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
-
-
-class EnvironmentContext(object):
-    """
-    Attributes:
-     - properties
-
-    """
-
-
-    def __init__(self, properties=None,):
-        self.properties = properties
-
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.MAP:
-                    self.properties = {}
-                    (_ktype368, _vtype369, _size367) = iprot.readMapBegin()
-                    for _i371 in range(_size367):
-                        _key372 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val373 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.properties[_key372] = _val373
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
-
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('EnvironmentContext')
-        if self.properties is not None:
-            oprot.writeFieldBegin('properties', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
             for kiter374, viter375 in self.properties.items():
                 oprot.writeString(kiter374.encode('utf-8') if sys.version_info[0] == 2 else kiter374)
@@ -28982,6 +28982,11 @@ FieldSchema.thrift_spec = (
     (2, TType.STRING, 'type', 'UTF8', None, ),  # 2
     (3, TType.STRING, 'comment', 'UTF8', None, ),  # 3
 )
+all_structs.append(EnvironmentContext)
+EnvironmentContext.thrift_spec = (
+    None,  # 0
+    (1, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 1
+)
 all_structs.append(SQLPrimaryKey)
 SQLPrimaryKey.thrift_spec = (
     None,  # 0
@@ -29552,11 +29557,6 @@ Schema.thrift_spec = (
     None,  # 0
     (1, TType.LIST, 'fieldSchemas', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 1
     (2, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 2
-)
-all_structs.append(EnvironmentContext)
-EnvironmentContext.thrift_spec = (
-    None,  # 0
-    (1, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 1
 )
 all_structs.append(PrimaryKeysRequest)
 PrimaryKeysRequest.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -241,6 +241,8 @@ class Version; end
 
 class FieldSchema; end
 
+class EnvironmentContext; end
+
 class SQLPrimaryKey; end
 
 class SQLForeignKey; end
@@ -370,8 +372,6 @@ class SetPartitionsStatsRequest; end
 class SetPartitionsStatsResponse; end
 
 class Schema; end
-
-class EnvironmentContext; end
 
 class PrimaryKeysRequest; end
 
@@ -879,6 +879,22 @@ class FieldSchema
     NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
     TYPE => {:type => ::Thrift::Types::STRING, :name => 'type'},
     COMMENT => {:type => ::Thrift::Types::STRING, :name => 'comment'}
+  }
+
+  def struct_fields; FIELDS; end
+
+  def validate
+  end
+
+  ::Thrift::Struct.generate_accessors self
+end
+
+class EnvironmentContext
+  include ::Thrift::Struct, ::Thrift::Struct_Union
+  PROPERTIES = 1
+
+  FIELDS = {
+    PROPERTIES => {:type => ::Thrift::Types::MAP, :name => 'properties', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}}
   }
 
   def struct_fields; FIELDS; end
@@ -2537,22 +2553,6 @@ class Schema
 
   FIELDS = {
     FIELDSCHEMAS => {:type => ::Thrift::Types::LIST, :name => 'fieldSchemas', :element => {:type => ::Thrift::Types::STRUCT, :class => ::FieldSchema}},
-    PROPERTIES => {:type => ::Thrift::Types::MAP, :name => 'properties', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}}
-  }
-
-  def struct_fields; FIELDS; end
-
-  def validate
-  end
-
-  ::Thrift::Struct.generate_accessors self
-end
-
-class EnvironmentContext
-  include ::Thrift::Struct, ::Thrift::Struct_Union
-  PROPERTIES = 1
-
-  FIELDS = {
     PROPERTIES => {:type => ::Thrift::Types::MAP, :name => 'properties', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}}
   }
 

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -45,6 +45,14 @@ struct FieldSchema {
   3: string comment
 }
 
+// Key-value store to be used with selected
+// Metastore APIs (create, alter methods).
+// The client can pass environment properties / configs that can be
+// accessed in hooks.
+struct EnvironmentContext {
+  1: map<string, string> properties
+}
+
 struct SQLPrimaryKey {
   1: string table_db,    // table schema
   2: string table_name,  // table name
@@ -695,14 +703,6 @@ struct Schema {
  // column names, types, comments
  1: list<FieldSchema> fieldSchemas,  // delimiters etc
  2: map<string, string> properties
-}
-
-// Key-value store to be used with selected
-// Metastore APIs (create, alter methods).
-// The client can pass environment properties / configs that can be
-// accessed in hooks.
-struct EnvironmentContext {
-  1: map<string, string> properties
 }
 
 struct PrimaryKeysRequest {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move the `EnvironmentContext` up in the thrift file, so the objects are generated in the correct order

### Why are the changes needed?
Otherwise the C++ HMS Thrift client does not compile

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests, and Impala unit tests