### PR TITLE
 Backport to 3.1: HIVE-24797: Disable validate default values when parsing Avro schemas #2670 

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -276,17 +276,20 @@ public class AvroSerdeUtils {
     return dec;
   }
 
+  private static Schema.Parser getSchemaParser() {
+    // HIVE-24797: Disable validate default values when parsing Avro schemas.
+    return new Schema.Parser().setValidateDefaults(false);
+  }
+
   public static Schema getSchemaFor(String str) {
-    Schema.Parser parser = new Schema.Parser();
-    Schema schema = parser.parse(str);
+    Schema schema = getSchemaParser().parse(str);
     return schema;
   }
 
   public static Schema getSchemaFor(File file) {
-    Schema.Parser parser = new Schema.Parser();
     Schema schema;
     try {
-      schema = parser.parse(file);
+      schema = getSchemaParser().parse(file);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Avro schema from " + file.getName(), e);
     }
@@ -294,10 +297,9 @@ public class AvroSerdeUtils {
   }
 
   public static Schema getSchemaFor(InputStream stream) {
-    Schema.Parser parser = new Schema.Parser();
     Schema schema;
     try {
-      schema = parser.parse(stream);
+      schema = getSchemaParser().parse(stream);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Avro schema", e);
     }


### PR DESCRIPTION
This cherry-picks the commit from #1994 (addressing HIVE-24797).

#2670 is the matching PR for version 3.