### PR TITLE
HIVE-25561: Killed task should not commit file.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -312,6 +312,7 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
 
       perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.TEZ_RUN_PROCESSOR);
     } catch (Throwable t) {
+      rproc.setAborted(true);
       originalThrowable = t;
     } finally {
       if (originalThrowable != null && (originalThrowable instanceof Error ||


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should set abort to true, when we catch any Exception.

### Why are the changes needed?

For tez engine in our cluster, I found some duplicate line, especially tez speculation is enabled. In partition dir, I found both 000002_0 and 000002_1 exist.
It's a very low probability event. HIVE-10429 has fix some bug about interrupt, but some exception was not caught.

In our cluster, Task receive SIGTERM, then ClientFinalizer(Hadoop Class) was called, hdfs client will close. Then will raise exception, but abort may not set to true.
Then removeTempOrDuplicateFiles may fail because of inconsistency, duplicate file will retain.
(Notes: Driver first list dir, then Task commit file, then Driver remove duplicate file. It is a inconsistency case)


### How was this patch tested?

Manual test in our cluster. 
And I add some delay in our test code, then increase the problem's probability.

https://issues.apache.org/jira/browse/HIVE-25561