### PR TITLE
HIVE-25686: UDFSpace result length calculation is incorrect after HADOOP-17901 and HADOOP-17905

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFSpace.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFSpace.java
@@ -44,7 +44,7 @@ public class UDFSpace extends UDF {
       len = 0;
     }
 
-    if (result.getBytes().length >= len) {
+    if (result.getLength() >= len) {
       result.set(result.getBytes(), 0, len);
     } else {
       byte[] spaces = new byte[len];

--- a/ql/src/test/queries/clientpositive/udf_space2.q
+++ b/ql/src/test/queries/clientpositive/udf_space2.q
@@ -1,0 +1,6 @@
+DESCRIBE FUNCTION space;
+DESCRIBE FUNCTION EXTENDED space;
+
+create table udf_space(i int);
+insert into udf_space values (5),(6),(7),(8),(9),(10),(11),(12),(13),(14);
+select i, SPACE(i) from udf_space;

--- a/ql/src/test/results/clientpositive/llap/udf_space2.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_space2.q.out
@@ -1,0 +1,50 @@
+PREHOOK: query: DESCRIBE FUNCTION space
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION space
+POSTHOOK: type: DESCFUNCTION
+space(n) - returns n spaces
+PREHOOK: query: DESCRIBE FUNCTION EXTENDED space
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION EXTENDED space
+POSTHOOK: type: DESCFUNCTION
+space(n) - returns n spaces
+Example:
+   > SELECT space(2) FROM src LIMIT 1;
+  '  '
+Function class:org.apache.hadoop.hive.ql.udf.UDFSpace
+Function type:BUILTIN
+PREHOOK: query: create table udf_space(i int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@udf_space
+POSTHOOK: query: create table udf_space(i int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@udf_space
+PREHOOK: query: insert into udf_space values (5),(6),(7),(8),(9),(10),(11),(12),(13),(14)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@udf_space
+POSTHOOK: query: insert into udf_space values (5),(6),(7),(8),(9),(10),(11),(12),(13),(14)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@udf_space
+POSTHOOK: Lineage: udf_space.i SCRIPT []
+PREHOOK: query: select i, SPACE(i) from udf_space
+PREHOOK: type: QUERY
+PREHOOK: Input: default@udf_space
+#### A masked pattern was here ####
+POSTHOOK: query: select i, SPACE(i) from udf_space
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@udf_space
+#### A masked pattern was here ####
+5	     
+6	      
+7	       
+8	        
+9	         
+10	          
+11	           
+12	            
+13	             
+14	              


### PR DESCRIPTION
### What changes were proposed in this pull request?
After the application of HADOOP-17901 and HADOOP-17905 they changed the backing array increment logic which is causing issues in the UDFSpace class.


### Why are the changes needed?
The previous `result.getBytes().length` is returning incorrect size which is causing error in the result output. By changing this method call to `result.getLength()` the size calculation is correct again any the original behaviour is restored.

Example of the UDFSpace behaviour with the different method calls:
```
space parameter - 11
result.getBytes().length - 0
result.getLength() - 0

space parameter - 12
result.getBytes().length - 11
result.getLength() - 11

space parameter - 13
result.getBytes().length - 16
result.getLength(): 12

space parameter - 14
result.getBytes().length - 16
result.getLength() - 13
```
Note that the issue is only present with Hadoop version that contains HADOOP-17901 and HADOOP-17905.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
The change was tested on live cluster and also in the new qtest that was introduced in the scope of this patch.
