### PR TITLE
HIVE-25690: Fix column reorder detection for Iceberg schema evolution

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -179,9 +179,12 @@ public final class HiveSchemaUtil {
   }
 
   /**
-   * Compares two lists of columns to each other, by name and index, to find the column that was moved by the
-   * schema evolution update (i.e. a column which was either moved to the first position, or moved after some specified
-   * column).
+   * Compares two lists of columns to each other to find the (singular) column that was moved. This works ideally for
+   * identifying the column that was moved by an ALTER TABLE ... CHANGE COLUMN command.
+   *
+   * Note: This method is only suitable for finding a single reordered column.
+   * Consequently, this method is NOT suitable for handling scenarios where multiple column reorders are possible at the
+   * same time, such as ALTER TABLE ... REPLACE COLUMNS commands.
    *
    * @param updated The list of the columns after some updates have taken place (if any)
    * @param old The list of the original columns
@@ -206,8 +209,9 @@ public final class HiveSchemaUtil {
       String oldName = old.get(oldIndex).getName();
       Integer newIndex = nameToNewIndex.get(oldName);
       if (newIndex != null) {
-        if (maxIndexDiff < Math.abs(newIndex - oldIndex)) {
-          maxIndexDiff = Math.abs(newIndex - oldIndex);
+        int indexDiff = Math.abs(newIndex - oldIndex);
+        if (maxIndexDiff < indexDiff) {
+          maxIndexDiff = indexDiff;
           reorderedColName = oldName;
         }
       }

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -201,12 +201,12 @@ public final class HiveSchemaUtil {
 
     // find the column which has the highest index difference between its position in the old vs the updated list
     String reorderedColName = null;
-    int maxIndexDiff = -1;
+    int maxIndexDiff = 0;
     for (int oldIndex = 0; oldIndex < old.size(); ++oldIndex) {
       String oldName = old.get(oldIndex).getName();
       Integer newIndex = nameToNewIndex.get(oldName);
       if (newIndex != null) {
-        if (maxIndexDiff < 0 || maxIndexDiff < Math.abs(newIndex - oldIndex)) {
+        if (maxIndexDiff < Math.abs(newIndex - oldIndex)) {
           maxIndexDiff = Math.abs(newIndex - oldIndex);
           reorderedColName = oldName;
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -574,7 +574,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       schemaDifference.getMissingFromFirst().forEach(icebergCols::remove);
     }
 
-    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getFirstOutOfOrderColumn(
+    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getReorderedColumn(
         hmsCols, icebergCols, ImmutableMap.of());
 
     // limit the scope of this operation to only dropping columns
@@ -612,8 +612,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
           schemaDifference.getMissingFromSecond().get(0).getName(),
           schemaDifference.getMissingFromFirst().get(0).getName());
     }
-    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getFirstOutOfOrderColumn(hmsCols, icebergCols,
-        renameMapping);
+    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getReorderedColumn(hmsCols, icebergCols, renameMapping);
 
     if (!schemaDifference.isEmpty() || outOfOrder != null) {
       transaction = icebergTable.newTransaction();

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -33,6 +32,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.Assert;

--- a/iceberg/iceberg-handler/src/test/queries/positive/llap_iceberg_read.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/llap_iceberg_read.q
@@ -53,8 +53,8 @@ SELECT i.name, i.description, SUM(o.quantity) FROM llap_items i JOIN llap_orders
 --adding a column
 ALTER TABLE llap_items ADD COLUMNS (to60 float);
 INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5);
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5);
 SELECT cat, min(to60) from llap_items group by cat;
 
 --removing a column
@@ -70,7 +70,7 @@ SELECT name, min(to60), max(cost) FROM llap_items WHERE itemid > 3 GROUP BY name
 ALTER TABLE llap_orders CHANGE tradets ordertime timestamp AFTER p2;
 ALTER TABLE llap_orders CHANGE p1 region string;
 INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU');
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'));
 SELECT region, min(ordertime), sum(quantity) FROM llap_orders WHERE itemid > 5 GROUP BY region;
 
 ALTER TABLE llap_orders CHANGE p2 state string;
@@ -79,25 +79,25 @@ SELECT region, state, min(ordertime), sum(quantity) FROM llap_orders WHERE itemi
 --adding new column
 ALTER TABLE llap_orders ADD COLUMNS (city string);
 INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München');
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München');
 SELECT state, max(city) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --making it a partition column
 ALTER TABLE llap_orders SET PARTITION SPEC (region, state, city);
 INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia');
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --de-partitioning a column
 ALTER TABLE llap_orders SET PARTITION SPEC (state, city);
 INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London');
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --removing a column from schema
-ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string);
+ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string);
 INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris');
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/vectorized_iceberg_read.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/vectorized_iceberg_read.q
@@ -42,7 +42,7 @@ insert into tbl_ice_orc_parted values
 -- query with projection of partition columns' subset
 select p1, a, min(b) from tbl_ice_orc_parted group by p1, a;
 
--- required for reordering between differnt types
+-- required for reordering between different types
 set hive.metastore.disallow.incompatible.col.type.changes=false;
 
 -- move partition columns
@@ -59,7 +59,7 @@ describe tbl_ice_orc_parted;
 -- should yield to the same result as previously
 select p1, a, min(b) from tbl_ice_orc_parted group by p1, a;
 
-insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria');
+insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria');
 
 -- projecting all columns
 select p1, p2, a, min(b) from tbl_ice_orc_parted group by p1, p2, a;

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read.q.out
@@ -144,14 +144,14 @@ POSTHOOK: type: ALTERTABLE_ADDCOLS
 POSTHOOK: Input: default@llap_items
 POSTHOOK: Output: default@llap_items
 PREHOOK: query: INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5)
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_items
 POSTHOOK: query: INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5)
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_items
@@ -216,12 +216,12 @@ POSTHOOK: type: ALTERTABLE_RENAMECOL
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU')
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'))
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU')
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -264,12 +264,12 @@ POSTHOOK: type: ALTERTABLE_ADDCOLS
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München')
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München')
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -295,12 +295,12 @@ POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia')
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia')
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -326,12 +326,12 @@ POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London')
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London')
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -349,21 +349,21 @@ FR	NULL	2.75
 HU	NULL	7.0
 IT	Venezia	6.0
 UK	London	2.0
-PREHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string)
+PREHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string)
 PREHOOK: type: ALTERTABLE_REPLACECOLS
 PREHOOK: Input: default@llap_orders
 PREHOOK: Output: default@llap_orders
-POSTHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string)
+POSTHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string)
 POSTHOOK: type: ALTERTABLE_REPLACECOLS
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris')
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris')
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
@@ -301,8 +301,8 @@ POSTHOOK: query: describe tbl_ice_orc_parted
 POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@tbl_ice_orc_parted
 p1                  	string              	from deserializer   
-a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
+a                   	int                 	from deserializer   
 p2                  	string              	from deserializer   
 	 	 
 # Partition Transform Information	 	 
@@ -319,11 +319,11 @@ POSTHOOK: Input: default@tbl_ice_orc_parted
 #### A masked pattern was here ####
 America	2	aa
 Europe	1	aa
-PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tbl_ice_orc_parted
-POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_orc_parted

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_read.q.out
@@ -229,8 +229,8 @@ POSTHOOK: query: describe tbl_ice_orc_parted
 POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@tbl_ice_orc_parted
 p1                  	string              	from deserializer   
-a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
+a                   	int                 	from deserializer   
 p2                  	string              	from deserializer   
 	 	 
 # Partition Transform Information	 	 
@@ -247,11 +247,11 @@ POSTHOOK: Input: default@tbl_ice_orc_parted
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 America	2	aa
 Europe	1	aa
-PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tbl_ice_orc_parted
-POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_orc_parted


### PR DESCRIPTION
### What changes were proposed in this pull request?
Revamp the algorithm which detects reordered columns. The current implementation is faulty. The new idea is too look for the column which has the highest index difference between its position in the HMS and Iceberg schemas.
E.g. Current schema: A, B, C, D
New schema (A moved to the end): B, C, D, A
Index difference for each column: A: 3, B: 1, C: 1, D: 1
So we know that A was the one that got moved.

In general, there are 3 scenarios: 
1) highest index diff = 0 -> there were no reorders
2) highest index diff = 1 -> two adjacent columns got swapped with each other:
E.g. A, B, C, D -> A, C, B, D
In this case we cannot identify for sure which one got moved by the user, but we it's okay because we can either do moveAfter(C, A) or moveAfter(B, C), they should be equivalent operations
3) highest index diff > 1 -> the reordered column can be identified definitively

### Why are the changes needed?
Fix correctness problem

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
new unit tests
