### PR TITLE
HIVE-25721: Outer join result is wrong

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/JoinUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/JoinUtil.java
@@ -324,7 +324,7 @@ public class JoinUtil {
       int columnSize = valueCols.size();
       StringBuilder colNames = new StringBuilder();
       StringBuilder colTypes = new StringBuilder();
-      if (columnSize <= 0) {
+      if (columnSize <= 0 && noFilter) {
         continue;
       }
       for (int k = 0; k < columnSize; k++) {
@@ -341,9 +341,12 @@ public class JoinUtil {
         colTypes.append(TypeInfoFactory.shortTypeInfo.getTypeName());
         colTypes.append(',');
       }
-      // remove the last ','
-      colNames.setLength(colNames.length() - 1);
-      colTypes.setLength(colTypes.length() - 1);
+      if (colNames.length() > 0) {
+        // remove the last ','
+        colNames.setLength(colNames.length() - 1);
+        colTypes.setLength(colTypes.length() - 1);
+      }
+
       Properties props = new Properties();
       props.put(org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_FORMAT, "" + Utilities.ctrlaCode);
       props.put(org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMNS, colNames.toString());

--- a/ql/src/test/queries/clientpositive/sort_merge_join.q
+++ b/ql/src/test/queries/clientpositive/sort_merge_join.q
@@ -1,0 +1,17 @@
+set hive.auto.convert.join=false;
+
+create table t_smj_left (key string, value int);
+
+insert into t_smj_left values
+('key1', 1),
+('key1', 2);
+
+create table t_smj_right (key string, value int);
+
+insert into t_smj_right values
+('key1', 1);
+
+select
+    t2.value
+from t_smj_left t1
+left join t_smj_right t2 on t1.key=t2.key and t1.value=2;

--- a/ql/src/test/results/clientpositive/llap/sort_merge_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/sort_merge_join.q.out
@@ -1,0 +1,60 @@
+PREHOOK: query: create table t_smj_left (key string, value int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_smj_left
+POSTHOOK: query: create table t_smj_left (key string, value int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_smj_left
+PREHOOK: query: insert into t_smj_left values
+('key1', 1),
+('key1', 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_smj_left
+POSTHOOK: query: insert into t_smj_left values
+('key1', 1),
+('key1', 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_smj_left
+POSTHOOK: Lineage: t_smj_left.key SCRIPT []
+POSTHOOK: Lineage: t_smj_left.value SCRIPT []
+PREHOOK: query: create table t_smj_right (key string, value int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_smj_right
+POSTHOOK: query: create table t_smj_right (key string, value int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_smj_right
+PREHOOK: query: insert into t_smj_right values
+('key1', 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_smj_right
+POSTHOOK: query: insert into t_smj_right values
+('key1', 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_smj_right
+POSTHOOK: Lineage: t_smj_right.key SCRIPT []
+POSTHOOK: Lineage: t_smj_right.value SCRIPT []
+PREHOOK: query: select
+    t2.value
+from t_smj_left t1
+left join t_smj_right t2 on t1.key=t2.key and t1.value=2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t_smj_left
+PREHOOK: Input: default@t_smj_right
+#### A masked pattern was here ####
+POSTHOOK: query: select
+    t2.value
+from t_smj_left t1
+left join t_smj_right t2 on t1.key=t2.key and t1.value=2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t_smj_left
+POSTHOOK: Input: default@t_smj_right
+#### A masked pattern was here ####
+NULL
+1


### PR DESCRIPTION
For CommonMergeJoinOperator, the tableDesc will be null in the case that all columns in that table is not used. The tableDesc is null lead to using a dummy row to denote all rows in that table instead of adding row into rowContainer.
However, rows in that table cannot be ignored when it contains filter in on clause.

Reproduced steps are commented in the following ticket.
https://issues.apache.org/jira/browse/HIVE-25721