### PR TITLE
HIVE-25617:fix bug introduced by CVE-2020-8908

### DIFF
--- a/spark-client/src/main/java/org/apache/hive/spark/client/RemoteDriver.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/RemoteDriver.java
@@ -18,13 +18,13 @@
 package org.apache.hive.spark.client;
 
 import com.google.common.base.Throwables;
-import com.google.common.io.Files;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +100,9 @@ public class RemoteDriver {
     this.activeJobs = Maps.newConcurrentMap();
     this.jcLock = new Object();
     this.shutdownLock = new Object();
-    localTmpDir = Files.createTempDir();
+    File tempDirBase = new File(System.getProperty("java.io.tmpdir"));
+    localTmpDir = Files.createTempDirectory(
+            tempDirBase.toPath(), System.currentTimeMillis() + "-").toFile();
 
     addShutdownHook();
 


### PR DESCRIPTION
see https://www.cvedetails.com/cve/CVE-2020-8908/

A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.