### PR TITLE
HIVE-25724: Support external tables only for special databases

### DIFF
--- a/ql/src/test/queries/clientnegative/create_acid_table_with_special_db_property.q
+++ b/ql/src/test/queries/clientnegative/create_acid_table_with_special_db_property.q
@@ -1,0 +1,11 @@
+-- Acid table creation is not allowed when EXTERNAL_TABLES_ONLY property is set on database.
+set hive.mapred.mode=nonstrict;
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.acid.direct.insert.enabled=false;
+set metastore.metadata.transformer.class=org.apache.hadoop.hive.metastore.MetastoreDefaultTransformer;
+
+create database repl_db_test with DBPROPERTIES('EXTERNAL_TABLES_ONLY'='true');
+use repl_db_test;
+
+CREATE TRANSACTIONAL TABLE transactional_table_test(key string, value string);

--- a/ql/src/test/results/clientnegative/create_acid_table_with_special_db_property.q.out
+++ b/ql/src/test/results/clientnegative/create_acid_table_with_special_db_property.q.out
@@ -1,0 +1,17 @@
+PREHOOK: query: create database repl_db_test with DBPROPERTIES('EXTERNAL_TABLES_ONLY'='true')
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:repl_db_test
+POSTHOOK: query: create database repl_db_test with DBPROPERTIES('EXTERNAL_TABLES_ONLY'='true')
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:repl_db_test
+PREHOOK: query: use repl_db_test
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:repl_db_test
+POSTHOOK: query: use repl_db_test
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:repl_db_test
+PREHOOK: query: CREATE TRANSACTIONAL TABLE transactional_table_test(key string, value string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:repl_db_test
+PREHOOK: Output: repl_db_test@transactional_table_test
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Creation of ACID table is not allowed when the property 'EXTERNAL_TABLES_ONLY'='TRUE' is set on the database.)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -671,14 +671,16 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
           // should we check tbl directory existence?
         }
       } else { // ACID table
-        if (processorCapabilities == null || processorCapabilities.isEmpty()) {
-          throw new MetaException("Processor has no capabilities, cannot create an ACID table.");
-        }
-
+        // if the property 'EXTERNAL_TABLES_ONLY'='true' is set on the database, then creating managed/ACID tables are prohibited. See HIVE-25724 for more details.
         if (db.getParameters().containsKey(EXTERNALTABLESONLY) &&
                 db.getParameters().get(EXTERNALTABLESONLY).equalsIgnoreCase("true")) {
           throw new MetaException("Creation of ACID table is not allowed when the property 'EXTERNAL_TABLES_ONLY'='TRUE' is set on the database.");
         }
+
+        if (processorCapabilities == null || processorCapabilities.isEmpty()) {
+          throw new MetaException("Processor has no capabilities, cannot create an ACID table.");
+        }
+
 
         newTable = validateTablePaths(table);
         if (isInsertAcid) { // MICRO_MANAGED Tables

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -70,6 +70,7 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
   private static final String OBJCAPABILITIES = "OBJCAPABILITIES".intern();
   private static final String MANAGERAWMETADATA = "MANAGE_RAW_METADATA".intern();
   private static final String ACCEPTSUNMODIFIEDMETADATA = "ACCEPTS_UNMODIFIED_METADATA".intern();
+  private static final String EXTERNALTABLESONLY = "EXTERNAL_TABLES_ONLY".intern();
 
   private static final List<String> ACIDCOMMONWRITELIST = new ArrayList(Arrays.asList(
       HIVEMANAGESTATS,
@@ -672,6 +673,11 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
       } else { // ACID table
         if (processorCapabilities == null || processorCapabilities.isEmpty()) {
           throw new MetaException("Processor has no capabilities, cannot create an ACID table.");
+        }
+
+        if (db.getParameters().containsKey(EXTERNALTABLESONLY) &&
+                db.getParameters().get(EXTERNALTABLESONLY).equalsIgnoreCase("true")) {
+          throw new MetaException("Creation of ACID table is not allowed when the property 'EXTERNAL_TABLES_ONLY'='TRUE' is set on the database.");
         }
 
         newTable = validateTablePaths(table);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Forbid ACID table creation when a property 'EXTERNAL_TABLES_ONLY'='TRUE' is set on the database. In that case only external tables creation is allowed in these databases.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Easy for Old replication engines like BDR to replicate tables.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Users will have to create a database with the property 'EXTERNAL_TABLES_ONLY'='TRUE' so that only external table creation is allowed within the database.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Local machine, Remote cluster
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
