### PR TITLE
HIVE-25529: Test reading/writing V2 tables with delete files

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.mr;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -41,6 +40,7 @@ import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.rules.TemporaryFolder;
 
 public class TestHelper {
@@ -82,7 +82,7 @@ public class TestHelper {
   }
 
   public Map<String, String> properties() {
-    Map<String, String> props = new HashMap<>(tblProps);
+    Map<String, String> props = Maps.newHashMap(tblProps);
     props.put(TableProperties.DEFAULT_FILE_FORMAT, fileFormat.name());
     props.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
     return props;

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.mr;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -50,17 +51,24 @@ public class TestHelper {
   private final PartitionSpec spec;
   private final FileFormat fileFormat;
   private final TemporaryFolder tmp;
+  private final Map<String, String> tblProps;
 
   private Table table;
 
   public TestHelper(Configuration conf, Tables tables, String tableIdentifier, Schema schema, PartitionSpec spec,
                     FileFormat fileFormat, TemporaryFolder tmp) {
+    this(conf, tables, tableIdentifier, schema, spec, fileFormat, ImmutableMap.of(), tmp);
+  }
+
+  public TestHelper(Configuration conf, Tables tables, String tableIdentifier, Schema schema, PartitionSpec spec,
+      FileFormat fileFormat, Map<String, String> tblProps, TemporaryFolder tmp) {
     this.conf = conf;
     this.tables = tables;
     this.tableIdentifier = tableIdentifier;
     this.schema = schema;
     this.spec = spec;
     this.fileFormat = fileFormat;
+    this.tblProps = tblProps;
     this.tmp = tmp;
   }
 
@@ -74,8 +82,10 @@ public class TestHelper {
   }
 
   public Map<String, String> properties() {
-    return ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, fileFormat.name(),
-        TableProperties.ENGINE_HIVE_ENABLED, "true");
+    Map<String, String> props = new HashMap<>(tblProps);
+    props.put(TableProperties.DEFAULT_FILE_FORMAT, fileFormat.name());
+    props.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
+    return props;
   }
 
   public Table createTable(Schema theSchema, PartitionSpec theSpec) {

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -356,8 +356,9 @@ public class HiveIcebergTestUtils {
   public static DeleteFile createPositionalDeleteFile(Table table, String deleteFilePath, FileFormat fileFormat,
       Map<String, Object> partitionValues, List<PositionDelete<Record>> deletes) throws IOException {
 
+    Schema posDeleteRowSchema = deletes.get(0).row() == null ? null : table.schema();
     FileAppenderFactory<Record> appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
-        null, null, table.schema());
+        null, null, posDeleteRowSchema);
     EncryptedOutputFile outputFile = table.encryption().encrypt(HadoopOutputFile.fromPath(
         new org.apache.hadoop.fs.Path(table.location(), deleteFilePath), new Configuration()));
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -516,7 +516,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableAboveExistingTable() throws IOException {
     // Create the Iceberg table
     testTables.createIcebergTable(shell.getHiveConf(), "customers", COMPLEX_SCHEMA, FileFormat.PARQUET,
-        Collections.emptyList());
+        Collections.emptyMap(), Collections.emptyList());
 
     if (testTableType == TestTables.TestTableType.HIVE_CATALOG) {
       // In HiveCatalog we just expect an exception since the table is already exists
@@ -894,7 +894,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Create the Iceberg table in non-HiveCatalog
     testTables.createIcebergTable(shell.getHiveConf(), identifier.name(),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, FileFormat.PARQUET,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+        Collections.emptyMap(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
 
     // Create Hive table on top
     String tableLocation = testTables.locationForCreateTableSQL(identifier);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -102,7 +102,7 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
     // delete one of the rows
     DataFile dataFile = StreamSupport.stream(tbl.currentSnapshot().addedFiles().spliterator(), false)
         .findFirst()
-        .orElseThrow(() -> new RuntimeException("Did not find data file with partition value customer_id=0"));
+        .orElseThrow(() -> new RuntimeException("Did not find any data files for test table"));
     List<PositionDelete<Record>> deletes = ImmutableList.of(new PositionDelete<Record>().set(
         dataFile.path(), 2L, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2))
     );
@@ -138,7 +138,7 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
         .filter(file -> file.partition().get(0, Long.class) == 0L)
         .filter(file -> file.recordCount() == 3)
         .findAny()
-        .orElseThrow(() -> new RuntimeException("Did not find data file with partition value customer_id=0"));
+        .orElseThrow(() -> new RuntimeException("Did not find the desired data file in the test table"));
     List<Record> rowsToDel = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
         .add(0L, "Laura", "Yellow").add(0L, "Blake", "Blue").build();
     List<PositionDelete<Record>> deletes = ImmutableList.of(

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * Tests Format V2 specific features, such as reading/writing V2 tables, using delete files, etc.
+ */
+public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
+
+  @Test
+  public void testReadAndWriteFormatV2UnpartitionedWithEqDelete() throws IOException {
+    Assume.assumeFalse("Reading V2 tables with delete files are only supported currently in " +
+        "non-vectorized mode and only Parquet/Avro", isVectorized || fileFormat == FileFormat.ORC);
+
+    Table tbl = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2);
+
+    // delete one of the rows
+    List<Record> toDelete = TestHelper.RecordsBuilder
+        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(1L, "Bob", null).build();
+    DeleteFile deleteFile = HiveIcebergTestUtils.createEqualityDeleteFile(tbl, "dummyPath",
+        ImmutableList.of("customer_id", "first_name"), fileFormat, toDelete);
+    tbl.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Object[]> objects = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+
+    // only the other two rows are present
+    Assert.assertEquals(2, objects.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, objects.get(0));
+    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, objects.get(1));
+  }
+
+  @Test
+  public void testReadAndWriteFormatV2PartitionedWithEqDelete() throws IOException {
+    Assume.assumeFalse("Reading V2 tables with delete files are only supported currently in " +
+        "non-vectorized mode and only Parquet/Avro", isVectorized || fileFormat == FileFormat.ORC);
+
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("customer_id").build();
+    Table tbl = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2);
+
+    // add one more row to the same partition
+    shell.executeStatement("insert into customers values (1, 'Bob', 'Hoover')");
+
+    // delete all rows with id=1 and first_name=Bob
+    List<Record> toDelete = TestHelper.RecordsBuilder
+        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(1L, "Bob", null).build();
+    DeleteFile deleteFile = HiveIcebergTestUtils.createEqualityDeleteFile(tbl, "dummyPath",
+        ImmutableList.of("customer_id", "first_name"), fileFormat, toDelete);
+    tbl.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Object[]> objects = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+
+    Assert.assertEquals(2, objects.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, objects.get(0));
+    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, objects.get(1));
+  }
+
+  @Test
+  public void testReadAndWriteFormatV2UnpartitionedWithPosDelete() throws IOException {
+    Assume.assumeFalse("Reading V2 tables with delete files are only supported currently in " +
+        "non-vectorized mode and only Parquet/Avro", isVectorized || fileFormat == FileFormat.ORC);
+
+    Table tbl = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2);
+
+    // delete one of the rows
+    DataFile dataFile = StreamSupport.stream(tbl.currentSnapshot().addedFiles().spliterator(), false)
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("Did not find data file with partition value customer_id=0"));
+    List<PositionDelete<Record>> deletes = ImmutableList.of(new PositionDelete<Record>().set(
+        dataFile.path(), 2L, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2))
+    );
+    DeleteFile deleteFile = HiveIcebergTestUtils.createPositionalDeleteFile(tbl, "dummyPath",
+        fileFormat, null, deletes);
+    tbl.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Object[]> objects = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+
+    // only the other two rows are present
+    Assert.assertEquals(2, objects.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, objects.get(0));
+    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, objects.get(1));
+  }
+
+  @Test
+  public void testReadAndWriteFormatV2PartitionedWithPosDelete() throws IOException {
+    Assume.assumeFalse("Reading V2 tables with delete files are only supported currently in " +
+        "non-vectorized mode and only Parquet/Avro", isVectorized || fileFormat == FileFormat.ORC);
+
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("customer_id").build();
+    Table tbl = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2);
+
+    // add some more data to the same partition
+    shell.executeStatement("insert into customers values (0, 'Laura', 'Yellow'), (0, 'John', 'Green'), " +
+        "(0, 'Blake', 'Blue')");
+    tbl.refresh();
+
+    // delete the first and third rows from the newly-added data file
+    DataFile dataFile = StreamSupport.stream(tbl.currentSnapshot().addedFiles().spliterator(), false)
+        .filter(file -> file.partition().get(0, Long.class) == 0L)
+        .filter(file -> file.recordCount() == 3)
+        .findAny()
+        .orElseThrow(() -> new RuntimeException("Did not find data file with partition value customer_id=0"));
+    List<Record> rowsToDel = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Laura", "Yellow").add(0L, "Blake", "Blue").build();
+    List<PositionDelete<Record>> deletes = ImmutableList.of(
+        new PositionDelete<Record>().set(dataFile.path(), 0L, rowsToDel.get(0)),
+        new PositionDelete<Record>().set(dataFile.path(), 2L, rowsToDel.get(1))
+    );
+    DeleteFile deleteFile = HiveIcebergTestUtils.createPositionalDeleteFile(tbl, "dummyPath",
+        fileFormat, ImmutableMap.of("customer_id", 0L), deletes);
+    tbl.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Object[]> objects = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id, first_name");
+
+    Assert.assertEquals(4, objects.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, objects.get(0));
+    Assert.assertArrayEquals(new Object[] {0L, "John", "Green"}, objects.get(1));
+    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, objects.get(2));
+    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, objects.get(3));
+  }
+}

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -50,7 +50,6 @@ import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.MetastoreUtil;
-import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestCatalogs;
 import org.apache.iceberg.mr.TestHelper;
@@ -161,8 +160,27 @@ abstract class TestTables {
    */
   public Table createTable(TestHiveShell shell, String tableName, Schema schema, FileFormat fileFormat,
       List<Record> records) throws IOException {
-    Table table = createIcebergTable(shell.getHiveConf(), tableName, schema, fileFormat, records);
-    String createHiveSQL = createHiveTableSQL(TableIdentifier.of("default", tableName), ImmutableMap.of());
+    return createTable(shell, tableName, schema, fileFormat, records, 1);
+  }
+
+  /**
+   * Creates an non partitioned Hive test table. Creates the Iceberg table/data and creates the corresponding Hive
+   * table as well when needed. The table will be in the 'default' database. The table will be populated with the
+   * provided List of {@link Record}s.
+   * @param shell The HiveShell used for Hive table creation
+   * @param tableName The name of the test table
+   * @param schema The schema used for the table creation
+   * @param fileFormat The file format used for writing the data
+   * @param records The records with which the table is populated
+   * @param formatVersion The version of the spec the table should use (format-version)
+   * @return The created table
+   * @throws IOException If there is an error writing data
+   */
+  public Table createTable(TestHiveShell shell, String tableName, Schema schema, FileFormat fileFormat,
+      List<Record> records, int formatVersion) throws IOException {
+    Map<String, String> tblProps = ImmutableMap.of(TableProperties.FORMAT_VERSION, Integer.toString(formatVersion));
+    Table table = createIcebergTable(shell.getHiveConf(), tableName, schema, fileFormat, tblProps, records);
+    String createHiveSQL = createHiveTableSQL(TableIdentifier.of("default", tableName), tblProps);
     if (createHiveSQL != null) {
       shell.executeStatement(createHiveSQL);
     }
@@ -184,16 +202,33 @@ abstract class TestTables {
    */
   public Table createTable(TestHiveShell shell, String tableName, Schema schema, PartitionSpec spec,
       FileFormat fileFormat, List<Record> records)  {
+    return createTable(shell, tableName, schema, spec, fileFormat, records, 1);
+  }
+
+  /**
+   * Creates a partitioned Hive test table using Hive SQL. The table will be in the 'default' database.
+   * The table will be populated with the provided List of {@link Record}s using a Hive insert statement.
+   * @param shell The HiveShell used for Hive table creation
+   * @param tableName The name of the test table
+   * @param schema The schema used for the table creation
+   * @param spec The partition specification for the table
+   * @param fileFormat The file format used for writing the data
+   * @param records The records with which the table is populated
+   * @param formatVersion The version of the spec the table should use (format-version)
+   * @return The created table
+   * @throws IOException If there is an error writing data
+   */
+  public Table createTable(TestHiveShell shell, String tableName, Schema schema, PartitionSpec spec,
+      FileFormat fileFormat, List<Record> records, Integer formatVersion)  {
     TableIdentifier identifier = TableIdentifier.of("default", tableName);
+    String tblProps = propertiesForCreateTableSQL(ImmutableMap.of(
+        TableProperties.DEFAULT_FILE_FORMAT, fileFormat.toString(),
+        InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(schema),
+        InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(spec),
+        TableProperties.FORMAT_VERSION, Integer.toString(formatVersion)));
+
     shell.executeStatement("CREATE EXTERNAL TABLE " + identifier +
-        " STORED BY '" + HiveIcebergStorageHandler.class.getName() + "' " +
-        locationForCreateTableSQL(identifier) +
-        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
-        SchemaParser.toJson(schema) + "', " +
-        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
-        PartitionSpecParser.toJson(spec) + "', " +
-        "'" + TableProperties.DEFAULT_FILE_FORMAT + "'='" + fileFormat + "', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        " STORED BY ICEBERG " + locationForCreateTableSQL(identifier) + tblProps);
 
     if (records != null && !records.isEmpty()) {
       String query = getInsertQuery(records, identifier, false);
@@ -248,10 +283,10 @@ abstract class TestTables {
    * @throws IOException If there is an error writing data
    */
   public Table createIcebergTable(Configuration configuration, String tableName, Schema schema, FileFormat fileFormat,
-      List<Record> records) throws IOException {
+      Map<String, String> additionalTableProps, List<Record> records) throws IOException {
     String identifier = identifier("default." + tableName);
     TestHelper helper = new TestHelper(new Configuration(configuration), tables(), identifier, schema,
-        PartitionSpec.unpartitioned(), fileFormat, temp);
+        PartitionSpec.unpartitioned(), fileFormat, additionalTableProps, temp);
     Table table = helper.createTable();
 
     if (records != null && !records.isEmpty()) {


### PR DESCRIPTION
- Add a couple of new helper methods to TestHelper and TestTables so we can easily create tables with V2 (formatVersion=2)
- Create new TestHiveIcebergV2 test suite for testing reads/writes to V2 tables with deletes
- Create new test util methods to create equality and position delete files in tests