### PR TITLE
HIVE-25618: Stack trace is difficult to find when qtest fails during setup/teardown

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCoreBlobstoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCoreBlobstoreCliDriver.java
@@ -54,81 +54,50 @@ public abstract class AbstractCoreBlobstoreCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String hiveConfDir = cliConfig.getHiveConfDir();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new QTestUtil(
-          QTestArguments.QTestArgumentsBuilder.instance()
-            .withOutDir(cliConfig.getResultsDir())
-            .withLogDir(cliConfig.getLogDir())
-            .withClusterType(miniMR)
-            .withConfDir(hiveConfDir)
-            .withInitScript(initScript)
-            .withCleanupScript(cleanupScript)
-            .withLlapIo(true)
-            .build());
+    qt = new QTestUtil(
+        QTestArguments.QTestArgumentsBuilder.instance()
+          .withOutDir(cliConfig.getResultsDir())
+          .withLogDir(cliConfig.getLogDir())
+          .withClusterType(miniMR)
+          .withConfDir(hiveConfDir)
+          .withInitScript(initScript)
+          .withCleanupScript(cleanupScript)
+          .withLlapIo(true)
+          .build());
 
-      if (Strings.isNullOrEmpty(qt.getConf().get(HCONF_TEST_BLOBSTORE_PATH))) {
-        fail(String.format("%s must be set. Try setting in blobstore-conf.xml", HCONF_TEST_BLOBSTORE_PATH));
-      }
-
-      // do a one time initialization
-      setupUniqueTestPath();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization", e);
+    if (Strings.isNullOrEmpty(qt.getConf().get(HCONF_TEST_BLOBSTORE_PATH))) {
+      fail(String.format("%s must be set. Try setting in blobstore-conf.xml", HCONF_TEST_BLOBSTORE_PATH));
     }
+
+    // do a one time initialization
+    setupUniqueTestPath();
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearTestSideEffects();
-      qt.clearPostTestEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearTestSideEffects();
+    qt.clearPostTestEffects();
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-      if (System.getenv(QTestUtil.QTEST_LEAVE_FILES) == null) {
-        qt.executeAdhocCommand("dfs -rmdir " + testBlobstorePathUnique);
-      }
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
+  public void shutdown() throws Exception {
+    qt.shutdown();
+    if (System.getenv(QTestUtil.QTEST_LEAVE_FILES) == null) {
+      qt.executeAdhocCommand("dfs -rmdir " + testBlobstorePathUnique);
     }
   }
 

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliAdapter.java
@@ -59,10 +59,10 @@ public abstract class CliAdapter {
   public abstract void beforeClass() throws Exception;
 
   // HIVE-14444 pending rename: before
-  public abstract void setUp();
+  public abstract void setUp() throws Exception;
 
   // HIVE-14444 pending rename: after
-  public abstract void tearDown();
+  public abstract void tearDown() throws Exception;
 
   // HIVE-14444 pending rename: afterClass
   public abstract void shutdown() throws Exception;

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreAccumuloCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreAccumuloCliDriver.java
@@ -44,54 +44,32 @@ public class CoreAccumuloCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new AccumuloQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR,
-          new AccumuloTestSetup(), initScript, cleanupScript);
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in setUp", e);
-    }
+    qt = new AccumuloQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR, new AccumuloTestSetup(),
+        initScript, cleanupScript);
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in tearDown", e);
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-      qt.clearTestSideEffects();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.clearTestSideEffects();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -56,7 +56,7 @@ public class CoreCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     String message = "Starting " + CoreCliDriver.class.getName() + " run at " + System.currentTimeMillis();
     LOG.info(message);
     System.err.println(message);
@@ -67,91 +67,60 @@ public class CoreCliDriver extends CliAdapter {
     String cleanupScript = cliConfig.getCleanupScript();
     Set<QTestExternalDB> externalDBs = cliConfig.getExternalDBs();
 
-    try {
-      qt = new ElapsedTimeLoggingWrapper<QTestUtil>() {
-        @Override
-        public QTestUtil invokeInternal() throws Exception {
-          return new QTestUtil(
-              QTestArguments.QTestArgumentsBuilder.instance()
-                .withOutDir(cliConfig.getResultsDir())
-                .withLogDir(cliConfig.getLogDir())
-                .withClusterType(miniMR)
-                .withConfDir(hiveConfDir)
-                .withInitScript(initScript)
-                .withCleanupScript(cleanupScript)
-                .withExternalDBs(externalDBs)
-                .withLlapIo(true)
-                .withFsType(cliConfig.getFsType())
-                .build());
-        }
-      }.invoke("QtestUtil instance created", LOG, true);
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization", e);
-    }
+    qt = new ElapsedTimeLoggingWrapper<QTestUtil>() {
+      @Override
+      public QTestUtil invokeInternal() throws Exception {
+        return new QTestUtil(
+            QTestArguments.QTestArgumentsBuilder.instance()
+              .withOutDir(cliConfig.getResultsDir())
+              .withLogDir(cliConfig.getLogDir())
+              .withClusterType(miniMR)
+              .withConfDir(hiveConfDir)
+              .withInitScript(initScript)
+              .withCleanupScript(cleanupScript)
+              .withExternalDBs(externalDBs)
+              .withLlapIo(true)
+              .withFsType(cliConfig.getFsType())
+              .build());
+      }
+    }.invoke("QtestUtil instance created", LOG, true);
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      new ElapsedTimeLoggingWrapper<Void>() {
-        @Override
-        public Void invokeInternal() throws Exception {
-          qt.newSession();
-          return null;
-        }
-      }.invoke("PerTestSetup done.", LOG, false);
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    new ElapsedTimeLoggingWrapper<Void>() {
+      @Override
+      public Void invokeInternal() throws Exception {
+        qt.newSession();
+        return null;
+      }
+    }.invoke("PerTestSetup done.", LOG, false);
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      new ElapsedTimeLoggingWrapper<Void>() {
-        @Override
-        public Void invokeInternal() throws Exception {
-          qt.clearPostTestEffects();
-          qt.clearTestSideEffects();
-          return null;
-        }
-      }.invoke("PerTestTearDown done.", LOG, false);
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    new ElapsedTimeLoggingWrapper<Void>() {
+      @Override
+      public Void invokeInternal() throws Exception {
+        qt.clearPostTestEffects();
+        qt.clearTestSideEffects();
+        return null;
+      }
+    }.invoke("PerTestTearDown done.", LOG, false);
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      new ElapsedTimeLoggingWrapper<Void>() {
-        @Override
-        public Void invokeInternal() throws Exception {
-          qt.shutdown();
-          return null;
-        }
-      }.invoke("Teardown done.", LOG, false);
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
-    }
+  public void shutdown() throws Exception {
+    new ElapsedTimeLoggingWrapper<Void>() {
+      @Override
+      public Void invokeInternal() throws Exception {
+        qt.shutdown();
+        return null;
+      }
+    }.invoke("Teardown done.", LOG, false);
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCompareCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCompareCliDriver.java
@@ -47,70 +47,40 @@ public class CoreCompareCliDriver extends CliAdapter{
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String hiveConfDir = cliConfig.getHiveConfDir();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new QTestUtil(
-          QTestArguments.QTestArgumentsBuilder.instance()
-            .withOutDir(cliConfig.getResultsDir())
-            .withLogDir(cliConfig.getLogDir())
-            .withClusterType(miniMR)
-            .withConfDir(hiveConfDir)
-            .withInitScript(initScript)
-            .withCleanupScript(cleanupScript)
-            .withLlapIo(false)
-            .build());
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization", e);
-    }
+    qt = new QTestUtil(
+        QTestArguments.QTestArgumentsBuilder.instance()
+          .withOutDir(cliConfig.getResultsDir())
+          .withLogDir(cliConfig.getLogDir())
+          .withClusterType(miniMR)
+          .withConfDir(hiveConfDir)
+          .withInitScript(initScript)
+          .withCleanupScript(cleanupScript)
+          .withLlapIo(false)
+          .build());
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.clearTestSideEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.clearTestSideEffects();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreHBaseCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreHBaseCliDriver.java
@@ -43,59 +43,31 @@ public class CoreHBaseCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new HBaseQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR,
-          new HBaseTestSetup(), initScript, cleanupScript);
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization: ", e);
-    }
+    qt = new HBaseQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR, new HBaseTestSetup(), initScript,
+        cleanupScript);
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-      qt.clearTestSideEffects();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.clearTestSideEffects();
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreHBaseNegativeCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreHBaseNegativeCliDriver.java
@@ -47,56 +47,27 @@ public class CoreHBaseNegativeCliDriver extends CliAdapter {
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new HBaseQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR,
-          new HBaseTestSetup(), initScript, cleanupScript);
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization: ", e);
-    }
+    qt = new HBaseQTestUtil(cliConfig.getResultsDir(), cliConfig.getLogDir(), miniMR, new HBaseTestSetup(), initScript,
+        cleanupScript);
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-      qt.clearTestSideEffects();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.clearTestSideEffects();
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreKuduCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreKuduCliDriver.java
@@ -45,60 +45,36 @@ public class CoreKuduCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
-    try {
-      qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance()
-          .withOutDir(cliConfig.getResultsDir())
-          .withLogDir(cliConfig.getLogDir())
-          .withClusterType(cliConfig.getClusterType())
-          .withConfDir(cliConfig.getHiveConfDir())
-          .withInitScript(cliConfig.getInitScript())
-          .withCleanupScript(cliConfig.getCleanupScript())
-          .withLlapIo(true)
-          .withQTestSetup(new KuduTestSetup())
-          .build());
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in setUp", e);
-    }
+  public void beforeClass() throws Exception {
+    qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance()
+        .withOutDir(cliConfig.getResultsDir())
+        .withLogDir(cliConfig.getLogDir())
+        .withClusterType(cliConfig.getClusterType())
+        .withConfDir(cliConfig.getHiveConfDir())
+        .withInitScript(cliConfig.getInitScript())
+        .withCleanupScript(cliConfig.getCleanupScript())
+        .withLlapIo(true)
+        .withQTestSetup(new KuduTestSetup())
+        .build());
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in tearDown", e);
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-      qt.clearTestSideEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.clearTestSideEffects();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreKuduNegativeCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreKuduNegativeCliDriver.java
@@ -45,60 +45,36 @@ public class CoreKuduNegativeCliDriver extends CliAdapter {
 
   @Override
   @BeforeClass
-  public void beforeClass() {
-    try {
-      qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance()
-          .withOutDir(cliConfig.getResultsDir())
-          .withLogDir(cliConfig.getLogDir())
-          .withClusterType(cliConfig.getClusterType())
-          .withConfDir(cliConfig.getHiveConfDir())
-          .withInitScript(cliConfig.getInitScript())
-          .withCleanupScript(cliConfig.getCleanupScript())
-          .withLlapIo(true)
-          .withQTestSetup(new KuduTestSetup())
-          .build());
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in setUp", e);
-    }
+  public void beforeClass() throws Exception {
+    qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance()
+        .withOutDir(cliConfig.getResultsDir())
+        .withLogDir(cliConfig.getLogDir())
+        .withClusterType(cliConfig.getClusterType())
+        .withConfDir(cliConfig.getHiveConfDir())
+        .withInitScript(cliConfig.getInitScript())
+        .withCleanupScript(cliConfig.getCleanupScript())
+        .withLlapIo(true)
+        .withQTestSetup(new KuduTestSetup())
+        .build());
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-    } catch (Exception e) {
-      throw new RuntimeException("Unexpected exception in tearDown", e);
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-      qt.clearTestSideEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.clearTestSideEffects();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreNegativeCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreNegativeCliDriver.java
@@ -70,44 +70,21 @@ public class CoreNegativeCliDriver extends CliAdapter{
 
   @Override
   @Before
-  public void setUp() {
-    try {
-      qt.newSession();
-
-    } catch (Throwable e) {
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in setup");
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
   @After
-  public void tearDown() {
-    try {
-      qt.clearTestSideEffects();
-      qt.clearPostTestEffects();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in tearDown");
-    }
+  public void tearDown() throws Exception {
+    qt.clearTestSideEffects();
+    qt.clearPostTestEffects();
   }
 
   @Override
   @AfterClass
-  public void shutdown() {
-    try {
-      qt.shutdown();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      fail("Unexpected exception in shutdown");
-    }
+  public void shutdown() throws Exception {
+    qt.shutdown();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CorePerfCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CorePerfCliDriver.java
@@ -46,20 +46,15 @@ public class CorePerfCliDriver extends CliAdapter {
   }
 
   @Override
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String hiveConfDir = cliConfig.getHiveConfDir();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance()
-          .withOutDir(cliConfig.getResultsDir()).withLogDir(cliConfig.getLogDir())
-          .withClusterType(miniMR).withConfDir(hiveConfDir).withInitScript(initScript)
-          .withCleanupScript(cleanupScript).withLlapIo(false).build());
-    } catch (Exception e) {
-      throw new RuntimeException("QTest initialization failed. See cause for details.", e);
-    }
+    qt = new QTestUtil(QTestArguments.QTestArgumentsBuilder.instance().withOutDir(cliConfig.getResultsDir())
+        .withLogDir(cliConfig.getLogDir()).withClusterType(miniMR).withConfDir(hiveConfDir).withInitScript(initScript)
+        .withCleanupScript(cleanupScript).withLlapIo(false).build());
   }
 
   @Override
@@ -68,21 +63,13 @@ public class CorePerfCliDriver extends CliAdapter {
   }
 
   @Override
-  public void setUp() {
-    try {
-      qt.newSession();
-    } catch (Exception e) {
-      throw new RuntimeException("Create session failed. See cause for details.", e);
-    }
+  public void setUp() throws Exception {
+    qt.newSession();
   }
 
   @Override
-  public void tearDown() {
-    try {
-      qt.clearPostTestEffects();
-    } catch (Exception e) {
-      throw new RuntimeException("Post test clean up failed. See cause for details.", e);
-    }
+  public void tearDown() throws Exception {
+    qt.clearPostTestEffects();
   }
 
   @Override

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/parse/CoreParseNegative.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/parse/CoreParseNegative.java
@@ -47,28 +47,21 @@ public class CoreParseNegative extends CliAdapter{
 
   @Override
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
     MiniClusterType miniMR = cliConfig.getClusterType();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
 
-    try {
-      qt = new QTestUtil(
-          QTestArguments.QTestArgumentsBuilder.instance()
-            .withOutDir(cliConfig.getResultsDir())
-            .withLogDir(cliConfig.getLogDir())
-            .withClusterType(miniMR)
-            .withConfDir(null)
-            .withInitScript(initScript)
-            .withCleanupScript(cleanupScript)
-            .withLlapIo(false)
-            .build());
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in static initialization", e);
-    }
+    qt = new QTestUtil(
+        QTestArguments.QTestArgumentsBuilder.instance()
+          .withOutDir(cliConfig.getResultsDir())
+          .withLogDir(cliConfig.getLogDir())
+          .withClusterType(miniMR)
+          .withConfDir(null)
+          .withInitScript(initScript)
+          .withCleanupScript(cleanupScript)
+          .withLlapIo(false)
+          .build());
   }
 
   @Override
@@ -82,19 +75,9 @@ public class CoreParseNegative extends CliAdapter{
 
   @Override
   @AfterClass
-  public void shutdown() {
-    String reason = "clear post test effects";
-    try {
-      qt.clearPostTestEffects();
-      reason = "shutdown";
-      qt.shutdown();
-
-    } catch (Exception e) {
-      System.err.println("Exception: " + e.getMessage());
-      e.printStackTrace();
-      System.err.flush();
-      throw new RuntimeException("Unexpected exception in " + reason, e);
-    }
+  public void shutdown() throws Exception {
+    qt.clearPostTestEffects();
+    qt.shutdown();
   }
 
   protected boolean shouldRunCreateScriptBeforeEveryTest() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the try, catch, print, and fail pattern (see below) in CLI drivers letting the exception to propagate. 

```
try {
  // Do something
} catch (Exception e) {
  System.err.println("Exception: " + e.getMessage());
  e.printStackTrace();
  System.err.flush();
  fail("Unexpected exception in tearDown");
}
```

### Why are the changes needed?
1. It is easier to find the original stack trace causing the failure without looking into multiple places.
2. It makes the code more readable.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual and existing tests