### PR TITLE
HIVE-25740: Avoid compaction heartbeater error logging in race conditions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -718,9 +718,9 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       }
       lockId = res.getLockid();
 
+      heartbeater = Executors.newSingleThreadScheduledExecutor();
       long txnTimeout = MetastoreConf.getTimeVar(conf, MetastoreConf.ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS);
       Thread beater = new CompactionHeartbeater(this, TxnUtils.getFullTableName(ci.dbname, ci.tableName), conf);
-      heartbeater = Executors.newSingleThreadScheduledExecutor();
       heartbeater.scheduleAtFixedRate(beater, 0, txnTimeout / 2, TimeUnit.MILLISECONDS);
     }
 


### PR DESCRIPTION
This patch fixes the following issue: once the compaction worker finishes, commitTxn/abortTxn is invoked first, and the heartbeater thread is only interrupted after that (that's because autoclosable resources in a try-with-resources (`CompactionTxn.close()` in this case) are executed before the finally block). This can lead to race conditions where the txn has already been deleted from the backend DB via commit/abort, but the concurrently running heartbeater thread still attempts to send a last heartbeat after that, but the txn id won't be found in the DB, leading to `NoSuchTxnException`.