### PR TITLE
HIVE-25663 Need to modify table/partition lock acquisition retry for Zookeeper lock manager

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/zookeeper/ZooKeeperHiveLockManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/zookeeper/ZooKeeperHiveLockManager.java
@@ -319,11 +319,10 @@ public class ZooKeeperHiveLockManager implements HiveLockManager {
             LOG.debug("Possibly transient ZooKeeper exception: ", e);
             break;
           default:
-            LOG.error("Serious Zookeeper exception: ", e);
             break;
           }
         } else {
-          LOG.error("Other unexpected exception: ", e1);
+          break; // stops retry for unexpected exceptions
         }
       }
     } while (tryNum < numRetriesForLock);
@@ -334,7 +333,11 @@ public class ZooKeeperHiveLockManager implements HiveLockManager {
           + tryNum + " attempts.");
       printConflictingLocks(key,mode,conflictingLocks);
       if (lastException != null) {
-        LOG.error("Exceeds maximum retries with errors: ", lastException);
+        if (tryNum == numRetriesForLock) {
+          LOG.error("Exceeds maximum retries with errors: ", lastException);
+        } else {
+          LOG.error("Retry stopped with error: ", lastException);
+        }
         throw new LockException(lastException);
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
- break out from retry loop when it meets unexpected exception
- remove redundent logging, too
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
- table/partition locks acquired for SQL are remained for a long time even though it is cancelled or timed out
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
```sql
LOCK TABLE default.my_table PARTITION (log_date='2021-10-30') EXCLUSIVE;
SET hive.query.timeout.seconds=5;
SELECT * FROM default.my_table WHERE log_date='2021-10-30' LIMIT 10;
```
Then `show locks` shows the result.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
