### PR TITLE
HIVE-25509: CLIService.closeOperation should not fail if operation handle is not present

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -195,7 +195,9 @@ public class HiveStatement implements java.sql.Statement {
       if (stmtHandle.isPresent()) {
         TCloseOperationReq closeReq = new TCloseOperationReq(stmtHandle.get());
         TCloseOperationResp closeResp = client.CloseOperation(closeReq);
-        Utils.verifySuccessWithInfo(closeResp.getStatus());
+        if (!checkInvalidOperationHandle(closeResp)) {
+          Utils.verifySuccessWithInfo(closeResp.getStatus());
+        }
       }
     } catch (SQLException e) {
       throw e;
@@ -212,6 +214,42 @@ public class HiveStatement implements java.sql.Statement {
     } finally {
       stmtHandle = Optional.empty();
     }
+  }
+
+  /**
+   * Invalid OperationHandle is a special case in HS2, which sometimes could be considered as safe to ignore.
+   * For instance: if the client retried due to HIVE-24786, and the retried operation happened to be the
+   * closeOperation, we don't care as the query might have already been removed from HS2's scope.
+   * @return true, if the response from server contains "Invalid OperationHandle"
+   */
+  private boolean checkInvalidOperationHandle(TCloseOperationResp closeResp) {
+    List<String> messages = closeResp.getStatus().getInfoMessages();
+    if (messages != null && messages.size() > 0) {
+      /*
+       * Here we need to handle 2 different cases, which can happen in CLIService.closeOperation, which actually does:
+       * sessionManager.getOperationManager().getOperation(opHandle).getParentSession().closeOperation(opHandle);
+       */
+      String message = messages.get(0);
+      if (message.contains("Invalid OperationHandle")) {
+        /*
+         * This happens when the first request properly removes the operation handle, then second request arrives, calls
+         * sessionManager.getOperationManager().getOperation(opHandle), and it doesn't find the handle.
+         */
+        LOG.warn("'Invalid OperationHandle' on server side (messages: " + messages + ")");
+        return true;
+      } else if (message.contains("Operation does not exist")) {
+        /*
+         * This is an extremely rare case, which represents a race condition when the first and second request
+         * arrives almost at the same time, both can get the OperationHandle instance
+         * from sessionManager's OperationManager, but the second fails, because it cannot get it again from the
+         * session's OperationManager, because it has been already removed in the meantime.
+         */
+        LOG.warn("'Operation does not exist' on server side (messages: " + messages + ")");
+        return true;
+      }
+    }
+
+    return false;
   }
 
   void closeClientOperation() throws SQLException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Let the JDBC client ignore invalid operation handle problems in case of a close operation.

### Why are the changes needed?
Because in case of socket timeout and due to the retry logic of HIVE-24786, 2 different close requests can arrive to the same operation, and after thorough testing, it turned out the timing of those are almost undefined (that's why we handled 2 detected cases in the patch)


### Does this PR introduce _any_ user-facing change?
Yes, if the client logging is set accordingly, WARN level messages will show that an invalid operation handle happened on server side while closing the operation, but the query still succeeds.


### How was this patch tested?
Tested on Azure (+AWS) where socket timeout happened quite often.
