### PR TITLE
HIVE-25726: Upgrade velocity to 2.3 due to CVE-2020-13936

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <tempus-fugit.version>1.1</tempus-fugit.version>
     <snappy.version>1.1.4</snappy.version>
     <wadl-resourcedoc-doclet.version>1.4</wadl-resourcedoc-doclet.version>
-    <velocity.version>1.5</velocity.version>
+    <velocity.version>2.3</velocity.version>
     <xerces.version>2.12.1</xerces.version>
     <xmlsec.version>2.2.1</xmlsec.version>
     <zookeeper.version>3.5.5</zookeeper.version>
@@ -596,7 +596,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
+        <artifactId>velocity-engine-core</artifactId>
         <version>${velocity.version}</version>
       </dependency>
       <dependency>

--- a/vector-code-gen/pom.xml
+++ b/vector-code-gen/pom.xml
@@ -43,16 +43,6 @@
       <artifactId>ant</artifactId>
       <version>${ant.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-           <exclusions>
-             <exclusion>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-          </exclusion>
-           </exclusions>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Velocity project announced CVE-2020-13936 on 20210309 and through NVD 20210317 to get detected internally.

https://nvd.nist.gov/vuln/detail/CVE-2020-13936
http://velocity.apache.org/news.html




### Why are the changes needed?
This patch addresses security vulnerability by upgrading velocity version.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Relying on existing tests. 
