### PR TITLE
HIVE-25706: ShuffleHandler: Make sure of properly releasing netty reference counted objects

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
@@ -1053,7 +1053,6 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     protected void sendError(ChannelHandlerContext ctx, String message, HttpResponseStatus status) {
       FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, status);
       sendError(ctx, message, response);
-      response.release();
     }
 
     protected void sendError(ChannelHandlerContext ctx, String message, FullHttpResponse response) {
@@ -1071,7 +1070,6 @@ public class ShuffleHandler implements AttemptRegistrationListener {
       header.write(out);
 
       sendError(ctx, wrappedBuffer(out.getData(), 0, out.getLength()), fullResponse);
-      fullResponse.release();
     }
 
     protected void sendError(ChannelHandlerContext ctx, ByteBuf content,
@@ -1086,6 +1084,11 @@ public class ShuffleHandler implements AttemptRegistrationListener {
 
       // Close the connection as soon as the error message is sent.
       ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+      /*
+       * The general rule of thumb is that the party that accesses a reference-counted object last
+       * is also responsible for the destruction of that reference-counted object.
+       */
+      content.release();
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Release the ByteBuf instance at the last usage point instead of releasing the http response.

### Why are the changes needed?
It threw exceptions silently in ShuffleHandler logs, easily reproducible in TestShuffleHandler.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Rerun TestShuffleHandler, IllegalReferenceCountException disappeared.
