### PR TITLE
Hive 25651

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -23,12 +23,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.io.DataCache;
+import org.apache.hadoop.hive.common.io.FileMetadataCache;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedSupport;
 import org.apache.hadoop.hive.ql.io.CombineHiveInputFormat;
+import org.apache.hadoop.hive.ql.io.LlapCacheOnlyInputFormatInterface;
 import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
@@ -55,7 +58,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
-    implements CombineHiveInputFormat.AvoidSplitCombination, VectorizedInputFormatInterface {
+    implements CombineHiveInputFormat.AvoidSplitCombination, VectorizedInputFormatInterface,
+    LlapCacheOnlyInputFormatInterface.VectorizedOnly {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergInputFormat.class);
   private static final String HIVE_VECTORIZED_RECORDREADER_CLASS =
@@ -133,6 +137,11 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
   @Override
   public VectorizedSupport.Support[] getSupportedFeatures() {
     return new VectorizedSupport.Support[]{ VectorizedSupport.Support.DECIMAL_64 };
+  }
+
+  @Override
+  public void injectCaches(FileMetadataCache metadataCache, DataCache dataCache, Configuration cacheConf) {
+    // no-op for Iceberg
   }
 
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.util.Collection;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.tez.HashableInputSplit;
-import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.mr.mapreduce.IcebergSplitContainer;
+import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 import org.apache.iceberg.util.SerializationUtil;
 
 // Hive requires file formats to return splits that are instances of `FileSplit`.
@@ -80,9 +80,7 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       for (FileScanTask task : fileScanTasks) {
         baos.write(task.file().path().toString().getBytes());
-        byte[] startBytes = new byte[Long.BYTES];
-        SerDeUtils.writeLong(startBytes, 0, task.start());
-        baos.write(startBytes);
+        baos.write(Longs.toByteArray(task.start()));
       }
       return baos.toByteArray();
     } catch (IOException ioe) {
@@ -113,5 +111,4 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
     innerSplit = new IcebergSplit();
     innerSplit.readFields(in);
   }
-
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -22,10 +22,13 @@ package org.apache.iceberg.mr.hive;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.mr.mapreduce.IcebergSplitContainer;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.util.SerializationUtil;
 
 // Hive requires file formats to return splits that are instances of `FileSplit`.
@@ -65,7 +68,12 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
 
   @Override
   public Path getPath() {
-    return new Path(tableLocation);
+    Collection<FileScanTask> fileScanTasks = innerSplit.task().files();
+    if (fileScanTasks.size() == 1) {
+      return new Path(Iterators.getOnlyElement(fileScanTasks.iterator()).file().path().toString());
+    } else {
+      return new Path(tableLocation);
+    }
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -19,20 +19,22 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.tez.HashableInputSplit;
+import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.mr.mapreduce.IcebergSplitContainer;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.util.SerializationUtil;
 
 // Hive requires file formats to return splits that are instances of `FileSplit`.
-public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer {
+public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer, HashableInputSplit {
 
   private IcebergSplit innerSplit;
 
@@ -68,11 +70,23 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
 
   @Override
   public Path getPath() {
+    return new Path(tableLocation);
+  }
+
+  @Override
+  public byte[] getBytesForHash() {
     Collection<FileScanTask> fileScanTasks = innerSplit.task().files();
-    if (fileScanTasks.size() == 1) {
-      return new Path(Iterators.getOnlyElement(fileScanTasks.iterator()).file().path().toString());
-    } else {
-      return new Path(tableLocation);
+
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      for (FileScanTask task : fileScanTasks) {
+        baos.write(task.file().path().toString().getBytes());
+        byte[] startBytes = new byte[Long.BYTES];
+        SerDeUtils.writeLong(startBytes, 0, task.start());
+        baos.write(startBytes);
+      }
+      return baos.toByteArray();
+    } catch (IOException ioe) {
+      throw new RuntimeException("Couldn't produce hash input bytes for HiveIcebergSplit: " + this, ioe);
     }
   }
 
@@ -99,4 +113,5 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
     innerSplit = new IcebergSplit();
     innerSplit.readFields(in);
   }
+
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.llap.LlapHiveUtils;
+import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -116,7 +117,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     }
     // In case of LLAP-based execution we ask Iceberg not to combine multiple fileScanTasks into one split.
     // This is so that cache affinity can work, and each file(split) is executed/cached on always the same LLAP daemon.
-    if (LlapHiveUtils.findMapWork((JobConf) conf).getCacheAffinity()) {
+    MapWork mapWork = LlapHiveUtils.findMapWork((JobConf) conf);
+    if (mapWork != null && mapWork.getCacheAffinity()) {
       Long openFileCost = splitSize > 0 ? splitSize : TableProperties.SPLIT_SIZE_DEFAULT;
       scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(openFileCost));
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -107,25 +107,33 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     if (snapshotId != -1) {
       scan = scan.useSnapshot(snapshotId);
     }
+
     long asOfTime = conf.getLong(InputFormatConfig.AS_OF_TIMESTAMP, -1);
     if (asOfTime != -1) {
       scan = scan.asOfTime(asOfTime);
     }
+
     long splitSize = conf.getLong(InputFormatConfig.SPLIT_SIZE, 0);
     if (splitSize > 0) {
       scan = scan.option(TableProperties.SPLIT_SIZE, String.valueOf(splitSize));
     }
+
     // In case of LLAP-based execution we ask Iceberg not to combine multiple fileScanTasks into one split.
     // This is so that cache affinity can work, and each file(split) is executed/cached on always the same LLAP daemon.
     MapWork mapWork = LlapHiveUtils.findMapWork((JobConf) conf);
     if (mapWork != null && mapWork.getCacheAffinity()) {
+      // Iceberg splits logically consist of buckets, where the bucket size equals to openFileCost setting if the files
+      // assigned to such bucket are smaller. This is how Iceberg would combine multiple files into one split, so here
+      // we need to enforce the bucket size to be equal to split size to avoid file combination.
       Long openFileCost = splitSize > 0 ? splitSize : TableProperties.SPLIT_SIZE_DEFAULT;
       scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(openFileCost));
     }
+
     String schemaStr = conf.get(InputFormatConfig.READ_SCHEMA);
     if (schemaStr != null) {
       scan.project(SchemaParser.fromJson(schemaStr));
     }
+
     String[] selectedColumns = conf.getStrings(InputFormatConfig.SELECTED_COLUMNS);
     if (selectedColumns != null) {
       scan.select(selectedColumns);
@@ -136,6 +144,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     if (filter != null) {
       scan = scan.filter(filter);
     }
+
     return scan;
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.llap.LlapHiveUtils;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
@@ -97,15 +99,9 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     return new InputFormatConfig.ConfigBuilder(job.getConfiguration());
   }
 
-  @Override
-  public List<InputSplit> getSplits(JobContext context) {
-    Configuration conf = context.getConfiguration();
-    Table table = Optional
-        .ofNullable(HiveIcebergStorageHandler.table(conf, conf.get(InputFormatConfig.TABLE_IDENTIFIER)))
-        .orElseGet(() -> Catalogs.loadTable(conf));
-
+  private static TableScan createTableScan(Table table, Configuration conf) {
     TableScan scan = table.newScan()
-            .caseSensitive(conf.getBoolean(InputFormatConfig.CASE_SENSITIVE, InputFormatConfig.CASE_SENSITIVE_DEFAULT));
+        .caseSensitive(conf.getBoolean(InputFormatConfig.CASE_SENSITIVE, InputFormatConfig.CASE_SENSITIVE_DEFAULT));
     long snapshotId = conf.getLong(InputFormatConfig.SNAPSHOT_ID, -1);
     if (snapshotId != -1) {
       scan = scan.useSnapshot(snapshotId);
@@ -117,6 +113,12 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     long splitSize = conf.getLong(InputFormatConfig.SPLIT_SIZE, 0);
     if (splitSize > 0) {
       scan = scan.option(TableProperties.SPLIT_SIZE, String.valueOf(splitSize));
+    }
+    // In case of LLAP-based execution we ask Iceberg not to combine multiple fileScanTasks into one split.
+    // This is so that cache affinity can work, and each file(split) is executed/cached on always the same LLAP daemon.
+    if (LlapHiveUtils.findMapWork((JobConf) conf).getCacheAffinity()) {
+      Long openFileCost = splitSize > 0 ? splitSize : TableProperties.SPLIT_SIZE_DEFAULT;
+      scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(openFileCost));
     }
     String schemaStr = conf.get(InputFormatConfig.READ_SCHEMA);
     if (schemaStr != null) {
@@ -132,6 +134,17 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     if (filter != null) {
       scan = scan.filter(filter);
     }
+    return scan;
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) {
+    Configuration conf = context.getConfiguration();
+    Table table = Optional
+        .ofNullable(HiveIcebergStorageHandler.table(conf, conf.get(InputFormatConfig.TABLE_IDENTIFIER)))
+        .orElseGet(() -> Catalogs.loadTable(conf));
+
+    TableScan scan = createTableScan(table, conf);
 
     List<InputSplit> splits = Lists.newArrayList();
     boolean applyResidual = !conf.getBoolean(InputFormatConfig.SKIP_RESIDUAL_FILTERING, false);

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
@@ -68,7 +68,7 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 460 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: no inputs
+            LLAP IO: all inputs (cache only)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -185,7 +185,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col9 (type: float)
             Execution mode: vectorized, llap
-            LLAP IO: no inputs
+            LLAP IO: all inputs (cache only)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HashableInputSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HashableInputSplit.java
@@ -1,0 +1,11 @@
+package org.apache.hadoop.hive.ql.exec.tez;
+
+/**
+ * An InputSplit type that has a custom/specific way of producing its serialized content, to be later used as input
+ * of a hash function. Used for LLAP cache affinity, so that a certain split always ends up on the same executor.
+ */
+public interface HashableInputSplit {
+
+  byte[] getBytesForHash();
+
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HashableInputSplit.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HashableInputSplit.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.exec.tez;
 
 /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HostAffinitySplitLocationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HostAffinitySplitLocationProvider.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 
-import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.split.SplitLocationProvider;
@@ -62,21 +61,17 @@ public class HostAffinitySplitLocationProvider implements SplitLocationProvider 
       return split.getLocations();
     }
     FileSplit fsplit = (FileSplit) split;
-    String splitDesc = "Split at " + fsplit.getPath() + " with offset= " + fsplit.getStart()
-        + ", length=" + fsplit.getLength();
-    String location = locations.get(determineLocation(
-        locations, fsplit.getPath().toString(), fsplit.getStart(), splitDesc));
+    String location = locations.get(determineLocation(locations, fsplit));
     return (location != null) ? new String[] { location } : null;
   }
 
   @VisibleForTesting
-  public static int determineLocation(
-      List<String> locations, String path, long start, String desc) {
-    byte[] bytes = getHashInputForSplit(path, start);
+  public static int determineLocation(List<String> locations, FileSplit fsplit) {
+    byte[] bytes = getHashInputForSplit(fsplit);
     long hash1 = hash1(bytes);
     int index = Hashing.consistentHash(hash1, locations.size());
     String location = locations.get(index);
-    LOG.debug("{} mapped to index={}, location={}", desc, index, location);
+    LOG.debug("{} mapped to index={}, location={}", getSplitDescForDebug(fsplit), index, location);
     int iter = 1;
     long hash2 = 0;
     // Since our probing method is totally bogus, give up after some time.
@@ -87,23 +82,18 @@ public class HostAffinitySplitLocationProvider implements SplitLocationProvider 
       // Note that this is not real double hashing since we have consistent hash on top.
       index = Hashing.consistentHash(hash1 + iter * hash2, locations.size());
       location = locations.get(index);
-      LOG.debug("{} remapped to index={}, location={}", desc, index, location);
+      LOG.debug("{} remapped to index={}, location={}", getSplitDescForDebug(fsplit), index, location);
       ++iter;
     }
     return index;
   }
 
-  private static byte[] getHashInputForSplit(String path, long start) {
-    // Explicitly using only the start offset of a split, and not the length. Splits generated on
-    // block boundaries and stripe boundaries can vary slightly. Try hashing both to the same node.
-    // There is the drawback of potentially hashing the same data on multiple nodes though, when a
-    // large split is sent to 1 node, and a second invocation uses smaller chunks of the previous
-    // large split and send them to different nodes.
-    byte[] pathBytes = path.getBytes();
-    byte[] allBytes = new byte[pathBytes.length + 8];
-    System.arraycopy(pathBytes, 0, allBytes, 0, pathBytes.length);
-    SerDeUtils.writeLong(allBytes, pathBytes.length, start >> 3);
-    return allBytes;
+  private static byte[] getHashInputForSplit(FileSplit fsplit) {
+    if (fsplit instanceof HashableInputSplit) {
+      return ((HashableInputSplit)fsplit).getBytesForHash();
+    } else {
+      throw new RuntimeException("Split is not a HashableInputSplit: " + fsplit);
+    }
   }
 
   private static long hash1(byte[] bytes) {
@@ -114,5 +104,13 @@ public class HostAffinitySplitLocationProvider implements SplitLocationProvider 
   private static long hash2(byte[] bytes) {
     final int PRIME = 1366661;
     return Murmur3.hash64(bytes, 0, bytes.length, PRIME);
+  }
+
+  private static String getSplitDescForDebug(FileSplit fsplit) {
+    if (LOG.isDebugEnabled()) {
+      return "Split at " + fsplit.getPath() + " with offset= " + fsplit.getStart() + ", length=" + fsplit.getLength();
+    } else {
+      return null;
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/BucketizedHiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/BucketizedHiveInputFormat.java
@@ -68,7 +68,7 @@ public class BucketizedHiveInputFormat<K extends WritableComparable, V extends W
       throw new IOException("cannot find class " + inputFormatClassName);
     }
 
-    pushProjectionsAndFiltersAndAsOf(job, inputFormatClass, hsplit.getPath());
+    pushProjectionsAndFiltersAndAsOf(job, hsplit.getPath());
 
     InputFormat inputFormat = getInputFormatFromCache(inputFormatClass, job);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
@@ -710,7 +710,7 @@ public class CombineHiveInputFormat<K extends WritableComparable, V extends Writ
       throw new IOException("cannot find class " + inputFormatClassName);
     }
 
-    pushProjectionsAndFiltersAndAsOf(job, inputFormatClass, hsplit.getPath(0));
+    pushProjectionsAndFiltersAndAsOf(job, hsplit.getPath(0));
 
     return ShimLoader.getHadoopShims().getCombineFileInputFormat()
         .getRecordReader(job,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/LlapCacheOnlyInputFormatInterface.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/LlapCacheOnlyInputFormatInterface.java
@@ -25,4 +25,11 @@ import org.apache.hadoop.hive.common.io.FileMetadataCache;
 /** Marker interface for LLAP IO. */
 public interface LlapCacheOnlyInputFormatInterface {
   void injectCaches(FileMetadataCache metadataCache, DataCache dataCache, Configuration cacheConf);
+
+  /**
+   * For inputformats that can only accept LLAP caching with vectorization turned on.
+   */
+  interface VectorizedOnly extends LlapCacheOnlyInputFormatInterface {
+
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
@@ -311,7 +311,8 @@ public class MapWork extends BaseWork {
           } else {
             hasLlap = true;
           }
-        } else if (isLlapOn && HiveInputFormat.canInjectCaches(inputFormatClass)) {
+        } else if (isLlapOn && HiveInputFormat.canInjectCaches(inputFormatClass,
+            Utilities.getIsVectorized(conf, this))) {
           hasCacheOnly = true;
         } else {
           hasNonLlap = true;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestHostAffinitySplitLocationProvider.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestHostAffinitySplitLocationProvider.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcSplit;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
@@ -319,8 +320,7 @@ public class TestHostAffinitySplitLocationProvider {
     doReturn(new Path(fakePathString)).when(fileSplit).getPath();
     doReturn(locations).when(fileSplit).getLocations();
 
-    doReturn(locations).when(fileSplit).getLocations();
-    return fileSplit;
+    return new HiveInputFormat.HiveInputSplit(fileSplit, "unused");
   }
 
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestHostAffinitySplitLocationProvider.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestHostAffinitySplitLocationProvider.java
@@ -215,8 +215,7 @@ public class TestHostAffinitySplitLocationProvider {
     int[] hitCounts = new int[locs];
     for (int splitIx = 0; splitIx < splits.length; ++splitIx) {
       state.set(0);
-      int index = HostAffinitySplitLocationProvider.determineLocation(partLocs,
-          splits[splitIx].getPath().toString(), splits[splitIx].getStart(), null);
+      int index = HostAffinitySplitLocationProvider.determineLocation(partLocs, splits[splitIx]);
       ++hitCounts[index];
     }
     SummaryStatistics ss = new SummaryStatistics();


### PR DESCRIPTION
Since HiveIcebergInputformat doesn't implement any LLAP marker interfaces, cache affinity is never tried, and so any split containing ORC file parts may go to a random LLAP daemon, causing subpar hit ratio later.

So we should:

let HS2 know that cache affinity is required for this inputformat
prevent Iceberg from grouping separate files together in one combined split in case of LLAP execution
provide proper getPath() result for HiveIcebergSplit, so that HostAffinitySplitLocationProvider calculates different hashes for different files (right now getPath() returns table location only)