### PR TITLE
Hive-25460 : Advance the Write ID by default 

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
@@ -28,6 +28,8 @@ public interface DDLDesc {
   interface DDLDescWithWriteId extends DDLDesc {
     void setWriteId(long writeId);
     String getFullTableName();
-    boolean mayNeedWriteId();
+    default boolean mayNeedWriteId() {
+      return true;
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
@@ -30,7 +30,7 @@ public interface DDLDesc {
     String getFullTableName();
     // We have to advance the Write Id during DDL for transactional tables, so that
     // we can provide strong consistency when serving the metadata from the cache.
-    // Override this method, only if you are sure that advancing the write Id is not relevant for your DDL.
+    // Override this method, only if you are sure that advancing the write Id is not required for your DDL.
     default boolean mayNeedWriteId() {
       return true;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLDesc.java
@@ -28,6 +28,9 @@ public interface DDLDesc {
   interface DDLDescWithWriteId extends DDLDesc {
     void setWriteId(long writeId);
     String getFullTableName();
+    // We have to advance the Write Id during DDL for transactional tables, so that
+    // we can provide strong consistency when serving the metadata from the cache.
+    // Override this method, only if you are sure that advancing the write Id is not relevant for your DDL.
     default boolean mayNeedWriteId() {
       return true;
     }


### PR DESCRIPTION


### What changes were proposed in this pull request?
Advance the write ID by default for DDLs. 

### Why are the changes needed?
We have to advance the write ID for the all DDLs, so that we can provide strong consistency while serving table metadata from HMS cache. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By current tests
