### PR TITLE
HIVE-25736: Close ORC readers

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestAcidOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestAcidOnTez.java
@@ -909,10 +909,11 @@ ekoifman:apache-hive-3.0.0-SNAPSHOT-bin ekoifman$ tree  ~/dev/hiverwgit/itests/h
       LocatedFileStatus lf = lfs.next();
       Path file = lf.getPath();
       if (!file.getName().startsWith(".") && !file.getName().startsWith("_")) {
-        Reader reader = OrcFile.createReader(file, OrcFile.readerOptions(new Configuration()));
-        OrcProto.Footer footer = reader.getFileTail().getFooter();
-        assertEquals("Reader based original check", expected, OrcInputFormat.isOriginal(reader));
-        assertEquals("Footer based original check", expected, OrcInputFormat.isOriginal(footer));
+        try (Reader reader = OrcFile.createReader(file, OrcFile.readerOptions(new Configuration()))) {
+          OrcProto.Footer footer = reader.getFileTail().getFooter();
+          assertEquals("Reader based original check", expected, OrcInputFormat.isOriginal(reader));
+          assertEquals("Footer based original check", expected, OrcInputFormat.isOriginal(footer));
+        }
         foundAnyFile = true;
       }
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -2148,9 +2148,10 @@ public class TestCompactor {
       + tblName1, driver, "Find Orc File bufer default");
     Assert.assertTrue("empty rs?", rs != null && rs.size() > 0);
     Path p = new Path(rs.get(0));
-    Reader orcReader = OrcFile.createReader(p.getFileSystem(conf), p);
-    Assert.assertEquals("Expected default compression size",
-      2700, orcReader.getCompressionSize());
+    try (Reader orcReader = OrcFile.createReader(p.getFileSystem(conf), p)) {
+      Assert.assertEquals("Expected default compression size",
+          2700, orcReader.getCompressionSize());
+    }
     //make sure 2700 is not the default so that we are testing if tblproperties indeed propagate
     Assert.assertNotEquals("Unexpected default compression size", 2700,
       OrcConf.BUFFER_SIZE.getDefaultValue());
@@ -2201,9 +2202,10 @@ public class TestCompactor {
       driver, "Find Compacted Orc File");
     Assert.assertTrue("empty rs?", rs != null && rs.size() > 0);
     p = new Path(rs.get(0));
-    orcReader = OrcFile.createReader(p.getFileSystem(conf), p);
-    Assert.assertEquals("File written with wrong buffer size",
-      3141, orcReader.getCompressionSize());
+    try (Reader orcReader = OrcFile.createReader(p.getFileSystem(conf), p)){
+      Assert.assertEquals("File written with wrong buffer size",
+          3141, orcReader.getCompressionSize());
+    }
   }
 
   @Test

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
@@ -154,6 +154,9 @@ public class OrcFileMergeOperator extends
 
       // next file in the path
       if (!k.getInputPath().equals(prevPath)) {
+        if (reader != null) {
+          reader.close();
+        }
         reader = OrcFile.createReader(fs, k.getInputPath());
       }
 
@@ -187,6 +190,15 @@ public class OrcFileMergeOperator extends
     } finally {
       if (exception) {
         closeOp(true);
+      }
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (IOException e) {
+          throw new HiveException(String.format("Unable to close reader for %s", filePath), e);
+        } finally {
+          reader = null;
+        }
       }
       if (fdis != null) {
         try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.hadoop.hive.ql.io.orc.Reader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FileStatus;
@@ -112,8 +113,9 @@ public class PostExecOrcFileDump implements ExecuteWithHookContext {
         LOG.info("Printing orc file dump for " + fileStatus.getPath());
         if (fileStatus.getLen() > 0) {
           try {
-            // just creating orc reader is going to do sanity checks to make sure its valid ORC file
-            OrcFile.createReader(fs, fileStatus.getPath());
+            try (Reader notUsed = OrcFile.createReader(fs, fileStatus.getPath())) {
+              // just creating orc reader is going to do sanity checks to make sure its valid ORC file
+            }
             console.printError("-- BEGIN ORC FILE DUMP --");
             FileDump.main(new String[]{fileStatus.getPath().toString(), "--rowindex=*"});
             console.printError("-- END ORC FILE DUMP --");

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -627,9 +627,9 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
           return false;
         }
       }
-      try {
-        OrcFile.createReader(file.getPath(),
-            OrcFile.readerOptions(conf).filesystem(fs).maxLength(file.getLen()));
+      try (Reader notUsed = OrcFile.createReader(file.getPath(),
+            OrcFile.readerOptions(conf).filesystem(fs).maxLength(file.getLen()))) {
+        // We do not use the reader itself. We just check if we can open the file.
       } catch (IOException e) {
         return false;
       }
@@ -1651,17 +1651,18 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
       // object contains the orc tail from the cache then we can skip creating orc reader avoiding
       // filesystem calls.
       if (orcTail == null) {
-        Reader orcReader = OrcFile.createReader(file.getPath(),
+        try (Reader orcReader = OrcFile.createReader(file.getPath(),
             OrcFile.readerOptions(context.conf)
                 .filesystem(fs)
-                .maxLength(context.isAcid ? AcidUtils.getLogicalLength(fs, file) : file.getLen()));
-        orcTail = new OrcTail(orcReader.getFileTail(), orcReader.getSerializedFileFooter(),
-            file.getModificationTime());
-        if (context.cacheStripeDetails) {
-          context.footerCache.put(new FooterCacheKey(fsFileId, file.getPath()), orcTail);
+                .maxLength(context.isAcid ? AcidUtils.getLogicalLength(fs, file) : file.getLen()))) {
+          orcTail = new OrcTail(orcReader.getFileTail(), orcReader.getSerializedFileFooter(),
+              file.getModificationTime());
+          if (context.cacheStripeDetails) {
+            context.footerCache.put(new FooterCacheKey(fsFileId, file.getPath()), orcTail);
+          }
+          stripes = orcReader.getStripes();
+          stripeStats = orcReader.getStripeStatistics();
         }
-        stripes = orcReader.getStripes();
-        stripeStats = orcReader.getStripeStatistics();
       } else {
         stripes = orcTail.getStripes();
         // Always convert To PROLEPTIC_GREGORIAN

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -1666,10 +1666,11 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
       } else {
         stripes = orcTail.getStripes();
         // Always convert To PROLEPTIC_GREGORIAN
-        org.apache.orc.Reader dummyReader = new org.apache.orc.impl.ReaderImpl(null,
+        try (org.apache.orc.Reader dummyReader = new org.apache.orc.impl.ReaderImpl(null,
             org.apache.orc.OrcFile.readerOptions(org.apache.orc.OrcFile.readerOptions(context.conf).getConfiguration())
-                .useUTCTimestamp(true).convertToProlepticGregorian(true).orcTail(orcTail));
-        stripeStats = dummyReader.getVariantStripeStatistics(null);
+                .useUTCTimestamp(true).convertToProlepticGregorian(true).orcTail(orcTail))) {
+          stripeStats = dummyReader.getVariantStripeStatistics(null);
+        }
       }
       fileTypes = orcTail.getTypes();
       TypeDescription fileSchema = OrcUtils.convertTypeFromProtobuf(fileTypes, 0);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRawRecordMerger.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRawRecordMerger.java
@@ -493,9 +493,9 @@ public class OrcRawRecordMerger implements AcidInputFormat.RawReader<OrcStruct>{
             isLastFileForThisBucket = true;
             continue;
           }
-          Reader copyReader = OrcFile.createReader(f.getFileStatus().getPath(),
-            OrcFile.readerOptions(conf));
-          rowIdOffsetTmp += copyReader.getNumberOfRows();
+          try (Reader copyReader = OrcFile.createReader(f.getFileStatus().getPath(), OrcFile.readerOptions(conf))) {
+            rowIdOffsetTmp += copyReader.getNumberOfRows();
+          }
         }
         this.rowIdOffset = rowIdOffsetTmp;
         if (rowIdOffset > 0) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -75,6 +75,7 @@ import org.apache.orc.impl.SchemaEvolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -464,179 +465,181 @@ public class VectorizedOrcAcidRowBatchReader
       return new OrcRawRecordMerger.KeyInterval(null, null);
     }
 
-    VectorizedOrcAcidRowBatchReader.ReaderData orcReaderData =
-        getOrcReaderData(orcSplit.getPath(), conf, cacheTag, orcSplit.getFileKey());
+    try (VectorizedOrcAcidRowBatchReader.ReaderData orcReaderData =
+        getOrcReaderData(orcSplit.getPath(), conf, cacheTag, orcSplit.getFileKey())) {
 
-    if(orcSplit.isOriginal()) {
-      /**
-       * Among originals we may have files with _copy_N suffix.  To properly
-       * generate a synthetic ROW___ID for them we need
-       * {@link OffsetAndBucketProperty} which could be an expensive computation
-       * if there are lots of copy_N files for a given bucketId. But unless
-       * there are delete events, we often don't need synthetic ROW__IDs at all.
-       * Kind of chicken-and-egg - deal with this later.
-       * See {@link OrcRawRecordMerger#discoverOriginalKeyBounds(Reader, int,
-       * Reader.Options, Configuration, OrcRawRecordMerger.Options)}*/
-      LOG.debug("findMinMaxKeys(original split)");
+      if(orcSplit.isOriginal()) {
+        /**
+         * Among originals we may have files with _copy_N suffix.  To properly
+         * generate a synthetic ROW___ID for them we need
+         * {@link OffsetAndBucketProperty} which could be an expensive computation
+         * if there are lots of copy_N files for a given bucketId. But unless
+         * there are delete events, we often don't need synthetic ROW__IDs at all.
+         * Kind of chicken-and-egg - deal with this later.
+         * See {@link OrcRawRecordMerger#discoverOriginalKeyBounds(Reader, int,
+         * Reader.Options, Configuration, OrcRawRecordMerger.Options)}*/
+        LOG.debug("findMinMaxKeys(original split)");
 
-      return findOriginalMinMaxKeys(orcSplit, orcReaderData.orcTail, deleteEventReaderOptions);
-    }
-
-    List<StripeInformation> stripes = orcReaderData.orcTail.getStripes();
-    final long splitStart = orcSplit.getStart();
-    final long splitEnd = splitStart + orcSplit.getLength();
-    int firstStripeIndex = -1;
-    int lastStripeIndex = -1;
-    for(int i = 0; i < stripes.size(); i++) {
-      StripeInformation stripe = stripes.get(i);
-      long stripeEnd = stripe.getOffset() + stripe.getLength();
-      if(firstStripeIndex == -1 && stripe.getOffset() >= splitStart) {
-        firstStripeIndex = i;
+        return findOriginalMinMaxKeys(orcSplit, orcReaderData.orcTail, deleteEventReaderOptions);
       }
-      if(lastStripeIndex == -1 && splitEnd <= stripeEnd) {
-        lastStripeIndex = i;
+
+      List<StripeInformation> stripes = orcReaderData.orcTail.getStripes();
+      final long splitStart = orcSplit.getStart();
+      final long splitEnd = splitStart + orcSplit.getLength();
+      int firstStripeIndex = -1;
+      int lastStripeIndex = -1;
+      for(int i = 0; i < stripes.size(); i++) {
+        StripeInformation stripe = stripes.get(i);
+        long stripeEnd = stripe.getOffset() + stripe.getLength();
+        if(firstStripeIndex == -1 && stripe.getOffset() >= splitStart) {
+          firstStripeIndex = i;
+        }
+        if(lastStripeIndex == -1 && splitEnd <= stripeEnd) {
+          lastStripeIndex = i;
+        }
       }
-    }
-    if(lastStripeIndex == -1) {
-      //split goes to the EOF which is > end of stripe since file has a footer
-      assert stripes.get(stripes.size() - 1).getOffset() +
-          stripes.get(stripes.size() - 1).getLength() < splitEnd;
-      lastStripeIndex = stripes.size() - 1;
-    }
+      if(lastStripeIndex == -1) {
+        //split goes to the EOF which is > end of stripe since file has a footer
+        assert stripes.get(stripes.size() - 1).getOffset() +
+            stripes.get(stripes.size() - 1).getLength() < splitEnd;
+        lastStripeIndex = stripes.size() - 1;
+      }
 
-    if (firstStripeIndex > lastStripeIndex || firstStripeIndex == -1) {
+      if (firstStripeIndex > lastStripeIndex || firstStripeIndex == -1) {
+        /**
+         * If the firstStripeIndex was set after the lastStripeIndex the split lies entirely within a single stripe.
+         * In case the split lies entirely within the last stripe, the firstStripeIndex will never be found, hence the
+         * second condition.
+         * In this case, the reader for this split will not read any data.
+         * See {@link org.apache.orc.impl.RecordReaderImpl#RecordReaderImpl
+         * Create a KeyInterval such that no delete delta records are loaded into memory in the deleteEventRegistry.
+         */
+
+        long minRowId = 1;
+        long maxRowId = 0;
+        int minBucketProp = 1;
+        int maxBucketProp = 0;
+
+        OrcRawRecordMerger.KeyInterval keyIntervalTmp =
+            new OrcRawRecordMerger.KeyInterval(new RecordIdentifier(1, minBucketProp, minRowId),
+            new RecordIdentifier(0, maxBucketProp, maxRowId));
+
+        setSARG(keyIntervalTmp, deleteEventReaderOptions, minBucketProp, maxBucketProp,
+            minRowId, maxRowId);
+        LOG.info("findMinMaxKeys(): " + keyIntervalTmp +
+            " stripes(" + firstStripeIndex + "," + lastStripeIndex + ")");
+
+        return keyIntervalTmp;
+      }
+
+      if(firstStripeIndex == -1 || lastStripeIndex == -1) {
+        //this should not happen but... if we don't know which stripe(s) are
+        //involved we can't figure out min/max bounds
+        LOG.warn("Could not find stripe (" + firstStripeIndex + "," +
+            lastStripeIndex + ")");
+        return new OrcRawRecordMerger.KeyInterval(null, null);
+      }
+      RecordIdentifier[] keyIndex = OrcRecordUpdater.parseKeyIndex(orcReaderData.orcTail);
+
+      if(keyIndex == null) {
+        LOG.warn("Could not find keyIndex (" + firstStripeIndex + "," +
+            lastStripeIndex + "," + stripes.size() + ")");
+      }
+
+      if(keyIndex != null && keyIndex.length != stripes.size()) {
+        LOG.warn("keyIndex length doesn't match (" +
+            firstStripeIndex + "," + lastStripeIndex + "," + stripes.size() +
+            "," + keyIndex.length + ")");
+        return new OrcRawRecordMerger.KeyInterval(null, null);
+      }
       /**
-       * If the firstStripeIndex was set after the lastStripeIndex the split lies entirely within a single stripe.
-       * In case the split lies entirely within the last stripe, the firstStripeIndex will never be found, hence the
-       * second condition.
-       * In this case, the reader for this split will not read any data.
-       * See {@link org.apache.orc.impl.RecordReaderImpl#RecordReaderImpl
-       * Create a KeyInterval such that no delete delta records are loaded into memory in the deleteEventRegistry.
-       */
+       * If {@link OrcConf.ROW_INDEX_STRIDE} is set to 0 all column stats on
+       * ORC file are disabled though objects for them exist but and have
+       * min/max set to MIN_LONG/MAX_LONG so we only use column stats if they
+       * are actually computed.  Streaming ingest used to set it 0 and Minor
+       * compaction so there are lots of legacy files with no (rather, bad)
+       * column stats*/
+      boolean columnStatsPresent = orcReaderData.orcTail.getFooter().getRowIndexStride() > 0;
+      if(!columnStatsPresent) {
+        LOG.debug("findMinMaxKeys() No ORC column stats");
+      }
 
-      long minRowId = 1;
-      long maxRowId = 0;
-      int minBucketProp = 1;
-      int maxBucketProp = 0;
+      List<StripeStatistics> stats = orcReaderData.reader.getVariantStripeStatistics(null);
+      assert stripes.size() == stats.size() : "str.s=" + stripes.size() +
+          " sta.s=" + stats.size();
 
-      OrcRawRecordMerger.KeyInterval keyIntervalTmp =
-          new OrcRawRecordMerger.KeyInterval(new RecordIdentifier(1, minBucketProp, minRowId),
-          new RecordIdentifier(0, maxBucketProp, maxRowId));
+      RecordIdentifier minKey = null;
+      if(firstStripeIndex > 0 && keyIndex != null) {
+        //valid keys are strictly > than this key
+        minKey = keyIndex[firstStripeIndex - 1];
+        //add 1 to make comparison >= to match the case of 0th stripe
+        minKey.setRowId(minKey.getRowId() + 1);
+      }
+      else {
+        if(columnStatsPresent) {
+          minKey = getKeyInterval(stats.get(firstStripeIndex).getColumnStatistics()).getMinKey();
+        }
+      }
 
-      setSARG(keyIntervalTmp, deleteEventReaderOptions, minBucketProp, maxBucketProp,
-          minRowId, maxRowId);
-      LOG.info("findMinMaxKeys(): " + keyIntervalTmp +
+      RecordIdentifier maxKey = null;
+
+      if (keyIndex != null) {
+        maxKey = keyIndex[lastStripeIndex];
+      } else {
+        if(columnStatsPresent) {
+          maxKey = getKeyInterval(stats.get(lastStripeIndex).getColumnStatistics()).getMaxKey();
+        }
+      }
+      OrcRawRecordMerger.KeyInterval keyInterval =
+          new OrcRawRecordMerger.KeyInterval(minKey, maxKey);
+      LOG.info("findMinMaxKeys(): " + keyInterval +
           " stripes(" + firstStripeIndex + "," + lastStripeIndex + ")");
 
-      return keyIntervalTmp;
-    }
-
-    if(firstStripeIndex == -1 || lastStripeIndex == -1) {
-      //this should not happen but... if we don't know which stripe(s) are
-      //involved we can't figure out min/max bounds
-      LOG.warn("Could not find stripe (" + firstStripeIndex + "," +
-          lastStripeIndex + ")");
-      return new OrcRawRecordMerger.KeyInterval(null, null);
-    }
-    RecordIdentifier[] keyIndex = OrcRecordUpdater.parseKeyIndex(orcReaderData.orcTail);
-
-    if(keyIndex == null) {
-      LOG.warn("Could not find keyIndex (" + firstStripeIndex + "," +
-          lastStripeIndex + "," + stripes.size() + ")");
-    }
-
-    if(keyIndex != null && keyIndex.length != stripes.size()) {
-      LOG.warn("keyIndex length doesn't match (" +
-          firstStripeIndex + "," + lastStripeIndex + "," + stripes.size() +
-          "," + keyIndex.length + ")");
-      return new OrcRawRecordMerger.KeyInterval(null, null);
-    }
-    /**
-     * If {@link OrcConf.ROW_INDEX_STRIDE} is set to 0 all column stats on
-     * ORC file are disabled though objects for them exist but and have
-     * min/max set to MIN_LONG/MAX_LONG so we only use column stats if they
-     * are actually computed.  Streaming ingest used to set it 0 and Minor
-     * compaction so there are lots of legacy files with no (rather, bad)
-     * column stats*/
-    boolean columnStatsPresent = orcReaderData.orcTail.getFooter().getRowIndexStride() > 0;
-    if(!columnStatsPresent) {
-      LOG.debug("findMinMaxKeys() No ORC column stats");
-    }
-
-    List<StripeStatistics> stats = orcReaderData.reader.getVariantStripeStatistics(null);
-    assert stripes.size() == stats.size() : "str.s=" + stripes.size() +
-        " sta.s=" + stats.size();
-
-    RecordIdentifier minKey = null;
-    if(firstStripeIndex > 0 && keyIndex != null) {
-      //valid keys are strictly > than this key
-      minKey = keyIndex[firstStripeIndex - 1];
-      //add 1 to make comparison >= to match the case of 0th stripe
-      minKey.setRowId(minKey.getRowId() + 1);
-    }
-    else {
+      long minBucketProp = Long.MAX_VALUE, maxBucketProp = Long.MIN_VALUE;
+      long minRowId = Long.MAX_VALUE, maxRowId = Long.MIN_VALUE;
       if(columnStatsPresent) {
-        minKey = getKeyInterval(stats.get(firstStripeIndex).getColumnStatistics()).getMinKey();
-      }
-    }
-
-    RecordIdentifier maxKey = null;
-
-    if (keyIndex != null) {
-      maxKey = keyIndex[lastStripeIndex];
-    } else {
-      if(columnStatsPresent) {
-        maxKey = getKeyInterval(stats.get(lastStripeIndex).getColumnStatistics()).getMaxKey();
-      }
-    }
-    OrcRawRecordMerger.KeyInterval keyInterval =
-        new OrcRawRecordMerger.KeyInterval(minKey, maxKey);
-    LOG.info("findMinMaxKeys(): " + keyInterval +
-        " stripes(" + firstStripeIndex + "," + lastStripeIndex + ")");
-
-    long minBucketProp = Long.MAX_VALUE, maxBucketProp = Long.MIN_VALUE;
-    long minRowId = Long.MAX_VALUE, maxRowId = Long.MIN_VALUE;
-    if(columnStatsPresent) {
-      /**
-       * figure out min/max bucket, rowid for push down.  This is different from
-       * min/max ROW__ID because ROW__ID comparison uses dictionary order on two
-       * tuples (a,b,c), but PPD can only do
-       * (a between (x,y) and b between(x1,y1) and c between(x2,y2))
-       * Consider:
-       * (0,536936448,0), (0,536936448,2), (10000001,536936448,0)
-       * 1st is min ROW_ID, 3r is max ROW_ID
-       * and Delete events (0,536936448,2),....,(10000001,536936448,1000000)
-       * So PPD based on min/max ROW_ID would have 0<= rowId <=0 which will
-       * miss this delete event.  But we still want PPD to filter out data if
-       * possible.
-       *
-       * So use stripe stats to find proper min/max for bucketProp and rowId
-       * writeId is the same in both cases
-       */
-      for(int i = firstStripeIndex; i <= lastStripeIndex; i++) {
-        OrcRawRecordMerger.KeyInterval key = getKeyInterval(stats.get(i).getColumnStatistics());
-        if(key.getMinKey().getBucketProperty() < minBucketProp) {
-          minBucketProp = key.getMinKey().getBucketProperty();
-        }
-        if(key.getMaxKey().getBucketProperty() > maxBucketProp) {
-          maxBucketProp = key.getMaxKey().getBucketProperty();
-        }
-        if(key.getMinKey().getRowId() < minRowId) {
-          minRowId = key.getMinKey().getRowId();
-        }
-        if(key.getMaxKey().getRowId() > maxRowId) {
-          maxRowId = key.getMaxKey().getRowId();
+        /**
+         * figure out min/max bucket, rowid for push down.  This is different from
+         * min/max ROW__ID because ROW__ID comparison uses dictionary order on two
+         * tuples (a,b,c), but PPD can only do
+         * (a between (x,y) and b between(x1,y1) and c between(x2,y2))
+         * Consider:
+         * (0,536936448,0), (0,536936448,2), (10000001,536936448,0)
+         * 1st is min ROW_ID, 3r is max ROW_ID
+         * and Delete events (0,536936448,2),....,(10000001,536936448,1000000)
+         * So PPD based on min/max ROW_ID would have 0<= rowId <=0 which will
+         * miss this delete event.  But we still want PPD to filter out data if
+         * possible.
+         *
+         * So use stripe stats to find proper min/max for bucketProp and rowId
+         * writeId is the same in both cases
+         */
+        for(int i = firstStripeIndex; i <= lastStripeIndex; i++) {
+          OrcRawRecordMerger.KeyInterval key = getKeyInterval(stats.get(i).getColumnStatistics());
+          if(key.getMinKey().getBucketProperty() < minBucketProp) {
+            minBucketProp = key.getMinKey().getBucketProperty();
+          }
+          if(key.getMaxKey().getBucketProperty() > maxBucketProp) {
+            maxBucketProp = key.getMaxKey().getBucketProperty();
+          }
+          if(key.getMinKey().getRowId() < minRowId) {
+            minRowId = key.getMinKey().getRowId();
+          }
+          if(key.getMaxKey().getRowId() > maxRowId) {
+            maxRowId = key.getMaxKey().getRowId();
+          }
         }
       }
-    }
-    if(minBucketProp == Long.MAX_VALUE) minBucketProp = Long.MIN_VALUE;
-    if(maxBucketProp == Long.MIN_VALUE) maxBucketProp = Long.MAX_VALUE;
-    if(minRowId == Long.MAX_VALUE) minRowId = Long.MIN_VALUE;
-    if(maxRowId == Long.MIN_VALUE) maxRowId = Long.MAX_VALUE;
+      if(minBucketProp == Long.MAX_VALUE) minBucketProp = Long.MIN_VALUE;
+      if(maxBucketProp == Long.MIN_VALUE) maxBucketProp = Long.MAX_VALUE;
+      if(minRowId == Long.MAX_VALUE) minRowId = Long.MIN_VALUE;
+      if(maxRowId == Long.MIN_VALUE) maxRowId = Long.MAX_VALUE;
 
-    setSARG(keyInterval, deleteEventReaderOptions, minBucketProp, maxBucketProp,
-        minRowId, maxRowId);
-    return keyInterval;
+      setSARG(keyInterval, deleteEventReaderOptions, minBucketProp, maxBucketProp,
+          minRowId, maxRowId);
+
+      return keyInterval;
+    }
   }
 
   private OrcRawRecordMerger.KeyInterval findOriginalMinMaxKeys(OrcSplit orcSplit, OrcTail orcTail,
@@ -701,9 +704,14 @@ public class VectorizedOrcAcidRowBatchReader
     return keyIntervalTmp;
   }
 
-  private static class ReaderData {
+  private static class ReaderData implements Closeable {
     OrcTail orcTail;
     Reader reader;
+
+    @Override
+    public void close() throws IOException {
+      reader.close();
+    }
   }
 
   /**
@@ -1944,36 +1952,37 @@ public class VectorizedOrcAcidRowBatchReader
               for (AcidInputFormat.DeltaFileMetaData fileMetaData : deltaMetaData.getDeltaFilesForStmtId(stmtId)) {
                 Path deleteDeltaFile = fileMetaData.getPath(deleteDeltaPath, bucket);
                 Object fileId = fileMetaData.getFileId(deleteDeltaFile, bucket, conf);
-                ReaderData readerData = getOrcReaderData(deleteDeltaFile, conf, cacheTag, fileId);
-                OrcTail orcTail = readerData.orcTail;
-                long numRows = orcTail.getFooter().getNumberOfRows();
-                if (numRows <= 0) {
-                  continue; // just a safe check to ensure that we are not reading empty delete files.
-                }
-                OrcRawRecordMerger.KeyInterval deleteKeyInterval = findDeleteMinMaxKeys(orcTail, deleteDeltaFile);
-                if (!deleteKeyInterval.isIntersects(keyInterval)) {
-                  // If there is no intersection between data and delete delta, do not read delete file
-                  continue;
-                }
+                try (ReaderData readerData = getOrcReaderData(deleteDeltaFile, conf, cacheTag, fileId)) {
+                  OrcTail orcTail = readerData.orcTail;
+                  long numRows = orcTail.getFooter().getNumberOfRows();
+                  if (numRows <= 0) {
+                    continue; // just a safe check to ensure that we are not reading empty delete files.
+                  }
+                  OrcRawRecordMerger.KeyInterval deleteKeyInterval = findDeleteMinMaxKeys(orcTail, deleteDeltaFile);
+                  if (!deleteKeyInterval.isIntersects(keyInterval)) {
+                    // If there is no intersection between data and delete delta, do not read delete file
+                    continue;
+                  }
 
-                totalDeleteEventCount += numRows;
+                  totalDeleteEventCount += numRows;
 
-                DeleteReaderValue deleteReaderValue = null;
+                  DeleteReaderValue deleteReaderValue = null;
 
-                // If reader is set, then it got set while retrieving the ORC tail, because reading was not possible
-                // with LLAP. In this case we continue with this reader. In other cases we rely on LLAP to read and
-                // cache delete delta files for us, so we won't create a reader instance ourselves here.
-                if (readerData.reader == null) {
-                  assert shouldReadDeleteDeltasWithLlap(conf, true);
-                }
-                deleteReaderValue = new DeleteReaderValue(readerData.reader, deleteDeltaFile, readerOptions, bucket,
-                    validWriteIdList, isBucketedTable, conf, keyInterval, orcSplit, numRows, cacheTag, fileId);
+                  // If reader is set, then it got set while retrieving the ORC tail, because reading was not possible
+                  // with LLAP. In this case we continue with this reader. In other cases we rely on LLAP to read and
+                  // cache delete delta files for us, so we won't create a reader instance ourselves here.
+                  if (readerData.reader == null) {
+                    assert shouldReadDeleteDeltasWithLlap(conf, true);
+                  }
+                  deleteReaderValue = new DeleteReaderValue(readerData.reader, deleteDeltaFile, readerOptions, bucket,
+                      validWriteIdList, isBucketedTable, conf, keyInterval, orcSplit, numRows, cacheTag, fileId);
 
-                DeleteRecordKey deleteRecordKey = new DeleteRecordKey();
-                if (deleteReaderValue.next(deleteRecordKey)) {
-                  sortMerger.put(deleteRecordKey, deleteReaderValue);
-                } else {
-                  deleteReaderValue.close();
+                  DeleteRecordKey deleteRecordKey = new DeleteRecordKey();
+                  if (deleteReaderValue.next(deleteRecordKey)) {
+                    sortMerger.put(deleteRecordKey, deleteReaderValue);
+                  } else {
+                    deleteReaderValue.close();
+                  }
                 }
               }
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
@@ -207,9 +207,8 @@ public class VectorizedOrcInputFormat extends FileInputFormat<NullWritable, Vect
       return false;
     }
     for (FileStatus file : files) {
-      try {
-        OrcFile.createReader(file.getPath(),
-            OrcFile.readerOptions(conf).filesystem(fs));
+      try (Reader notUsed = OrcFile.createReader(file.getPath(), OrcFile.readerOptions(conf).filesystem(fs))) {
+        // We do not use the reader itself. We just check if we can open the file.
       } catch (IOException e) {
         return false;
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -4171,13 +4171,17 @@ public class TestInputOutputFormat {
     long fileLength = fs.getFileStatus(testFilePath).getLen();
 
     // Find the last stripe.
-    Reader orcReader = OrcFile.createReader(fs, testFilePath);
-    List<StripeInformation> stripes = orcReader.getStripes();
+    List<StripeInformation> stripes;
+    RecordIdentifier[] keyIndex;
+    try (Reader orcReader = OrcFile.createReader(fs, testFilePath)) {
+      stripes = orcReader.getStripes();
+      keyIndex = OrcRecordUpdater.parseKeyIndex(orcReader);
+    }
+
     StripeInformation lastStripe = stripes.get(stripes.size() - 1);
     long lastStripeOffset = lastStripe.getOffset();
     long lastStripeLength = lastStripe.getLength();
 
-    RecordIdentifier[] keyIndex = OrcRecordUpdater.parseKeyIndex(orcReader);
     Assert.assertEquals("Index length doesn't match number of stripes",
         stripes.size(), keyIndex.length);
     Assert.assertEquals("1st Index entry mismatch",

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -3819,15 +3819,15 @@ public class TestInputOutputFormat {
       Reader.Options orcReaderOptions = new Reader.Options();
       orcReaderOptions.range(split.getStart(), split.getLength());
       OrcFile.ReaderOptions qlReaderOptions = OrcFile.readerOptions(conf).maxLength(split.getFileLength());
-      Reader reader = OrcFile.createReader(split.getPath(), qlReaderOptions);
-      RecordReader recordReader = reader.rowsOptions(orcReaderOptions);
-      for(int j = 0; recordReader.hasNext(); j++) {
-        long rowNum = (i * 5000) + j;
-        long rowNumActual = recordReader.getRowNumber();
-        assertEquals("rowNum=" + rowNum, rowNum, rowNumActual);
-        Object row = recordReader.next(null);
+      try (Reader reader = OrcFile.createReader(split.getPath(), qlReaderOptions)) {
+        RecordReader recordReader = reader.rowsOptions(orcReaderOptions);
+        for (int j = 0; recordReader.hasNext(); j++) {
+          long rowNum = (i * 5000) + j;
+          long rowNumActual = recordReader.getRowNumber();
+          assertEquals("rowNum=" + rowNum, rowNum, rowNumActual);
+          Object row = recordReader.next(null);
+        }
       }
-      recordReader.close();
     }
 
     // Reset the conf variable values that we changed for this test.

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestNewInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestNewInputOutputFormat.java
@@ -225,7 +225,8 @@ public class TestNewInputOutputFormat {
     
     assertEquals(intWritable.get(), firstIntValue);
     assertEquals(text.toString(), firstStringValue);
-    
+
+    rows.close();
     localFs.delete(outputPath, true);
   }
   
@@ -258,9 +259,9 @@ public class TestNewInputOutputFormat {
     assertTrue(result);
     
     Path outputFilePath = new Path(outputPath, "part-m-00000");
-    Reader reader = OrcFile.createReader(outputFilePath,
-        OrcFile.readerOptions(conf).filesystem(localFs));
-    assertEquals(reader.getCompression(), CompressionKind.SNAPPY);
+    try (Reader reader = OrcFile.createReader(outputFilePath, OrcFile.readerOptions(conf).filesystem(localFs))) {
+      assertEquals(reader.getCompression(), CompressionKind.SNAPPY);
+    }
     
     localFs.delete(outputPath, true);
   }
@@ -410,7 +411,8 @@ public class TestNewInputOutputFormat {
     assertEquals(map.get("were"), Integer.valueOf(3));
     
     assertFalse(rows.hasNext());
-    
+
+    rows.close();
     localFs.delete(outputPath, true);
   }
   

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFile.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFile.java
@@ -556,6 +556,7 @@ public class TestOrcFile {
     boolean[] expected = new boolean[] {false};
     boolean[] included = OrcUtils.includeColumns("", writer.getSchema());
     assertEquals(true, Arrays.equals(expected, included));
+    rows.close();
   }
 
   @Test
@@ -592,6 +593,7 @@ public class TestOrcFile {
     assertEquals(2, stats[0].getNumberOfValues());
     assertEquals(0, stats[1].getNumberOfValues());
     assertEquals(true, stats[1].hasNull());
+    rows.close();
   }
 
   @Test
@@ -660,6 +662,7 @@ public class TestOrcFile {
     assertEquals(HiveDecimal.create(1), ((DecimalColumnStatistics) stats[1]).getMinimum());
     assertEquals(HiveDecimal.create(6), ((DecimalColumnStatistics) stats[1]).getSum());
     assertEquals(true, stats[1].hasNull());
+    rows.close();
   }
 
   @Test
@@ -854,6 +857,7 @@ public class TestOrcFile {
     items = index[1].getEntryList();
     assertEquals(2,
         items.get(0).getStatistics().getIntStatistics().getMaximum());
+    reader.close();
   }
 
   @Test
@@ -1234,6 +1238,7 @@ public class TestOrcFile {
     assertEquals(false, reader.getMetadataKeys().iterator().hasNext());
     assertEquals(3, reader.getContentLength());
     assertEquals(false, reader.getStripes().iterator().hasNext());
+    reader.close();
   }
 
   @Test
@@ -1288,6 +1293,7 @@ public class TestOrcFile {
     assertEquals(3, i);
     int numStripes = reader.getStripeStatistics().size();
     assertEquals(1, numStripes);
+    reader.close();
   }
 
   /**
@@ -1340,6 +1346,7 @@ public class TestOrcFile {
             row.getFieldValue(1));
       }
     }
+    rows.close();
   }
 
   @Test
@@ -1971,6 +1978,7 @@ public class TestOrcFile {
     }
     assertEquals(25, i);
     assertEquals(2500, reader.getNumberOfRows());
+    reader.close();
   }
 
   @Test
@@ -2017,6 +2025,7 @@ public class TestOrcFile {
     // compared to 25 stripes in version 0.11 (above test case)
     assertEquals(3, i);
     assertEquals(2500, reader.getNumberOfRows());
+    reader.close();
   }
 
   @Test
@@ -2103,6 +2112,7 @@ public class TestOrcFile {
     }
     assertTrue(!rows.hasNext());
     assertEquals(3500, rows.getRowNumber());
+    rows.close();
   }
 
   @Test
@@ -2135,6 +2145,7 @@ public class TestOrcFile {
       Object row = rows.next(null);
       Assert.assertEquals(input.get(idx++).longValue(), ((LongWritable) row).get());
     }
+    rows.close();
   }
 
   static class MyList {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcRecordUpdater.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcRecordUpdater.java
@@ -139,6 +139,7 @@ public class TestOrcRecordUpdater {
     Reader reader = OrcFile.createReader(bucketPath,
         new OrcFile.ReaderOptions(conf).filesystem(fs).maxLength(len));
     assertEquals(3, reader.getNumberOfRows());
+    reader.close();
 
     // read the second flush and make sure we see all 5 rows
     len = side.readLong();
@@ -185,6 +186,7 @@ public class TestOrcRecordUpdater {
     assertEquals("fifth",
         OrcRecordUpdater.getRow(row).getFieldValue(0).toString());
     assertEquals(false, rows.hasNext());
+    rows.close();
 
     // add one more record and close
     updater.insert(20, new MyRow("sixth"));
@@ -193,6 +195,7 @@ public class TestOrcRecordUpdater {
         new OrcFile.ReaderOptions(conf).filesystem(fs));
     assertEquals(6, reader.getNumberOfRows());
     assertEquals(6L, updater.getStats().getRowCount());
+    reader.close();
 
     assertEquals(false, fs.exists(sidePath));
   }
@@ -323,6 +326,7 @@ public class TestOrcRecordUpdater {
     assertNull(OrcRecordUpdater.getRow(row));
 
     assertEquals(false, rows.hasNext());
+    rows.close();
   }
 
   /*

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSerDeStats.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSerDeStats.java
@@ -321,6 +321,7 @@ public class TestOrcSerDeStats {
     assertEquals(5000, reader.getNumberOfRows());
     assertEquals(430040000, reader.getRawDataSize());
     assertEquals(430020000, reader.getRawDataSizeOfColumns(Lists.newArrayList("list1")));
+    reader.close();
   }
 
   @Test
@@ -353,6 +354,7 @@ public class TestOrcSerDeStats {
     assertEquals(1000, reader.getNumberOfRows());
     assertEquals(958000, reader.getRawDataSize());
     assertEquals(954000, reader.getRawDataSizeOfColumns(Lists.newArrayList("map1")));
+    reader.close();
   }
 
   @Test
@@ -387,6 +389,7 @@ public class TestOrcSerDeStats {
     assertEquals(1500, reader.getRawDataSizeOfColumns(Lists.newArrayList("bytes1")));
     assertEquals(43000, reader.getRawDataSizeOfColumns(Lists.newArrayList("string1")));
     assertEquals(44500, reader.getRawDataSizeOfColumns(Lists.newArrayList("bytes1", "string1")));
+    reader.close();
   }
 
   @Test
@@ -479,6 +482,7 @@ public class TestOrcSerDeStats {
         stats[7].toString());
 
     assertEquals("count: 2 hasNull: false bytesOnDisk: 14 min: bye max: hi sum: 5", stats[9].toString());
+    reader.close();
   }
 
   @Test
@@ -578,6 +582,7 @@ public class TestOrcSerDeStats {
     assertEquals("hi", ((StringColumnStatistics) stats[9]).getMaximum());
     assertEquals(5, ((StringColumnStatistics) stats[9]).getSum());
     assertEquals("count: 2 hasNull: false bytesOnDisk: 20 min: bye max: hi sum: 5", stats[9].toString());
+    reader.close();
   }
 
   @Test(expected = ClassCastException.class)
@@ -647,6 +652,7 @@ public class TestOrcSerDeStats {
     // this should throw ClassCastException
     assertEquals(5, ((BinaryColumnStatistics) stats[8]).getSum());
 
+    reader.close();
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
@@ -53,16 +53,17 @@ public class CompactorTestUtilities {
    */
   private static int getAcidVersionFromDataFile(Path dataFile, FileSystem fs) throws IOException {
     FileStatus fileStatus = fs.getFileStatus(dataFile);
-    Reader orcReader = OrcFile.createReader(dataFile,
+    try (Reader orcReader = OrcFile.createReader(dataFile,
         OrcFile.readerOptions(fs.getConf())
             .filesystem(fs)
             //make sure to check for side file in case streaming ingest died
-            .maxLength(AcidUtils.getLogicalLength(fs, fileStatus)));
-    if (orcReader.hasMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)) {
-      char[] versionChar =
-          UTF8.decode(orcReader.getMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)).array();
-      String version = new String(versionChar);
-      return Integer.valueOf(version);
+            .maxLength(AcidUtils.getLogicalLength(fs, fileStatus)))) {
+      if (orcReader.hasMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)) {
+        char[] versionChar =
+            UTF8.decode(orcReader.getMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)).array();
+        String version = new String(versionChar);
+        return Integer.valueOf(version);
+      }
     }
     return ORC_ACID_VERSION_DEFAULT;
   }

--- a/streaming/src/test/org/apache/hive/streaming/TestStreaming.java
+++ b/streaming/src/test/org/apache/hive/streaming/TestStreaming.java
@@ -2139,19 +2139,18 @@ public class TestStreaming {
 
   private ArrayList<SampleRec> dumpBucket(Path orcFile) throws IOException {
     org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration());
-    Reader reader = OrcFile.createReader(orcFile,
-      OrcFile.readerOptions(conf).filesystem(fs));
-
-    RecordReader rows = reader.rows();
-    StructObjectInspector inspector = (StructObjectInspector) reader
-      .getObjectInspector();
-
-    System.out.format("Found Bucket File : %s \n", orcFile.getName());
     ArrayList<SampleRec> result = new ArrayList<SampleRec>();
-    while (rows.hasNext()) {
-      Object row = rows.next(null);
-      SampleRec rec = (SampleRec) deserializeDeltaFileRow(row, inspector)[5];
-      result.add(rec);
+    try (Reader reader = OrcFile.createReader(orcFile, OrcFile.readerOptions(conf).filesystem(fs))) {
+      RecordReader rows = reader.rows();
+      StructObjectInspector inspector = (StructObjectInspector) reader
+          .getObjectInspector();
+
+      System.out.format("Found Bucket File : %s \n", orcFile.getName());
+      while (rows.hasNext()) {
+        Object row = rows.next(null);
+        SampleRec rec = (SampleRec) deserializeDeltaFileRow(row, inspector)[5];
+        result.add(rec);
+      }
     }
 
     return result;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Closing the ORC readers explicitly

### Why are the changes needed?
This fixes the resource leak where the file readers remain open until a GC cleans them up

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests should remain green
