### PR TITLE
HIVE-25675: Intermittent PSQLException when trying to connect to Postgres in tests

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
@@ -17,10 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.externalDB;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-
 /**
  * MySQLExternalDB is a extension of abstractExternalDB
  * Designed for MySQL external database connection
@@ -52,16 +48,8 @@ public class PostgresExternalDB extends AbstractExternalDB {
     }
 
     public boolean isContainerReady(ProcessResults pr) {
-        if (pr.stdout.contains("PostgreSQL init process complete; ready for start up")) {
-            try (Socket socket = new Socket()) {
-                socket.connect(new InetSocketAddress(getContainerHostAddress(), 5432), 1000);
-                return true;
-            } catch (IOException e) {
-                LOG.info("cant connect to postgres; {}", e.getMessage());
-                return false;
-            }
-        }
-        return false;
+        return pr.stdout.contains("database system is ready to accept connections") &&
+            pr.stderr.contains("database system is ready to accept connections");
     }
 
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
@@ -17,19 +17,10 @@
  */
 package org.apache.hadoop.hive.metastore.dbinstall.rules;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * JUnit TestRule for Postgres.
  */
 public class Postgres extends DatabaseRule {
-  private static final Logger LOG = LoggerFactory.getLogger(Postgres.class);
-
   @Override
   public String getDockerImageName() {
     return "postgres:11.6";
@@ -72,16 +63,8 @@ public class Postgres extends DatabaseRule {
 
   @Override
   public boolean isContainerReady(ProcessResults pr) {
-    if (pr.stdout.contains("PostgreSQL init process complete; ready for start up")) {
-      try (Socket socket = new Socket()) {
-        socket.connect(new InetSocketAddress(getContainerHostAddress(), 5432), 1000);
-        return true;
-      } catch (IOException e) {
-        LOG.info("cant connect to postgres; {}", e.getMessage());
-        return false;
-      }
-    }
-    return false;
+    return pr.stdout.contains("database system is ready to accept connections") &&
+        pr.stderr.contains("database system is ready to accept connections");
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Ensure the database is ready by checking a certain message appears two times in the logs.
2. Remove the now unused logger.

### Why are the changes needed?
Sometimes when we try to connect to Postgres, the database is not yet completely ready despite the fact that the respective port is open thus leading to the following exception.

`PSQLException: FATAL: the database system is starting up`

### Does this PR introduce _any_ user-facing change?
Avoids intermittent failures due to partially initialised Postgres.

### How was this patch tested?
Run the flaky-checker on some tests relying on the dockerized Postgres (e.g., `qt_database_postgres.q`, `qt_database_all.q`, `jdbc_table_with_schema_postgres.q`).