### PR TITLE
HIVE-25580: Increase the performance of getTableColumnStatistics and getPartitionColumnStatistics

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -9856,8 +9856,10 @@ public class ObjectStore implements RawStore, Configurable {
     try {
       openTransaction();
       query = pm.newQuery(MTableColumnStatistics.class);
+      query.setFilter("tableName == t1 && dbName == t2 && catName == t3");
+      query.declareParameters("java.lang.String t1, java.lang.String t2, java.lang.String t3");
       query.setResult("DISTINCT engine");
-      Collection names = (Collection) query.execute();
+      Collection names = (Collection) query.execute(tableName, dbName, catName);
       List<String> engines = new ArrayList<>();
       for (Iterator i = names.iterator(); i.hasNext();) {
         engines.add((String) i.next());
@@ -9962,8 +9964,10 @@ public class ObjectStore implements RawStore, Configurable {
     try {
       openTransaction();
       query = pm.newQuery(MPartitionColumnStatistics.class);
+      query.setFilter("tableName == t1 && dbName == t2 && catName == t3");
+      query.declareParameters("java.lang.String t1, java.lang.String t2, java.lang.String t3");
       query.setResult("DISTINCT engine");
-      Collection names = (Collection) query.execute();
+      Collection names = (Collection) query.execute(tableName, dbName, catName);
       List<String> engines = new ArrayList<>();
       for (Iterator i = names.iterator(); i.hasNext();) {
         engines.add((String) i.next());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit the query range based on the cat/db/table

### Why are the changes needed?
To gain performance

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a test to run a quick check, but existing test should already cover this path
