### PR TITLE
HIVE-24390 Spelling serde

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/RandomTypeUtil.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/RandomTypeUtil.java
@@ -131,7 +131,7 @@ public class RandomTypeUtil {
 
   public static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
   public static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
-  public static final long NANOSECONDS_PER_MILLISSECOND = TimeUnit.MILLISECONDS.toNanos(1);
+  public static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
 
   private static final ThreadLocal<DateFormat> DATE_FORMAT =
       new ThreadLocal<DateFormat>() {
@@ -172,12 +172,12 @@ public class RandomTypeUtil {
     case 2:
       // Limit to milliseconds only...
       optionalNanos = String.format(".%09d",
-          Integer.valueOf(r.nextInt((int) MILLISECONDS_PER_SECOND)) * NANOSECONDS_PER_MILLISSECOND);
+          Integer.valueOf(r.nextInt((int) MILLISECONDS_PER_SECOND)) * NANOSECONDS_PER_MILLISECOND);
       break;
     case 3:
       // Limit to below milliseconds only...
       optionalNanos = String.format(".%09d",
-          Integer.valueOf(r.nextInt((int) NANOSECONDS_PER_MILLISSECOND)));
+          Integer.valueOf(r.nextInt((int) NANOSECONDS_PER_MILLISECOND)));
       break;
     }
     String timestampStr = String.format("%04d-%02d-%02d %02d:%02d:%02d%s",

--- a/serde/src/java/org/apache/hadoop/hive/serde2/SerDeStatsStruct.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/SerDeStatsStruct.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.serde2;
 public interface SerDeStatsStruct {
 
   /**
-   * Rerurns the serialized size of the object.
+   * Returns the serialized size of the object.
    */
   public long getRawDataSerializedSize();
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/SerDeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/SerDeUtils.java
@@ -112,7 +112,7 @@ public final class SerDeUtils {
         escape.append('t');
         break;
       default:
-        // Control characeters! According to JSON RFC u0020
+        // Control characters! According to JSON RFC u0020
         if (c < ' ') {
           String hex = Integer.toHexString(c);
           escape.append('\\');

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
@@ -158,7 +158,7 @@ class AvroDeserializer {
    * @param writable Instance of GenericAvroWritable to deserialize
    * @param readerSchema Schema of the writable to deserialize
    * @return A list of objects suitable for Hive to work with further
-   * @throws AvroSerdeException For any exception during deseriliazation
+   * @throws AvroSerdeException For any exception during deserialization
    */
   public Object deserialize(List<String> columnNames, List<TypeInfo> columnTypes,
                             Writable writable, Schema readerSchema) throws AvroSerdeException {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
@@ -427,7 +427,7 @@ class AvroDeserializer {
                                  ListTypeInfo columnType) throws AvroSerdeException {
     // Need to check the original schema to see if this is actually a Fixed.
     if(recordSchema.getType().equals(Schema.Type.FIXED)) {
-    // We're faking out Hive to work through a type system impedence mismatch.
+    // We're faking out Hive to work through a type system impedance mismatch.
     // Pull out the backing array and convert to a list.
       GenericData.Fixed fixed = (GenericData.Fixed) datum;
       List<Byte> asList = new ArrayList<Byte>(fixed.bytes().length);

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
@@ -418,9 +418,9 @@ class AvroDeserializer {
     // and we would end up doing calculations twice to get the same tag
     int fsTag = GenericData.get().resolveUnion(fileSchema, datum); // Determine index of value from fileSchema
     int rsTag = GenericData.get().resolveUnion(recordSchema, datum); // Determine index of value from recordSchema
-    Object desered = worker(datum, fileSchema == null ? null : fileSchema.getTypes().get(fsTag),
+    Object desired = worker(datum, fileSchema == null ? null : fileSchema.getTypes().get(fsTag),
         recordSchema.getTypes().get(rsTag), columnType.getAllUnionObjectTypeInfos().get(rsTag));
-    return new StandardUnionObjectInspector.StandardUnion((byte)rsTag, desered);
+    return new StandardUnionObjectInspector.StandardUnion((byte)rsTag, desired);
   }
 
   private Object deserializeList(Object datum, Schema fileSchema, Schema recordSchema,

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerializer.java
@@ -161,7 +161,7 @@ class AvroSerializer {
 
   /** private cache to avoid lots of EnumSymbol creation while serializing.
    *  Two levels because the enum symbol is specific to a schema.
-   *  Object because we want to avoid the overhead of repeated toString calls while maintaining compatability.
+   *  Object because we want to avoid the overhead of repeated toString calls while maintaining compatibility.
    *  Provided there are few enum types per record, and few symbols per enum, memory use should be moderate.
    *  eg 20 types with 50 symbols each as length-10 Strings should be on the order of 100KB per AvroSerializer.
    */

--- a/serde/src/java/org/apache/hadoop/hive/serde2/columnar/ColumnarSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/columnar/ColumnarSerDe.java
@@ -88,7 +88,7 @@ public class ColumnarSerDe extends ColumnarSerDeBase {
     serdeParams = new LazySerDeParameters(configuration, properties, getClass().getName());
 
     // Create the ObjectInspectors for the fields. Note: Currently
-    // ColumnarObject uses same ObjectInpector as LazyStruct
+    // ColumnarObject uses same ObjectInspector as LazyStruct
     cachedObjectInspector = LazyFactory.createColumnarStructInspector(
         serdeParams.getColumnNames(), serdeParams.getColumnTypes(), serdeParams);
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
@@ -26,7 +26,7 @@ import org.apache.hive.common.util.HiveStringUtils;
 /**
  * HiveCharWritable.
  * String values will be padded to full char length.
- * Character legnth, comparison, hashCode should ignore trailing spaces.
+ * Character length, comparison, hashCode should ignore trailing spaces.
  */
 public class HiveCharWritable extends HiveBaseCharWritable 
     implements WritableComparable<HiveCharWritable> {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/json/HiveJsonReader.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/json/HiveJsonReader.java
@@ -469,7 +469,7 @@ public class HiveJsonReader {
   /**
    * Matches the JSON object's field name with the Hive data type.
    *
-   * @param oi The ObjectInsepctor to lookup the matching in
+   * @param oi The ObjectInspector to lookup the matching in
    * @param fieldName The name of the field parsed from the JSON text
    * @return The meta data of regarding this field
    * @throws SerDeException The SerDe is not configured correctly

--- a/serde/src/java/org/apache/hadoop/hive/serde2/json/HiveJsonWriter.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/json/HiveJsonWriter.java
@@ -171,7 +171,7 @@ public class HiveJsonWriter {
   /**
    * Visit a vertex in the graph that is a Java Map.
    *
-   * @param oi The map's OjectInspector
+   * @param oi The map's ObjectInspector
    * @param o The Map object
    * @return A JsonNode representation of the Map
    * @throws SerDeException The Map cannot be parsed
@@ -199,7 +199,7 @@ public class HiveJsonWriter {
   /**
    * Visit a vertex in the graph that is a Java List.
    *
-   * @param oi The list's OjectInspector
+   * @param oi The list's ObjectInspector
    * @param o The List object
    * @return A JsonNode representation of the List
    * @throws SerDeException The List cannot be parsed
@@ -225,7 +225,7 @@ public class HiveJsonWriter {
    * represented as a Java List where the name associated with each element in
    * the list is stored in the ObjectInspector.
    *
-   * @param oi The struct's OjectInspector
+   * @param oi The struct's ObjectInspector
    * @param o The List object
    * @param fieldNames List of names to override the default field names
    * @return A JsonNode representation of the List
@@ -256,7 +256,7 @@ public class HiveJsonWriter {
   /**
    * Visit a vertex in the graph that is a union data type.
    *
-   * @param oi The union's OjectInspector
+   * @param oi The union's ObjectInspector
    * @param o The Union object
    * @return A JsonNode representation of the union
    * @throws SerDeException The union cannot be parsed

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyFactory.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyFactory.java
@@ -84,7 +84,7 @@ public final class LazyFactory {
    * of the lazy object.
    *
    * @param poi PrimitiveObjectInspector
-   * @param typeBinary a switch to return either a LazyPrimtive class or it's binary
+   * @param typeBinary a switch to return either a LazyPrimitive class or it's binary
    *        companion
    * @return LazyPrimitive&lt;? extends ObjectInspector, ? extends Writable&gt;
    */

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyHiveDecimal.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyHiveDecimal.java
@@ -58,7 +58,7 @@ public class LazyHiveDecimal extends LazyPrimitive<LazyHiveDecimalObjectInspecto
   }
 
   /**
-   * Initilizes LazyHiveDecimal object by interpreting the input bytes
+   * Initializes LazyHiveDecimal object by interpreting the input bytes
    * as a numeric string
    *
    * @param bytes

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyTimestamp.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyTimestamp.java
@@ -46,7 +46,7 @@ public class LazyTimestamp extends LazyPrimitive<LazyTimestampObjectInspector, T
   }
 
   /**
-   * Initilizes LazyTimestamp object by interpreting the input bytes
+   * Initializes LazyTimestamp object by interpreting the input bytes
    * as a JDBC timestamp string
    *
    * @param bytes

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/fast/StringToDouble.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/fast/StringToDouble.java
@@ -71,7 +71,7 @@ public class StringToDouble {
     int c;
     int exp = 0;		/* Exponent read from "EX" field. */
     int fracExp = 0;		/* Exponent that derives from the fractional
-				 * part.  Under normal circumstatnces, it is
+				 * part.  Under normal circumstances, it is
 				 * the negative of the number of digits in F.
 				 * However, if I is very long, the last digits
 				 * of I get dropped (otherwise a long I with a

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryArray.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryArray.java
@@ -135,9 +135,9 @@ public class LazyBinaryArray extends
     // adjust arrays
     adjustArraySize(arraySize);
     // find out the null-bytes
-    int aarryByteStart = start + vInt.length;
-    int nullByteCur = aarryByteStart;
-    int nullByteEnd = aarryByteStart + (arraySize + 7) / 8;
+    int arrayByteStart = start + vInt.length;
+    int nullByteCur = arrayByteStart;
+    int nullByteEnd = arrayByteStart + (arraySize + 7) / 8;
     // the begin the real elements
     int lastElementByteEnd = nullByteEnd;
     // the list element object inspector

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryArray.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinaryArray.java
@@ -135,9 +135,9 @@ public class LazyBinaryArray extends
     // adjust arrays
     adjustArraySize(arraySize);
     // find out the null-bytes
-    int arryByteStart = start + vInt.length;
-    int nullByteCur = arryByteStart;
-    int nullByteEnd = arryByteStart + (arraySize + 7) / 8;
+    int aarryByteStart = start + vInt.length;
+    int nullByteCur = aarryByteStart;
+    int nullByteEnd = aarryByteStart + (arraySize + 7) / 8;
     // the begin the real elements
     int lastElementByteEnd = nullByteEnd;
     // the list element object inspector

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe2.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazybinary/LazyBinarySerDe2.java
@@ -65,7 +65,7 @@ import org.apache.hadoop.io.Writable;
 /**
  * Subclass of LazyBinarySerDe with faster serialization, initializing a serializer based on the
  * row columns rather than checking the ObjectInspector category/primitiveType for every value.
- * This appears to be around 3x faster than the LazyBinarSerDe serialization.
+ * This appears to be around 3x faster than the LazyBinarySerDe serialization.
  */
 @SerDeSpec(schemaProps = {serdeConstants.LIST_COLUMNS, serdeConstants.LIST_COLUMN_TYPES})
 public class LazyBinarySerDe2 extends LazyBinarySerDe {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ListObjectsEqualComparer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ListObjectsEqualComparer.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
  * Compare two list of objects.
  * Two lists are expected to have same types. Type information for every object is
  * passed when calling Constructor to avoid the step of figuring out types from
- * ObjectInspetor and determine how to compare the types when comparing.
+ * ObjectInspector and determine how to compare the types when comparing.
  * Also, for string and text elements, it performs slightly better than
  * using ObjectInspectorUtils.compare() == 0, which instead of calling .compare()
  * calls .equalTo(), which compares size before byte by byte comparison.

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -439,7 +439,7 @@ public final class ObjectInspectorConverters {
     UnionObjectInspector inputOI;
     SettableUnionObjectInspector outputOI;
 
-    // Object inspectors for the tags for the input and output unionss
+    // Object inspectors for the tags for the input and output unions
     List<? extends ObjectInspector> inputTagsOIs;
     List<? extends ObjectInspector> outputTagsOIs;
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -631,7 +631,7 @@ public final class ObjectInspectorUtils {
   /**
    * Computes the bucket number to which the bucketFields belong to
    * @param bucketFields  the bucketed fields of the row
-   * @param bucketFieldInspectors  the ObjectInpsectors for each of the bucketed fields
+   * @param bucketFieldInspectors  the ObjectInspectors for each of the bucketed fields
    * @param totalBuckets the number of buckets in the table
    * @return the bucket number using Murmur hash
    */
@@ -642,7 +642,7 @@ public final class ObjectInspectorUtils {
   /**
    * Computes the bucket number to which the bucketFields belong to
    * @param bucketFields  the bucketed fields of the row
-   * @param bucketFieldInspectors  the ObjectInpsectors for each of the bucketed fields
+   * @param bucketFieldInspectors  the ObjectInspectors for each of the bucketed fields
    * @param totalBuckets the number of buckets in the table
    * @return the bucket number
    */

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorUtils.java
@@ -1418,7 +1418,7 @@ public final class PrimitiveObjectInspectorUtils {
    * Based on the PrimitiveCategory of a type, return the PrimitiveGrouping
    * that the PrimitiveCategory belongs to (numeric, string, date, etc).
    * @param primitiveCategory Primitive category of the type
-   * @return PrimitveGrouping corresponding to the PrimitiveCategory,
+   * @return PrimitiveGrouping corresponding to the PrimitiveCategory,
    *         or UNKNOWN_GROUP if the type does not match to a grouping.
    */
   public static PrimitiveGrouping getPrimitiveGrouping(PrimitiveCategory primitiveCategory) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinaryDataInputStream.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinaryDataInputStream.java
@@ -136,7 +136,7 @@ public class TeradataBinaryDataInputStream extends SwappedDataInputStream {
    * Read CHAR(N).
    * The representation of char in Teradata binary format is
    * the byte number to read is based on the [charLength] * [bytePerChar] &lt;- totalLength,
-   * bytePerChar is decided by the charset: LATAIN charset is 2 bytes per char and UNICODE charset is 3 bytes per char.
+   * bytePerChar is decided by the charset: LATIN charset is 2 bytes per char and UNICODE charset is 3 bytes per char.
    * the null char will use space to pad.
    *
    * @param totalLength the total length

--- a/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinaryDataOutputStream.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinaryDataOutputStream.java
@@ -165,7 +165,7 @@ public class TeradataBinaryDataOutputStream extends ByteArrayOutputStream {
    * Write CHAR(N).
    * The representation of char in Teradata binary format is:
    * the byte number to read is based on the [charLength] * [bytePerChar] &lt;- totalLength,
-   * bytePerChar is decided by the charset: LATAIN charset is 2 bytes per char and UNICODE charset is 3 bytes per char.
+   * bytePerChar is decided by the charset: LATIN charset is 2 bytes per char and UNICODE charset is 3 bytes per char.
    * the null char will use space to pad.
    *
    * @param writable the writable

--- a/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
@@ -413,7 +413,7 @@ import static java.lang.String.format;
       throws IOException, ParseException, SerDeException {
     // isNull:
     // In the Teradata Binary file, even if the field is null (isNull=true),
-    // thd data still has some default values to pad the record.
+    // the data still has some default values to pad the record.
     // In this case, you cannot avoid reading the bytes even it is not used.
     switch (type.getCategory()) {
     case PRIMITIVE:

--- a/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/teradata/TeradataBinarySerde.java
@@ -412,7 +412,7 @@ import static java.lang.String.format;
   private Object deserializeField(TeradataBinaryDataInputStream in, TypeInfo type, Object reuse, boolean isNull)
       throws IOException, ParseException, SerDeException {
     // isNull:
-    // In the Teradata Binary file, even the field is null (isNull=true),
+    // In the Teradata Binary file, even if the field is null (isNull=true),
     // thd data still has some default values to pad the record.
     // In this case, you cannot avoid reading the bytes even it is not used.
     switch (type.getCategory()) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/thrift/TCTLSeparatedProtocol.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/thrift/TCTLSeparatedProtocol.java
@@ -182,7 +182,7 @@ public class TCTLSeparatedProtocol extends TProtocol implements
   protected final TTransport innerTransport;
 
   /**
-   * Strings used to lookup the various configurable paramaters of this
+   * Strings used to lookup the various configurable parameters of this
    * protocol.
    */
   public static final String ReturnNullsKey = "separators.return_nulls";

--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TimestampLocalTZTypeInfo.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TimestampLocalTZTypeInfo.java
@@ -45,7 +45,7 @@ public class TimestampLocalTZTypeInfo extends PrimitiveTypeInfo {
 
   @Override
   public void setTypeName(String typeName) {
-    // No need to set type name, it should always be timestamplocal tz
+    // No need to set type name, it should always be {@link serdeConstants.TIMESTAMPLOCALTZ_TYPE_NAME}
     return;
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TimestampLocalTZTypeInfo.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TimestampLocalTZTypeInfo.java
@@ -45,7 +45,7 @@ public class TimestampLocalTZTypeInfo extends PrimitiveTypeInfo {
 
   @Override
   public void setTypeName(String typeName) {
-    // No need to set type name, it should always be timestamplocaltz
+    // No need to set type name, it should always be timestamplocal tz
     return;
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
@@ -712,9 +712,9 @@ public final class TypeInfoUtils {
         break;
       }
       case STRUCT: {
-        StructTypeInfo strucTypeInfo = (StructTypeInfo) typeInfo;
-        List<String> fieldNames = strucTypeInfo.getAllStructFieldNames();
-        List<TypeInfo> fieldTypeInfos = strucTypeInfo
+        StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
+        List<String> fieldNames = structTypeInfo.getAllStructFieldNames();
+        List<TypeInfo> fieldTypeInfos = structTypeInfo
             .getAllStructFieldTypeInfos();
         List<ObjectInspector> fieldObjectInspectors = new ArrayList<ObjectInspector>(
             fieldTypeInfos.size());

--- a/serde/src/test/org/apache/hadoop/hive/serde2/SerdeRandomRowSource.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/SerdeRandomRowSource.java
@@ -457,7 +457,7 @@ public class SerdeRandomRowSource {
         primitiveObjectInspectorList.add(null);
         break;
       default:
-        throw new RuntimeException("Unexpected catagory " + category);
+        throw new RuntimeException("Unexpected category " + category);
       }
       objectInspectorList.add(objectInspector);
 

--- a/serde/src/test/org/apache/hadoop/hive/serde2/TestJsonSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/TestJsonSerDe.java
@@ -49,7 +49,7 @@ import org.junit.Test;
 public class TestJsonSerDe {
 
   @Test
-  public void testPrimativeDataTypes() throws Exception {
+  public void testPrimitiveDataTypes() throws Exception {
     Properties props = new Properties();
     props.setProperty(serdeConstants.LIST_COLUMNS,
         "name,height,weight,endangered,born");

--- a/serde/src/test/org/apache/hadoop/hive/serde2/TestJsonSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/TestJsonSerDe.java
@@ -168,7 +168,7 @@ public class TestJsonSerDe {
   /**
    * Test when a map has a key defined as a numeric value. Technically, JSON
    * does not support this because each key in a map must be a quoted string.
-   * Unquoted strings (hence an int value) is allowed by Javascript, but not by
+   * Unquoted strings (hence an int value) is allowed by JavaScript, but not by
    * JSON specification. For Hive, the int map key type is stored as a string
    * and must be converted back into an int type.
    */

--- a/serde/src/test/org/apache/hadoop/hive/serde2/TestTCTLSeparatedProtocol.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/TestTCTLSeparatedProtocol.java
@@ -530,7 +530,7 @@ public class TestTCTLSeparatedProtocol {
     separatedProtocol.initialize(null, new Properties());
     try {
       separatedProtocol.readStructBegin();
-      fail("Runtime Exception is expected if the intialization of tokenizer failed.");
+      fail("Runtime Exception is expected if the initialization of tokenizer failed.");
     } catch (Exception e) {
       assertTrue(e.getCause() instanceof TTransportException);
     }

--- a/serde/src/test/org/apache/hadoop/hive/serde2/TestTCTLSeparatedProtocol.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/TestTCTLSeparatedProtocol.java
@@ -231,12 +231,12 @@ public class TestTCTLSeparatedProtocol {
     assertTrue(prot.readString().equals("bye!"));
     prot.readFieldEnd();
 
-    // shouldl return nulls at end
+    // should return nulls at end
     prot.readFieldBegin();
     assertNull(prot.readString());
     prot.readFieldEnd();
 
-    // shouldl return nulls at end
+    // should return nulls at end
     prot.readFieldBegin();
     assertNull(prot.readString());
     prot.readFieldEnd();
@@ -299,12 +299,12 @@ public class TestTCTLSeparatedProtocol {
     prot.readListEnd();
     prot.readFieldEnd();
 
-    // shouldl return nulls at end
+    // should return nulls at end
     prot.readFieldBegin();
     assertNull(prot.readString());
     prot.readFieldEnd();
 
-    // shouldl return nulls at end
+    // should return nulls at end
     prot.readFieldBegin();
     assertNull(prot.readString());
     prot.readFieldEnd();

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroDeserializer.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroDeserializer.java
@@ -510,7 +510,7 @@ public class TestAvroDeserializer {
     assertEquals("DALEKS", finalValue);
   }
 
-  @Test // Fixed doesn't exist in Hive. Fixeds go in, lists of bytes go out.
+  @Test // Fixed doesn't exist in Hive. Fixed go in, lists of bytes go out.
   public void canDeserializeFixed() throws SerDeException, IOException {
     Schema s = AvroSerdeUtils.getSchemaFor(TestAvroObjectInspectorGenerator.FIXED_SCHEMA);
     GenericData.Record record = new GenericData.Record(s);

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
@@ -413,7 +413,7 @@ public class TestAvroObjectInspectorGenerator {
    * Check a given AvroObjectInspectorGenerator to verify that it matches our test
    * schema's expected map.
    * @param aoig should already have been intitialized, may not be null
-   * @param fieldName name of the contianed column, will always fail if null.
+   * @param fieldName name of the contained column, will always fail if null.
    */
   private void verifyMap(final AvroObjectInspectorGenerator aoig, final String fieldName) {
     // Column names

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
@@ -412,7 +412,7 @@ public class TestAvroObjectInspectorGenerator {
   /**
    * Check a given AvroObjectInspectorGenerator to verify that it matches our test
    * schema's expected map.
-   * @param aoig should already have been intitialized, may not be null
+   * @param aoig should already have been initialized, may not be null
    * @param fieldName name of the contained column, will always fail if null.
    */
   private void verifyMap(final AvroObjectInspectorGenerator aoig, final String fieldName) {

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroObjectInspectorGenerator.java
@@ -162,7 +162,7 @@ public class TestAvroObjectInspectorGenerator {
       "  \"fields\": [\n" +
       "   {\n" +
       "      \"name\":\"baddies\",\n" +
-      "      \"type\":{\"type\":\"enum\",\"name\":\"villians\", \"symbols\": " +
+      "      \"type\":{\"type\":\"enum\",\"name\":\"villains\", \"symbols\": " +
           "[\"DALEKS\", \"CYBERMEN\", \"SLITHEEN\", \"JAGRAFESS\"]}\n" +
       "      \n" +
       "      \n" +
@@ -206,7 +206,7 @@ public class TestAvroObjectInspectorGenerator {
       "  \"fields\": [\n" +
       "   {\n" +
       "      \"name\":\"nullableEnum\",\n" +
-      "      \"type\": [\"null\", {\"type\":\"enum\",\"name\":\"villians\", \"symbols\": " +
+      "      \"type\": [\"null\", {\"type\":\"enum\",\"name\":\"villains\", \"symbols\": " +
           "[\"DALEKS\", \"CYBERMEN\", \"SLITHEEN\", \"JAGRAFESS\"]}]\n" +
       "      \n" +
       "      \n" +

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
@@ -48,7 +48,7 @@ public class TestAvroSerdeUtils {
       "    {\"name\":\"mayBeNull\", \"type\":[\"string\", \"null\"]}\n" +
       "  ]\n" +
       "}";
-  // Same union, order reveresed
+  // Same union, order reversed
   private final String NULLABLE_UNION2 = "{\n" +
     "  \"type\": \"record\", \n" +
     "  \"name\": \"nullTest\",\n" +

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroSerdeUtils.java
@@ -151,7 +151,7 @@ public class TestAvroSerdeUtils {
   }
 
   @Test
-  public void detemineSchemaTriesToOpenUrl() throws AvroSerdeException, IOException {
+  public void determineSchemaTriesToOpenUrl() throws AvroSerdeException, IOException {
     Configuration conf = new Configuration();
     Properties props = new Properties();
     props.put(AvroTableProperties.SCHEMA_URL.getPropName(), "not:///a.real.url");

--- a/serde/src/test/org/apache/hadoop/hive/serde2/binarysortable/TestBinarySortableFast.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/binarysortable/TestBinarySortableFast.java
@@ -338,7 +338,7 @@ public class TestBinarySortableFast {
         }
       }
       if (!VerifyLazy.lazyCompare(typeInfo, complexFieldObj, expectedObject)) {
-        fail("Comparision failed typeInfo " + typeInfo.toString());
+        fail("Comparison failed typeInfo " + typeInfo.toString());
       }
     }
   }

--- a/serde/src/test/org/apache/hadoop/hive/serde2/lazy/TestLazySimpleFast.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/lazy/TestLazySimpleFast.java
@@ -244,7 +244,7 @@ public class TestLazySimpleFast {
         }
       }
       if (!VerifyLazy.lazyCompare(typeInfo, complexFieldObj, expectedObject)) {
-        fail("Comparision failed typeInfo " + typeInfo.toString());
+        fail("Comparison failed typeInfo " + typeInfo.toString());
       }
     }
   }

--- a/serde/src/test/org/apache/hadoop/hive/serde2/lazybinary/TestLazyBinaryFast.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/lazybinary/TestLazyBinaryFast.java
@@ -240,7 +240,7 @@ public class TestLazyBinaryFast {
         }
       }
       if (!VerifyLazy.lazyCompare(typeInfo, complexFieldObj, expectedObject)) {
-        fail("Comparision failed typeInfo " + typeInfo.toString());
+        fail("Comparison failed typeInfo " + typeInfo.toString());
       }
     }
   }

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorConverters.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorConverters.java
@@ -85,7 +85,7 @@ public class TestObjectInspectorConverters {
       convertText();
 
       // Binary
-      converBinary();
+      convertBinary();
 
       // Union
       convertUnion();
@@ -185,7 +185,7 @@ private void convertUnion() {
       assertEquals(expectedObjectExtra, convertedObjectExtra); // we should get back null
 }
 
-private void converBinary() {
+private void convertBinary() {
 	Converter baConverter = ObjectInspectorConverters.getConverter(
           PrimitiveObjectInspectorFactory.javaStringObjectInspector,
           PrimitiveObjectInspectorFactory.writableBinaryObjectInspector);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling) in the `serde` directory.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Typos lead to all sorts of problems, branding errors, tests that don't test what's expected, difficulty in understanding both the code and the product.

Landing this would make it possible to add the check-spelling workflow for the `serde/` directory and then slowly land fixes for other directories (while guarding against additional typos in them once a directory's typos have been fixed). See https://github.com/apache/hive/pull/1674#issuecomment-973098911

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, unless there's a javadoc for `org.apache.hadoop.hive.serde2.RandomTypeUtil. NANOSECONDS_PER_MILLISSECOND` (which is being renamed).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The CI does testing (initially https://github.com/jsoref/hive/commit/27ec490bd8e36d2c7b33863ca0e20989fb9f1e62) and the goal is to include it. Initially, I'd like to get these changes merged and then I can provide a PR which just adds the CI (or maybe the CI and a handful of fixes if that many sneak in between now and then).