### PR TITLE
HIVE-25628

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
@@ -116,8 +116,8 @@ public class HiveVectorizedReader {
           // and Iceberg will make a mapping between the file schema and the current reading schema.
           job.setBoolean(OrcConf.FORCE_POSITIONAL_EVOLUTION.getHiveConfName(), false);
 
-          // Iceberg currently does not track the last modification time of a file. Until that's added, we need to set
-          // Long.MIN_VALUE as last modification time in the fileId triplet.
+          // TODO: Iceberg currently does not track the last modification time of a file. Until that's added,
+          // we need to set Long.MIN_VALUE as last modification time in the fileId triplet.
           SyntheticFileId fileId = new SyntheticFileId(path, task.file().fileSizeInBytes(), Long.MIN_VALUE);
 
           VectorizedReadUtils.handleIcebergProjection(inputFile, task, job, fileId);


### PR DESCRIPTION
In case the query execution is vectorized for an Iceberg table, we need to make an extra file open operation on the ORC file to learn what the file schema is (to be matched later with the logical schema).

In LLAP configuration the file schema could be retrieved through LLAP cache as ORC metadata is cached, so we should avoid the file operation when possible.

Also: LLAP relies on cache keys that are usually triplets of file information and is constructed by an FS.listStatus call. For iceberg tables we should rely on such file information provided by Iceberg's metadata to spare this call too.