### PR TITLE
Hive 25518 compaction txn handle NPE fix

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -388,8 +388,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
           return false;
         }
       }
-      ci = CompactionInfo.optionalCompactionInfoStructToInfo(
-              msc.findNextCompact(new FindNextCompactRequest(workerName, runtimeVersion)));
+      ci = nextCompactForWorkerAndRuntime();
       LOG.debug("Processing compaction request " + ci);
 
       if (ci == null) {
@@ -583,6 +582,12 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       }
     }
     return true;
+  }
+
+  @VisibleForTesting
+  public CompactionInfo nextCompactForWorkerAndRuntime() throws TException {
+    return CompactionInfo.optionalCompactionInfoStructToInfo(
+            msc.findNextCompact(new FindNextCompactRequest(workerName, runtimeVersion)));
   }
 
   private LockRequest createLockRequest(CompactionInfo ci, long txnId) {

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -439,6 +439,23 @@ public class TestCompactionTxnHandler {
     txnHandler.purgeCompactionHistory();
   }
 
+  @Test
+  public void testMarkFailedCreatesACompactionCompletedIfNoCompactionInfoProvided() throws Exception {
+    txnHandler.markFailed(null);
+    ShowCompactResponse response = txnHandler.showCompact(new ShowCompactRequest());
+
+    List<ShowCompactResponseElement> compacts = response.getCompacts();
+    assertEquals(compacts.size(), 1);
+
+    ShowCompactResponseElement firstCompact = compacts.get(0);
+    assertEquals(firstCompact.getTablename(), "unspecified table");
+    assertEquals(firstCompact.getDbname(), "unspecified db");
+    assertEquals(firstCompact.getState(), "did not initiate");
+    assertEquals(firstCompact.getType(), CompactionType.MINOR);
+    assertEquals(firstCompact.getTablename(), "unspecified table");
+    assertEquals(firstCompact.getErrorMessage(), "Compaction Queue Information was missing");
+  }
+
   private void checkShowCompaction(String dbName, String tableName, String partition,
       String status, String errorMessage) throws MetaException {
     ShowCompactResponse showCompactResponse = txnHandler.showCompact(new ShowCompactRequest());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3487,6 +3487,16 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     }
   }
 
+  long generateCompactionQueueId(Connection dbConn) throws SQLException, MetaException {
+    Statement stmt = null;
+    try {
+      stmt = dbConn.createStatement();
+      return generateCompactionQueueId(stmt);
+    } finally {
+      closeStmt(stmt);
+    }
+  }
+
   long generateCompactionQueueId(Statement stmt) throws SQLException, MetaException {
     // Get the id for the next entry in the queue
     String s = sqlGenerator.addForUpdateClause("SELECT \"NCQ_NEXT\" FROM \"NEXT_COMPACTION_QUEUE_ID\"");
@@ -3578,7 +3588,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
         }
 
         pst = sqlGenerator.prepareStmtWithParameters(dbConn, sb.toString(), params);
-        LOG.debug("Going to execute query <" + sb.toString() + ">");
+        LOG.debug("Going to execute query <" + sb + ">");
         ResultSet rs = pst.executeQuery();
         if(rs.next()) {
           long enqueuedId = rs.getLong(1);


### PR DESCRIPTION
In the hive-exec when the `Worker` in the Compaction encounters an Exception it might try to mark failed a compaction without any compaction info. To make the method more resilient, a null-safe code branch was added to the int the `CompactionTxnHandler` 