### PR TITLE
HIVE-25642 Log a warning if multiple Compaction Worker versions are running compactions

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -571,8 +571,8 @@ public class MetastoreConf {
             "tables or partitions to be compacted once they are determined to need compaction.\n" +
             "It will also increase the background load on the Hadoop cluster as more MapReduce jobs\n" +
             "will be running in the background."),
-    COMPACTOR_WORKER_DETECT_MULTIPLE_VERSION_THRESHOLD("metastore.compactor.worker.detect_multiple_versions.threshold",
-      "hive.metastore.compactor.worker.detect_versions.threshold", 24,
+    COMPACTOR_WORKER_DETECT_MULTIPLE_VERSION_THRESHOLD("metastore.compactor.worker.detect.multiple.versions.threshold",
+      "hive.metastore.compactor.worker.detect.multiple.versions.threshold", 24, TimeUnit.HOURS,
       "Defines a time-window in hours from the current time backwards\n," +
             "in which a warning is being raised if multiple worker version are detected.\n" +
             "The setting has no effect if the metastore.metrics.enabled is disabled \n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
@@ -111,9 +111,9 @@ public class AcidMetricService implements MetastoreTaskThread {
   }
 
   private void detectMultipleWorkerVersions(ShowCompactResponse currentCompactions) {
-    long workerVersionThresholdInHours = MetastoreConf.getLongVar(conf,
-        MetastoreConf.ConfVars.COMPACTOR_WORKER_DETECT_MULTIPLE_VERSION_THRESHOLD);
-    long since = System.currentTimeMillis() - hoursInMillis(workerVersionThresholdInHours);
+    long workerVersionThresholdInMillis = MetastoreConf.getTimeVar(conf,
+        MetastoreConf.ConfVars.COMPACTOR_WORKER_DETECT_MULTIPLE_VERSION_THRESHOLD, TimeUnit.MILLISECONDS);
+    long since = System.currentTimeMillis() - workerVersionThresholdInMillis;
 
     List<String> versions = collectWorkerVersions(currentCompactions.getCompacts(), since);
     if (versions.size() > 1) {
@@ -124,11 +124,6 @@ public class AcidMetricService implements MetastoreTaskThread {
   private void updateMetrics(ShowCompactResponse currentCompactions) throws MetaException {
     updateMetricsFromShowCompact(currentCompactions, conf);
     updateDBMetrics();
-  }
-
-  @VisibleForTesting
-  public static long hoursInMillis(long hours) {
-    return hours * 60 * 60 * 1000;
   }
 
   @VisibleForTesting

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMultipleWorkerVersionDetection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMultipleWorkerVersionDetection.java
@@ -35,17 +35,6 @@ public class TestMultipleWorkerVersionDetection {
   private final long SINCE_EPOCH = 0L;
 
   @Test
-  public void testHoursInMillis() {
-    assertThat(AcidMetricService.hoursInMillis(-123), CoreMatchers.is(-442_800_000L));
-    assertThat(AcidMetricService.hoursInMillis(-10), CoreMatchers.is(-36_000_000L));
-    assertThat(AcidMetricService.hoursInMillis(-1), CoreMatchers.is(-3_600_000L));
-    assertThat(AcidMetricService.hoursInMillis(0), CoreMatchers.is(0L));
-    assertThat(AcidMetricService.hoursInMillis(1), CoreMatchers.is(3_600_000L));
-    assertThat(AcidMetricService.hoursInMillis(10), CoreMatchers.is(36_000_000L));
-    assertThat(AcidMetricService.hoursInMillis(456), CoreMatchers.is(1_641_600_000L));
-  }
-
-  @Test
   public void testCollectWorkerVersionsEmptyLists() {
     assertThat(AcidMetricService.collectWorkerVersions(null, SINCE_EPOCH), CoreMatchers.is(Collections.emptyList()));
     assertThat(AcidMetricService.collectWorkerVersions(Collections.emptyList(), SINCE_EPOCH),
@@ -114,7 +103,7 @@ public class TestMultipleWorkerVersionDetection {
   private static ShowCompactResponseElement showCompactResponse(String workerVersion, String state,
       Long enqueuedTime, Long startTime, Long endTime) {
 
-    ShowCompactResponseElement e = new ShowCompactResponseElement("db0bane", "table-name", CompactionType.MINOR, state);
+    ShowCompactResponseElement e = new ShowCompactResponseElement("db_name", "table_name", CompactionType.MINOR, state);
     e.setWorkerVersion(workerVersion);
 
     if (enqueuedTime != null) {


### PR DESCRIPTION
Log a warning if multiple Compaction Worker versions are running compactions
- New property has been added `metastore.compactor.worker.detect_multiple_versions.threshold`
- The detection implementation has added to the AcidMetricService and work only if the metrics are enabled
