### PR TITLE
HIVE-25517: Fixes a bug in setting external table location if the table name is in uppercase 

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.hadoop.hive.metastore.client.builder.GetTablesRequestBuilder;
 import org.apache.hadoop.hive.metastore.api.Catalog;
@@ -44,6 +45,7 @@ import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_NONE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_READONLY;
@@ -155,11 +157,12 @@ public class TestHiveMetastoreTransformer {
 
   /**
    * EXTERNAL_TABLE
-   *   1) Old table with no capabilities
-   *   2a) New table with capabilities with no client requirements
-   *   2b) New table with capabilities with no matching client requirements
-   *   2c) New table with capabilities with partial match requirements
-   *   2d) New table with capabilities with full match requirements
+   *   1) Old table (name in upper case) with no capabilities
+   *   2) Old table with no capabilities
+   *   3a) New table with capabilities with no client requirements
+   *   3b) New table with capabilities with no matching client requirements
+   *   3c) New table with capabilities with partial match requirements
+   *   3d) New table with capabilities with full match requirements
    */
   @Test
   public void testTransformerExternalTable() throws Exception {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -355,7 +355,11 @@ public class Warehouse {
     Path dbPath = null;
     if (isExternal) {
       dbPath = new Path(db.getLocationUri());
-      if (FileUtils.isSubdirectory(getWhRoot().toString(), dbPath.toString() + Path.SEPARATOR)) {
+      Path dbLocation = Path.getPathWithoutSchemeAndAuthority(dbPath);
+      Path whRootLocation = Path.getPathWithoutSchemeAndAuthority(getWhRoot());
+
+      if (FileUtils.isSubdirectory(whRootLocation.toString(), dbLocation.toString()) ||
+          dbLocation.equals(whRootLocation)) {
         // db metadata incorrect, find new location based on external warehouse root
         dbPath = getDefaultExternalDatabasePath(db.getName());
       }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -355,11 +355,8 @@ public class Warehouse {
     Path dbPath = null;
     if (isExternal) {
       dbPath = new Path(db.getLocationUri());
-      Path dbLocation = Path.getPathWithoutSchemeAndAuthority(dbPath);
-      Path whRootLocation = Path.getPathWithoutSchemeAndAuthority(getWhRoot());
-
-      if (FileUtils.isSubdirectory(whRootLocation.toString(), dbLocation.toString()) ||
-          dbLocation.equals(whRootLocation)) {
+      if (FileUtils.isSubdirectory(getWhRoot().toString(), dbPath.toString()) ||
+          getWhRoot().equals(dbPath)) {
         // db metadata incorrect, find new location based on external warehouse root
         dbPath = getDefaultExternalDatabasePath(db.getName());
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -943,13 +943,7 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
           return table;
         }
       } else {
-        dbLocation = Path.getPathWithoutSchemeAndAuthority(new Path(db.getLocationUri()));
-        Path tablePath = null;
-        if (!FileUtils.isSubdirectory(whRootPath.toString(), dbLocation.toString())) {
-          tablePath = new Path(db.getLocationUri(), table.getTableName().toLowerCase());
-        } else {
-          tablePath = hmsHandler.getWh().getDefaultTablePath(db, table.getTableName(), true);
-        }
+        Path tablePath = hmsHandler.getWh().getDefaultTablePath(db, table.getTableName(), true);
         table.getSd().setLocation(tablePath.toString());
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is a follow up on https://issues.apache.org/jira/browse/HIVE-24951 which fixes a bug in setting table location for an external table (with name in uppercase). 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When creating an external table (name in uppercase), if a user does not specify table location explicitly, the leaf in table location path is in upper case for example for create table TAB1 (c1 int), the table location is set to say hdfs:///user/external/warehouse/TAB1 whereas the expected location is  hdfs:///user/external/warehouse/tab1. It is because of a bug in MetastoreDefaultTransformer. This issue has already been addressed in https://issues.apache.org/jira/browse/HIVE-24951. This PR refactors that fix and also adds additional unit tests.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added additional unit test.