### PR TITLE
Switch back to alter_partition(s) in HMS client for Hive 3.1.x

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1800,8 +1800,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   @Override
   public void alter_partition(String catName, String dbName, String tblName, Partition newPart,
                               EnvironmentContext environmentContext) throws TException {
-    client.alter_partition_with_environment_context(prependCatalogToDbName(catName, dbName, conf), tblName,
-        newPart, environmentContext);
+    if (environmentContext == null) {
+      client.alter_partition(dbName, tblName, newPart);
+    } else {
+      client.alter_partition_with_environment_context(prependCatalogToDbName(catName, dbName, conf), tblName,
+              newPart, environmentContext);
+    }
   }
 
   @Override
@@ -1820,8 +1824,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   public void alter_partitions(String catName, String dbName, String tblName,
                                List<Partition> newParts,
                                EnvironmentContext environmentContext) throws TException {
-    client.alter_partitions_with_environment_context(prependCatalogToDbName(catName, dbName, conf),
-        tblName, newParts, environmentContext);
+    if (environmentContext == null) {
+      client.alter_partitions(dbName, tblName, newParts);
+    } else {
+      client.alter_partitions_with_environment_context(prependCatalogToDbName(catName, dbName, conf),
+              tblName, newParts, environmentContext);
+    }
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `alter_partition`, `alter_partitions` when `EnvironmentContext` is null.

### Why are the changes needed?
[HIVE-12730](https://issues.apache.org/jira/browse/HIVE-12730) uses `alter_partition_with_environment_context` and `alter_partitions_with_environment_context` instead of `alter_partition` and `alter_partitions` when the `EnvironmentContext` is null.
This causes the client version to be greater than 2.1 to connect to server<2.1, and this error will occur.

```java
Caused by: org.apache.thrift.TApplicationException: Invalid method name: 'alter_partitions_with_environment_context'
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:79)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_alter_partitions_with_environment_context(ThriftHiveMetastore.java:2843)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.alter_partitions_with_environment_context(ThriftHiveMetastore.java:2827)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.alter_partitions(HiveMetaStoreClient.java:1524)
```


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
exist UT
