### PR TITLE
HIVE-25741: Close previous writer in proto logger

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
@@ -313,7 +313,10 @@ public class HiveProtoLoggingHook implements ExecuteWithHookContext {
       for (int retryCount = 0; retryCount <= MAX_RETRIES; ++retryCount) {
         try {
           if (eventPerFile) {
-            maybeRolloverWriterForDay();
+            if (!maybeRolloverWriterForDay()) {
+              IOUtils.closeQuietly(writer);
+              writer = logger.getWriter(logFileName + "_" + ++logFileCount);
+            }
             LOG.debug("Event per file enabled. New proto event file: {}", writer.getPath());
             writer.writeProto(event);
             IOUtils.closeQuietly(writer);

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
@@ -313,10 +313,10 @@ public class HiveProtoLoggingHook implements ExecuteWithHookContext {
       for (int retryCount = 0; retryCount <= MAX_RETRIES; ++retryCount) {
         try {
           if (eventPerFile) {
-            if (!maybeRolloverWriterForDay()) {
+            if (writer != null) {
               IOUtils.closeQuietly(writer);
-              writer = logger.getWriter(logFileName + "_" + ++logFileCount);
             }
+            writer = logger.getWriter(logFileName + "_" + ++logFileCount);
             LOG.debug("Event per file enabled. New proto event file: {}", writer.getPath());
             writer.writeProto(event);
             IOUtils.closeQuietly(writer);
@@ -334,7 +334,7 @@ public class HiveProtoLoggingHook implements ExecuteWithHookContext {
           if (retryCount < MAX_RETRIES) {
             LOG.warn("Error writing proto message for query {}, eventType: {}, retryCount: {}," +
                 " error: {} ", event.getHiveQueryId(), event.getEventType(), retryCount,
-                e.getMessage());
+                e.getMessage(), e);
             LOG.trace("Exception", e);
           } else {
             LOG.error("Error writing proto message for query {}, eventType: {}: ",

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
@@ -313,9 +313,7 @@ public class HiveProtoLoggingHook implements ExecuteWithHookContext {
       for (int retryCount = 0; retryCount <= MAX_RETRIES; ++retryCount) {
         try {
           if (eventPerFile) {
-            if (!maybeRolloverWriterForDay()) {
-              writer = logger.getWriter(logFileName + "_" + ++logFileCount);
-            }
+            maybeRolloverWriterForDay();
             LOG.debug("Event per file enabled. New proto event file: {}", writer.getPath());
             writer.writeProto(event);
             IOUtils.closeQuietly(writer);


### PR DESCRIPTION
If `hive.hook.proto.file.per.event=true` (recommended for S3A filesystem), the Hive proto `EventLogger` will create a new file for each proto event. However, if we already had an appropriate writer (i.e. maybeRolloverWriterForDay() returns false) from some previous operation - we don't close the previous writer instance before creating a new one.