### PR TITLE
HIVE-25676: Uncaught exception in QTestDatabaseHandler causes unrelated test failures

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/qoption/QTestDatabaseHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/qoption/QTestDatabaseHandler.java
@@ -104,9 +104,6 @@ public class QTestDatabaseHandler implements QTestOptionHandler {
 
   @Override
   public void beforeTest(QTestUtil qt) throws Exception {
-    if (databaseToScript.isEmpty()) {
-      return;
-    }
     for (Map.Entry<DatabaseType, String> dbEntry : databaseToScript.entrySet()) {
       String scriptsDir = QTestUtil.getScriptsDir(qt.getConf());
       Path dbScript = Paths.get(scriptsDir, dbEntry.getValue());
@@ -122,12 +119,13 @@ public class QTestDatabaseHandler implements QTestOptionHandler {
 
   @Override
   public void afterTest(QTestUtil qt) throws Exception {
-    if (databaseToScript.isEmpty()) {
-      return;
-    }
     for (Map.Entry<DatabaseType, String> dbEntry : databaseToScript.entrySet()) {
       AbstractExternalDB db = dbEntry.getKey().create();
-      db.cleanupDockerContainer();
+      try {
+        db.cleanupDockerContainer();
+      } catch (Exception e) {
+        LOG.error("Failed to cleanup database {}", dbEntry.getKey(), e);
+      }
     }
     databaseToScript.clear();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Catch the exception and log the problem instead of propagating it. 
2. Removing redundant isEmpty() check (Minor refactoring).

### Why are the changes needed?
To allow subsequent cleanup actions to run and avoid unrelated failures in other tests.

### Does this PR introduce _any_ user-facing change?
Improves developer experience by protecting against unrelated failures.

### How was this patch tested?
Manually causing failures in `cleanupDockerContainer` and monitoring the impact in other tests.