### PR TITLE
HIVE-25691: LLAP: ShuffleHandler port should respect value in config

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
@@ -285,6 +285,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
       maxShuffleThreads = 2 * Runtime.getRuntime().availableProcessors();
     }
 
+    port = conf.getInt(SHUFFLE_PORT_CONFIG_KEY, DEFAULT_SHUFFLE_PORT);
     // TODO: this is never used
     localDirs = conf.getTrimmedStrings(SHUFFLE_HANDLER_LOCAL_DIRS);
 
@@ -360,7 +361,6 @@ public class ShuffleHandler implements AttemptRegistrationListener {
         .childOption(ChannelOption.SO_KEEPALIVE, true);
     initPipeline(bootstrap, conf);
 
-    port = conf.getInt(SHUFFLE_PORT_CONFIG_KEY, DEFAULT_SHUFFLE_PORT);
     Channel ch = bootstrap.bind().sync().channel();
     accepted.add(ch);
     port = ((InetSocketAddress)ch.localAddress()).getPort();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Initializing shuffle port in the constructor before it's assigned to a random port in start()

### Why are the changes needed?
Described in jira.


### Does this PR introduce _any_ user-facing change?
Not really, shuffle port was random until now, user not necessarily noticed.


### How was this patch tested?
Tested on Cloudera Warehouse and added unit test.