### PR TITLE
HIVE-25744: Support backward compatibility of thrift struct CreationMetadata

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -65,8 +65,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 
 import com.google.common.collect.Lists;
 
-import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils.asTableNames;
-
 /**
  * Operation process of describing a table.
  */
@@ -299,7 +297,7 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
     if (table.isMaterializedView()) {
       table.setOutdatedForRewriting(context.getDb().isOutdatedMaterializedView(
               table,
-              asTableNames(table.getCreationMetadata().getTablesUsed()),
+              table.getMVMetadata().getSourceTableNames(),
               false,
               SessionState.get().getTxnMgr()));
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -33,7 +33,6 @@ import org.apache.calcite.tools.Frameworks;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.LockState;
-import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
@@ -70,7 +70,7 @@ public class AlterMaterializedViewRewriteAnalyzer extends BaseSemanticAnalyzer {
     // One last test: if we are enabling the rewrite, we need to check that query
     // only uses transactional (MM and ACID) tables
     if (rewriteEnable) {
-      for (SourceTable sourceTable : materializedViewTable.getCreationMetadata().getTablesUsed()) {
+      for (SourceTable sourceTable : materializedViewTable.getMVMetadata().getSourceTables()) {
         if (!AcidUtils.isTransactionalTable(sourceTable.getTable())) {
           throw new SemanticException("Automatic rewriting for materialized view cannot be enabled if the " +
               "materialized view uses non-transactional tables");

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
@@ -19,17 +19,13 @@
 package org.apache.hadoop.hive.ql.ddl.view.materialized.update;
 
 import org.apache.hadoop.hive.common.ValidTxnWriteIdList;
-import org.apache.hadoop.hive.metastore.api.CreationMetadata;
-import org.apache.hadoop.hive.metastore.api.SourceTable;
-import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveMaterializedViewsRegistry;
+import org.apache.hadoop.hive.ql.metadata.MaterializedViewMetadata;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ExplainConfiguration.AnalyzeState;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Operation process of updating a materialized view.
@@ -56,18 +52,10 @@ public class MaterializedViewUpdateOperation extends DDLOperation<MaterializedVi
       } else if (desc.isUpdateCreationMetadata()) {
         // We need to update the status of the creation signature
         Table mvTable = context.getDb().getTable(desc.getName());
-        CreationMetadata cm = new CreationMetadata(MetaStoreUtils.getDefaultCatalog(context.getConf()),
-            mvTable.getDbName(), mvTable.getTableName(),
-            ImmutableSet.copyOf(mvTable.getCreationMetadata().getTablesUsed()));
-        cm.setValidTxnList(context.getConf().get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY));
-        // Reset source table stats
-        for (SourceTable sourceTable : cm.getTablesUsed()) {
-          sourceTable.setInsertedCount(0L);
-          sourceTable.setUpdatedCount(0L);
-          sourceTable.setDeletedCount(0L);
-        }
-        context.getDb().updateCreationMetadata(mvTable.getDbName(), mvTable.getTableName(), cm);
-        mvTable.setCreationMetadata(cm);
+        MaterializedViewMetadata newMetadata = mvTable.getMVMetadata().reset(
+                context.getConf().get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY));
+        context.getDb().updateCreationMetadata(mvTable.getDbName(), mvTable.getTableName(), newMetadata);
+        mvTable.setMaterializedViewMetadata(newMetadata);
         HiveMaterializedViewsRegistry.get().createMaterializedView(context.getDb().getConf(), mvTable);
       }
     } catch (HiveException e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -182,7 +182,7 @@ public final class HiveMaterializedViewsRegistry {
               Table existingMVTable = HiveMaterializedViewUtils.extractTable(existingMV);
               if (existingMVTable.getCreateTime() < mvTable.getCreateTime() ||
                   (existingMVTable.getCreateTime() == mvTable.getCreateTime() &&
-                      existingMVTable.getCreationMetadata().getMaterializationTime() <= mvTable.getCreationMetadata().getMaterializationTime())) {
+                      existingMVTable.getMVMetadata().getMaterializationTime() <= mvTable.getMVMetadata().getMaterializationTime())) {
                 refreshMaterializedView(db.getConf(), existingMVTable, mvTable);
               }
             } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewMetadata.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewMetadata.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.metadata;
+
+import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.api.CreationMetadata;
+import org.apache.hadoop.hive.metastore.api.SourceTable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
+
+public class MaterializedViewMetadata {
+  final CreationMetadata creationMetadata;
+
+  MaterializedViewMetadata(CreationMetadata creationMetadata) {
+    this.creationMetadata = creationMetadata;
+  }
+
+  public MaterializedViewMetadata(
+          String catalogName, String dbName, String mvName, Set<SourceTable> sourceTables, String validTxnList) {
+    this.creationMetadata = new CreationMetadata(catalogName, dbName, mvName, toFullTableNames(sourceTables));
+    this.creationMetadata.setValidTxnList(validTxnList);
+    this.creationMetadata.setSourceTables(unmodifiableSet(sourceTables));
+  }
+
+  public Set<String> getSourceTableFullNames() {
+    if (!creationMetadata.isSetSourceTables()) {
+      return emptySet();
+    }
+
+    return toFullTableNames(creationMetadata.getSourceTables());
+  }
+
+  private Set<String> toFullTableNames(Set<SourceTable> sourceTables) {
+    return unmodifiableSet(sourceTables.stream()
+            .map(sourceTable -> TableName.getDbTable(
+                    sourceTable.getTable().getDbName(), sourceTable.getTable().getTableName()))
+            .collect(Collectors.toSet()));
+  }
+
+  public Set<TableName> getSourceTableNames() {
+    if (!creationMetadata.isSetSourceTables()) {
+      return emptySet();
+    }
+
+    return unmodifiableSet(creationMetadata.getSourceTables().stream()
+            .map(sourceTable -> new TableName(
+                    sourceTable.getTable().getCatName(),
+                    sourceTable.getTable().getDbName(),
+                    sourceTable.getTable().getTableName()))
+            .collect(Collectors.toSet()));
+  }
+
+  public Set<SourceTable> getSourceTables() {
+    if (!creationMetadata.isSetSourceTables()) {
+      return emptySet();
+    }
+
+    return unmodifiableSet(creationMetadata.getSourceTables());
+  }
+
+  public String getValidTxnList() {
+    return creationMetadata.getValidTxnList();
+  }
+
+  public long getMaterializationTime() {
+    return creationMetadata.getMaterializationTime();
+  }
+
+  public MaterializedViewMetadata reset(String validTxnList) {
+    Set<SourceTable> newSourceTables =
+            creationMetadata.getSourceTables().stream().map(this::from).collect(Collectors.toSet());
+
+    return new MaterializedViewMetadata(
+            creationMetadata.getCatName(),
+            creationMetadata.getDbName(),
+            creationMetadata.getTblName(),
+            unmodifiableSet(newSourceTables),
+            validTxnList);
+  }
+
+  private SourceTable from(SourceTable sourceTable) {
+    SourceTable newSourceTable = new SourceTable();
+
+    newSourceTable.setTable(sourceTable.getTable());
+    newSourceTable.setInsertedCount(0L);
+    newSourceTable.setUpdatedCount(0L);
+    newSourceTable.setDeletedCount(0L);
+
+    return newSourceTable;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
@@ -110,6 +110,7 @@ public class Table implements Serializable {
 
   private transient HiveStorageHandler storageHandler;
   private transient StorageHandlerInfo storageHandlerInfo;
+  private transient MaterializedViewMetadata materializedViewMetadata;
 
   private TableSpec tableSpec;
 
@@ -960,16 +961,24 @@ public class Table implements Serializable {
   /**
    * @return the creation metadata (only for materialized views)
    */
-  public CreationMetadata getCreationMetadata() {
-    return tTable.getCreationMetadata();
+  public MaterializedViewMetadata getMVMetadata() {
+    if (tTable.getCreationMetadata() == null) {
+      return null;
+    }
+    if (materializedViewMetadata == null) {
+      materializedViewMetadata = new MaterializedViewMetadata(tTable.getCreationMetadata());
+    }
+
+    return materializedViewMetadata;
   }
 
   /**
-   * @param creationMetadata
+   * @param materializedViewMetadata
    *          the creation metadata (only for materialized views)
    */
-  public void setCreationMetadata(CreationMetadata creationMetadata) {
-    tTable.setCreationMetadata(creationMetadata);
+  public void setMaterializedViewMetadata(MaterializedViewMetadata materializedViewMetadata) {
+    this.materializedViewMetadata = materializedViewMetadata;
+    tTable.setCreationMetadata(materializedViewMetadata.creationMetadata);
   }
 
   public void clearSerDeInfo() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -12199,7 +12199,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         if (table.isMaterializedView()) {
           // When we are querying a materialized view directly, we check whether the source tables
           // do not apply any policies.
-          for (SourceTable sourceTable : table.getCreationMetadata().getTablesUsed()) {
+          for (SourceTable sourceTable : table.getMVMetadata().getSourceTables()) {
             String qualifiedTableName = TableName.getDbTable(
                     sourceTable.getTable().getDbName(), sourceTable.getTable().getTableName());
             try {

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
@@ -2561,14 +2561,14 @@ uint32_t ThriftHiveMetastore_get_databases_result::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1738;
-            ::apache::thrift::protocol::TType _etype1741;
-            xfer += iprot->readListBegin(_etype1741, _size1738);
-            this->success.resize(_size1738);
-            uint32_t _i1742;
-            for (_i1742 = 0; _i1742 < _size1738; ++_i1742)
+            uint32_t _size1745;
+            ::apache::thrift::protocol::TType _etype1748;
+            xfer += iprot->readListBegin(_etype1748, _size1745);
+            this->success.resize(_size1745);
+            uint32_t _i1749;
+            for (_i1749 = 0; _i1749 < _size1745; ++_i1749)
             {
-              xfer += iprot->readString(this->success[_i1742]);
+              xfer += iprot->readString(this->success[_i1749]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2607,10 +2607,10 @@ uint32_t ThriftHiveMetastore_get_databases_result::write(::apache::thrift::proto
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1743;
-      for (_iter1743 = this->success.begin(); _iter1743 != this->success.end(); ++_iter1743)
+      std::vector<std::string> ::const_iterator _iter1750;
+      for (_iter1750 = this->success.begin(); _iter1750 != this->success.end(); ++_iter1750)
       {
-        xfer += oprot->writeString((*_iter1743));
+        xfer += oprot->writeString((*_iter1750));
       }
       xfer += oprot->writeListEnd();
     }
@@ -2655,14 +2655,14 @@ uint32_t ThriftHiveMetastore_get_databases_presult::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1744;
-            ::apache::thrift::protocol::TType _etype1747;
-            xfer += iprot->readListBegin(_etype1747, _size1744);
-            (*(this->success)).resize(_size1744);
-            uint32_t _i1748;
-            for (_i1748 = 0; _i1748 < _size1744; ++_i1748)
+            uint32_t _size1751;
+            ::apache::thrift::protocol::TType _etype1754;
+            xfer += iprot->readListBegin(_etype1754, _size1751);
+            (*(this->success)).resize(_size1751);
+            uint32_t _i1755;
+            for (_i1755 = 0; _i1755 < _size1751; ++_i1755)
             {
-              xfer += iprot->readString((*(this->success))[_i1748]);
+              xfer += iprot->readString((*(this->success))[_i1755]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2779,14 +2779,14 @@ uint32_t ThriftHiveMetastore_get_all_databases_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1749;
-            ::apache::thrift::protocol::TType _etype1752;
-            xfer += iprot->readListBegin(_etype1752, _size1749);
-            this->success.resize(_size1749);
-            uint32_t _i1753;
-            for (_i1753 = 0; _i1753 < _size1749; ++_i1753)
+            uint32_t _size1756;
+            ::apache::thrift::protocol::TType _etype1759;
+            xfer += iprot->readListBegin(_etype1759, _size1756);
+            this->success.resize(_size1756);
+            uint32_t _i1760;
+            for (_i1760 = 0; _i1760 < _size1756; ++_i1760)
             {
-              xfer += iprot->readString(this->success[_i1753]);
+              xfer += iprot->readString(this->success[_i1760]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2825,10 +2825,10 @@ uint32_t ThriftHiveMetastore_get_all_databases_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1754;
-      for (_iter1754 = this->success.begin(); _iter1754 != this->success.end(); ++_iter1754)
+      std::vector<std::string> ::const_iterator _iter1761;
+      for (_iter1761 = this->success.begin(); _iter1761 != this->success.end(); ++_iter1761)
       {
-        xfer += oprot->writeString((*_iter1754));
+        xfer += oprot->writeString((*_iter1761));
       }
       xfer += oprot->writeListEnd();
     }
@@ -2873,14 +2873,14 @@ uint32_t ThriftHiveMetastore_get_all_databases_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1755;
-            ::apache::thrift::protocol::TType _etype1758;
-            xfer += iprot->readListBegin(_etype1758, _size1755);
-            (*(this->success)).resize(_size1755);
-            uint32_t _i1759;
-            for (_i1759 = 0; _i1759 < _size1755; ++_i1759)
+            uint32_t _size1762;
+            ::apache::thrift::protocol::TType _etype1765;
+            xfer += iprot->readListBegin(_etype1765, _size1762);
+            (*(this->success)).resize(_size1762);
+            uint32_t _i1766;
+            for (_i1766 = 0; _i1766 < _size1762; ++_i1766)
             {
-              xfer += iprot->readString((*(this->success))[_i1759]);
+              xfer += iprot->readString((*(this->success))[_i1766]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3933,14 +3933,14 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_result::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1760;
-            ::apache::thrift::protocol::TType _etype1763;
-            xfer += iprot->readListBegin(_etype1763, _size1760);
-            this->success.resize(_size1760);
-            uint32_t _i1764;
-            for (_i1764 = 0; _i1764 < _size1760; ++_i1764)
+            uint32_t _size1767;
+            ::apache::thrift::protocol::TType _etype1770;
+            xfer += iprot->readListBegin(_etype1770, _size1767);
+            this->success.resize(_size1767);
+            uint32_t _i1771;
+            for (_i1771 = 0; _i1771 < _size1767; ++_i1771)
             {
-              xfer += iprot->readString(this->success[_i1764]);
+              xfer += iprot->readString(this->success[_i1771]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3979,10 +3979,10 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_result::write(::apache::thrift::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1765;
-      for (_iter1765 = this->success.begin(); _iter1765 != this->success.end(); ++_iter1765)
+      std::vector<std::string> ::const_iterator _iter1772;
+      for (_iter1772 = this->success.begin(); _iter1772 != this->success.end(); ++_iter1772)
       {
-        xfer += oprot->writeString((*_iter1765));
+        xfer += oprot->writeString((*_iter1772));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4027,14 +4027,14 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_presult::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1766;
-            ::apache::thrift::protocol::TType _etype1769;
-            xfer += iprot->readListBegin(_etype1769, _size1766);
-            (*(this->success)).resize(_size1766);
-            uint32_t _i1770;
-            for (_i1770 = 0; _i1770 < _size1766; ++_i1770)
+            uint32_t _size1773;
+            ::apache::thrift::protocol::TType _etype1776;
+            xfer += iprot->readListBegin(_etype1776, _size1773);
+            (*(this->success)).resize(_size1773);
+            uint32_t _i1777;
+            for (_i1777 = 0; _i1777 < _size1773; ++_i1777)
             {
-              xfer += iprot->readString((*(this->success))[_i1770]);
+              xfer += iprot->readString((*(this->success))[_i1777]);
             }
             xfer += iprot->readListEnd();
           }
@@ -5096,17 +5096,17 @@ uint32_t ThriftHiveMetastore_get_type_all_result::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size1771;
-            ::apache::thrift::protocol::TType _ktype1772;
-            ::apache::thrift::protocol::TType _vtype1773;
-            xfer += iprot->readMapBegin(_ktype1772, _vtype1773, _size1771);
-            uint32_t _i1775;
-            for (_i1775 = 0; _i1775 < _size1771; ++_i1775)
+            uint32_t _size1778;
+            ::apache::thrift::protocol::TType _ktype1779;
+            ::apache::thrift::protocol::TType _vtype1780;
+            xfer += iprot->readMapBegin(_ktype1779, _vtype1780, _size1778);
+            uint32_t _i1782;
+            for (_i1782 = 0; _i1782 < _size1778; ++_i1782)
             {
-              std::string _key1776;
-              xfer += iprot->readString(_key1776);
-              Type& _val1777 = this->success[_key1776];
-              xfer += _val1777.read(iprot);
+              std::string _key1783;
+              xfer += iprot->readString(_key1783);
+              Type& _val1784 = this->success[_key1783];
+              xfer += _val1784.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -5145,11 +5145,11 @@ uint32_t ThriftHiveMetastore_get_type_all_result::write(::apache::thrift::protoc
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::map<std::string, Type> ::const_iterator _iter1778;
-      for (_iter1778 = this->success.begin(); _iter1778 != this->success.end(); ++_iter1778)
+      std::map<std::string, Type> ::const_iterator _iter1785;
+      for (_iter1785 = this->success.begin(); _iter1785 != this->success.end(); ++_iter1785)
       {
-        xfer += oprot->writeString(_iter1778->first);
-        xfer += _iter1778->second.write(oprot);
+        xfer += oprot->writeString(_iter1785->first);
+        xfer += _iter1785->second.write(oprot);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -5194,17 +5194,17 @@ uint32_t ThriftHiveMetastore_get_type_all_presult::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size1779;
-            ::apache::thrift::protocol::TType _ktype1780;
-            ::apache::thrift::protocol::TType _vtype1781;
-            xfer += iprot->readMapBegin(_ktype1780, _vtype1781, _size1779);
-            uint32_t _i1783;
-            for (_i1783 = 0; _i1783 < _size1779; ++_i1783)
+            uint32_t _size1786;
+            ::apache::thrift::protocol::TType _ktype1787;
+            ::apache::thrift::protocol::TType _vtype1788;
+            xfer += iprot->readMapBegin(_ktype1787, _vtype1788, _size1786);
+            uint32_t _i1790;
+            for (_i1790 = 0; _i1790 < _size1786; ++_i1790)
             {
-              std::string _key1784;
-              xfer += iprot->readString(_key1784);
-              Type& _val1785 = (*(this->success))[_key1784];
-              xfer += _val1785.read(iprot);
+              std::string _key1791;
+              xfer += iprot->readString(_key1791);
+              Type& _val1792 = (*(this->success))[_key1791];
+              xfer += _val1792.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -5358,14 +5358,14 @@ uint32_t ThriftHiveMetastore_get_fields_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1786;
-            ::apache::thrift::protocol::TType _etype1789;
-            xfer += iprot->readListBegin(_etype1789, _size1786);
-            this->success.resize(_size1786);
-            uint32_t _i1790;
-            for (_i1790 = 0; _i1790 < _size1786; ++_i1790)
+            uint32_t _size1793;
+            ::apache::thrift::protocol::TType _etype1796;
+            xfer += iprot->readListBegin(_etype1796, _size1793);
+            this->success.resize(_size1793);
+            uint32_t _i1797;
+            for (_i1797 = 0; _i1797 < _size1793; ++_i1797)
             {
-              xfer += this->success[_i1790].read(iprot);
+              xfer += this->success[_i1797].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5420,10 +5420,10 @@ uint32_t ThriftHiveMetastore_get_fields_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1791;
-      for (_iter1791 = this->success.begin(); _iter1791 != this->success.end(); ++_iter1791)
+      std::vector<FieldSchema> ::const_iterator _iter1798;
+      for (_iter1798 = this->success.begin(); _iter1798 != this->success.end(); ++_iter1798)
       {
-        xfer += (*_iter1791).write(oprot);
+        xfer += (*_iter1798).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5476,14 +5476,14 @@ uint32_t ThriftHiveMetastore_get_fields_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1792;
-            ::apache::thrift::protocol::TType _etype1795;
-            xfer += iprot->readListBegin(_etype1795, _size1792);
-            (*(this->success)).resize(_size1792);
-            uint32_t _i1796;
-            for (_i1796 = 0; _i1796 < _size1792; ++_i1796)
+            uint32_t _size1799;
+            ::apache::thrift::protocol::TType _etype1802;
+            xfer += iprot->readListBegin(_etype1802, _size1799);
+            (*(this->success)).resize(_size1799);
+            uint32_t _i1803;
+            for (_i1803 = 0; _i1803 < _size1799; ++_i1803)
             {
-              xfer += (*(this->success))[_i1796].read(iprot);
+              xfer += (*(this->success))[_i1803].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5669,14 +5669,14 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_result::read(::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1797;
-            ::apache::thrift::protocol::TType _etype1800;
-            xfer += iprot->readListBegin(_etype1800, _size1797);
-            this->success.resize(_size1797);
-            uint32_t _i1801;
-            for (_i1801 = 0; _i1801 < _size1797; ++_i1801)
+            uint32_t _size1804;
+            ::apache::thrift::protocol::TType _etype1807;
+            xfer += iprot->readListBegin(_etype1807, _size1804);
+            this->success.resize(_size1804);
+            uint32_t _i1808;
+            for (_i1808 = 0; _i1808 < _size1804; ++_i1808)
             {
-              xfer += this->success[_i1801].read(iprot);
+              xfer += this->success[_i1808].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5731,10 +5731,10 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_result::write(:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1802;
-      for (_iter1802 = this->success.begin(); _iter1802 != this->success.end(); ++_iter1802)
+      std::vector<FieldSchema> ::const_iterator _iter1809;
+      for (_iter1809 = this->success.begin(); _iter1809 != this->success.end(); ++_iter1809)
       {
-        xfer += (*_iter1802).write(oprot);
+        xfer += (*_iter1809).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5787,14 +5787,14 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_presult::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1803;
-            ::apache::thrift::protocol::TType _etype1806;
-            xfer += iprot->readListBegin(_etype1806, _size1803);
-            (*(this->success)).resize(_size1803);
-            uint32_t _i1807;
-            for (_i1807 = 0; _i1807 < _size1803; ++_i1807)
+            uint32_t _size1810;
+            ::apache::thrift::protocol::TType _etype1813;
+            xfer += iprot->readListBegin(_etype1813, _size1810);
+            (*(this->success)).resize(_size1810);
+            uint32_t _i1814;
+            for (_i1814 = 0; _i1814 < _size1810; ++_i1814)
             {
-              xfer += (*(this->success))[_i1807].read(iprot);
+              xfer += (*(this->success))[_i1814].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6211,14 +6211,14 @@ uint32_t ThriftHiveMetastore_get_schema_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1808;
-            ::apache::thrift::protocol::TType _etype1811;
-            xfer += iprot->readListBegin(_etype1811, _size1808);
-            this->success.resize(_size1808);
-            uint32_t _i1812;
-            for (_i1812 = 0; _i1812 < _size1808; ++_i1812)
+            uint32_t _size1815;
+            ::apache::thrift::protocol::TType _etype1818;
+            xfer += iprot->readListBegin(_etype1818, _size1815);
+            this->success.resize(_size1815);
+            uint32_t _i1819;
+            for (_i1819 = 0; _i1819 < _size1815; ++_i1819)
             {
-              xfer += this->success[_i1812].read(iprot);
+              xfer += this->success[_i1819].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6273,10 +6273,10 @@ uint32_t ThriftHiveMetastore_get_schema_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1813;
-      for (_iter1813 = this->success.begin(); _iter1813 != this->success.end(); ++_iter1813)
+      std::vector<FieldSchema> ::const_iterator _iter1820;
+      for (_iter1820 = this->success.begin(); _iter1820 != this->success.end(); ++_iter1820)
       {
-        xfer += (*_iter1813).write(oprot);
+        xfer += (*_iter1820).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -6329,14 +6329,14 @@ uint32_t ThriftHiveMetastore_get_schema_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1814;
-            ::apache::thrift::protocol::TType _etype1817;
-            xfer += iprot->readListBegin(_etype1817, _size1814);
-            (*(this->success)).resize(_size1814);
-            uint32_t _i1818;
-            for (_i1818 = 0; _i1818 < _size1814; ++_i1818)
+            uint32_t _size1821;
+            ::apache::thrift::protocol::TType _etype1824;
+            xfer += iprot->readListBegin(_etype1824, _size1821);
+            (*(this->success)).resize(_size1821);
+            uint32_t _i1825;
+            for (_i1825 = 0; _i1825 < _size1821; ++_i1825)
             {
-              xfer += (*(this->success))[_i1818].read(iprot);
+              xfer += (*(this->success))[_i1825].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6522,14 +6522,14 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_result::read(::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1819;
-            ::apache::thrift::protocol::TType _etype1822;
-            xfer += iprot->readListBegin(_etype1822, _size1819);
-            this->success.resize(_size1819);
-            uint32_t _i1823;
-            for (_i1823 = 0; _i1823 < _size1819; ++_i1823)
+            uint32_t _size1826;
+            ::apache::thrift::protocol::TType _etype1829;
+            xfer += iprot->readListBegin(_etype1829, _size1826);
+            this->success.resize(_size1826);
+            uint32_t _i1830;
+            for (_i1830 = 0; _i1830 < _size1826; ++_i1830)
             {
-              xfer += this->success[_i1823].read(iprot);
+              xfer += this->success[_i1830].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6584,10 +6584,10 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_result::write(:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1824;
-      for (_iter1824 = this->success.begin(); _iter1824 != this->success.end(); ++_iter1824)
+      std::vector<FieldSchema> ::const_iterator _iter1831;
+      for (_iter1831 = this->success.begin(); _iter1831 != this->success.end(); ++_iter1831)
       {
-        xfer += (*_iter1824).write(oprot);
+        xfer += (*_iter1831).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -6640,14 +6640,14 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_presult::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1825;
-            ::apache::thrift::protocol::TType _etype1828;
-            xfer += iprot->readListBegin(_etype1828, _size1825);
-            (*(this->success)).resize(_size1825);
-            uint32_t _i1829;
-            for (_i1829 = 0; _i1829 < _size1825; ++_i1829)
+            uint32_t _size1832;
+            ::apache::thrift::protocol::TType _etype1835;
+            xfer += iprot->readListBegin(_etype1835, _size1832);
+            (*(this->success)).resize(_size1832);
+            uint32_t _i1836;
+            for (_i1836 = 0; _i1836 < _size1832; ++_i1836)
             {
-              xfer += (*(this->success))[_i1829].read(iprot);
+              xfer += (*(this->success))[_i1836].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7487,14 +7487,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size1830;
-            ::apache::thrift::protocol::TType _etype1833;
-            xfer += iprot->readListBegin(_etype1833, _size1830);
-            this->primaryKeys.resize(_size1830);
-            uint32_t _i1834;
-            for (_i1834 = 0; _i1834 < _size1830; ++_i1834)
+            uint32_t _size1837;
+            ::apache::thrift::protocol::TType _etype1840;
+            xfer += iprot->readListBegin(_etype1840, _size1837);
+            this->primaryKeys.resize(_size1837);
+            uint32_t _i1841;
+            for (_i1841 = 0; _i1841 < _size1837; ++_i1841)
             {
-              xfer += this->primaryKeys[_i1834].read(iprot);
+              xfer += this->primaryKeys[_i1841].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7507,14 +7507,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size1835;
-            ::apache::thrift::protocol::TType _etype1838;
-            xfer += iprot->readListBegin(_etype1838, _size1835);
-            this->foreignKeys.resize(_size1835);
-            uint32_t _i1839;
-            for (_i1839 = 0; _i1839 < _size1835; ++_i1839)
+            uint32_t _size1842;
+            ::apache::thrift::protocol::TType _etype1845;
+            xfer += iprot->readListBegin(_etype1845, _size1842);
+            this->foreignKeys.resize(_size1842);
+            uint32_t _i1846;
+            for (_i1846 = 0; _i1846 < _size1842; ++_i1846)
             {
-              xfer += this->foreignKeys[_i1839].read(iprot);
+              xfer += this->foreignKeys[_i1846].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7527,14 +7527,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size1840;
-            ::apache::thrift::protocol::TType _etype1843;
-            xfer += iprot->readListBegin(_etype1843, _size1840);
-            this->uniqueConstraints.resize(_size1840);
-            uint32_t _i1844;
-            for (_i1844 = 0; _i1844 < _size1840; ++_i1844)
+            uint32_t _size1847;
+            ::apache::thrift::protocol::TType _etype1850;
+            xfer += iprot->readListBegin(_etype1850, _size1847);
+            this->uniqueConstraints.resize(_size1847);
+            uint32_t _i1851;
+            for (_i1851 = 0; _i1851 < _size1847; ++_i1851)
             {
-              xfer += this->uniqueConstraints[_i1844].read(iprot);
+              xfer += this->uniqueConstraints[_i1851].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7547,14 +7547,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size1845;
-            ::apache::thrift::protocol::TType _etype1848;
-            xfer += iprot->readListBegin(_etype1848, _size1845);
-            this->notNullConstraints.resize(_size1845);
-            uint32_t _i1849;
-            for (_i1849 = 0; _i1849 < _size1845; ++_i1849)
+            uint32_t _size1852;
+            ::apache::thrift::protocol::TType _etype1855;
+            xfer += iprot->readListBegin(_etype1855, _size1852);
+            this->notNullConstraints.resize(_size1852);
+            uint32_t _i1856;
+            for (_i1856 = 0; _i1856 < _size1852; ++_i1856)
             {
-              xfer += this->notNullConstraints[_i1849].read(iprot);
+              xfer += this->notNullConstraints[_i1856].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7567,14 +7567,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size1850;
-            ::apache::thrift::protocol::TType _etype1853;
-            xfer += iprot->readListBegin(_etype1853, _size1850);
-            this->defaultConstraints.resize(_size1850);
-            uint32_t _i1854;
-            for (_i1854 = 0; _i1854 < _size1850; ++_i1854)
+            uint32_t _size1857;
+            ::apache::thrift::protocol::TType _etype1860;
+            xfer += iprot->readListBegin(_etype1860, _size1857);
+            this->defaultConstraints.resize(_size1857);
+            uint32_t _i1861;
+            for (_i1861 = 0; _i1861 < _size1857; ++_i1861)
             {
-              xfer += this->defaultConstraints[_i1854].read(iprot);
+              xfer += this->defaultConstraints[_i1861].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7587,14 +7587,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size1855;
-            ::apache::thrift::protocol::TType _etype1858;
-            xfer += iprot->readListBegin(_etype1858, _size1855);
-            this->checkConstraints.resize(_size1855);
-            uint32_t _i1859;
-            for (_i1859 = 0; _i1859 < _size1855; ++_i1859)
+            uint32_t _size1862;
+            ::apache::thrift::protocol::TType _etype1865;
+            xfer += iprot->readListBegin(_etype1865, _size1862);
+            this->checkConstraints.resize(_size1862);
+            uint32_t _i1866;
+            for (_i1866 = 0; _i1866 < _size1862; ++_i1866)
             {
-              xfer += this->checkConstraints[_i1859].read(iprot);
+              xfer += this->checkConstraints[_i1866].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7627,10 +7627,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter1860;
-    for (_iter1860 = this->primaryKeys.begin(); _iter1860 != this->primaryKeys.end(); ++_iter1860)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter1867;
+    for (_iter1867 = this->primaryKeys.begin(); _iter1867 != this->primaryKeys.end(); ++_iter1867)
     {
-      xfer += (*_iter1860).write(oprot);
+      xfer += (*_iter1867).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7639,10 +7639,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter1861;
-    for (_iter1861 = this->foreignKeys.begin(); _iter1861 != this->foreignKeys.end(); ++_iter1861)
+    std::vector<SQLForeignKey> ::const_iterator _iter1868;
+    for (_iter1868 = this->foreignKeys.begin(); _iter1868 != this->foreignKeys.end(); ++_iter1868)
     {
-      xfer += (*_iter1861).write(oprot);
+      xfer += (*_iter1868).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7651,10 +7651,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter1862;
-    for (_iter1862 = this->uniqueConstraints.begin(); _iter1862 != this->uniqueConstraints.end(); ++_iter1862)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter1869;
+    for (_iter1869 = this->uniqueConstraints.begin(); _iter1869 != this->uniqueConstraints.end(); ++_iter1869)
     {
-      xfer += (*_iter1862).write(oprot);
+      xfer += (*_iter1869).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7663,10 +7663,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter1863;
-    for (_iter1863 = this->notNullConstraints.begin(); _iter1863 != this->notNullConstraints.end(); ++_iter1863)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter1870;
+    for (_iter1870 = this->notNullConstraints.begin(); _iter1870 != this->notNullConstraints.end(); ++_iter1870)
     {
-      xfer += (*_iter1863).write(oprot);
+      xfer += (*_iter1870).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7675,10 +7675,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter1864;
-    for (_iter1864 = this->defaultConstraints.begin(); _iter1864 != this->defaultConstraints.end(); ++_iter1864)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter1871;
+    for (_iter1871 = this->defaultConstraints.begin(); _iter1871 != this->defaultConstraints.end(); ++_iter1871)
     {
-      xfer += (*_iter1864).write(oprot);
+      xfer += (*_iter1871).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7687,10 +7687,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 7);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter1865;
-    for (_iter1865 = this->checkConstraints.begin(); _iter1865 != this->checkConstraints.end(); ++_iter1865)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter1872;
+    for (_iter1872 = this->checkConstraints.begin(); _iter1872 != this->checkConstraints.end(); ++_iter1872)
     {
-      xfer += (*_iter1865).write(oprot);
+      xfer += (*_iter1872).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7718,10 +7718,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->primaryKeys)).size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter1866;
-    for (_iter1866 = (*(this->primaryKeys)).begin(); _iter1866 != (*(this->primaryKeys)).end(); ++_iter1866)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter1873;
+    for (_iter1873 = (*(this->primaryKeys)).begin(); _iter1873 != (*(this->primaryKeys)).end(); ++_iter1873)
     {
-      xfer += (*_iter1866).write(oprot);
+      xfer += (*_iter1873).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7730,10 +7730,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->foreignKeys)).size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter1867;
-    for (_iter1867 = (*(this->foreignKeys)).begin(); _iter1867 != (*(this->foreignKeys)).end(); ++_iter1867)
+    std::vector<SQLForeignKey> ::const_iterator _iter1874;
+    for (_iter1874 = (*(this->foreignKeys)).begin(); _iter1874 != (*(this->foreignKeys)).end(); ++_iter1874)
     {
-      xfer += (*_iter1867).write(oprot);
+      xfer += (*_iter1874).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7742,10 +7742,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->uniqueConstraints)).size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter1868;
-    for (_iter1868 = (*(this->uniqueConstraints)).begin(); _iter1868 != (*(this->uniqueConstraints)).end(); ++_iter1868)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter1875;
+    for (_iter1875 = (*(this->uniqueConstraints)).begin(); _iter1875 != (*(this->uniqueConstraints)).end(); ++_iter1875)
     {
-      xfer += (*_iter1868).write(oprot);
+      xfer += (*_iter1875).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7754,10 +7754,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->notNullConstraints)).size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter1869;
-    for (_iter1869 = (*(this->notNullConstraints)).begin(); _iter1869 != (*(this->notNullConstraints)).end(); ++_iter1869)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter1876;
+    for (_iter1876 = (*(this->notNullConstraints)).begin(); _iter1876 != (*(this->notNullConstraints)).end(); ++_iter1876)
     {
-      xfer += (*_iter1869).write(oprot);
+      xfer += (*_iter1876).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7766,10 +7766,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->defaultConstraints)).size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter1870;
-    for (_iter1870 = (*(this->defaultConstraints)).begin(); _iter1870 != (*(this->defaultConstraints)).end(); ++_iter1870)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter1877;
+    for (_iter1877 = (*(this->defaultConstraints)).begin(); _iter1877 != (*(this->defaultConstraints)).end(); ++_iter1877)
     {
-      xfer += (*_iter1870).write(oprot);
+      xfer += (*_iter1877).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7778,10 +7778,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 7);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->checkConstraints)).size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter1871;
-    for (_iter1871 = (*(this->checkConstraints)).begin(); _iter1871 != (*(this->checkConstraints)).end(); ++_iter1871)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter1878;
+    for (_iter1878 = (*(this->checkConstraints)).begin(); _iter1878 != (*(this->checkConstraints)).end(); ++_iter1878)
     {
-      xfer += (*_iter1871).write(oprot);
+      xfer += (*_iter1878).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -10463,14 +10463,14 @@ uint32_t ThriftHiveMetastore_truncate_table_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size1872;
-            ::apache::thrift::protocol::TType _etype1875;
-            xfer += iprot->readListBegin(_etype1875, _size1872);
-            this->partNames.resize(_size1872);
-            uint32_t _i1876;
-            for (_i1876 = 0; _i1876 < _size1872; ++_i1876)
+            uint32_t _size1879;
+            ::apache::thrift::protocol::TType _etype1882;
+            xfer += iprot->readListBegin(_etype1882, _size1879);
+            this->partNames.resize(_size1879);
+            uint32_t _i1883;
+            for (_i1883 = 0; _i1883 < _size1879; ++_i1883)
             {
-              xfer += iprot->readString(this->partNames[_i1876]);
+              xfer += iprot->readString(this->partNames[_i1883]);
             }
             xfer += iprot->readListEnd();
           }
@@ -10507,10 +10507,10 @@ uint32_t ThriftHiveMetastore_truncate_table_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-    std::vector<std::string> ::const_iterator _iter1877;
-    for (_iter1877 = this->partNames.begin(); _iter1877 != this->partNames.end(); ++_iter1877)
+    std::vector<std::string> ::const_iterator _iter1884;
+    for (_iter1884 = this->partNames.begin(); _iter1884 != this->partNames.end(); ++_iter1884)
     {
-      xfer += oprot->writeString((*_iter1877));
+      xfer += oprot->writeString((*_iter1884));
     }
     xfer += oprot->writeListEnd();
   }
@@ -10542,10 +10542,10 @@ uint32_t ThriftHiveMetastore_truncate_table_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partNames)).size()));
-    std::vector<std::string> ::const_iterator _iter1878;
-    for (_iter1878 = (*(this->partNames)).begin(); _iter1878 != (*(this->partNames)).end(); ++_iter1878)
+    std::vector<std::string> ::const_iterator _iter1885;
+    for (_iter1885 = (*(this->partNames)).begin(); _iter1885 != (*(this->partNames)).end(); ++_iter1885)
     {
-      xfer += oprot->writeString((*_iter1878));
+      xfer += oprot->writeString((*_iter1885));
     }
     xfer += oprot->writeListEnd();
   }
@@ -10996,14 +10996,14 @@ uint32_t ThriftHiveMetastore_get_tables_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1879;
-            ::apache::thrift::protocol::TType _etype1882;
-            xfer += iprot->readListBegin(_etype1882, _size1879);
-            this->success.resize(_size1879);
-            uint32_t _i1883;
-            for (_i1883 = 0; _i1883 < _size1879; ++_i1883)
+            uint32_t _size1886;
+            ::apache::thrift::protocol::TType _etype1889;
+            xfer += iprot->readListBegin(_etype1889, _size1886);
+            this->success.resize(_size1886);
+            uint32_t _i1890;
+            for (_i1890 = 0; _i1890 < _size1886; ++_i1890)
             {
-              xfer += iprot->readString(this->success[_i1883]);
+              xfer += iprot->readString(this->success[_i1890]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11042,10 +11042,10 @@ uint32_t ThriftHiveMetastore_get_tables_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1884;
-      for (_iter1884 = this->success.begin(); _iter1884 != this->success.end(); ++_iter1884)
+      std::vector<std::string> ::const_iterator _iter1891;
+      for (_iter1891 = this->success.begin(); _iter1891 != this->success.end(); ++_iter1891)
       {
-        xfer += oprot->writeString((*_iter1884));
+        xfer += oprot->writeString((*_iter1891));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11090,14 +11090,14 @@ uint32_t ThriftHiveMetastore_get_tables_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1885;
-            ::apache::thrift::protocol::TType _etype1888;
-            xfer += iprot->readListBegin(_etype1888, _size1885);
-            (*(this->success)).resize(_size1885);
-            uint32_t _i1889;
-            for (_i1889 = 0; _i1889 < _size1885; ++_i1889)
+            uint32_t _size1892;
+            ::apache::thrift::protocol::TType _etype1895;
+            xfer += iprot->readListBegin(_etype1895, _size1892);
+            (*(this->success)).resize(_size1892);
+            uint32_t _i1896;
+            for (_i1896 = 0; _i1896 < _size1892; ++_i1896)
             {
-              xfer += iprot->readString((*(this->success))[_i1889]);
+              xfer += iprot->readString((*(this->success))[_i1896]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11267,14 +11267,14 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_result::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1890;
-            ::apache::thrift::protocol::TType _etype1893;
-            xfer += iprot->readListBegin(_etype1893, _size1890);
-            this->success.resize(_size1890);
-            uint32_t _i1894;
-            for (_i1894 = 0; _i1894 < _size1890; ++_i1894)
+            uint32_t _size1897;
+            ::apache::thrift::protocol::TType _etype1900;
+            xfer += iprot->readListBegin(_etype1900, _size1897);
+            this->success.resize(_size1897);
+            uint32_t _i1901;
+            for (_i1901 = 0; _i1901 < _size1897; ++_i1901)
             {
-              xfer += iprot->readString(this->success[_i1894]);
+              xfer += iprot->readString(this->success[_i1901]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11313,10 +11313,10 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_result::write(::apache::thrift::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1895;
-      for (_iter1895 = this->success.begin(); _iter1895 != this->success.end(); ++_iter1895)
+      std::vector<std::string> ::const_iterator _iter1902;
+      for (_iter1902 = this->success.begin(); _iter1902 != this->success.end(); ++_iter1902)
       {
-        xfer += oprot->writeString((*_iter1895));
+        xfer += oprot->writeString((*_iter1902));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11361,14 +11361,14 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_presult::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1896;
-            ::apache::thrift::protocol::TType _etype1899;
-            xfer += iprot->readListBegin(_etype1899, _size1896);
-            (*(this->success)).resize(_size1896);
-            uint32_t _i1900;
-            for (_i1900 = 0; _i1900 < _size1896; ++_i1900)
+            uint32_t _size1903;
+            ::apache::thrift::protocol::TType _etype1906;
+            xfer += iprot->readListBegin(_etype1906, _size1903);
+            (*(this->success)).resize(_size1903);
+            uint32_t _i1907;
+            for (_i1907 = 0; _i1907 < _size1903; ++_i1907)
             {
-              xfer += iprot->readString((*(this->success))[_i1900]);
+              xfer += iprot->readString((*(this->success))[_i1907]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11485,14 +11485,14 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_res
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1901;
-            ::apache::thrift::protocol::TType _etype1904;
-            xfer += iprot->readListBegin(_etype1904, _size1901);
-            this->success.resize(_size1901);
-            uint32_t _i1905;
-            for (_i1905 = 0; _i1905 < _size1901; ++_i1905)
+            uint32_t _size1908;
+            ::apache::thrift::protocol::TType _etype1911;
+            xfer += iprot->readListBegin(_etype1911, _size1908);
+            this->success.resize(_size1908);
+            uint32_t _i1912;
+            for (_i1912 = 0; _i1912 < _size1908; ++_i1912)
             {
-              xfer += this->success[_i1905].read(iprot);
+              xfer += this->success[_i1912].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11531,10 +11531,10 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_res
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Table> ::const_iterator _iter1906;
-      for (_iter1906 = this->success.begin(); _iter1906 != this->success.end(); ++_iter1906)
+      std::vector<Table> ::const_iterator _iter1913;
+      for (_iter1913 = this->success.begin(); _iter1913 != this->success.end(); ++_iter1913)
       {
-        xfer += (*_iter1906).write(oprot);
+        xfer += (*_iter1913).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -11579,14 +11579,14 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_pre
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1907;
-            ::apache::thrift::protocol::TType _etype1910;
-            xfer += iprot->readListBegin(_etype1910, _size1907);
-            (*(this->success)).resize(_size1907);
-            uint32_t _i1911;
-            for (_i1911 = 0; _i1911 < _size1907; ++_i1911)
+            uint32_t _size1914;
+            ::apache::thrift::protocol::TType _etype1917;
+            xfer += iprot->readListBegin(_etype1917, _size1914);
+            (*(this->success)).resize(_size1914);
+            uint32_t _i1918;
+            for (_i1918 = 0; _i1918 < _size1914; ++_i1918)
             {
-              xfer += (*(this->success))[_i1911].read(iprot);
+              xfer += (*(this->success))[_i1918].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11724,14 +11724,14 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_result::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1912;
-            ::apache::thrift::protocol::TType _etype1915;
-            xfer += iprot->readListBegin(_etype1915, _size1912);
-            this->success.resize(_size1912);
-            uint32_t _i1916;
-            for (_i1916 = 0; _i1916 < _size1912; ++_i1916)
+            uint32_t _size1919;
+            ::apache::thrift::protocol::TType _etype1922;
+            xfer += iprot->readListBegin(_etype1922, _size1919);
+            this->success.resize(_size1919);
+            uint32_t _i1923;
+            for (_i1923 = 0; _i1923 < _size1919; ++_i1923)
             {
-              xfer += iprot->readString(this->success[_i1916]);
+              xfer += iprot->readString(this->success[_i1923]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11770,10 +11770,10 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_result::write(
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1917;
-      for (_iter1917 = this->success.begin(); _iter1917 != this->success.end(); ++_iter1917)
+      std::vector<std::string> ::const_iterator _iter1924;
+      for (_iter1924 = this->success.begin(); _iter1924 != this->success.end(); ++_iter1924)
       {
-        xfer += oprot->writeString((*_iter1917));
+        xfer += oprot->writeString((*_iter1924));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11818,14 +11818,14 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_presult::read(
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1918;
-            ::apache::thrift::protocol::TType _etype1921;
-            xfer += iprot->readListBegin(_etype1921, _size1918);
-            (*(this->success)).resize(_size1918);
-            uint32_t _i1922;
-            for (_i1922 = 0; _i1922 < _size1918; ++_i1922)
+            uint32_t _size1925;
+            ::apache::thrift::protocol::TType _etype1928;
+            xfer += iprot->readListBegin(_etype1928, _size1925);
+            (*(this->success)).resize(_size1925);
+            uint32_t _i1929;
+            for (_i1929 = 0; _i1929 < _size1925; ++_i1929)
             {
-              xfer += iprot->readString((*(this->success))[_i1922]);
+              xfer += iprot->readString((*(this->success))[_i1929]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11900,14 +11900,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tbl_types.clear();
-            uint32_t _size1923;
-            ::apache::thrift::protocol::TType _etype1926;
-            xfer += iprot->readListBegin(_etype1926, _size1923);
-            this->tbl_types.resize(_size1923);
-            uint32_t _i1927;
-            for (_i1927 = 0; _i1927 < _size1923; ++_i1927)
+            uint32_t _size1930;
+            ::apache::thrift::protocol::TType _etype1933;
+            xfer += iprot->readListBegin(_etype1933, _size1930);
+            this->tbl_types.resize(_size1930);
+            uint32_t _i1934;
+            for (_i1934 = 0; _i1934 < _size1930; ++_i1934)
             {
-              xfer += iprot->readString(this->tbl_types[_i1927]);
+              xfer += iprot->readString(this->tbl_types[_i1934]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11944,10 +11944,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("tbl_types", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tbl_types.size()));
-    std::vector<std::string> ::const_iterator _iter1928;
-    for (_iter1928 = this->tbl_types.begin(); _iter1928 != this->tbl_types.end(); ++_iter1928)
+    std::vector<std::string> ::const_iterator _iter1935;
+    for (_iter1935 = this->tbl_types.begin(); _iter1935 != this->tbl_types.end(); ++_iter1935)
     {
-      xfer += oprot->writeString((*_iter1928));
+      xfer += oprot->writeString((*_iter1935));
     }
     xfer += oprot->writeListEnd();
   }
@@ -11979,10 +11979,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("tbl_types", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->tbl_types)).size()));
-    std::vector<std::string> ::const_iterator _iter1929;
-    for (_iter1929 = (*(this->tbl_types)).begin(); _iter1929 != (*(this->tbl_types)).end(); ++_iter1929)
+    std::vector<std::string> ::const_iterator _iter1936;
+    for (_iter1936 = (*(this->tbl_types)).begin(); _iter1936 != (*(this->tbl_types)).end(); ++_iter1936)
     {
-      xfer += oprot->writeString((*_iter1929));
+      xfer += oprot->writeString((*_iter1936));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12023,14 +12023,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1930;
-            ::apache::thrift::protocol::TType _etype1933;
-            xfer += iprot->readListBegin(_etype1933, _size1930);
-            this->success.resize(_size1930);
-            uint32_t _i1934;
-            for (_i1934 = 0; _i1934 < _size1930; ++_i1934)
+            uint32_t _size1937;
+            ::apache::thrift::protocol::TType _etype1940;
+            xfer += iprot->readListBegin(_etype1940, _size1937);
+            this->success.resize(_size1937);
+            uint32_t _i1941;
+            for (_i1941 = 0; _i1941 < _size1937; ++_i1941)
             {
-              xfer += this->success[_i1934].read(iprot);
+              xfer += this->success[_i1941].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12069,10 +12069,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<TableMeta> ::const_iterator _iter1935;
-      for (_iter1935 = this->success.begin(); _iter1935 != this->success.end(); ++_iter1935)
+      std::vector<TableMeta> ::const_iterator _iter1942;
+      for (_iter1942 = this->success.begin(); _iter1942 != this->success.end(); ++_iter1942)
       {
-        xfer += (*_iter1935).write(oprot);
+        xfer += (*_iter1942).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -12117,14 +12117,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1936;
-            ::apache::thrift::protocol::TType _etype1939;
-            xfer += iprot->readListBegin(_etype1939, _size1936);
-            (*(this->success)).resize(_size1936);
-            uint32_t _i1940;
-            for (_i1940 = 0; _i1940 < _size1936; ++_i1940)
+            uint32_t _size1943;
+            ::apache::thrift::protocol::TType _etype1946;
+            xfer += iprot->readListBegin(_etype1946, _size1943);
+            (*(this->success)).resize(_size1943);
+            uint32_t _i1947;
+            for (_i1947 = 0; _i1947 < _size1943; ++_i1947)
             {
-              xfer += (*(this->success))[_i1940].read(iprot);
+              xfer += (*(this->success))[_i1947].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12262,14 +12262,14 @@ uint32_t ThriftHiveMetastore_get_all_tables_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1941;
-            ::apache::thrift::protocol::TType _etype1944;
-            xfer += iprot->readListBegin(_etype1944, _size1941);
-            this->success.resize(_size1941);
-            uint32_t _i1945;
-            for (_i1945 = 0; _i1945 < _size1941; ++_i1945)
+            uint32_t _size1948;
+            ::apache::thrift::protocol::TType _etype1951;
+            xfer += iprot->readListBegin(_etype1951, _size1948);
+            this->success.resize(_size1948);
+            uint32_t _i1952;
+            for (_i1952 = 0; _i1952 < _size1948; ++_i1952)
             {
-              xfer += iprot->readString(this->success[_i1945]);
+              xfer += iprot->readString(this->success[_i1952]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12308,10 +12308,10 @@ uint32_t ThriftHiveMetastore_get_all_tables_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1946;
-      for (_iter1946 = this->success.begin(); _iter1946 != this->success.end(); ++_iter1946)
+      std::vector<std::string> ::const_iterator _iter1953;
+      for (_iter1953 = this->success.begin(); _iter1953 != this->success.end(); ++_iter1953)
       {
-        xfer += oprot->writeString((*_iter1946));
+        xfer += oprot->writeString((*_iter1953));
       }
       xfer += oprot->writeListEnd();
     }
@@ -12356,14 +12356,14 @@ uint32_t ThriftHiveMetastore_get_all_tables_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1947;
-            ::apache::thrift::protocol::TType _etype1950;
-            xfer += iprot->readListBegin(_etype1950, _size1947);
-            (*(this->success)).resize(_size1947);
-            uint32_t _i1951;
-            for (_i1951 = 0; _i1951 < _size1947; ++_i1951)
+            uint32_t _size1954;
+            ::apache::thrift::protocol::TType _etype1957;
+            xfer += iprot->readListBegin(_etype1957, _size1954);
+            (*(this->success)).resize(_size1954);
+            uint32_t _i1958;
+            for (_i1958 = 0; _i1958 < _size1954; ++_i1958)
             {
-              xfer += iprot->readString((*(this->success))[_i1951]);
+              xfer += iprot->readString((*(this->success))[_i1958]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12673,14 +12673,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_args::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tbl_names.clear();
-            uint32_t _size1952;
-            ::apache::thrift::protocol::TType _etype1955;
-            xfer += iprot->readListBegin(_etype1955, _size1952);
-            this->tbl_names.resize(_size1952);
-            uint32_t _i1956;
-            for (_i1956 = 0; _i1956 < _size1952; ++_i1956)
+            uint32_t _size1959;
+            ::apache::thrift::protocol::TType _etype1962;
+            xfer += iprot->readListBegin(_etype1962, _size1959);
+            this->tbl_names.resize(_size1959);
+            uint32_t _i1963;
+            for (_i1963 = 0; _i1963 < _size1959; ++_i1963)
             {
-              xfer += iprot->readString(this->tbl_names[_i1956]);
+              xfer += iprot->readString(this->tbl_names[_i1963]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12713,10 +12713,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_args::write(::apache::thr
   xfer += oprot->writeFieldBegin("tbl_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tbl_names.size()));
-    std::vector<std::string> ::const_iterator _iter1957;
-    for (_iter1957 = this->tbl_names.begin(); _iter1957 != this->tbl_names.end(); ++_iter1957)
+    std::vector<std::string> ::const_iterator _iter1964;
+    for (_iter1964 = this->tbl_names.begin(); _iter1964 != this->tbl_names.end(); ++_iter1964)
     {
-      xfer += oprot->writeString((*_iter1957));
+      xfer += oprot->writeString((*_iter1964));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12744,10 +12744,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_pargs::write(::apache::th
   xfer += oprot->writeFieldBegin("tbl_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->tbl_names)).size()));
-    std::vector<std::string> ::const_iterator _iter1958;
-    for (_iter1958 = (*(this->tbl_names)).begin(); _iter1958 != (*(this->tbl_names)).end(); ++_iter1958)
+    std::vector<std::string> ::const_iterator _iter1965;
+    for (_iter1965 = (*(this->tbl_names)).begin(); _iter1965 != (*(this->tbl_names)).end(); ++_iter1965)
     {
-      xfer += oprot->writeString((*_iter1958));
+      xfer += oprot->writeString((*_iter1965));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12788,14 +12788,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1959;
-            ::apache::thrift::protocol::TType _etype1962;
-            xfer += iprot->readListBegin(_etype1962, _size1959);
-            this->success.resize(_size1959);
-            uint32_t _i1963;
-            for (_i1963 = 0; _i1963 < _size1959; ++_i1963)
+            uint32_t _size1966;
+            ::apache::thrift::protocol::TType _etype1969;
+            xfer += iprot->readListBegin(_etype1969, _size1966);
+            this->success.resize(_size1966);
+            uint32_t _i1970;
+            for (_i1970 = 0; _i1970 < _size1966; ++_i1970)
             {
-              xfer += this->success[_i1963].read(iprot);
+              xfer += this->success[_i1970].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12826,10 +12826,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Table> ::const_iterator _iter1964;
-      for (_iter1964 = this->success.begin(); _iter1964 != this->success.end(); ++_iter1964)
+      std::vector<Table> ::const_iterator _iter1971;
+      for (_iter1971 = this->success.begin(); _iter1971 != this->success.end(); ++_iter1971)
       {
-        xfer += (*_iter1964).write(oprot);
+        xfer += (*_iter1971).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -12870,14 +12870,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1965;
-            ::apache::thrift::protocol::TType _etype1968;
-            xfer += iprot->readListBegin(_etype1968, _size1965);
-            (*(this->success)).resize(_size1965);
-            uint32_t _i1969;
-            for (_i1969 = 0; _i1969 < _size1965; ++_i1969)
+            uint32_t _size1972;
+            ::apache::thrift::protocol::TType _etype1975;
+            xfer += iprot->readListBegin(_etype1975, _size1972);
+            (*(this->success)).resize(_size1972);
+            uint32_t _i1976;
+            for (_i1976 = 0; _i1976 < _size1972; ++_i1976)
             {
-              xfer += (*(this->success))[_i1969].read(iprot);
+              xfer += (*(this->success))[_i1976].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13007,14 +13007,14 @@ uint32_t ThriftHiveMetastore_get_tables_ext_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1970;
-            ::apache::thrift::protocol::TType _etype1973;
-            xfer += iprot->readListBegin(_etype1973, _size1970);
-            this->success.resize(_size1970);
-            uint32_t _i1974;
-            for (_i1974 = 0; _i1974 < _size1970; ++_i1974)
+            uint32_t _size1977;
+            ::apache::thrift::protocol::TType _etype1980;
+            xfer += iprot->readListBegin(_etype1980, _size1977);
+            this->success.resize(_size1977);
+            uint32_t _i1981;
+            for (_i1981 = 0; _i1981 < _size1977; ++_i1981)
             {
-              xfer += this->success[_i1974].read(iprot);
+              xfer += this->success[_i1981].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13053,10 +13053,10 @@ uint32_t ThriftHiveMetastore_get_tables_ext_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<ExtendedTableInfo> ::const_iterator _iter1975;
-      for (_iter1975 = this->success.begin(); _iter1975 != this->success.end(); ++_iter1975)
+      std::vector<ExtendedTableInfo> ::const_iterator _iter1982;
+      for (_iter1982 = this->success.begin(); _iter1982 != this->success.end(); ++_iter1982)
       {
-        xfer += (*_iter1975).write(oprot);
+        xfer += (*_iter1982).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -13101,14 +13101,14 @@ uint32_t ThriftHiveMetastore_get_tables_ext_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1976;
-            ::apache::thrift::protocol::TType _etype1979;
-            xfer += iprot->readListBegin(_etype1979, _size1976);
-            (*(this->success)).resize(_size1976);
-            uint32_t _i1980;
-            for (_i1980 = 0; _i1980 < _size1976; ++_i1980)
+            uint32_t _size1983;
+            ::apache::thrift::protocol::TType _etype1986;
+            xfer += iprot->readListBegin(_etype1986, _size1983);
+            (*(this->success)).resize(_size1983);
+            uint32_t _i1987;
+            for (_i1987 = 0; _i1987 < _size1983; ++_i1987)
             {
-              xfer += (*(this->success))[_i1980].read(iprot);
+              xfer += (*(this->success))[_i1987].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13645,6 +13645,14 @@ uint32_t ThriftHiveMetastore_get_materialization_invalidation_info_args::read(::
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->validTxnList);
+          this->__isset.validTxnList = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -13666,6 +13674,10 @@ uint32_t ThriftHiveMetastore_get_materialization_invalidation_info_args::write(:
   xfer += this->creation_metadata.write(oprot);
   xfer += oprot->writeFieldEnd();
 
+  xfer += oprot->writeFieldBegin("validTxnList", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString(this->validTxnList);
+  xfer += oprot->writeFieldEnd();
+
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -13683,6 +13695,10 @@ uint32_t ThriftHiveMetastore_get_materialization_invalidation_info_pargs::write(
 
   xfer += oprot->writeFieldBegin("creation_metadata", ::apache::thrift::protocol::T_STRUCT, 1);
   xfer += (*(this->creation_metadata)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("validTxnList", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString((*(this->validTxnList)));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldStop();
@@ -14274,14 +14290,14 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1981;
-            ::apache::thrift::protocol::TType _etype1984;
-            xfer += iprot->readListBegin(_etype1984, _size1981);
-            this->success.resize(_size1981);
-            uint32_t _i1985;
-            for (_i1985 = 0; _i1985 < _size1981; ++_i1985)
+            uint32_t _size1988;
+            ::apache::thrift::protocol::TType _etype1991;
+            xfer += iprot->readListBegin(_etype1991, _size1988);
+            this->success.resize(_size1988);
+            uint32_t _i1992;
+            for (_i1992 = 0; _i1992 < _size1988; ++_i1992)
             {
-              xfer += iprot->readString(this->success[_i1985]);
+              xfer += iprot->readString(this->success[_i1992]);
             }
             xfer += iprot->readListEnd();
           }
@@ -14336,10 +14352,10 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1986;
-      for (_iter1986 = this->success.begin(); _iter1986 != this->success.end(); ++_iter1986)
+      std::vector<std::string> ::const_iterator _iter1993;
+      for (_iter1993 = this->success.begin(); _iter1993 != this->success.end(); ++_iter1993)
       {
-        xfer += oprot->writeString((*_iter1986));
+        xfer += oprot->writeString((*_iter1993));
       }
       xfer += oprot->writeListEnd();
     }
@@ -14392,14 +14408,14 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1987;
-            ::apache::thrift::protocol::TType _etype1990;
-            xfer += iprot->readListBegin(_etype1990, _size1987);
-            (*(this->success)).resize(_size1987);
-            uint32_t _i1991;
-            for (_i1991 = 0; _i1991 < _size1987; ++_i1991)
+            uint32_t _size1994;
+            ::apache::thrift::protocol::TType _etype1997;
+            xfer += iprot->readListBegin(_etype1997, _size1994);
+            (*(this->success)).resize(_size1994);
+            uint32_t _i1998;
+            for (_i1998 = 0; _i1998 < _size1994; ++_i1998)
             {
-              xfer += iprot->readString((*(this->success))[_i1991]);
+              xfer += iprot->readString((*(this->success))[_i1998]);
             }
             xfer += iprot->readListEnd();
           }
@@ -15960,14 +15976,14 @@ uint32_t ThriftHiveMetastore_add_partitions_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size1992;
-            ::apache::thrift::protocol::TType _etype1995;
-            xfer += iprot->readListBegin(_etype1995, _size1992);
-            this->new_parts.resize(_size1992);
-            uint32_t _i1996;
-            for (_i1996 = 0; _i1996 < _size1992; ++_i1996)
+            uint32_t _size1999;
+            ::apache::thrift::protocol::TType _etype2002;
+            xfer += iprot->readListBegin(_etype2002, _size1999);
+            this->new_parts.resize(_size1999);
+            uint32_t _i2003;
+            for (_i2003 = 0; _i2003 < _size1999; ++_i2003)
             {
-              xfer += this->new_parts[_i1996].read(iprot);
+              xfer += this->new_parts[_i2003].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -15996,10 +16012,10 @@ uint32_t ThriftHiveMetastore_add_partitions_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter1997;
-    for (_iter1997 = this->new_parts.begin(); _iter1997 != this->new_parts.end(); ++_iter1997)
+    std::vector<Partition> ::const_iterator _iter2004;
+    for (_iter2004 = this->new_parts.begin(); _iter2004 != this->new_parts.end(); ++_iter2004)
     {
-      xfer += (*_iter1997).write(oprot);
+      xfer += (*_iter2004).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16023,10 +16039,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter1998;
-    for (_iter1998 = (*(this->new_parts)).begin(); _iter1998 != (*(this->new_parts)).end(); ++_iter1998)
+    std::vector<Partition> ::const_iterator _iter2005;
+    for (_iter2005 = (*(this->new_parts)).begin(); _iter2005 != (*(this->new_parts)).end(); ++_iter2005)
     {
-      xfer += (*_iter1998).write(oprot);
+      xfer += (*_iter2005).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16235,14 +16251,14 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_args::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size1999;
-            ::apache::thrift::protocol::TType _etype2002;
-            xfer += iprot->readListBegin(_etype2002, _size1999);
-            this->new_parts.resize(_size1999);
-            uint32_t _i2003;
-            for (_i2003 = 0; _i2003 < _size1999; ++_i2003)
+            uint32_t _size2006;
+            ::apache::thrift::protocol::TType _etype2009;
+            xfer += iprot->readListBegin(_etype2009, _size2006);
+            this->new_parts.resize(_size2006);
+            uint32_t _i2010;
+            for (_i2010 = 0; _i2010 < _size2006; ++_i2010)
             {
-              xfer += this->new_parts[_i2003].read(iprot);
+              xfer += this->new_parts[_i2010].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16271,10 +16287,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_args::write(::apache::thrift::
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<PartitionSpec> ::const_iterator _iter2004;
-    for (_iter2004 = this->new_parts.begin(); _iter2004 != this->new_parts.end(); ++_iter2004)
+    std::vector<PartitionSpec> ::const_iterator _iter2011;
+    for (_iter2011 = this->new_parts.begin(); _iter2011 != this->new_parts.end(); ++_iter2011)
     {
-      xfer += (*_iter2004).write(oprot);
+      xfer += (*_iter2011).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16298,10 +16314,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_pargs::write(::apache::thrift:
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<PartitionSpec> ::const_iterator _iter2005;
-    for (_iter2005 = (*(this->new_parts)).begin(); _iter2005 != (*(this->new_parts)).end(); ++_iter2005)
+    std::vector<PartitionSpec> ::const_iterator _iter2012;
+    for (_iter2012 = (*(this->new_parts)).begin(); _iter2012 != (*(this->new_parts)).end(); ++_iter2012)
     {
-      xfer += (*_iter2005).write(oprot);
+      xfer += (*_iter2012).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16526,14 +16542,14 @@ uint32_t ThriftHiveMetastore_append_partition_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2006;
-            ::apache::thrift::protocol::TType _etype2009;
-            xfer += iprot->readListBegin(_etype2009, _size2006);
-            this->part_vals.resize(_size2006);
-            uint32_t _i2010;
-            for (_i2010 = 0; _i2010 < _size2006; ++_i2010)
+            uint32_t _size2013;
+            ::apache::thrift::protocol::TType _etype2016;
+            xfer += iprot->readListBegin(_etype2016, _size2013);
+            this->part_vals.resize(_size2013);
+            uint32_t _i2017;
+            for (_i2017 = 0; _i2017 < _size2013; ++_i2017)
             {
-              xfer += iprot->readString(this->part_vals[_i2010]);
+              xfer += iprot->readString(this->part_vals[_i2017]);
             }
             xfer += iprot->readListEnd();
           }
@@ -16570,10 +16586,10 @@ uint32_t ThriftHiveMetastore_append_partition_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2011;
-    for (_iter2011 = this->part_vals.begin(); _iter2011 != this->part_vals.end(); ++_iter2011)
+    std::vector<std::string> ::const_iterator _iter2018;
+    for (_iter2018 = this->part_vals.begin(); _iter2018 != this->part_vals.end(); ++_iter2018)
     {
-      xfer += oprot->writeString((*_iter2011));
+      xfer += oprot->writeString((*_iter2018));
     }
     xfer += oprot->writeListEnd();
   }
@@ -16605,10 +16621,10 @@ uint32_t ThriftHiveMetastore_append_partition_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2012;
-    for (_iter2012 = (*(this->part_vals)).begin(); _iter2012 != (*(this->part_vals)).end(); ++_iter2012)
+    std::vector<std::string> ::const_iterator _iter2019;
+    for (_iter2019 = (*(this->part_vals)).begin(); _iter2019 != (*(this->part_vals)).end(); ++_iter2019)
     {
-      xfer += oprot->writeString((*_iter2012));
+      xfer += oprot->writeString((*_iter2019));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17080,14 +17096,14 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_args::rea
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2013;
-            ::apache::thrift::protocol::TType _etype2016;
-            xfer += iprot->readListBegin(_etype2016, _size2013);
-            this->part_vals.resize(_size2013);
-            uint32_t _i2017;
-            for (_i2017 = 0; _i2017 < _size2013; ++_i2017)
+            uint32_t _size2020;
+            ::apache::thrift::protocol::TType _etype2023;
+            xfer += iprot->readListBegin(_etype2023, _size2020);
+            this->part_vals.resize(_size2020);
+            uint32_t _i2024;
+            for (_i2024 = 0; _i2024 < _size2020; ++_i2024)
             {
-              xfer += iprot->readString(this->part_vals[_i2017]);
+              xfer += iprot->readString(this->part_vals[_i2024]);
             }
             xfer += iprot->readListEnd();
           }
@@ -17132,10 +17148,10 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_args::wri
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2018;
-    for (_iter2018 = this->part_vals.begin(); _iter2018 != this->part_vals.end(); ++_iter2018)
+    std::vector<std::string> ::const_iterator _iter2025;
+    for (_iter2025 = this->part_vals.begin(); _iter2025 != this->part_vals.end(); ++_iter2025)
     {
-      xfer += oprot->writeString((*_iter2018));
+      xfer += oprot->writeString((*_iter2025));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17171,10 +17187,10 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_pargs::wr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2019;
-    for (_iter2019 = (*(this->part_vals)).begin(); _iter2019 != (*(this->part_vals)).end(); ++_iter2019)
+    std::vector<std::string> ::const_iterator _iter2026;
+    for (_iter2026 = (*(this->part_vals)).begin(); _iter2026 != (*(this->part_vals)).end(); ++_iter2026)
     {
-      xfer += oprot->writeString((*_iter2019));
+      xfer += oprot->writeString((*_iter2026));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17977,14 +17993,14 @@ uint32_t ThriftHiveMetastore_drop_partition_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2020;
-            ::apache::thrift::protocol::TType _etype2023;
-            xfer += iprot->readListBegin(_etype2023, _size2020);
-            this->part_vals.resize(_size2020);
-            uint32_t _i2024;
-            for (_i2024 = 0; _i2024 < _size2020; ++_i2024)
+            uint32_t _size2027;
+            ::apache::thrift::protocol::TType _etype2030;
+            xfer += iprot->readListBegin(_etype2030, _size2027);
+            this->part_vals.resize(_size2027);
+            uint32_t _i2031;
+            for (_i2031 = 0; _i2031 < _size2027; ++_i2031)
             {
-              xfer += iprot->readString(this->part_vals[_i2024]);
+              xfer += iprot->readString(this->part_vals[_i2031]);
             }
             xfer += iprot->readListEnd();
           }
@@ -18029,10 +18045,10 @@ uint32_t ThriftHiveMetastore_drop_partition_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2025;
-    for (_iter2025 = this->part_vals.begin(); _iter2025 != this->part_vals.end(); ++_iter2025)
+    std::vector<std::string> ::const_iterator _iter2032;
+    for (_iter2032 = this->part_vals.begin(); _iter2032 != this->part_vals.end(); ++_iter2032)
     {
-      xfer += oprot->writeString((*_iter2025));
+      xfer += oprot->writeString((*_iter2032));
     }
     xfer += oprot->writeListEnd();
   }
@@ -18068,10 +18084,10 @@ uint32_t ThriftHiveMetastore_drop_partition_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2026;
-    for (_iter2026 = (*(this->part_vals)).begin(); _iter2026 != (*(this->part_vals)).end(); ++_iter2026)
+    std::vector<std::string> ::const_iterator _iter2033;
+    for (_iter2033 = (*(this->part_vals)).begin(); _iter2033 != (*(this->part_vals)).end(); ++_iter2033)
     {
-      xfer += oprot->writeString((*_iter2026));
+      xfer += oprot->writeString((*_iter2033));
     }
     xfer += oprot->writeListEnd();
   }
@@ -18280,14 +18296,14 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_args::read(
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2027;
-            ::apache::thrift::protocol::TType _etype2030;
-            xfer += iprot->readListBegin(_etype2030, _size2027);
-            this->part_vals.resize(_size2027);
-            uint32_t _i2031;
-            for (_i2031 = 0; _i2031 < _size2027; ++_i2031)
+            uint32_t _size2034;
+            ::apache::thrift::protocol::TType _etype2037;
+            xfer += iprot->readListBegin(_etype2037, _size2034);
+            this->part_vals.resize(_size2034);
+            uint32_t _i2038;
+            for (_i2038 = 0; _i2038 < _size2034; ++_i2038)
             {
-              xfer += iprot->readString(this->part_vals[_i2031]);
+              xfer += iprot->readString(this->part_vals[_i2038]);
             }
             xfer += iprot->readListEnd();
           }
@@ -18340,10 +18356,10 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_args::write
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2032;
-    for (_iter2032 = this->part_vals.begin(); _iter2032 != this->part_vals.end(); ++_iter2032)
+    std::vector<std::string> ::const_iterator _iter2039;
+    for (_iter2039 = this->part_vals.begin(); _iter2039 != this->part_vals.end(); ++_iter2039)
     {
-      xfer += oprot->writeString((*_iter2032));
+      xfer += oprot->writeString((*_iter2039));
     }
     xfer += oprot->writeListEnd();
   }
@@ -18383,10 +18399,10 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_pargs::writ
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2033;
-    for (_iter2033 = (*(this->part_vals)).begin(); _iter2033 != (*(this->part_vals)).end(); ++_iter2033)
+    std::vector<std::string> ::const_iterator _iter2040;
+    for (_iter2040 = (*(this->part_vals)).begin(); _iter2040 != (*(this->part_vals)).end(); ++_iter2040)
     {
-      xfer += oprot->writeString((*_iter2033));
+      xfer += oprot->writeString((*_iter2040));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19392,14 +19408,14 @@ uint32_t ThriftHiveMetastore_get_partition_args::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2034;
-            ::apache::thrift::protocol::TType _etype2037;
-            xfer += iprot->readListBegin(_etype2037, _size2034);
-            this->part_vals.resize(_size2034);
-            uint32_t _i2038;
-            for (_i2038 = 0; _i2038 < _size2034; ++_i2038)
+            uint32_t _size2041;
+            ::apache::thrift::protocol::TType _etype2044;
+            xfer += iprot->readListBegin(_etype2044, _size2041);
+            this->part_vals.resize(_size2041);
+            uint32_t _i2045;
+            for (_i2045 = 0; _i2045 < _size2041; ++_i2045)
             {
-              xfer += iprot->readString(this->part_vals[_i2038]);
+              xfer += iprot->readString(this->part_vals[_i2045]);
             }
             xfer += iprot->readListEnd();
           }
@@ -19436,10 +19452,10 @@ uint32_t ThriftHiveMetastore_get_partition_args::write(::apache::thrift::protoco
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2039;
-    for (_iter2039 = this->part_vals.begin(); _iter2039 != this->part_vals.end(); ++_iter2039)
+    std::vector<std::string> ::const_iterator _iter2046;
+    for (_iter2046 = this->part_vals.begin(); _iter2046 != this->part_vals.end(); ++_iter2046)
     {
-      xfer += oprot->writeString((*_iter2039));
+      xfer += oprot->writeString((*_iter2046));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19471,10 +19487,10 @@ uint32_t ThriftHiveMetastore_get_partition_pargs::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2040;
-    for (_iter2040 = (*(this->part_vals)).begin(); _iter2040 != (*(this->part_vals)).end(); ++_iter2040)
+    std::vector<std::string> ::const_iterator _iter2047;
+    for (_iter2047 = (*(this->part_vals)).begin(); _iter2047 != (*(this->part_vals)).end(); ++_iter2047)
     {
-      xfer += oprot->writeString((*_iter2040));
+      xfer += oprot->writeString((*_iter2047));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19890,17 +19906,17 @@ uint32_t ThriftHiveMetastore_exchange_partition_args::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->partitionSpecs.clear();
-            uint32_t _size2041;
-            ::apache::thrift::protocol::TType _ktype2042;
-            ::apache::thrift::protocol::TType _vtype2043;
-            xfer += iprot->readMapBegin(_ktype2042, _vtype2043, _size2041);
-            uint32_t _i2045;
-            for (_i2045 = 0; _i2045 < _size2041; ++_i2045)
+            uint32_t _size2048;
+            ::apache::thrift::protocol::TType _ktype2049;
+            ::apache::thrift::protocol::TType _vtype2050;
+            xfer += iprot->readMapBegin(_ktype2049, _vtype2050, _size2048);
+            uint32_t _i2052;
+            for (_i2052 = 0; _i2052 < _size2048; ++_i2052)
             {
-              std::string _key2046;
-              xfer += iprot->readString(_key2046);
-              std::string& _val2047 = this->partitionSpecs[_key2046];
-              xfer += iprot->readString(_val2047);
+              std::string _key2053;
+              xfer += iprot->readString(_key2053);
+              std::string& _val2054 = this->partitionSpecs[_key2053];
+              xfer += iprot->readString(_val2054);
             }
             xfer += iprot->readMapEnd();
           }
@@ -19961,11 +19977,11 @@ uint32_t ThriftHiveMetastore_exchange_partition_args::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionSpecs.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2048;
-    for (_iter2048 = this->partitionSpecs.begin(); _iter2048 != this->partitionSpecs.end(); ++_iter2048)
+    std::map<std::string, std::string> ::const_iterator _iter2055;
+    for (_iter2055 = this->partitionSpecs.begin(); _iter2055 != this->partitionSpecs.end(); ++_iter2055)
     {
-      xfer += oprot->writeString(_iter2048->first);
-      xfer += oprot->writeString(_iter2048->second);
+      xfer += oprot->writeString(_iter2055->first);
+      xfer += oprot->writeString(_iter2055->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20005,11 +20021,11 @@ uint32_t ThriftHiveMetastore_exchange_partition_pargs::write(::apache::thrift::p
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partitionSpecs)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2049;
-    for (_iter2049 = (*(this->partitionSpecs)).begin(); _iter2049 != (*(this->partitionSpecs)).end(); ++_iter2049)
+    std::map<std::string, std::string> ::const_iterator _iter2056;
+    for (_iter2056 = (*(this->partitionSpecs)).begin(); _iter2056 != (*(this->partitionSpecs)).end(); ++_iter2056)
     {
-      xfer += oprot->writeString(_iter2049->first);
-      xfer += oprot->writeString(_iter2049->second);
+      xfer += oprot->writeString(_iter2056->first);
+      xfer += oprot->writeString(_iter2056->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20254,17 +20270,17 @@ uint32_t ThriftHiveMetastore_exchange_partitions_args::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->partitionSpecs.clear();
-            uint32_t _size2050;
-            ::apache::thrift::protocol::TType _ktype2051;
-            ::apache::thrift::protocol::TType _vtype2052;
-            xfer += iprot->readMapBegin(_ktype2051, _vtype2052, _size2050);
-            uint32_t _i2054;
-            for (_i2054 = 0; _i2054 < _size2050; ++_i2054)
+            uint32_t _size2057;
+            ::apache::thrift::protocol::TType _ktype2058;
+            ::apache::thrift::protocol::TType _vtype2059;
+            xfer += iprot->readMapBegin(_ktype2058, _vtype2059, _size2057);
+            uint32_t _i2061;
+            for (_i2061 = 0; _i2061 < _size2057; ++_i2061)
             {
-              std::string _key2055;
-              xfer += iprot->readString(_key2055);
-              std::string& _val2056 = this->partitionSpecs[_key2055];
-              xfer += iprot->readString(_val2056);
+              std::string _key2062;
+              xfer += iprot->readString(_key2062);
+              std::string& _val2063 = this->partitionSpecs[_key2062];
+              xfer += iprot->readString(_val2063);
             }
             xfer += iprot->readMapEnd();
           }
@@ -20325,11 +20341,11 @@ uint32_t ThriftHiveMetastore_exchange_partitions_args::write(::apache::thrift::p
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionSpecs.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2057;
-    for (_iter2057 = this->partitionSpecs.begin(); _iter2057 != this->partitionSpecs.end(); ++_iter2057)
+    std::map<std::string, std::string> ::const_iterator _iter2064;
+    for (_iter2064 = this->partitionSpecs.begin(); _iter2064 != this->partitionSpecs.end(); ++_iter2064)
     {
-      xfer += oprot->writeString(_iter2057->first);
-      xfer += oprot->writeString(_iter2057->second);
+      xfer += oprot->writeString(_iter2064->first);
+      xfer += oprot->writeString(_iter2064->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20369,11 +20385,11 @@ uint32_t ThriftHiveMetastore_exchange_partitions_pargs::write(::apache::thrift::
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partitionSpecs)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2058;
-    for (_iter2058 = (*(this->partitionSpecs)).begin(); _iter2058 != (*(this->partitionSpecs)).end(); ++_iter2058)
+    std::map<std::string, std::string> ::const_iterator _iter2065;
+    for (_iter2065 = (*(this->partitionSpecs)).begin(); _iter2065 != (*(this->partitionSpecs)).end(); ++_iter2065)
     {
-      xfer += oprot->writeString(_iter2058->first);
-      xfer += oprot->writeString(_iter2058->second);
+      xfer += oprot->writeString(_iter2065->first);
+      xfer += oprot->writeString(_iter2065->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20430,14 +20446,14 @@ uint32_t ThriftHiveMetastore_exchange_partitions_result::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2059;
-            ::apache::thrift::protocol::TType _etype2062;
-            xfer += iprot->readListBegin(_etype2062, _size2059);
-            this->success.resize(_size2059);
-            uint32_t _i2063;
-            for (_i2063 = 0; _i2063 < _size2059; ++_i2063)
+            uint32_t _size2066;
+            ::apache::thrift::protocol::TType _etype2069;
+            xfer += iprot->readListBegin(_etype2069, _size2066);
+            this->success.resize(_size2066);
+            uint32_t _i2070;
+            for (_i2070 = 0; _i2070 < _size2066; ++_i2070)
             {
-              xfer += this->success[_i2063].read(iprot);
+              xfer += this->success[_i2070].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20500,10 +20516,10 @@ uint32_t ThriftHiveMetastore_exchange_partitions_result::write(::apache::thrift:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2064;
-      for (_iter2064 = this->success.begin(); _iter2064 != this->success.end(); ++_iter2064)
+      std::vector<Partition> ::const_iterator _iter2071;
+      for (_iter2071 = this->success.begin(); _iter2071 != this->success.end(); ++_iter2071)
       {
-        xfer += (*_iter2064).write(oprot);
+        xfer += (*_iter2071).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -20560,14 +20576,14 @@ uint32_t ThriftHiveMetastore_exchange_partitions_presult::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2065;
-            ::apache::thrift::protocol::TType _etype2068;
-            xfer += iprot->readListBegin(_etype2068, _size2065);
-            (*(this->success)).resize(_size2065);
-            uint32_t _i2069;
-            for (_i2069 = 0; _i2069 < _size2065; ++_i2069)
+            uint32_t _size2072;
+            ::apache::thrift::protocol::TType _etype2075;
+            xfer += iprot->readListBegin(_etype2075, _size2072);
+            (*(this->success)).resize(_size2072);
+            uint32_t _i2076;
+            for (_i2076 = 0; _i2076 < _size2072; ++_i2076)
             {
-              xfer += (*(this->success))[_i2069].read(iprot);
+              xfer += (*(this->success))[_i2076].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20666,14 +20682,14 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2070;
-            ::apache::thrift::protocol::TType _etype2073;
-            xfer += iprot->readListBegin(_etype2073, _size2070);
-            this->part_vals.resize(_size2070);
-            uint32_t _i2074;
-            for (_i2074 = 0; _i2074 < _size2070; ++_i2074)
+            uint32_t _size2077;
+            ::apache::thrift::protocol::TType _etype2080;
+            xfer += iprot->readListBegin(_etype2080, _size2077);
+            this->part_vals.resize(_size2077);
+            uint32_t _i2081;
+            for (_i2081 = 0; _i2081 < _size2077; ++_i2081)
             {
-              xfer += iprot->readString(this->part_vals[_i2074]);
+              xfer += iprot->readString(this->part_vals[_i2081]);
             }
             xfer += iprot->readListEnd();
           }
@@ -20694,14 +20710,14 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2075;
-            ::apache::thrift::protocol::TType _etype2078;
-            xfer += iprot->readListBegin(_etype2078, _size2075);
-            this->group_names.resize(_size2075);
-            uint32_t _i2079;
-            for (_i2079 = 0; _i2079 < _size2075; ++_i2079)
+            uint32_t _size2082;
+            ::apache::thrift::protocol::TType _etype2085;
+            xfer += iprot->readListBegin(_etype2085, _size2082);
+            this->group_names.resize(_size2082);
+            uint32_t _i2086;
+            for (_i2086 = 0; _i2086 < _size2082; ++_i2086)
             {
-              xfer += iprot->readString(this->group_names[_i2079]);
+              xfer += iprot->readString(this->group_names[_i2086]);
             }
             xfer += iprot->readListEnd();
           }
@@ -20738,10 +20754,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2080;
-    for (_iter2080 = this->part_vals.begin(); _iter2080 != this->part_vals.end(); ++_iter2080)
+    std::vector<std::string> ::const_iterator _iter2087;
+    for (_iter2087 = this->part_vals.begin(); _iter2087 != this->part_vals.end(); ++_iter2087)
     {
-      xfer += oprot->writeString((*_iter2080));
+      xfer += oprot->writeString((*_iter2087));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20754,10 +20770,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2081;
-    for (_iter2081 = this->group_names.begin(); _iter2081 != this->group_names.end(); ++_iter2081)
+    std::vector<std::string> ::const_iterator _iter2088;
+    for (_iter2088 = this->group_names.begin(); _iter2088 != this->group_names.end(); ++_iter2088)
     {
-      xfer += oprot->writeString((*_iter2081));
+      xfer += oprot->writeString((*_iter2088));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20789,10 +20805,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2082;
-    for (_iter2082 = (*(this->part_vals)).begin(); _iter2082 != (*(this->part_vals)).end(); ++_iter2082)
+    std::vector<std::string> ::const_iterator _iter2089;
+    for (_iter2089 = (*(this->part_vals)).begin(); _iter2089 != (*(this->part_vals)).end(); ++_iter2089)
     {
-      xfer += oprot->writeString((*_iter2082));
+      xfer += oprot->writeString((*_iter2089));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20805,10 +20821,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2083;
-    for (_iter2083 = (*(this->group_names)).begin(); _iter2083 != (*(this->group_names)).end(); ++_iter2083)
+    std::vector<std::string> ::const_iterator _iter2090;
+    for (_iter2090 = (*(this->group_names)).begin(); _iter2090 != (*(this->group_names)).end(); ++_iter2090)
     {
-      xfer += oprot->writeString((*_iter2083));
+      xfer += oprot->writeString((*_iter2090));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21367,14 +21383,14 @@ uint32_t ThriftHiveMetastore_get_partitions_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2084;
-            ::apache::thrift::protocol::TType _etype2087;
-            xfer += iprot->readListBegin(_etype2087, _size2084);
-            this->success.resize(_size2084);
-            uint32_t _i2088;
-            for (_i2088 = 0; _i2088 < _size2084; ++_i2088)
+            uint32_t _size2091;
+            ::apache::thrift::protocol::TType _etype2094;
+            xfer += iprot->readListBegin(_etype2094, _size2091);
+            this->success.resize(_size2091);
+            uint32_t _i2095;
+            for (_i2095 = 0; _i2095 < _size2091; ++_i2095)
             {
-              xfer += this->success[_i2088].read(iprot);
+              xfer += this->success[_i2095].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21421,10 +21437,10 @@ uint32_t ThriftHiveMetastore_get_partitions_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2089;
-      for (_iter2089 = this->success.begin(); _iter2089 != this->success.end(); ++_iter2089)
+      std::vector<Partition> ::const_iterator _iter2096;
+      for (_iter2096 = this->success.begin(); _iter2096 != this->success.end(); ++_iter2096)
       {
-        xfer += (*_iter2089).write(oprot);
+        xfer += (*_iter2096).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -21473,14 +21489,14 @@ uint32_t ThriftHiveMetastore_get_partitions_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2090;
-            ::apache::thrift::protocol::TType _etype2093;
-            xfer += iprot->readListBegin(_etype2093, _size2090);
-            (*(this->success)).resize(_size2090);
-            uint32_t _i2094;
-            for (_i2094 = 0; _i2094 < _size2090; ++_i2094)
+            uint32_t _size2097;
+            ::apache::thrift::protocol::TType _etype2100;
+            xfer += iprot->readListBegin(_etype2100, _size2097);
+            (*(this->success)).resize(_size2097);
+            uint32_t _i2101;
+            for (_i2101 = 0; _i2101 < _size2097; ++_i2101)
             {
-              xfer += (*(this->success))[_i2094].read(iprot);
+              xfer += (*(this->success))[_i2101].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21806,14 +21822,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_args::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2095;
-            ::apache::thrift::protocol::TType _etype2098;
-            xfer += iprot->readListBegin(_etype2098, _size2095);
-            this->group_names.resize(_size2095);
-            uint32_t _i2099;
-            for (_i2099 = 0; _i2099 < _size2095; ++_i2099)
+            uint32_t _size2102;
+            ::apache::thrift::protocol::TType _etype2105;
+            xfer += iprot->readListBegin(_etype2105, _size2102);
+            this->group_names.resize(_size2102);
+            uint32_t _i2106;
+            for (_i2106 = 0; _i2106 < _size2102; ++_i2106)
             {
-              xfer += iprot->readString(this->group_names[_i2099]);
+              xfer += iprot->readString(this->group_names[_i2106]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21858,10 +21874,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_args::write(::apache::thri
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2100;
-    for (_iter2100 = this->group_names.begin(); _iter2100 != this->group_names.end(); ++_iter2100)
+    std::vector<std::string> ::const_iterator _iter2107;
+    for (_iter2107 = this->group_names.begin(); _iter2107 != this->group_names.end(); ++_iter2107)
     {
-      xfer += oprot->writeString((*_iter2100));
+      xfer += oprot->writeString((*_iter2107));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21901,10 +21917,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_pargs::write(::apache::thr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2101;
-    for (_iter2101 = (*(this->group_names)).begin(); _iter2101 != (*(this->group_names)).end(); ++_iter2101)
+    std::vector<std::string> ::const_iterator _iter2108;
+    for (_iter2108 = (*(this->group_names)).begin(); _iter2108 != (*(this->group_names)).end(); ++_iter2108)
     {
-      xfer += oprot->writeString((*_iter2101));
+      xfer += oprot->writeString((*_iter2108));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21945,14 +21961,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2102;
-            ::apache::thrift::protocol::TType _etype2105;
-            xfer += iprot->readListBegin(_etype2105, _size2102);
-            this->success.resize(_size2102);
-            uint32_t _i2106;
-            for (_i2106 = 0; _i2106 < _size2102; ++_i2106)
+            uint32_t _size2109;
+            ::apache::thrift::protocol::TType _etype2112;
+            xfer += iprot->readListBegin(_etype2112, _size2109);
+            this->success.resize(_size2109);
+            uint32_t _i2113;
+            for (_i2113 = 0; _i2113 < _size2109; ++_i2113)
             {
-              xfer += this->success[_i2106].read(iprot);
+              xfer += this->success[_i2113].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21999,10 +22015,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2107;
-      for (_iter2107 = this->success.begin(); _iter2107 != this->success.end(); ++_iter2107)
+      std::vector<Partition> ::const_iterator _iter2114;
+      for (_iter2114 = this->success.begin(); _iter2114 != this->success.end(); ++_iter2114)
       {
-        xfer += (*_iter2107).write(oprot);
+        xfer += (*_iter2114).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22051,14 +22067,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2108;
-            ::apache::thrift::protocol::TType _etype2111;
-            xfer += iprot->readListBegin(_etype2111, _size2108);
-            (*(this->success)).resize(_size2108);
-            uint32_t _i2112;
-            for (_i2112 = 0; _i2112 < _size2108; ++_i2112)
+            uint32_t _size2115;
+            ::apache::thrift::protocol::TType _etype2118;
+            xfer += iprot->readListBegin(_etype2118, _size2115);
+            (*(this->success)).resize(_size2115);
+            uint32_t _i2119;
+            for (_i2119 = 0; _i2119 < _size2115; ++_i2119)
             {
-              xfer += (*(this->success))[_i2112].read(iprot);
+              xfer += (*(this->success))[_i2119].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22236,14 +22252,14 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_result::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2113;
-            ::apache::thrift::protocol::TType _etype2116;
-            xfer += iprot->readListBegin(_etype2116, _size2113);
-            this->success.resize(_size2113);
-            uint32_t _i2117;
-            for (_i2117 = 0; _i2117 < _size2113; ++_i2117)
+            uint32_t _size2120;
+            ::apache::thrift::protocol::TType _etype2123;
+            xfer += iprot->readListBegin(_etype2123, _size2120);
+            this->success.resize(_size2120);
+            uint32_t _i2124;
+            for (_i2124 = 0; _i2124 < _size2120; ++_i2124)
             {
-              xfer += this->success[_i2117].read(iprot);
+              xfer += this->success[_i2124].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22290,10 +22306,10 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_result::write(::apache::thrift
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<PartitionSpec> ::const_iterator _iter2118;
-      for (_iter2118 = this->success.begin(); _iter2118 != this->success.end(); ++_iter2118)
+      std::vector<PartitionSpec> ::const_iterator _iter2125;
+      for (_iter2125 = this->success.begin(); _iter2125 != this->success.end(); ++_iter2125)
       {
-        xfer += (*_iter2118).write(oprot);
+        xfer += (*_iter2125).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22342,14 +22358,14 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_presult::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2119;
-            ::apache::thrift::protocol::TType _etype2122;
-            xfer += iprot->readListBegin(_etype2122, _size2119);
-            (*(this->success)).resize(_size2119);
-            uint32_t _i2123;
-            for (_i2123 = 0; _i2123 < _size2119; ++_i2123)
+            uint32_t _size2126;
+            ::apache::thrift::protocol::TType _etype2129;
+            xfer += iprot->readListBegin(_etype2129, _size2126);
+            (*(this->success)).resize(_size2126);
+            uint32_t _i2130;
+            for (_i2130 = 0; _i2130 < _size2126; ++_i2130)
             {
-              xfer += (*(this->success))[_i2123].read(iprot);
+              xfer += (*(this->success))[_i2130].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22527,14 +22543,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_result::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2124;
-            ::apache::thrift::protocol::TType _etype2127;
-            xfer += iprot->readListBegin(_etype2127, _size2124);
-            this->success.resize(_size2124);
-            uint32_t _i2128;
-            for (_i2128 = 0; _i2128 < _size2124; ++_i2128)
+            uint32_t _size2131;
+            ::apache::thrift::protocol::TType _etype2134;
+            xfer += iprot->readListBegin(_etype2134, _size2131);
+            this->success.resize(_size2131);
+            uint32_t _i2135;
+            for (_i2135 = 0; _i2135 < _size2131; ++_i2135)
             {
-              xfer += iprot->readString(this->success[_i2128]);
+              xfer += iprot->readString(this->success[_i2135]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22581,10 +22597,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_result::write(::apache::thrift:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2129;
-      for (_iter2129 = this->success.begin(); _iter2129 != this->success.end(); ++_iter2129)
+      std::vector<std::string> ::const_iterator _iter2136;
+      for (_iter2136 = this->success.begin(); _iter2136 != this->success.end(); ++_iter2136)
       {
-        xfer += oprot->writeString((*_iter2129));
+        xfer += oprot->writeString((*_iter2136));
       }
       xfer += oprot->writeListEnd();
     }
@@ -22633,14 +22649,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_presult::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2130;
-            ::apache::thrift::protocol::TType _etype2133;
-            xfer += iprot->readListBegin(_etype2133, _size2130);
-            (*(this->success)).resize(_size2130);
-            uint32_t _i2134;
-            for (_i2134 = 0; _i2134 < _size2130; ++_i2134)
+            uint32_t _size2137;
+            ::apache::thrift::protocol::TType _etype2140;
+            xfer += iprot->readListBegin(_etype2140, _size2137);
+            (*(this->success)).resize(_size2137);
+            uint32_t _i2141;
+            for (_i2141 = 0; _i2141 < _size2137; ++_i2141)
             {
-              xfer += iprot->readString((*(this->success))[_i2134]);
+              xfer += iprot->readString((*(this->success))[_i2141]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22950,14 +22966,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_args::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2135;
-            ::apache::thrift::protocol::TType _etype2138;
-            xfer += iprot->readListBegin(_etype2138, _size2135);
-            this->part_vals.resize(_size2135);
-            uint32_t _i2139;
-            for (_i2139 = 0; _i2139 < _size2135; ++_i2139)
+            uint32_t _size2142;
+            ::apache::thrift::protocol::TType _etype2145;
+            xfer += iprot->readListBegin(_etype2145, _size2142);
+            this->part_vals.resize(_size2142);
+            uint32_t _i2146;
+            for (_i2146 = 0; _i2146 < _size2142; ++_i2146)
             {
-              xfer += iprot->readString(this->part_vals[_i2139]);
+              xfer += iprot->readString(this->part_vals[_i2146]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23002,10 +23018,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_args::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2140;
-    for (_iter2140 = this->part_vals.begin(); _iter2140 != this->part_vals.end(); ++_iter2140)
+    std::vector<std::string> ::const_iterator _iter2147;
+    for (_iter2147 = this->part_vals.begin(); _iter2147 != this->part_vals.end(); ++_iter2147)
     {
-      xfer += oprot->writeString((*_iter2140));
+      xfer += oprot->writeString((*_iter2147));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23041,10 +23057,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_pargs::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2141;
-    for (_iter2141 = (*(this->part_vals)).begin(); _iter2141 != (*(this->part_vals)).end(); ++_iter2141)
+    std::vector<std::string> ::const_iterator _iter2148;
+    for (_iter2148 = (*(this->part_vals)).begin(); _iter2148 != (*(this->part_vals)).end(); ++_iter2148)
     {
-      xfer += oprot->writeString((*_iter2141));
+      xfer += oprot->writeString((*_iter2148));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23089,14 +23105,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2142;
-            ::apache::thrift::protocol::TType _etype2145;
-            xfer += iprot->readListBegin(_etype2145, _size2142);
-            this->success.resize(_size2142);
-            uint32_t _i2146;
-            for (_i2146 = 0; _i2146 < _size2142; ++_i2146)
+            uint32_t _size2149;
+            ::apache::thrift::protocol::TType _etype2152;
+            xfer += iprot->readListBegin(_etype2152, _size2149);
+            this->success.resize(_size2149);
+            uint32_t _i2153;
+            for (_i2153 = 0; _i2153 < _size2149; ++_i2153)
             {
-              xfer += this->success[_i2146].read(iprot);
+              xfer += this->success[_i2153].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23143,10 +23159,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2147;
-      for (_iter2147 = this->success.begin(); _iter2147 != this->success.end(); ++_iter2147)
+      std::vector<Partition> ::const_iterator _iter2154;
+      for (_iter2154 = this->success.begin(); _iter2154 != this->success.end(); ++_iter2154)
       {
-        xfer += (*_iter2147).write(oprot);
+        xfer += (*_iter2154).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -23195,14 +23211,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2148;
-            ::apache::thrift::protocol::TType _etype2151;
-            xfer += iprot->readListBegin(_etype2151, _size2148);
-            (*(this->success)).resize(_size2148);
-            uint32_t _i2152;
-            for (_i2152 = 0; _i2152 < _size2148; ++_i2152)
+            uint32_t _size2155;
+            ::apache::thrift::protocol::TType _etype2158;
+            xfer += iprot->readListBegin(_etype2158, _size2155);
+            (*(this->success)).resize(_size2155);
+            uint32_t _i2159;
+            for (_i2159 = 0; _i2159 < _size2155; ++_i2159)
             {
-              xfer += (*(this->success))[_i2152].read(iprot);
+              xfer += (*(this->success))[_i2159].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23285,14 +23301,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2153;
-            ::apache::thrift::protocol::TType _etype2156;
-            xfer += iprot->readListBegin(_etype2156, _size2153);
-            this->part_vals.resize(_size2153);
-            uint32_t _i2157;
-            for (_i2157 = 0; _i2157 < _size2153; ++_i2157)
+            uint32_t _size2160;
+            ::apache::thrift::protocol::TType _etype2163;
+            xfer += iprot->readListBegin(_etype2163, _size2160);
+            this->part_vals.resize(_size2160);
+            uint32_t _i2164;
+            for (_i2164 = 0; _i2164 < _size2160; ++_i2164)
             {
-              xfer += iprot->readString(this->part_vals[_i2157]);
+              xfer += iprot->readString(this->part_vals[_i2164]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23321,14 +23337,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2158;
-            ::apache::thrift::protocol::TType _etype2161;
-            xfer += iprot->readListBegin(_etype2161, _size2158);
-            this->group_names.resize(_size2158);
-            uint32_t _i2162;
-            for (_i2162 = 0; _i2162 < _size2158; ++_i2162)
+            uint32_t _size2165;
+            ::apache::thrift::protocol::TType _etype2168;
+            xfer += iprot->readListBegin(_etype2168, _size2165);
+            this->group_names.resize(_size2165);
+            uint32_t _i2169;
+            for (_i2169 = 0; _i2169 < _size2165; ++_i2169)
             {
-              xfer += iprot->readString(this->group_names[_i2162]);
+              xfer += iprot->readString(this->group_names[_i2169]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23365,10 +23381,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::write(::apache::t
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2163;
-    for (_iter2163 = this->part_vals.begin(); _iter2163 != this->part_vals.end(); ++_iter2163)
+    std::vector<std::string> ::const_iterator _iter2170;
+    for (_iter2170 = this->part_vals.begin(); _iter2170 != this->part_vals.end(); ++_iter2170)
     {
-      xfer += oprot->writeString((*_iter2163));
+      xfer += oprot->writeString((*_iter2170));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23385,10 +23401,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::write(::apache::t
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2164;
-    for (_iter2164 = this->group_names.begin(); _iter2164 != this->group_names.end(); ++_iter2164)
+    std::vector<std::string> ::const_iterator _iter2171;
+    for (_iter2171 = this->group_names.begin(); _iter2171 != this->group_names.end(); ++_iter2171)
     {
-      xfer += oprot->writeString((*_iter2164));
+      xfer += oprot->writeString((*_iter2171));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23420,10 +23436,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_pargs::write(::apache::
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2165;
-    for (_iter2165 = (*(this->part_vals)).begin(); _iter2165 != (*(this->part_vals)).end(); ++_iter2165)
+    std::vector<std::string> ::const_iterator _iter2172;
+    for (_iter2172 = (*(this->part_vals)).begin(); _iter2172 != (*(this->part_vals)).end(); ++_iter2172)
     {
-      xfer += oprot->writeString((*_iter2165));
+      xfer += oprot->writeString((*_iter2172));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23440,10 +23456,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_pargs::write(::apache::
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2166;
-    for (_iter2166 = (*(this->group_names)).begin(); _iter2166 != (*(this->group_names)).end(); ++_iter2166)
+    std::vector<std::string> ::const_iterator _iter2173;
+    for (_iter2173 = (*(this->group_names)).begin(); _iter2173 != (*(this->group_names)).end(); ++_iter2173)
     {
-      xfer += oprot->writeString((*_iter2166));
+      xfer += oprot->writeString((*_iter2173));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23484,14 +23500,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_result::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2167;
-            ::apache::thrift::protocol::TType _etype2170;
-            xfer += iprot->readListBegin(_etype2170, _size2167);
-            this->success.resize(_size2167);
-            uint32_t _i2171;
-            for (_i2171 = 0; _i2171 < _size2167; ++_i2171)
+            uint32_t _size2174;
+            ::apache::thrift::protocol::TType _etype2177;
+            xfer += iprot->readListBegin(_etype2177, _size2174);
+            this->success.resize(_size2174);
+            uint32_t _i2178;
+            for (_i2178 = 0; _i2178 < _size2174; ++_i2178)
             {
-              xfer += this->success[_i2171].read(iprot);
+              xfer += this->success[_i2178].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23538,10 +23554,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_result::write(::apache:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2172;
-      for (_iter2172 = this->success.begin(); _iter2172 != this->success.end(); ++_iter2172)
+      std::vector<Partition> ::const_iterator _iter2179;
+      for (_iter2179 = this->success.begin(); _iter2179 != this->success.end(); ++_iter2179)
       {
-        xfer += (*_iter2172).write(oprot);
+        xfer += (*_iter2179).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -23590,14 +23606,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_presult::read(::apache:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2173;
-            ::apache::thrift::protocol::TType _etype2176;
-            xfer += iprot->readListBegin(_etype2176, _size2173);
-            (*(this->success)).resize(_size2173);
-            uint32_t _i2177;
-            for (_i2177 = 0; _i2177 < _size2173; ++_i2177)
+            uint32_t _size2180;
+            ::apache::thrift::protocol::TType _etype2183;
+            xfer += iprot->readListBegin(_etype2183, _size2180);
+            (*(this->success)).resize(_size2180);
+            uint32_t _i2184;
+            for (_i2184 = 0; _i2184 < _size2180; ++_i2184)
             {
-              xfer += (*(this->success))[_i2177].read(iprot);
+              xfer += (*(this->success))[_i2184].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23907,14 +23923,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_args::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2178;
-            ::apache::thrift::protocol::TType _etype2181;
-            xfer += iprot->readListBegin(_etype2181, _size2178);
-            this->part_vals.resize(_size2178);
-            uint32_t _i2182;
-            for (_i2182 = 0; _i2182 < _size2178; ++_i2182)
+            uint32_t _size2185;
+            ::apache::thrift::protocol::TType _etype2188;
+            xfer += iprot->readListBegin(_etype2188, _size2185);
+            this->part_vals.resize(_size2185);
+            uint32_t _i2189;
+            for (_i2189 = 0; _i2189 < _size2185; ++_i2189)
             {
-              xfer += iprot->readString(this->part_vals[_i2182]);
+              xfer += iprot->readString(this->part_vals[_i2189]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23959,10 +23975,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_args::write(::apache::thrift
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2183;
-    for (_iter2183 = this->part_vals.begin(); _iter2183 != this->part_vals.end(); ++_iter2183)
+    std::vector<std::string> ::const_iterator _iter2190;
+    for (_iter2190 = this->part_vals.begin(); _iter2190 != this->part_vals.end(); ++_iter2190)
     {
-      xfer += oprot->writeString((*_iter2183));
+      xfer += oprot->writeString((*_iter2190));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23998,10 +24014,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_pargs::write(::apache::thrif
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2184;
-    for (_iter2184 = (*(this->part_vals)).begin(); _iter2184 != (*(this->part_vals)).end(); ++_iter2184)
+    std::vector<std::string> ::const_iterator _iter2191;
+    for (_iter2191 = (*(this->part_vals)).begin(); _iter2191 != (*(this->part_vals)).end(); ++_iter2191)
     {
-      xfer += oprot->writeString((*_iter2184));
+      xfer += oprot->writeString((*_iter2191));
     }
     xfer += oprot->writeListEnd();
   }
@@ -24046,14 +24062,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2185;
-            ::apache::thrift::protocol::TType _etype2188;
-            xfer += iprot->readListBegin(_etype2188, _size2185);
-            this->success.resize(_size2185);
-            uint32_t _i2189;
-            for (_i2189 = 0; _i2189 < _size2185; ++_i2189)
+            uint32_t _size2192;
+            ::apache::thrift::protocol::TType _etype2195;
+            xfer += iprot->readListBegin(_etype2195, _size2192);
+            this->success.resize(_size2192);
+            uint32_t _i2196;
+            for (_i2196 = 0; _i2196 < _size2192; ++_i2196)
             {
-              xfer += iprot->readString(this->success[_i2189]);
+              xfer += iprot->readString(this->success[_i2196]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24100,10 +24116,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2190;
-      for (_iter2190 = this->success.begin(); _iter2190 != this->success.end(); ++_iter2190)
+      std::vector<std::string> ::const_iterator _iter2197;
+      for (_iter2197 = this->success.begin(); _iter2197 != this->success.end(); ++_iter2197)
       {
-        xfer += oprot->writeString((*_iter2190));
+        xfer += oprot->writeString((*_iter2197));
       }
       xfer += oprot->writeListEnd();
     }
@@ -24152,14 +24168,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2191;
-            ::apache::thrift::protocol::TType _etype2194;
-            xfer += iprot->readListBegin(_etype2194, _size2191);
-            (*(this->success)).resize(_size2191);
-            uint32_t _i2195;
-            for (_i2195 = 0; _i2195 < _size2191; ++_i2195)
+            uint32_t _size2198;
+            ::apache::thrift::protocol::TType _etype2201;
+            xfer += iprot->readListBegin(_etype2201, _size2198);
+            (*(this->success)).resize(_size2198);
+            uint32_t _i2202;
+            for (_i2202 = 0; _i2202 < _size2198; ++_i2202)
             {
-              xfer += iprot->readString((*(this->success))[_i2195]);
+              xfer += iprot->readString((*(this->success))[_i2202]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24532,14 +24548,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2196;
-            ::apache::thrift::protocol::TType _etype2199;
-            xfer += iprot->readListBegin(_etype2199, _size2196);
-            this->success.resize(_size2196);
-            uint32_t _i2200;
-            for (_i2200 = 0; _i2200 < _size2196; ++_i2200)
+            uint32_t _size2203;
+            ::apache::thrift::protocol::TType _etype2206;
+            xfer += iprot->readListBegin(_etype2206, _size2203);
+            this->success.resize(_size2203);
+            uint32_t _i2207;
+            for (_i2207 = 0; _i2207 < _size2203; ++_i2207)
             {
-              xfer += iprot->readString(this->success[_i2200]);
+              xfer += iprot->readString(this->success[_i2207]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24586,10 +24602,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2201;
-      for (_iter2201 = this->success.begin(); _iter2201 != this->success.end(); ++_iter2201)
+      std::vector<std::string> ::const_iterator _iter2208;
+      for (_iter2208 = this->success.begin(); _iter2208 != this->success.end(); ++_iter2208)
       {
-        xfer += oprot->writeString((*_iter2201));
+        xfer += oprot->writeString((*_iter2208));
       }
       xfer += oprot->writeListEnd();
     }
@@ -24638,14 +24654,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2202;
-            ::apache::thrift::protocol::TType _etype2205;
-            xfer += iprot->readListBegin(_etype2205, _size2202);
-            (*(this->success)).resize(_size2202);
-            uint32_t _i2206;
-            for (_i2206 = 0; _i2206 < _size2202; ++_i2206)
+            uint32_t _size2209;
+            ::apache::thrift::protocol::TType _etype2212;
+            xfer += iprot->readListBegin(_etype2212, _size2209);
+            (*(this->success)).resize(_size2209);
+            uint32_t _i2213;
+            for (_i2213 = 0; _i2213 < _size2209; ++_i2213)
             {
-              xfer += iprot->readString((*(this->success))[_i2206]);
+              xfer += iprot->readString((*(this->success))[_i2213]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24839,14 +24855,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2207;
-            ::apache::thrift::protocol::TType _etype2210;
-            xfer += iprot->readListBegin(_etype2210, _size2207);
-            this->success.resize(_size2207);
-            uint32_t _i2211;
-            for (_i2211 = 0; _i2211 < _size2207; ++_i2211)
+            uint32_t _size2214;
+            ::apache::thrift::protocol::TType _etype2217;
+            xfer += iprot->readListBegin(_etype2217, _size2214);
+            this->success.resize(_size2214);
+            uint32_t _i2218;
+            for (_i2218 = 0; _i2218 < _size2214; ++_i2218)
             {
-              xfer += this->success[_i2211].read(iprot);
+              xfer += this->success[_i2218].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24893,10 +24909,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2212;
-      for (_iter2212 = this->success.begin(); _iter2212 != this->success.end(); ++_iter2212)
+      std::vector<Partition> ::const_iterator _iter2219;
+      for (_iter2219 = this->success.begin(); _iter2219 != this->success.end(); ++_iter2219)
       {
-        xfer += (*_iter2212).write(oprot);
+        xfer += (*_iter2219).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -24945,14 +24961,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2213;
-            ::apache::thrift::protocol::TType _etype2216;
-            xfer += iprot->readListBegin(_etype2216, _size2213);
-            (*(this->success)).resize(_size2213);
-            uint32_t _i2217;
-            for (_i2217 = 0; _i2217 < _size2213; ++_i2217)
+            uint32_t _size2220;
+            ::apache::thrift::protocol::TType _etype2223;
+            xfer += iprot->readListBegin(_etype2223, _size2220);
+            (*(this->success)).resize(_size2220);
+            uint32_t _i2224;
+            for (_i2224 = 0; _i2224 < _size2220; ++_i2224)
             {
-              xfer += (*(this->success))[_i2217].read(iprot);
+              xfer += (*(this->success))[_i2224].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -25146,14 +25162,14 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2218;
-            ::apache::thrift::protocol::TType _etype2221;
-            xfer += iprot->readListBegin(_etype2221, _size2218);
-            this->success.resize(_size2218);
-            uint32_t _i2222;
-            for (_i2222 = 0; _i2222 < _size2218; ++_i2222)
+            uint32_t _size2225;
+            ::apache::thrift::protocol::TType _etype2228;
+            xfer += iprot->readListBegin(_etype2228, _size2225);
+            this->success.resize(_size2225);
+            uint32_t _i2229;
+            for (_i2229 = 0; _i2229 < _size2225; ++_i2229)
             {
-              xfer += this->success[_i2222].read(iprot);
+              xfer += this->success[_i2229].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -25200,10 +25216,10 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<PartitionSpec> ::const_iterator _iter2223;
-      for (_iter2223 = this->success.begin(); _iter2223 != this->success.end(); ++_iter2223)
+      std::vector<PartitionSpec> ::const_iterator _iter2230;
+      for (_iter2230 = this->success.begin(); _iter2230 != this->success.end(); ++_iter2230)
       {
-        xfer += (*_iter2223).write(oprot);
+        xfer += (*_iter2230).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -25252,14 +25268,14 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2224;
-            ::apache::thrift::protocol::TType _etype2227;
-            xfer += iprot->readListBegin(_etype2227, _size2224);
-            (*(this->success)).resize(_size2224);
-            uint32_t _i2228;
-            for (_i2228 = 0; _i2228 < _size2224; ++_i2228)
+            uint32_t _size2231;
+            ::apache::thrift::protocol::TType _etype2234;
+            xfer += iprot->readListBegin(_etype2234, _size2231);
+            (*(this->success)).resize(_size2231);
+            uint32_t _i2235;
+            for (_i2235 = 0; _i2235 < _size2231; ++_i2235)
             {
-              xfer += (*(this->success))[_i2228].read(iprot);
+              xfer += (*(this->success))[_i2235].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26055,14 +26071,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size2229;
-            ::apache::thrift::protocol::TType _etype2232;
-            xfer += iprot->readListBegin(_etype2232, _size2229);
-            this->names.resize(_size2229);
-            uint32_t _i2233;
-            for (_i2233 = 0; _i2233 < _size2229; ++_i2233)
+            uint32_t _size2236;
+            ::apache::thrift::protocol::TType _etype2239;
+            xfer += iprot->readListBegin(_etype2239, _size2236);
+            this->names.resize(_size2236);
+            uint32_t _i2240;
+            for (_i2240 = 0; _i2240 < _size2236; ++_i2240)
             {
-              xfer += iprot->readString(this->names[_i2233]);
+              xfer += iprot->readString(this->names[_i2240]);
             }
             xfer += iprot->readListEnd();
           }
@@ -26099,10 +26115,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-    std::vector<std::string> ::const_iterator _iter2234;
-    for (_iter2234 = this->names.begin(); _iter2234 != this->names.end(); ++_iter2234)
+    std::vector<std::string> ::const_iterator _iter2241;
+    for (_iter2241 = this->names.begin(); _iter2241 != this->names.end(); ++_iter2241)
     {
-      xfer += oprot->writeString((*_iter2234));
+      xfer += oprot->writeString((*_iter2241));
     }
     xfer += oprot->writeListEnd();
   }
@@ -26134,10 +26150,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->names)).size()));
-    std::vector<std::string> ::const_iterator _iter2235;
-    for (_iter2235 = (*(this->names)).begin(); _iter2235 != (*(this->names)).end(); ++_iter2235)
+    std::vector<std::string> ::const_iterator _iter2242;
+    for (_iter2242 = (*(this->names)).begin(); _iter2242 != (*(this->names)).end(); ++_iter2242)
     {
-      xfer += oprot->writeString((*_iter2235));
+      xfer += oprot->writeString((*_iter2242));
     }
     xfer += oprot->writeListEnd();
   }
@@ -26178,14 +26194,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2236;
-            ::apache::thrift::protocol::TType _etype2239;
-            xfer += iprot->readListBegin(_etype2239, _size2236);
-            this->success.resize(_size2236);
-            uint32_t _i2240;
-            for (_i2240 = 0; _i2240 < _size2236; ++_i2240)
+            uint32_t _size2243;
+            ::apache::thrift::protocol::TType _etype2246;
+            xfer += iprot->readListBegin(_etype2246, _size2243);
+            this->success.resize(_size2243);
+            uint32_t _i2247;
+            for (_i2247 = 0; _i2247 < _size2243; ++_i2247)
             {
-              xfer += this->success[_i2240].read(iprot);
+              xfer += this->success[_i2247].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26232,10 +26248,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2241;
-      for (_iter2241 = this->success.begin(); _iter2241 != this->success.end(); ++_iter2241)
+      std::vector<Partition> ::const_iterator _iter2248;
+      for (_iter2248 = this->success.begin(); _iter2248 != this->success.end(); ++_iter2248)
       {
-        xfer += (*_iter2241).write(oprot);
+        xfer += (*_iter2248).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -26284,14 +26300,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2242;
-            ::apache::thrift::protocol::TType _etype2245;
-            xfer += iprot->readListBegin(_etype2245, _size2242);
-            (*(this->success)).resize(_size2242);
-            uint32_t _i2246;
-            for (_i2246 = 0; _i2246 < _size2242; ++_i2246)
+            uint32_t _size2249;
+            ::apache::thrift::protocol::TType _etype2252;
+            xfer += iprot->readListBegin(_etype2252, _size2249);
+            (*(this->success)).resize(_size2249);
+            uint32_t _i2253;
+            for (_i2253 = 0; _i2253 < _size2249; ++_i2253)
             {
-              xfer += (*(this->success))[_i2246].read(iprot);
+              xfer += (*(this->success))[_i2253].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26840,14 +26856,14 @@ uint32_t ThriftHiveMetastore_alter_partitions_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size2247;
-            ::apache::thrift::protocol::TType _etype2250;
-            xfer += iprot->readListBegin(_etype2250, _size2247);
-            this->new_parts.resize(_size2247);
-            uint32_t _i2251;
-            for (_i2251 = 0; _i2251 < _size2247; ++_i2251)
+            uint32_t _size2254;
+            ::apache::thrift::protocol::TType _etype2257;
+            xfer += iprot->readListBegin(_etype2257, _size2254);
+            this->new_parts.resize(_size2254);
+            uint32_t _i2258;
+            for (_i2258 = 0; _i2258 < _size2254; ++_i2258)
             {
-              xfer += this->new_parts[_i2251].read(iprot);
+              xfer += this->new_parts[_i2258].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26884,10 +26900,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter2252;
-    for (_iter2252 = this->new_parts.begin(); _iter2252 != this->new_parts.end(); ++_iter2252)
+    std::vector<Partition> ::const_iterator _iter2259;
+    for (_iter2259 = this->new_parts.begin(); _iter2259 != this->new_parts.end(); ++_iter2259)
     {
-      xfer += (*_iter2252).write(oprot);
+      xfer += (*_iter2259).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26919,10 +26935,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter2253;
-    for (_iter2253 = (*(this->new_parts)).begin(); _iter2253 != (*(this->new_parts)).end(); ++_iter2253)
+    std::vector<Partition> ::const_iterator _iter2260;
+    for (_iter2260 = (*(this->new_parts)).begin(); _iter2260 != (*(this->new_parts)).end(); ++_iter2260)
     {
-      xfer += (*_iter2253).write(oprot);
+      xfer += (*_iter2260).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -27107,14 +27123,14 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_args::rea
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size2254;
-            ::apache::thrift::protocol::TType _etype2257;
-            xfer += iprot->readListBegin(_etype2257, _size2254);
-            this->new_parts.resize(_size2254);
-            uint32_t _i2258;
-            for (_i2258 = 0; _i2258 < _size2254; ++_i2258)
+            uint32_t _size2261;
+            ::apache::thrift::protocol::TType _etype2264;
+            xfer += iprot->readListBegin(_etype2264, _size2261);
+            this->new_parts.resize(_size2261);
+            uint32_t _i2265;
+            for (_i2265 = 0; _i2265 < _size2261; ++_i2265)
             {
-              xfer += this->new_parts[_i2258].read(iprot);
+              xfer += this->new_parts[_i2265].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -27159,10 +27175,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_args::wri
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter2259;
-    for (_iter2259 = this->new_parts.begin(); _iter2259 != this->new_parts.end(); ++_iter2259)
+    std::vector<Partition> ::const_iterator _iter2266;
+    for (_iter2266 = this->new_parts.begin(); _iter2266 != this->new_parts.end(); ++_iter2266)
     {
-      xfer += (*_iter2259).write(oprot);
+      xfer += (*_iter2266).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -27198,10 +27214,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_pargs::wr
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter2260;
-    for (_iter2260 = (*(this->new_parts)).begin(); _iter2260 != (*(this->new_parts)).end(); ++_iter2260)
+    std::vector<Partition> ::const_iterator _iter2267;
+    for (_iter2267 = (*(this->new_parts)).begin(); _iter2267 != (*(this->new_parts)).end(); ++_iter2267)
     {
-      xfer += (*_iter2260).write(oprot);
+      xfer += (*_iter2267).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -27872,14 +27888,14 @@ uint32_t ThriftHiveMetastore_rename_partition_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2261;
-            ::apache::thrift::protocol::TType _etype2264;
-            xfer += iprot->readListBegin(_etype2264, _size2261);
-            this->part_vals.resize(_size2261);
-            uint32_t _i2265;
-            for (_i2265 = 0; _i2265 < _size2261; ++_i2265)
+            uint32_t _size2268;
+            ::apache::thrift::protocol::TType _etype2271;
+            xfer += iprot->readListBegin(_etype2271, _size2268);
+            this->part_vals.resize(_size2268);
+            uint32_t _i2272;
+            for (_i2272 = 0; _i2272 < _size2268; ++_i2272)
             {
-              xfer += iprot->readString(this->part_vals[_i2265]);
+              xfer += iprot->readString(this->part_vals[_i2272]);
             }
             xfer += iprot->readListEnd();
           }
@@ -27924,10 +27940,10 @@ uint32_t ThriftHiveMetastore_rename_partition_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2266;
-    for (_iter2266 = this->part_vals.begin(); _iter2266 != this->part_vals.end(); ++_iter2266)
+    std::vector<std::string> ::const_iterator _iter2273;
+    for (_iter2273 = this->part_vals.begin(); _iter2273 != this->part_vals.end(); ++_iter2273)
     {
-      xfer += oprot->writeString((*_iter2266));
+      xfer += oprot->writeString((*_iter2273));
     }
     xfer += oprot->writeListEnd();
   }
@@ -27963,10 +27979,10 @@ uint32_t ThriftHiveMetastore_rename_partition_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2267;
-    for (_iter2267 = (*(this->part_vals)).begin(); _iter2267 != (*(this->part_vals)).end(); ++_iter2267)
+    std::vector<std::string> ::const_iterator _iter2274;
+    for (_iter2274 = (*(this->part_vals)).begin(); _iter2274 != (*(this->part_vals)).end(); ++_iter2274)
     {
-      xfer += oprot->writeString((*_iter2267));
+      xfer += oprot->writeString((*_iter2274));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28366,14 +28382,14 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_args::read(::ap
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2268;
-            ::apache::thrift::protocol::TType _etype2271;
-            xfer += iprot->readListBegin(_etype2271, _size2268);
-            this->part_vals.resize(_size2268);
-            uint32_t _i2272;
-            for (_i2272 = 0; _i2272 < _size2268; ++_i2272)
+            uint32_t _size2275;
+            ::apache::thrift::protocol::TType _etype2278;
+            xfer += iprot->readListBegin(_etype2278, _size2275);
+            this->part_vals.resize(_size2275);
+            uint32_t _i2279;
+            for (_i2279 = 0; _i2279 < _size2275; ++_i2279)
             {
-              xfer += iprot->readString(this->part_vals[_i2272]);
+              xfer += iprot->readString(this->part_vals[_i2279]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28410,10 +28426,10 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_args::write(::a
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2273;
-    for (_iter2273 = this->part_vals.begin(); _iter2273 != this->part_vals.end(); ++_iter2273)
+    std::vector<std::string> ::const_iterator _iter2280;
+    for (_iter2280 = this->part_vals.begin(); _iter2280 != this->part_vals.end(); ++_iter2280)
     {
-      xfer += oprot->writeString((*_iter2273));
+      xfer += oprot->writeString((*_iter2280));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28441,10 +28457,10 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_pargs::write(::
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2274;
-    for (_iter2274 = (*(this->part_vals)).begin(); _iter2274 != (*(this->part_vals)).end(); ++_iter2274)
+    std::vector<std::string> ::const_iterator _iter2281;
+    for (_iter2281 = (*(this->part_vals)).begin(); _iter2281 != (*(this->part_vals)).end(); ++_iter2281)
     {
-      xfer += oprot->writeString((*_iter2274));
+      xfer += oprot->writeString((*_iter2281));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28919,14 +28935,14 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2275;
-            ::apache::thrift::protocol::TType _etype2278;
-            xfer += iprot->readListBegin(_etype2278, _size2275);
-            this->success.resize(_size2275);
-            uint32_t _i2279;
-            for (_i2279 = 0; _i2279 < _size2275; ++_i2279)
+            uint32_t _size2282;
+            ::apache::thrift::protocol::TType _etype2285;
+            xfer += iprot->readListBegin(_etype2285, _size2282);
+            this->success.resize(_size2282);
+            uint32_t _i2286;
+            for (_i2286 = 0; _i2286 < _size2282; ++_i2286)
             {
-              xfer += iprot->readString(this->success[_i2279]);
+              xfer += iprot->readString(this->success[_i2286]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28965,10 +28981,10 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2280;
-      for (_iter2280 = this->success.begin(); _iter2280 != this->success.end(); ++_iter2280)
+      std::vector<std::string> ::const_iterator _iter2287;
+      for (_iter2287 = this->success.begin(); _iter2287 != this->success.end(); ++_iter2287)
       {
-        xfer += oprot->writeString((*_iter2280));
+        xfer += oprot->writeString((*_iter2287));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29013,14 +29029,14 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2281;
-            ::apache::thrift::protocol::TType _etype2284;
-            xfer += iprot->readListBegin(_etype2284, _size2281);
-            (*(this->success)).resize(_size2281);
-            uint32_t _i2285;
-            for (_i2285 = 0; _i2285 < _size2281; ++_i2285)
+            uint32_t _size2288;
+            ::apache::thrift::protocol::TType _etype2291;
+            xfer += iprot->readListBegin(_etype2291, _size2288);
+            (*(this->success)).resize(_size2288);
+            uint32_t _i2292;
+            for (_i2292 = 0; _i2292 < _size2288; ++_i2292)
             {
-              xfer += iprot->readString((*(this->success))[_i2285]);
+              xfer += iprot->readString((*(this->success))[_i2292]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29158,17 +29174,17 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size2286;
-            ::apache::thrift::protocol::TType _ktype2287;
-            ::apache::thrift::protocol::TType _vtype2288;
-            xfer += iprot->readMapBegin(_ktype2287, _vtype2288, _size2286);
-            uint32_t _i2290;
-            for (_i2290 = 0; _i2290 < _size2286; ++_i2290)
+            uint32_t _size2293;
+            ::apache::thrift::protocol::TType _ktype2294;
+            ::apache::thrift::protocol::TType _vtype2295;
+            xfer += iprot->readMapBegin(_ktype2294, _vtype2295, _size2293);
+            uint32_t _i2297;
+            for (_i2297 = 0; _i2297 < _size2293; ++_i2297)
             {
-              std::string _key2291;
-              xfer += iprot->readString(_key2291);
-              std::string& _val2292 = this->success[_key2291];
-              xfer += iprot->readString(_val2292);
+              std::string _key2298;
+              xfer += iprot->readString(_key2298);
+              std::string& _val2299 = this->success[_key2298];
+              xfer += iprot->readString(_val2299);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29207,11 +29223,11 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::map<std::string, std::string> ::const_iterator _iter2293;
-      for (_iter2293 = this->success.begin(); _iter2293 != this->success.end(); ++_iter2293)
+      std::map<std::string, std::string> ::const_iterator _iter2300;
+      for (_iter2300 = this->success.begin(); _iter2300 != this->success.end(); ++_iter2300)
       {
-        xfer += oprot->writeString(_iter2293->first);
-        xfer += oprot->writeString(_iter2293->second);
+        xfer += oprot->writeString(_iter2300->first);
+        xfer += oprot->writeString(_iter2300->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -29256,17 +29272,17 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size2294;
-            ::apache::thrift::protocol::TType _ktype2295;
-            ::apache::thrift::protocol::TType _vtype2296;
-            xfer += iprot->readMapBegin(_ktype2295, _vtype2296, _size2294);
-            uint32_t _i2298;
-            for (_i2298 = 0; _i2298 < _size2294; ++_i2298)
+            uint32_t _size2301;
+            ::apache::thrift::protocol::TType _ktype2302;
+            ::apache::thrift::protocol::TType _vtype2303;
+            xfer += iprot->readMapBegin(_ktype2302, _vtype2303, _size2301);
+            uint32_t _i2305;
+            for (_i2305 = 0; _i2305 < _size2301; ++_i2305)
             {
-              std::string _key2299;
-              xfer += iprot->readString(_key2299);
-              std::string& _val2300 = (*(this->success))[_key2299];
-              xfer += iprot->readString(_val2300);
+              std::string _key2306;
+              xfer += iprot->readString(_key2306);
+              std::string& _val2307 = (*(this->success))[_key2306];
+              xfer += iprot->readString(_val2307);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29341,17 +29357,17 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->part_vals.clear();
-            uint32_t _size2301;
-            ::apache::thrift::protocol::TType _ktype2302;
-            ::apache::thrift::protocol::TType _vtype2303;
-            xfer += iprot->readMapBegin(_ktype2302, _vtype2303, _size2301);
-            uint32_t _i2305;
-            for (_i2305 = 0; _i2305 < _size2301; ++_i2305)
+            uint32_t _size2308;
+            ::apache::thrift::protocol::TType _ktype2309;
+            ::apache::thrift::protocol::TType _vtype2310;
+            xfer += iprot->readMapBegin(_ktype2309, _vtype2310, _size2308);
+            uint32_t _i2312;
+            for (_i2312 = 0; _i2312 < _size2308; ++_i2312)
             {
-              std::string _key2306;
-              xfer += iprot->readString(_key2306);
-              std::string& _val2307 = this->part_vals[_key2306];
-              xfer += iprot->readString(_val2307);
+              std::string _key2313;
+              xfer += iprot->readString(_key2313);
+              std::string& _val2314 = this->part_vals[_key2313];
+              xfer += iprot->readString(_val2314);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29362,9 +29378,9 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::read(::apache::thrift::
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2308;
-          xfer += iprot->readI32(ecast2308);
-          this->eventType = (PartitionEventType::type)ecast2308;
+          int32_t ecast2315;
+          xfer += iprot->readI32(ecast2315);
+          this->eventType = (PartitionEventType::type)ecast2315;
           this->__isset.eventType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -29398,11 +29414,11 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::write(::apache::thrift:
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2309;
-    for (_iter2309 = this->part_vals.begin(); _iter2309 != this->part_vals.end(); ++_iter2309)
+    std::map<std::string, std::string> ::const_iterator _iter2316;
+    for (_iter2316 = this->part_vals.begin(); _iter2316 != this->part_vals.end(); ++_iter2316)
     {
-      xfer += oprot->writeString(_iter2309->first);
-      xfer += oprot->writeString(_iter2309->second);
+      xfer += oprot->writeString(_iter2316->first);
+      xfer += oprot->writeString(_iter2316->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29438,11 +29454,11 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_pargs::write(::apache::thrift
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2310;
-    for (_iter2310 = (*(this->part_vals)).begin(); _iter2310 != (*(this->part_vals)).end(); ++_iter2310)
+    std::map<std::string, std::string> ::const_iterator _iter2317;
+    for (_iter2317 = (*(this->part_vals)).begin(); _iter2317 != (*(this->part_vals)).end(); ++_iter2317)
     {
-      xfer += oprot->writeString(_iter2310->first);
-      xfer += oprot->writeString(_iter2310->second);
+      xfer += oprot->writeString(_iter2317->first);
+      xfer += oprot->writeString(_iter2317->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29711,17 +29727,17 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->part_vals.clear();
-            uint32_t _size2311;
-            ::apache::thrift::protocol::TType _ktype2312;
-            ::apache::thrift::protocol::TType _vtype2313;
-            xfer += iprot->readMapBegin(_ktype2312, _vtype2313, _size2311);
-            uint32_t _i2315;
-            for (_i2315 = 0; _i2315 < _size2311; ++_i2315)
+            uint32_t _size2318;
+            ::apache::thrift::protocol::TType _ktype2319;
+            ::apache::thrift::protocol::TType _vtype2320;
+            xfer += iprot->readMapBegin(_ktype2319, _vtype2320, _size2318);
+            uint32_t _i2322;
+            for (_i2322 = 0; _i2322 < _size2318; ++_i2322)
             {
-              std::string _key2316;
-              xfer += iprot->readString(_key2316);
-              std::string& _val2317 = this->part_vals[_key2316];
-              xfer += iprot->readString(_val2317);
+              std::string _key2323;
+              xfer += iprot->readString(_key2323);
+              std::string& _val2324 = this->part_vals[_key2323];
+              xfer += iprot->readString(_val2324);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29732,9 +29748,9 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::read(::apache::thri
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2318;
-          xfer += iprot->readI32(ecast2318);
-          this->eventType = (PartitionEventType::type)ecast2318;
+          int32_t ecast2325;
+          xfer += iprot->readI32(ecast2325);
+          this->eventType = (PartitionEventType::type)ecast2325;
           this->__isset.eventType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -29768,11 +29784,11 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::write(::apache::thr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2319;
-    for (_iter2319 = this->part_vals.begin(); _iter2319 != this->part_vals.end(); ++_iter2319)
+    std::map<std::string, std::string> ::const_iterator _iter2326;
+    for (_iter2326 = this->part_vals.begin(); _iter2326 != this->part_vals.end(); ++_iter2326)
     {
-      xfer += oprot->writeString(_iter2319->first);
-      xfer += oprot->writeString(_iter2319->second);
+      xfer += oprot->writeString(_iter2326->first);
+      xfer += oprot->writeString(_iter2326->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29808,11 +29824,11 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_pargs::write(::apache::th
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2320;
-    for (_iter2320 = (*(this->part_vals)).begin(); _iter2320 != (*(this->part_vals)).end(); ++_iter2320)
+    std::map<std::string, std::string> ::const_iterator _iter2327;
+    for (_iter2327 = (*(this->part_vals)).begin(); _iter2327 != (*(this->part_vals)).end(); ++_iter2327)
     {
-      xfer += oprot->writeString(_iter2320->first);
-      xfer += oprot->writeString(_iter2320->second);
+      xfer += oprot->writeString(_iter2327->first);
+      xfer += oprot->writeString(_iter2327->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -35941,14 +35957,14 @@ uint32_t ThriftHiveMetastore_get_functions_result::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2321;
-            ::apache::thrift::protocol::TType _etype2324;
-            xfer += iprot->readListBegin(_etype2324, _size2321);
-            this->success.resize(_size2321);
-            uint32_t _i2325;
-            for (_i2325 = 0; _i2325 < _size2321; ++_i2325)
+            uint32_t _size2328;
+            ::apache::thrift::protocol::TType _etype2331;
+            xfer += iprot->readListBegin(_etype2331, _size2328);
+            this->success.resize(_size2328);
+            uint32_t _i2332;
+            for (_i2332 = 0; _i2332 < _size2328; ++_i2332)
             {
-              xfer += iprot->readString(this->success[_i2325]);
+              xfer += iprot->readString(this->success[_i2332]);
             }
             xfer += iprot->readListEnd();
           }
@@ -35987,10 +36003,10 @@ uint32_t ThriftHiveMetastore_get_functions_result::write(::apache::thrift::proto
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2326;
-      for (_iter2326 = this->success.begin(); _iter2326 != this->success.end(); ++_iter2326)
+      std::vector<std::string> ::const_iterator _iter2333;
+      for (_iter2333 = this->success.begin(); _iter2333 != this->success.end(); ++_iter2333)
       {
-        xfer += oprot->writeString((*_iter2326));
+        xfer += oprot->writeString((*_iter2333));
       }
       xfer += oprot->writeListEnd();
     }
@@ -36035,14 +36051,14 @@ uint32_t ThriftHiveMetastore_get_functions_presult::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2327;
-            ::apache::thrift::protocol::TType _etype2330;
-            xfer += iprot->readListBegin(_etype2330, _size2327);
-            (*(this->success)).resize(_size2327);
-            uint32_t _i2331;
-            for (_i2331 = 0; _i2331 < _size2327; ++_i2331)
+            uint32_t _size2334;
+            ::apache::thrift::protocol::TType _etype2337;
+            xfer += iprot->readListBegin(_etype2337, _size2334);
+            (*(this->success)).resize(_size2334);
+            uint32_t _i2338;
+            for (_i2338 = 0; _i2338 < _size2334; ++_i2338)
             {
-              xfer += iprot->readString((*(this->success))[_i2331]);
+              xfer += iprot->readString((*(this->success))[_i2338]);
             }
             xfer += iprot->readListEnd();
           }
@@ -37002,14 +37018,14 @@ uint32_t ThriftHiveMetastore_get_role_names_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2332;
-            ::apache::thrift::protocol::TType _etype2335;
-            xfer += iprot->readListBegin(_etype2335, _size2332);
-            this->success.resize(_size2332);
-            uint32_t _i2336;
-            for (_i2336 = 0; _i2336 < _size2332; ++_i2336)
+            uint32_t _size2339;
+            ::apache::thrift::protocol::TType _etype2342;
+            xfer += iprot->readListBegin(_etype2342, _size2339);
+            this->success.resize(_size2339);
+            uint32_t _i2343;
+            for (_i2343 = 0; _i2343 < _size2339; ++_i2343)
             {
-              xfer += iprot->readString(this->success[_i2336]);
+              xfer += iprot->readString(this->success[_i2343]);
             }
             xfer += iprot->readListEnd();
           }
@@ -37048,10 +37064,10 @@ uint32_t ThriftHiveMetastore_get_role_names_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2337;
-      for (_iter2337 = this->success.begin(); _iter2337 != this->success.end(); ++_iter2337)
+      std::vector<std::string> ::const_iterator _iter2344;
+      for (_iter2344 = this->success.begin(); _iter2344 != this->success.end(); ++_iter2344)
       {
-        xfer += oprot->writeString((*_iter2337));
+        xfer += oprot->writeString((*_iter2344));
       }
       xfer += oprot->writeListEnd();
     }
@@ -37096,14 +37112,14 @@ uint32_t ThriftHiveMetastore_get_role_names_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2338;
-            ::apache::thrift::protocol::TType _etype2341;
-            xfer += iprot->readListBegin(_etype2341, _size2338);
-            (*(this->success)).resize(_size2338);
-            uint32_t _i2342;
-            for (_i2342 = 0; _i2342 < _size2338; ++_i2342)
+            uint32_t _size2345;
+            ::apache::thrift::protocol::TType _etype2348;
+            xfer += iprot->readListBegin(_etype2348, _size2345);
+            (*(this->success)).resize(_size2345);
+            uint32_t _i2349;
+            for (_i2349 = 0; _i2349 < _size2345; ++_i2349)
             {
-              xfer += iprot->readString((*(this->success))[_i2342]);
+              xfer += iprot->readString((*(this->success))[_i2349]);
             }
             xfer += iprot->readListEnd();
           }
@@ -37176,9 +37192,9 @@ uint32_t ThriftHiveMetastore_grant_role_args::read(::apache::thrift::protocol::T
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2343;
-          xfer += iprot->readI32(ecast2343);
-          this->principal_type = (PrincipalType::type)ecast2343;
+          int32_t ecast2350;
+          xfer += iprot->readI32(ecast2350);
+          this->principal_type = (PrincipalType::type)ecast2350;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37194,9 +37210,9 @@ uint32_t ThriftHiveMetastore_grant_role_args::read(::apache::thrift::protocol::T
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2344;
-          xfer += iprot->readI32(ecast2344);
-          this->grantorType = (PrincipalType::type)ecast2344;
+          int32_t ecast2351;
+          xfer += iprot->readI32(ecast2351);
+          this->grantorType = (PrincipalType::type)ecast2351;
           this->__isset.grantorType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37467,9 +37483,9 @@ uint32_t ThriftHiveMetastore_revoke_role_args::read(::apache::thrift::protocol::
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2345;
-          xfer += iprot->readI32(ecast2345);
-          this->principal_type = (PrincipalType::type)ecast2345;
+          int32_t ecast2352;
+          xfer += iprot->readI32(ecast2352);
+          this->principal_type = (PrincipalType::type)ecast2352;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37700,9 +37716,9 @@ uint32_t ThriftHiveMetastore_list_roles_args::read(::apache::thrift::protocol::T
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2346;
-          xfer += iprot->readI32(ecast2346);
-          this->principal_type = (PrincipalType::type)ecast2346;
+          int32_t ecast2353;
+          xfer += iprot->readI32(ecast2353);
+          this->principal_type = (PrincipalType::type)ecast2353;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37791,14 +37807,14 @@ uint32_t ThriftHiveMetastore_list_roles_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2347;
-            ::apache::thrift::protocol::TType _etype2350;
-            xfer += iprot->readListBegin(_etype2350, _size2347);
-            this->success.resize(_size2347);
-            uint32_t _i2351;
-            for (_i2351 = 0; _i2351 < _size2347; ++_i2351)
+            uint32_t _size2354;
+            ::apache::thrift::protocol::TType _etype2357;
+            xfer += iprot->readListBegin(_etype2357, _size2354);
+            this->success.resize(_size2354);
+            uint32_t _i2358;
+            for (_i2358 = 0; _i2358 < _size2354; ++_i2358)
             {
-              xfer += this->success[_i2351].read(iprot);
+              xfer += this->success[_i2358].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -37837,10 +37853,10 @@ uint32_t ThriftHiveMetastore_list_roles_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Role> ::const_iterator _iter2352;
-      for (_iter2352 = this->success.begin(); _iter2352 != this->success.end(); ++_iter2352)
+      std::vector<Role> ::const_iterator _iter2359;
+      for (_iter2359 = this->success.begin(); _iter2359 != this->success.end(); ++_iter2359)
       {
-        xfer += (*_iter2352).write(oprot);
+        xfer += (*_iter2359).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -37885,14 +37901,14 @@ uint32_t ThriftHiveMetastore_list_roles_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2353;
-            ::apache::thrift::protocol::TType _etype2356;
-            xfer += iprot->readListBegin(_etype2356, _size2353);
-            (*(this->success)).resize(_size2353);
-            uint32_t _i2357;
-            for (_i2357 = 0; _i2357 < _size2353; ++_i2357)
+            uint32_t _size2360;
+            ::apache::thrift::protocol::TType _etype2363;
+            xfer += iprot->readListBegin(_etype2363, _size2360);
+            (*(this->success)).resize(_size2360);
+            uint32_t _i2364;
+            for (_i2364 = 0; _i2364 < _size2360; ++_i2364)
             {
-              xfer += (*(this->success))[_i2357].read(iprot);
+              xfer += (*(this->success))[_i2364].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -38588,14 +38604,14 @@ uint32_t ThriftHiveMetastore_get_privilege_set_args::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2358;
-            ::apache::thrift::protocol::TType _etype2361;
-            xfer += iprot->readListBegin(_etype2361, _size2358);
-            this->group_names.resize(_size2358);
-            uint32_t _i2362;
-            for (_i2362 = 0; _i2362 < _size2358; ++_i2362)
+            uint32_t _size2365;
+            ::apache::thrift::protocol::TType _etype2368;
+            xfer += iprot->readListBegin(_etype2368, _size2365);
+            this->group_names.resize(_size2365);
+            uint32_t _i2369;
+            for (_i2369 = 0; _i2369 < _size2365; ++_i2369)
             {
-              xfer += iprot->readString(this->group_names[_i2362]);
+              xfer += iprot->readString(this->group_names[_i2369]);
             }
             xfer += iprot->readListEnd();
           }
@@ -38632,10 +38648,10 @@ uint32_t ThriftHiveMetastore_get_privilege_set_args::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2363;
-    for (_iter2363 = this->group_names.begin(); _iter2363 != this->group_names.end(); ++_iter2363)
+    std::vector<std::string> ::const_iterator _iter2370;
+    for (_iter2370 = this->group_names.begin(); _iter2370 != this->group_names.end(); ++_iter2370)
     {
-      xfer += oprot->writeString((*_iter2363));
+      xfer += oprot->writeString((*_iter2370));
     }
     xfer += oprot->writeListEnd();
   }
@@ -38667,10 +38683,10 @@ uint32_t ThriftHiveMetastore_get_privilege_set_pargs::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2364;
-    for (_iter2364 = (*(this->group_names)).begin(); _iter2364 != (*(this->group_names)).end(); ++_iter2364)
+    std::vector<std::string> ::const_iterator _iter2371;
+    for (_iter2371 = (*(this->group_names)).begin(); _iter2371 != (*(this->group_names)).end(); ++_iter2371)
     {
-      xfer += oprot->writeString((*_iter2364));
+      xfer += oprot->writeString((*_iter2371));
     }
     xfer += oprot->writeListEnd();
   }
@@ -38845,9 +38861,9 @@ uint32_t ThriftHiveMetastore_list_privileges_args::read(::apache::thrift::protoc
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2365;
-          xfer += iprot->readI32(ecast2365);
-          this->principal_type = (PrincipalType::type)ecast2365;
+          int32_t ecast2372;
+          xfer += iprot->readI32(ecast2372);
+          this->principal_type = (PrincipalType::type)ecast2372;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -38952,14 +38968,14 @@ uint32_t ThriftHiveMetastore_list_privileges_result::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2366;
-            ::apache::thrift::protocol::TType _etype2369;
-            xfer += iprot->readListBegin(_etype2369, _size2366);
-            this->success.resize(_size2366);
-            uint32_t _i2370;
-            for (_i2370 = 0; _i2370 < _size2366; ++_i2370)
+            uint32_t _size2373;
+            ::apache::thrift::protocol::TType _etype2376;
+            xfer += iprot->readListBegin(_etype2376, _size2373);
+            this->success.resize(_size2373);
+            uint32_t _i2377;
+            for (_i2377 = 0; _i2377 < _size2373; ++_i2377)
             {
-              xfer += this->success[_i2370].read(iprot);
+              xfer += this->success[_i2377].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -38998,10 +39014,10 @@ uint32_t ThriftHiveMetastore_list_privileges_result::write(::apache::thrift::pro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<HiveObjectPrivilege> ::const_iterator _iter2371;
-      for (_iter2371 = this->success.begin(); _iter2371 != this->success.end(); ++_iter2371)
+      std::vector<HiveObjectPrivilege> ::const_iterator _iter2378;
+      for (_iter2378 = this->success.begin(); _iter2378 != this->success.end(); ++_iter2378)
       {
-        xfer += (*_iter2371).write(oprot);
+        xfer += (*_iter2378).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -39046,14 +39062,14 @@ uint32_t ThriftHiveMetastore_list_privileges_presult::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2372;
-            ::apache::thrift::protocol::TType _etype2375;
-            xfer += iprot->readListBegin(_etype2375, _size2372);
-            (*(this->success)).resize(_size2372);
-            uint32_t _i2376;
-            for (_i2376 = 0; _i2376 < _size2372; ++_i2376)
+            uint32_t _size2379;
+            ::apache::thrift::protocol::TType _etype2382;
+            xfer += iprot->readListBegin(_etype2382, _size2379);
+            (*(this->success)).resize(_size2379);
+            uint32_t _i2383;
+            for (_i2383 = 0; _i2383 < _size2379; ++_i2383)
             {
-              xfer += (*(this->success))[_i2376].read(iprot);
+              xfer += (*(this->success))[_i2383].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -39980,14 +39996,14 @@ uint32_t ThriftHiveMetastore_set_ugi_args::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2377;
-            ::apache::thrift::protocol::TType _etype2380;
-            xfer += iprot->readListBegin(_etype2380, _size2377);
-            this->group_names.resize(_size2377);
-            uint32_t _i2381;
-            for (_i2381 = 0; _i2381 < _size2377; ++_i2381)
+            uint32_t _size2384;
+            ::apache::thrift::protocol::TType _etype2387;
+            xfer += iprot->readListBegin(_etype2387, _size2384);
+            this->group_names.resize(_size2384);
+            uint32_t _i2388;
+            for (_i2388 = 0; _i2388 < _size2384; ++_i2388)
             {
-              xfer += iprot->readString(this->group_names[_i2381]);
+              xfer += iprot->readString(this->group_names[_i2388]);
             }
             xfer += iprot->readListEnd();
           }
@@ -40020,10 +40036,10 @@ uint32_t ThriftHiveMetastore_set_ugi_args::write(::apache::thrift::protocol::TPr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2382;
-    for (_iter2382 = this->group_names.begin(); _iter2382 != this->group_names.end(); ++_iter2382)
+    std::vector<std::string> ::const_iterator _iter2389;
+    for (_iter2389 = this->group_names.begin(); _iter2389 != this->group_names.end(); ++_iter2389)
     {
-      xfer += oprot->writeString((*_iter2382));
+      xfer += oprot->writeString((*_iter2389));
     }
     xfer += oprot->writeListEnd();
   }
@@ -40051,10 +40067,10 @@ uint32_t ThriftHiveMetastore_set_ugi_pargs::write(::apache::thrift::protocol::TP
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2383;
-    for (_iter2383 = (*(this->group_names)).begin(); _iter2383 != (*(this->group_names)).end(); ++_iter2383)
+    std::vector<std::string> ::const_iterator _iter2390;
+    for (_iter2390 = (*(this->group_names)).begin(); _iter2390 != (*(this->group_names)).end(); ++_iter2390)
     {
-      xfer += oprot->writeString((*_iter2383));
+      xfer += oprot->writeString((*_iter2390));
     }
     xfer += oprot->writeListEnd();
   }
@@ -40095,14 +40111,14 @@ uint32_t ThriftHiveMetastore_set_ugi_result::read(::apache::thrift::protocol::TP
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2384;
-            ::apache::thrift::protocol::TType _etype2387;
-            xfer += iprot->readListBegin(_etype2387, _size2384);
-            this->success.resize(_size2384);
-            uint32_t _i2388;
-            for (_i2388 = 0; _i2388 < _size2384; ++_i2388)
+            uint32_t _size2391;
+            ::apache::thrift::protocol::TType _etype2394;
+            xfer += iprot->readListBegin(_etype2394, _size2391);
+            this->success.resize(_size2391);
+            uint32_t _i2395;
+            for (_i2395 = 0; _i2395 < _size2391; ++_i2395)
             {
-              xfer += iprot->readString(this->success[_i2388]);
+              xfer += iprot->readString(this->success[_i2395]);
             }
             xfer += iprot->readListEnd();
           }
@@ -40141,10 +40157,10 @@ uint32_t ThriftHiveMetastore_set_ugi_result::write(::apache::thrift::protocol::T
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2389;
-      for (_iter2389 = this->success.begin(); _iter2389 != this->success.end(); ++_iter2389)
+      std::vector<std::string> ::const_iterator _iter2396;
+      for (_iter2396 = this->success.begin(); _iter2396 != this->success.end(); ++_iter2396)
       {
-        xfer += oprot->writeString((*_iter2389));
+        xfer += oprot->writeString((*_iter2396));
       }
       xfer += oprot->writeListEnd();
     }
@@ -40189,14 +40205,14 @@ uint32_t ThriftHiveMetastore_set_ugi_presult::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2390;
-            ::apache::thrift::protocol::TType _etype2393;
-            xfer += iprot->readListBegin(_etype2393, _size2390);
-            (*(this->success)).resize(_size2390);
-            uint32_t _i2394;
-            for (_i2394 = 0; _i2394 < _size2390; ++_i2394)
+            uint32_t _size2397;
+            ::apache::thrift::protocol::TType _etype2400;
+            xfer += iprot->readListBegin(_etype2400, _size2397);
+            (*(this->success)).resize(_size2397);
+            uint32_t _i2401;
+            for (_i2401 = 0; _i2401 < _size2397; ++_i2401)
             {
-              xfer += iprot->readString((*(this->success))[_i2394]);
+              xfer += iprot->readString((*(this->success))[_i2401]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41507,14 +41523,14 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2395;
-            ::apache::thrift::protocol::TType _etype2398;
-            xfer += iprot->readListBegin(_etype2398, _size2395);
-            this->success.resize(_size2395);
-            uint32_t _i2399;
-            for (_i2399 = 0; _i2399 < _size2395; ++_i2399)
+            uint32_t _size2402;
+            ::apache::thrift::protocol::TType _etype2405;
+            xfer += iprot->readListBegin(_etype2405, _size2402);
+            this->success.resize(_size2402);
+            uint32_t _i2406;
+            for (_i2406 = 0; _i2406 < _size2402; ++_i2406)
             {
-              xfer += iprot->readString(this->success[_i2399]);
+              xfer += iprot->readString(this->success[_i2406]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41545,10 +41561,10 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2400;
-      for (_iter2400 = this->success.begin(); _iter2400 != this->success.end(); ++_iter2400)
+      std::vector<std::string> ::const_iterator _iter2407;
+      for (_iter2407 = this->success.begin(); _iter2407 != this->success.end(); ++_iter2407)
       {
-        xfer += oprot->writeString((*_iter2400));
+        xfer += oprot->writeString((*_iter2407));
       }
       xfer += oprot->writeListEnd();
     }
@@ -41589,14 +41605,14 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2401;
-            ::apache::thrift::protocol::TType _etype2404;
-            xfer += iprot->readListBegin(_etype2404, _size2401);
-            (*(this->success)).resize(_size2401);
-            uint32_t _i2405;
-            for (_i2405 = 0; _i2405 < _size2401; ++_i2405)
+            uint32_t _size2408;
+            ::apache::thrift::protocol::TType _etype2411;
+            xfer += iprot->readListBegin(_etype2411, _size2408);
+            (*(this->success)).resize(_size2408);
+            uint32_t _i2412;
+            for (_i2412 = 0; _i2412 < _size2408; ++_i2412)
             {
-              xfer += iprot->readString((*(this->success))[_i2405]);
+              xfer += iprot->readString((*(this->success))[_i2412]);
             }
             xfer += iprot->readListEnd();
           }
@@ -42322,14 +42338,14 @@ uint32_t ThriftHiveMetastore_get_master_keys_result::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2406;
-            ::apache::thrift::protocol::TType _etype2409;
-            xfer += iprot->readListBegin(_etype2409, _size2406);
-            this->success.resize(_size2406);
-            uint32_t _i2410;
-            for (_i2410 = 0; _i2410 < _size2406; ++_i2410)
+            uint32_t _size2413;
+            ::apache::thrift::protocol::TType _etype2416;
+            xfer += iprot->readListBegin(_etype2416, _size2413);
+            this->success.resize(_size2413);
+            uint32_t _i2417;
+            for (_i2417 = 0; _i2417 < _size2413; ++_i2417)
             {
-              xfer += iprot->readString(this->success[_i2410]);
+              xfer += iprot->readString(this->success[_i2417]);
             }
             xfer += iprot->readListEnd();
           }
@@ -42360,10 +42376,10 @@ uint32_t ThriftHiveMetastore_get_master_keys_result::write(::apache::thrift::pro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2411;
-      for (_iter2411 = this->success.begin(); _iter2411 != this->success.end(); ++_iter2411)
+      std::vector<std::string> ::const_iterator _iter2418;
+      for (_iter2418 = this->success.begin(); _iter2418 != this->success.end(); ++_iter2418)
       {
-        xfer += oprot->writeString((*_iter2411));
+        xfer += oprot->writeString((*_iter2418));
       }
       xfer += oprot->writeListEnd();
     }
@@ -42404,14 +42420,14 @@ uint32_t ThriftHiveMetastore_get_master_keys_presult::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2412;
-            ::apache::thrift::protocol::TType _etype2415;
-            xfer += iprot->readListBegin(_etype2415, _size2412);
-            (*(this->success)).resize(_size2412);
-            uint32_t _i2416;
-            for (_i2416 = 0; _i2416 < _size2412; ++_i2416)
+            uint32_t _size2419;
+            ::apache::thrift::protocol::TType _etype2422;
+            xfer += iprot->readListBegin(_etype2422, _size2419);
+            (*(this->success)).resize(_size2419);
+            uint32_t _i2423;
+            for (_i2423 = 0; _i2423 < _size2419; ++_i2423)
             {
-              xfer += iprot->readString((*(this->success))[_i2416]);
+              xfer += iprot->readString((*(this->success))[_i2423]);
             }
             xfer += iprot->readListEnd();
           }
@@ -47664,14 +47680,14 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2417;
-            ::apache::thrift::protocol::TType _etype2420;
-            xfer += iprot->readListBegin(_etype2420, _size2417);
-            this->success.resize(_size2417);
-            uint32_t _i2421;
-            for (_i2421 = 0; _i2421 < _size2417; ++_i2421)
+            uint32_t _size2424;
+            ::apache::thrift::protocol::TType _etype2427;
+            xfer += iprot->readListBegin(_etype2427, _size2424);
+            this->success.resize(_size2424);
+            uint32_t _i2428;
+            for (_i2428 = 0; _i2428 < _size2424; ++_i2428)
             {
-              xfer += iprot->readString(this->success[_i2421]);
+              xfer += iprot->readString(this->success[_i2428]);
             }
             xfer += iprot->readListEnd();
           }
@@ -47702,10 +47718,10 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2422;
-      for (_iter2422 = this->success.begin(); _iter2422 != this->success.end(); ++_iter2422)
+      std::vector<std::string> ::const_iterator _iter2429;
+      for (_iter2429 = this->success.begin(); _iter2429 != this->success.end(); ++_iter2429)
       {
-        xfer += oprot->writeString((*_iter2422));
+        xfer += oprot->writeString((*_iter2429));
       }
       xfer += oprot->writeListEnd();
     }
@@ -47746,14 +47762,14 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2423;
-            ::apache::thrift::protocol::TType _etype2426;
-            xfer += iprot->readListBegin(_etype2426, _size2423);
-            (*(this->success)).resize(_size2423);
-            uint32_t _i2427;
-            for (_i2427 = 0; _i2427 < _size2423; ++_i2427)
+            uint32_t _size2430;
+            ::apache::thrift::protocol::TType _etype2433;
+            xfer += iprot->readListBegin(_etype2433, _size2430);
+            (*(this->success)).resize(_size2430);
+            uint32_t _i2434;
+            for (_i2434 = 0; _i2434 < _size2430; ++_i2434)
             {
-              xfer += iprot->readString((*(this->success))[_i2427]);
+              xfer += iprot->readString((*(this->success))[_i2434]);
             }
             xfer += iprot->readListEnd();
           }
@@ -57095,14 +57111,14 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2428;
-            ::apache::thrift::protocol::TType _etype2431;
-            xfer += iprot->readListBegin(_etype2431, _size2428);
-            this->success.resize(_size2428);
-            uint32_t _i2432;
-            for (_i2432 = 0; _i2432 < _size2428; ++_i2432)
+            uint32_t _size2435;
+            ::apache::thrift::protocol::TType _etype2438;
+            xfer += iprot->readListBegin(_etype2438, _size2435);
+            this->success.resize(_size2435);
+            uint32_t _i2439;
+            for (_i2439 = 0; _i2439 < _size2435; ++_i2439)
             {
-              xfer += this->success[_i2432].read(iprot);
+              xfer += this->success[_i2439].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -57149,10 +57165,10 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<SchemaVersion> ::const_iterator _iter2433;
-      for (_iter2433 = this->success.begin(); _iter2433 != this->success.end(); ++_iter2433)
+      std::vector<SchemaVersion> ::const_iterator _iter2440;
+      for (_iter2440 = this->success.begin(); _iter2440 != this->success.end(); ++_iter2440)
       {
-        xfer += (*_iter2433).write(oprot);
+        xfer += (*_iter2440).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -57201,14 +57217,14 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2434;
-            ::apache::thrift::protocol::TType _etype2437;
-            xfer += iprot->readListBegin(_etype2437, _size2434);
-            (*(this->success)).resize(_size2434);
-            uint32_t _i2438;
-            for (_i2438 = 0; _i2438 < _size2434; ++_i2438)
+            uint32_t _size2441;
+            ::apache::thrift::protocol::TType _etype2444;
+            xfer += iprot->readListBegin(_etype2444, _size2441);
+            (*(this->success)).resize(_size2441);
+            uint32_t _i2445;
+            for (_i2445 = 0; _i2445 < _size2441; ++_i2445)
             {
-              xfer += (*(this->success))[_i2438].read(iprot);
+              xfer += (*(this->success))[_i2445].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -59261,14 +59277,14 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2439;
-            ::apache::thrift::protocol::TType _etype2442;
-            xfer += iprot->readListBegin(_etype2442, _size2439);
-            this->success.resize(_size2439);
-            uint32_t _i2443;
-            for (_i2443 = 0; _i2443 < _size2439; ++_i2443)
+            uint32_t _size2446;
+            ::apache::thrift::protocol::TType _etype2449;
+            xfer += iprot->readListBegin(_etype2449, _size2446);
+            this->success.resize(_size2446);
+            uint32_t _i2450;
+            for (_i2450 = 0; _i2450 < _size2446; ++_i2450)
             {
-              xfer += this->success[_i2443].read(iprot);
+              xfer += this->success[_i2450].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -59307,10 +59323,10 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<RuntimeStat> ::const_iterator _iter2444;
-      for (_iter2444 = this->success.begin(); _iter2444 != this->success.end(); ++_iter2444)
+      std::vector<RuntimeStat> ::const_iterator _iter2451;
+      for (_iter2451 = this->success.begin(); _iter2451 != this->success.end(); ++_iter2451)
       {
-        xfer += (*_iter2444).write(oprot);
+        xfer += (*_iter2451).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -59355,14 +59371,14 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2445;
-            ::apache::thrift::protocol::TType _etype2448;
-            xfer += iprot->readListBegin(_etype2448, _size2445);
-            (*(this->success)).resize(_size2445);
-            uint32_t _i2449;
-            for (_i2449 = 0; _i2449 < _size2445; ++_i2449)
+            uint32_t _size2452;
+            ::apache::thrift::protocol::TType _etype2455;
+            xfer += iprot->readListBegin(_etype2455, _size2452);
+            (*(this->success)).resize(_size2452);
+            uint32_t _i2456;
+            for (_i2456 = 0; _i2456 < _size2452; ++_i2456)
             {
-              xfer += (*(this->success))[_i2449].read(iprot);
+              xfer += (*(this->success))[_i2456].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -61797,14 +61813,14 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2450;
-            ::apache::thrift::protocol::TType _etype2453;
-            xfer += iprot->readListBegin(_etype2453, _size2450);
-            this->success.resize(_size2450);
-            uint32_t _i2454;
-            for (_i2454 = 0; _i2454 < _size2450; ++_i2454)
+            uint32_t _size2457;
+            ::apache::thrift::protocol::TType _etype2460;
+            xfer += iprot->readListBegin(_etype2460, _size2457);
+            this->success.resize(_size2457);
+            uint32_t _i2461;
+            for (_i2461 = 0; _i2461 < _size2457; ++_i2461)
             {
-              xfer += iprot->readString(this->success[_i2454]);
+              xfer += iprot->readString(this->success[_i2461]);
             }
             xfer += iprot->readListEnd();
           }
@@ -61843,10 +61859,10 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2455;
-      for (_iter2455 = this->success.begin(); _iter2455 != this->success.end(); ++_iter2455)
+      std::vector<std::string> ::const_iterator _iter2462;
+      for (_iter2462 = this->success.begin(); _iter2462 != this->success.end(); ++_iter2462)
       {
-        xfer += oprot->writeString((*_iter2455));
+        xfer += oprot->writeString((*_iter2462));
       }
       xfer += oprot->writeListEnd();
     }
@@ -61891,14 +61907,14 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2456;
-            ::apache::thrift::protocol::TType _etype2459;
-            xfer += iprot->readListBegin(_etype2459, _size2456);
-            (*(this->success)).resize(_size2456);
-            uint32_t _i2460;
-            for (_i2460 = 0; _i2460 < _size2456; ++_i2460)
+            uint32_t _size2463;
+            ::apache::thrift::protocol::TType _etype2466;
+            xfer += iprot->readListBegin(_etype2466, _size2463);
+            (*(this->success)).resize(_size2463);
+            uint32_t _i2467;
+            for (_i2467 = 0; _i2467 < _size2463; ++_i2467)
             {
-              xfer += iprot->readString((*(this->success))[_i2460]);
+              xfer += iprot->readString((*(this->success))[_i2467]);
             }
             xfer += iprot->readListEnd();
           }
@@ -62450,14 +62466,14 @@ uint32_t ThriftHiveMetastore_get_all_packages_result::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2461;
-            ::apache::thrift::protocol::TType _etype2464;
-            xfer += iprot->readListBegin(_etype2464, _size2461);
-            this->success.resize(_size2461);
-            uint32_t _i2465;
-            for (_i2465 = 0; _i2465 < _size2461; ++_i2465)
+            uint32_t _size2468;
+            ::apache::thrift::protocol::TType _etype2471;
+            xfer += iprot->readListBegin(_etype2471, _size2468);
+            this->success.resize(_size2468);
+            uint32_t _i2472;
+            for (_i2472 = 0; _i2472 < _size2468; ++_i2472)
             {
-              xfer += iprot->readString(this->success[_i2465]);
+              xfer += iprot->readString(this->success[_i2472]);
             }
             xfer += iprot->readListEnd();
           }
@@ -62496,10 +62512,10 @@ uint32_t ThriftHiveMetastore_get_all_packages_result::write(::apache::thrift::pr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2466;
-      for (_iter2466 = this->success.begin(); _iter2466 != this->success.end(); ++_iter2466)
+      std::vector<std::string> ::const_iterator _iter2473;
+      for (_iter2473 = this->success.begin(); _iter2473 != this->success.end(); ++_iter2473)
       {
-        xfer += oprot->writeString((*_iter2466));
+        xfer += oprot->writeString((*_iter2473));
       }
       xfer += oprot->writeListEnd();
     }
@@ -62544,14 +62560,14 @@ uint32_t ThriftHiveMetastore_get_all_packages_presult::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2467;
-            ::apache::thrift::protocol::TType _etype2470;
-            xfer += iprot->readListBegin(_etype2470, _size2467);
-            (*(this->success)).resize(_size2467);
-            uint32_t _i2471;
-            for (_i2471 = 0; _i2471 < _size2467; ++_i2471)
+            uint32_t _size2474;
+            ::apache::thrift::protocol::TType _etype2477;
+            xfer += iprot->readListBegin(_etype2477, _size2474);
+            (*(this->success)).resize(_size2474);
+            uint32_t _i2478;
+            for (_i2478 = 0; _i2478 < _size2474; ++_i2478)
             {
-              xfer += iprot->readString((*(this->success))[_i2471]);
+              xfer += iprot->readString((*(this->success))[_i2478]);
             }
             xfer += iprot->readListEnd();
           }
@@ -62876,14 +62892,14 @@ uint32_t ThriftHiveMetastore_get_all_write_event_info_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2472;
-            ::apache::thrift::protocol::TType _etype2475;
-            xfer += iprot->readListBegin(_etype2475, _size2472);
-            this->success.resize(_size2472);
-            uint32_t _i2476;
-            for (_i2476 = 0; _i2476 < _size2472; ++_i2476)
+            uint32_t _size2479;
+            ::apache::thrift::protocol::TType _etype2482;
+            xfer += iprot->readListBegin(_etype2482, _size2479);
+            this->success.resize(_size2479);
+            uint32_t _i2483;
+            for (_i2483 = 0; _i2483 < _size2479; ++_i2483)
             {
-              xfer += this->success[_i2476].read(iprot);
+              xfer += this->success[_i2483].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -62922,10 +62938,10 @@ uint32_t ThriftHiveMetastore_get_all_write_event_info_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<WriteEventInfo> ::const_iterator _iter2477;
-      for (_iter2477 = this->success.begin(); _iter2477 != this->success.end(); ++_iter2477)
+      std::vector<WriteEventInfo> ::const_iterator _iter2484;
+      for (_iter2484 = this->success.begin(); _iter2484 != this->success.end(); ++_iter2484)
       {
-        xfer += (*_iter2477).write(oprot);
+        xfer += (*_iter2484).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -62970,14 +62986,14 @@ uint32_t ThriftHiveMetastore_get_all_write_event_info_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2478;
-            ::apache::thrift::protocol::TType _etype2481;
-            xfer += iprot->readListBegin(_etype2481, _size2478);
-            (*(this->success)).resize(_size2478);
-            uint32_t _i2482;
-            for (_i2482 = 0; _i2482 < _size2478; ++_i2482)
+            uint32_t _size2485;
+            ::apache::thrift::protocol::TType _etype2488;
+            xfer += iprot->readListBegin(_etype2488, _size2485);
+            (*(this->success)).resize(_size2485);
+            uint32_t _i2489;
+            for (_i2489 = 0; _i2489 < _size2485; ++_i2489)
             {
-              xfer += (*(this->success))[_i2482].read(iprot);
+              xfer += (*(this->success))[_i2489].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -66521,19 +66537,20 @@ void ThriftHiveMetastoreClient::recv_get_table_objects_by_name_req(GetTablesResu
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "get_table_objects_by_name_req failed: unknown result");
 }
 
-void ThriftHiveMetastoreClient::get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata)
+void ThriftHiveMetastoreClient::get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList)
 {
-  send_get_materialization_invalidation_info(creation_metadata);
+  send_get_materialization_invalidation_info(creation_metadata, validTxnList);
   recv_get_materialization_invalidation_info(_return);
 }
 
-void ThriftHiveMetastoreClient::send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata)
+void ThriftHiveMetastoreClient::send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata, const std::string& validTxnList)
 {
   int32_t cseqid = 0;
   oprot_->writeMessageBegin("get_materialization_invalidation_info", ::apache::thrift::protocol::T_CALL, cseqid);
 
   ThriftHiveMetastore_get_materialization_invalidation_info_pargs args;
   args.creation_metadata = &creation_metadata;
+  args.validTxnList = &validTxnList;
   args.write(oprot_);
 
   oprot_->writeMessageEnd();
@@ -83090,7 +83107,7 @@ void ThriftHiveMetastoreProcessor::process_get_materialization_invalidation_info
 
   ThriftHiveMetastore_get_materialization_invalidation_info_result result;
   try {
-    iface_->get_materialization_invalidation_info(result.success, args.creation_metadata);
+    iface_->get_materialization_invalidation_info(result.success, args.creation_metadata, args.validTxnList);
     result.__isset.success = true;
   } catch (MetaException &o1) {
     result.o1 = o1;
@@ -100533,13 +100550,13 @@ void ThriftHiveMetastoreConcurrentClient::recv_get_table_objects_by_name_req(Get
   } // end while(true)
 }
 
-void ThriftHiveMetastoreConcurrentClient::get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata)
+void ThriftHiveMetastoreConcurrentClient::get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList)
 {
-  int32_t seqid = send_get_materialization_invalidation_info(creation_metadata);
+  int32_t seqid = send_get_materialization_invalidation_info(creation_metadata, validTxnList);
   recv_get_materialization_invalidation_info(_return, seqid);
 }
 
-int32_t ThriftHiveMetastoreConcurrentClient::send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata)
+int32_t ThriftHiveMetastoreConcurrentClient::send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata, const std::string& validTxnList)
 {
   int32_t cseqid = this->sync_->generateSeqId();
   ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
@@ -100547,6 +100564,7 @@ int32_t ThriftHiveMetastoreConcurrentClient::send_get_materialization_invalidati
 
   ThriftHiveMetastore_get_materialization_invalidation_info_pargs args;
   args.creation_metadata = &creation_metadata;
+  args.validTxnList = &validTxnList;
   args.write(oprot_);
 
   oprot_->writeMessageEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.h
@@ -82,7 +82,7 @@ class ThriftHiveMetastoreIf : virtual public  ::facebook::fb303::FacebookService
   virtual void get_tables_ext(std::vector<ExtendedTableInfo> & _return, const GetTablesExtRequest& req) = 0;
   virtual void get_table_req(GetTableResult& _return, const GetTableRequest& req) = 0;
   virtual void get_table_objects_by_name_req(GetTablesResult& _return, const GetTablesRequest& req) = 0;
-  virtual void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata) = 0;
+  virtual void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList) = 0;
   virtual void update_creation_metadata(const std::string& catName, const std::string& dbname, const std::string& tbl_name, const CreationMetadata& creation_metadata) = 0;
   virtual void get_table_names_by_filter(std::vector<std::string> & _return, const std::string& dbname, const std::string& filter, const int16_t max_tables) = 0;
   virtual void alter_table(const std::string& dbname, const std::string& tbl_name, const Table& new_tbl) = 0;
@@ -491,7 +491,7 @@ class ThriftHiveMetastoreNull : virtual public ThriftHiveMetastoreIf , virtual p
   void get_table_objects_by_name_req(GetTablesResult& /* _return */, const GetTablesRequest& /* req */) {
     return;
   }
-  void get_materialization_invalidation_info(Materialization& /* _return */, const CreationMetadata& /* creation_metadata */) {
+  void get_materialization_invalidation_info(Materialization& /* _return */, const CreationMetadata& /* creation_metadata */, const std::string& /* validTxnList */) {
     return;
   }
   void update_creation_metadata(const std::string& /* catName */, const std::string& /* dbname */, const std::string& /* tbl_name */, const CreationMetadata& /* creation_metadata */) {
@@ -7925,8 +7925,9 @@ class ThriftHiveMetastore_get_table_objects_by_name_req_presult {
 };
 
 typedef struct _ThriftHiveMetastore_get_materialization_invalidation_info_args__isset {
-  _ThriftHiveMetastore_get_materialization_invalidation_info_args__isset() : creation_metadata(false) {}
+  _ThriftHiveMetastore_get_materialization_invalidation_info_args__isset() : creation_metadata(false), validTxnList(false) {}
   bool creation_metadata :1;
+  bool validTxnList :1;
 } _ThriftHiveMetastore_get_materialization_invalidation_info_args__isset;
 
 class ThriftHiveMetastore_get_materialization_invalidation_info_args {
@@ -7934,19 +7935,24 @@ class ThriftHiveMetastore_get_materialization_invalidation_info_args {
 
   ThriftHiveMetastore_get_materialization_invalidation_info_args(const ThriftHiveMetastore_get_materialization_invalidation_info_args&);
   ThriftHiveMetastore_get_materialization_invalidation_info_args& operator=(const ThriftHiveMetastore_get_materialization_invalidation_info_args&);
-  ThriftHiveMetastore_get_materialization_invalidation_info_args() {
+  ThriftHiveMetastore_get_materialization_invalidation_info_args() : validTxnList() {
   }
 
   virtual ~ThriftHiveMetastore_get_materialization_invalidation_info_args() noexcept;
   CreationMetadata creation_metadata;
+  std::string validTxnList;
 
   _ThriftHiveMetastore_get_materialization_invalidation_info_args__isset __isset;
 
   void __set_creation_metadata(const CreationMetadata& val);
 
+  void __set_validTxnList(const std::string& val);
+
   bool operator == (const ThriftHiveMetastore_get_materialization_invalidation_info_args & rhs) const
   {
     if (!(creation_metadata == rhs.creation_metadata))
+      return false;
+    if (!(validTxnList == rhs.validTxnList))
       return false;
     return true;
   }
@@ -7968,6 +7974,7 @@ class ThriftHiveMetastore_get_materialization_invalidation_info_pargs {
 
   virtual ~ThriftHiveMetastore_get_materialization_invalidation_info_pargs() noexcept;
   const CreationMetadata* creation_metadata;
+  const std::string* validTxnList;
 
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
 
@@ -33422,8 +33429,8 @@ class ThriftHiveMetastoreClient : virtual public ThriftHiveMetastoreIf, public  
   void get_table_objects_by_name_req(GetTablesResult& _return, const GetTablesRequest& req);
   void send_get_table_objects_by_name_req(const GetTablesRequest& req);
   void recv_get_table_objects_by_name_req(GetTablesResult& _return);
-  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata);
-  void send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata);
+  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList);
+  void send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata, const std::string& validTxnList);
   void recv_get_materialization_invalidation_info(Materialization& _return);
   void update_creation_metadata(const std::string& catName, const std::string& dbname, const std::string& tbl_name, const CreationMetadata& creation_metadata);
   void send_update_creation_metadata(const std::string& catName, const std::string& dbname, const std::string& tbl_name, const CreationMetadata& creation_metadata);
@@ -35165,13 +35172,13 @@ class ThriftHiveMetastoreMultiface : virtual public ThriftHiveMetastoreIf, publi
     return;
   }
 
-  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata) {
+  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList) {
     size_t sz = ifaces_.size();
     size_t i = 0;
     for (; i < (sz - 1); ++i) {
-      ifaces_[i]->get_materialization_invalidation_info(_return, creation_metadata);
+      ifaces_[i]->get_materialization_invalidation_info(_return, creation_metadata, validTxnList);
     }
-    ifaces_[i]->get_materialization_invalidation_info(_return, creation_metadata);
+    ifaces_[i]->get_materialization_invalidation_info(_return, creation_metadata, validTxnList);
     return;
   }
 
@@ -37374,8 +37381,8 @@ class ThriftHiveMetastoreConcurrentClient : virtual public ThriftHiveMetastoreIf
   void get_table_objects_by_name_req(GetTablesResult& _return, const GetTablesRequest& req);
   int32_t send_get_table_objects_by_name_req(const GetTablesRequest& req);
   void recv_get_table_objects_by_name_req(GetTablesResult& _return, const int32_t seqid);
-  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata);
-  int32_t send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata);
+  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList);
+  int32_t send_get_materialization_invalidation_info(const CreationMetadata& creation_metadata, const std::string& validTxnList);
   void recv_get_materialization_invalidation_info(Materialization& _return, const int32_t seqid);
   void update_creation_metadata(const std::string& catName, const std::string& dbname, const std::string& tbl_name, const CreationMetadata& creation_metadata);
   int32_t send_update_creation_metadata(const std::string& catName, const std::string& dbname, const std::string& tbl_name, const CreationMetadata& creation_metadata);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore_server.skeleton.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore_server.skeleton.cpp
@@ -300,7 +300,7 @@ class ThriftHiveMetastoreHandler : virtual public ThriftHiveMetastoreIf {
     printf("get_table_objects_by_name_req\n");
   }
 
-  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata) {
+  void get_materialization_invalidation_info(Materialization& _return, const CreationMetadata& creation_metadata, const std::string& validTxnList) {
     // Your implementation goes here
     printf("get_materialization_invalidation_info\n");
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -8230,7 +8230,7 @@ void CreationMetadata::__set_tblName(const std::string& val) {
   this->tblName = val;
 }
 
-void CreationMetadata::__set_tablesUsed(const std::set<SourceTable> & val) {
+void CreationMetadata::__set_tablesUsed(const std::set<std::string> & val) {
   this->tablesUsed = val;
 }
 
@@ -8242,6 +8242,11 @@ __isset.validTxnList = true;
 void CreationMetadata::__set_materializationTime(const int64_t val) {
   this->materializationTime = val;
 __isset.materializationTime = true;
+}
+
+void CreationMetadata::__set_sourceTables(const std::set<SourceTable> & val) {
+  this->sourceTables = val;
+__isset.sourceTables = true;
 }
 std::ostream& operator<<(std::ostream& out, const CreationMetadata& obj)
 {
@@ -8309,8 +8314,8 @@ uint32_t CreationMetadata::read(::apache::thrift::protocol::TProtocol* iprot) {
             uint32_t _i301;
             for (_i301 = 0; _i301 < _size297; ++_i301)
             {
-              SourceTable _elem302;
-              xfer += _elem302.read(iprot);
+              std::string _elem302;
+              xfer += iprot->readString(_elem302);
               this->tablesUsed.insert(_elem302);
             }
             xfer += iprot->readSetEnd();
@@ -8332,6 +8337,27 @@ uint32_t CreationMetadata::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I64) {
           xfer += iprot->readI64(this->materializationTime);
           this->__isset.materializationTime = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_SET) {
+          {
+            this->sourceTables.clear();
+            uint32_t _size303;
+            ::apache::thrift::protocol::TType _etype306;
+            xfer += iprot->readSetBegin(_etype306, _size303);
+            uint32_t _i307;
+            for (_i307 = 0; _i307 < _size303; ++_i307)
+            {
+              SourceTable _elem308;
+              xfer += _elem308.read(iprot);
+              this->sourceTables.insert(_elem308);
+            }
+            xfer += iprot->readSetEnd();
+          }
+          this->__isset.sourceTables = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -8375,11 +8401,11 @@ uint32_t CreationMetadata::write(::apache::thrift::protocol::TProtocol* oprot) c
 
   xfer += oprot->writeFieldBegin("tablesUsed", ::apache::thrift::protocol::T_SET, 4);
   {
-    xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tablesUsed.size()));
-    std::set<SourceTable> ::const_iterator _iter303;
-    for (_iter303 = this->tablesUsed.begin(); _iter303 != this->tablesUsed.end(); ++_iter303)
+    xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tablesUsed.size()));
+    std::set<std::string> ::const_iterator _iter309;
+    for (_iter309 = this->tablesUsed.begin(); _iter309 != this->tablesUsed.end(); ++_iter309)
     {
-      xfer += (*_iter303).write(oprot);
+      xfer += oprot->writeString((*_iter309));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -8395,6 +8421,19 @@ uint32_t CreationMetadata::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeI64(this->materializationTime);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.sourceTables) {
+    xfer += oprot->writeFieldBegin("sourceTables", ::apache::thrift::protocol::T_SET, 7);
+    {
+      xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sourceTables.size()));
+      std::set<SourceTable> ::const_iterator _iter310;
+      for (_iter310 = this->sourceTables.begin(); _iter310 != this->sourceTables.end(); ++_iter310)
+      {
+        xfer += (*_iter310).write(oprot);
+      }
+      xfer += oprot->writeSetEnd();
+    }
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -8408,26 +8447,29 @@ void swap(CreationMetadata &a, CreationMetadata &b) {
   swap(a.tablesUsed, b.tablesUsed);
   swap(a.validTxnList, b.validTxnList);
   swap(a.materializationTime, b.materializationTime);
+  swap(a.sourceTables, b.sourceTables);
   swap(a.__isset, b.__isset);
 }
 
-CreationMetadata::CreationMetadata(const CreationMetadata& other304) {
-  catName = other304.catName;
-  dbName = other304.dbName;
-  tblName = other304.tblName;
-  tablesUsed = other304.tablesUsed;
-  validTxnList = other304.validTxnList;
-  materializationTime = other304.materializationTime;
-  __isset = other304.__isset;
+CreationMetadata::CreationMetadata(const CreationMetadata& other311) {
+  catName = other311.catName;
+  dbName = other311.dbName;
+  tblName = other311.tblName;
+  tablesUsed = other311.tablesUsed;
+  validTxnList = other311.validTxnList;
+  materializationTime = other311.materializationTime;
+  sourceTables = other311.sourceTables;
+  __isset = other311.__isset;
 }
-CreationMetadata& CreationMetadata::operator=(const CreationMetadata& other305) {
-  catName = other305.catName;
-  dbName = other305.dbName;
-  tblName = other305.tblName;
-  tablesUsed = other305.tablesUsed;
-  validTxnList = other305.validTxnList;
-  materializationTime = other305.materializationTime;
-  __isset = other305.__isset;
+CreationMetadata& CreationMetadata::operator=(const CreationMetadata& other312) {
+  catName = other312.catName;
+  dbName = other312.dbName;
+  tblName = other312.tblName;
+  tablesUsed = other312.tablesUsed;
+  validTxnList = other312.validTxnList;
+  materializationTime = other312.materializationTime;
+  sourceTables = other312.sourceTables;
+  __isset = other312.__isset;
   return *this;
 }
 void CreationMetadata::printTo(std::ostream& out) const {
@@ -8439,6 +8481,7 @@ void CreationMetadata::printTo(std::ostream& out) const {
   out << ", " << "tablesUsed=" << to_string(tablesUsed);
   out << ", " << "validTxnList="; (__isset.validTxnList ? (out << to_string(validTxnList)) : (out << "<null>"));
   out << ", " << "materializationTime="; (__isset.materializationTime ? (out << to_string(materializationTime)) : (out << "<null>"));
+  out << ", " << "sourceTables="; (__isset.sourceTables ? (out << to_string(sourceTables)) : (out << "<null>"));
   out << ")";
 }
 
@@ -8580,19 +8623,19 @@ void swap(BooleanColumnStatsData &a, BooleanColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-BooleanColumnStatsData::BooleanColumnStatsData(const BooleanColumnStatsData& other306) {
-  numTrues = other306.numTrues;
-  numFalses = other306.numFalses;
-  numNulls = other306.numNulls;
-  bitVectors = other306.bitVectors;
-  __isset = other306.__isset;
+BooleanColumnStatsData::BooleanColumnStatsData(const BooleanColumnStatsData& other313) {
+  numTrues = other313.numTrues;
+  numFalses = other313.numFalses;
+  numNulls = other313.numNulls;
+  bitVectors = other313.bitVectors;
+  __isset = other313.__isset;
 }
-BooleanColumnStatsData& BooleanColumnStatsData::operator=(const BooleanColumnStatsData& other307) {
-  numTrues = other307.numTrues;
-  numFalses = other307.numFalses;
-  numNulls = other307.numNulls;
-  bitVectors = other307.bitVectors;
-  __isset = other307.__isset;
+BooleanColumnStatsData& BooleanColumnStatsData::operator=(const BooleanColumnStatsData& other314) {
+  numTrues = other314.numTrues;
+  numFalses = other314.numFalses;
+  numNulls = other314.numNulls;
+  bitVectors = other314.bitVectors;
+  __isset = other314.__isset;
   return *this;
 }
 void BooleanColumnStatsData::printTo(std::ostream& out) const {
@@ -8761,21 +8804,21 @@ void swap(DoubleColumnStatsData &a, DoubleColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DoubleColumnStatsData::DoubleColumnStatsData(const DoubleColumnStatsData& other308) {
-  lowValue = other308.lowValue;
-  highValue = other308.highValue;
-  numNulls = other308.numNulls;
-  numDVs = other308.numDVs;
-  bitVectors = other308.bitVectors;
-  __isset = other308.__isset;
+DoubleColumnStatsData::DoubleColumnStatsData(const DoubleColumnStatsData& other315) {
+  lowValue = other315.lowValue;
+  highValue = other315.highValue;
+  numNulls = other315.numNulls;
+  numDVs = other315.numDVs;
+  bitVectors = other315.bitVectors;
+  __isset = other315.__isset;
 }
-DoubleColumnStatsData& DoubleColumnStatsData::operator=(const DoubleColumnStatsData& other309) {
-  lowValue = other309.lowValue;
-  highValue = other309.highValue;
-  numNulls = other309.numNulls;
-  numDVs = other309.numDVs;
-  bitVectors = other309.bitVectors;
-  __isset = other309.__isset;
+DoubleColumnStatsData& DoubleColumnStatsData::operator=(const DoubleColumnStatsData& other316) {
+  lowValue = other316.lowValue;
+  highValue = other316.highValue;
+  numNulls = other316.numNulls;
+  numDVs = other316.numDVs;
+  bitVectors = other316.bitVectors;
+  __isset = other316.__isset;
   return *this;
 }
 void DoubleColumnStatsData::printTo(std::ostream& out) const {
@@ -8945,21 +8988,21 @@ void swap(LongColumnStatsData &a, LongColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-LongColumnStatsData::LongColumnStatsData(const LongColumnStatsData& other310) {
-  lowValue = other310.lowValue;
-  highValue = other310.highValue;
-  numNulls = other310.numNulls;
-  numDVs = other310.numDVs;
-  bitVectors = other310.bitVectors;
-  __isset = other310.__isset;
+LongColumnStatsData::LongColumnStatsData(const LongColumnStatsData& other317) {
+  lowValue = other317.lowValue;
+  highValue = other317.highValue;
+  numNulls = other317.numNulls;
+  numDVs = other317.numDVs;
+  bitVectors = other317.bitVectors;
+  __isset = other317.__isset;
 }
-LongColumnStatsData& LongColumnStatsData::operator=(const LongColumnStatsData& other311) {
-  lowValue = other311.lowValue;
-  highValue = other311.highValue;
-  numNulls = other311.numNulls;
-  numDVs = other311.numDVs;
-  bitVectors = other311.bitVectors;
-  __isset = other311.__isset;
+LongColumnStatsData& LongColumnStatsData::operator=(const LongColumnStatsData& other318) {
+  lowValue = other318.lowValue;
+  highValue = other318.highValue;
+  numNulls = other318.numNulls;
+  numDVs = other318.numDVs;
+  bitVectors = other318.bitVectors;
+  __isset = other318.__isset;
   return *this;
 }
 void LongColumnStatsData::printTo(std::ostream& out) const {
@@ -9131,21 +9174,21 @@ void swap(StringColumnStatsData &a, StringColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-StringColumnStatsData::StringColumnStatsData(const StringColumnStatsData& other312) {
-  maxColLen = other312.maxColLen;
-  avgColLen = other312.avgColLen;
-  numNulls = other312.numNulls;
-  numDVs = other312.numDVs;
-  bitVectors = other312.bitVectors;
-  __isset = other312.__isset;
+StringColumnStatsData::StringColumnStatsData(const StringColumnStatsData& other319) {
+  maxColLen = other319.maxColLen;
+  avgColLen = other319.avgColLen;
+  numNulls = other319.numNulls;
+  numDVs = other319.numDVs;
+  bitVectors = other319.bitVectors;
+  __isset = other319.__isset;
 }
-StringColumnStatsData& StringColumnStatsData::operator=(const StringColumnStatsData& other313) {
-  maxColLen = other313.maxColLen;
-  avgColLen = other313.avgColLen;
-  numNulls = other313.numNulls;
-  numDVs = other313.numDVs;
-  bitVectors = other313.bitVectors;
-  __isset = other313.__isset;
+StringColumnStatsData& StringColumnStatsData::operator=(const StringColumnStatsData& other320) {
+  maxColLen = other320.maxColLen;
+  avgColLen = other320.avgColLen;
+  numNulls = other320.numNulls;
+  numDVs = other320.numDVs;
+  bitVectors = other320.bitVectors;
+  __isset = other320.__isset;
   return *this;
 }
 void StringColumnStatsData::printTo(std::ostream& out) const {
@@ -9297,19 +9340,19 @@ void swap(BinaryColumnStatsData &a, BinaryColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-BinaryColumnStatsData::BinaryColumnStatsData(const BinaryColumnStatsData& other314) {
-  maxColLen = other314.maxColLen;
-  avgColLen = other314.avgColLen;
-  numNulls = other314.numNulls;
-  bitVectors = other314.bitVectors;
-  __isset = other314.__isset;
+BinaryColumnStatsData::BinaryColumnStatsData(const BinaryColumnStatsData& other321) {
+  maxColLen = other321.maxColLen;
+  avgColLen = other321.avgColLen;
+  numNulls = other321.numNulls;
+  bitVectors = other321.bitVectors;
+  __isset = other321.__isset;
 }
-BinaryColumnStatsData& BinaryColumnStatsData::operator=(const BinaryColumnStatsData& other315) {
-  maxColLen = other315.maxColLen;
-  avgColLen = other315.avgColLen;
-  numNulls = other315.numNulls;
-  bitVectors = other315.bitVectors;
-  __isset = other315.__isset;
+BinaryColumnStatsData& BinaryColumnStatsData::operator=(const BinaryColumnStatsData& other322) {
+  maxColLen = other322.maxColLen;
+  avgColLen = other322.avgColLen;
+  numNulls = other322.numNulls;
+  bitVectors = other322.bitVectors;
+  __isset = other322.__isset;
   return *this;
 }
 void BinaryColumnStatsData::printTo(std::ostream& out) const {
@@ -9420,13 +9463,13 @@ void swap(Decimal &a, Decimal &b) {
   swap(a.unscaled, b.unscaled);
 }
 
-Decimal::Decimal(const Decimal& other316) {
-  scale = other316.scale;
-  unscaled = other316.unscaled;
+Decimal::Decimal(const Decimal& other323) {
+  scale = other323.scale;
+  unscaled = other323.unscaled;
 }
-Decimal& Decimal::operator=(const Decimal& other317) {
-  scale = other317.scale;
-  unscaled = other317.unscaled;
+Decimal& Decimal::operator=(const Decimal& other324) {
+  scale = other324.scale;
+  unscaled = other324.unscaled;
   return *this;
 }
 void Decimal::printTo(std::ostream& out) const {
@@ -9593,21 +9636,21 @@ void swap(DecimalColumnStatsData &a, DecimalColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DecimalColumnStatsData::DecimalColumnStatsData(const DecimalColumnStatsData& other318) {
-  lowValue = other318.lowValue;
-  highValue = other318.highValue;
-  numNulls = other318.numNulls;
-  numDVs = other318.numDVs;
-  bitVectors = other318.bitVectors;
-  __isset = other318.__isset;
+DecimalColumnStatsData::DecimalColumnStatsData(const DecimalColumnStatsData& other325) {
+  lowValue = other325.lowValue;
+  highValue = other325.highValue;
+  numNulls = other325.numNulls;
+  numDVs = other325.numDVs;
+  bitVectors = other325.bitVectors;
+  __isset = other325.__isset;
 }
-DecimalColumnStatsData& DecimalColumnStatsData::operator=(const DecimalColumnStatsData& other319) {
-  lowValue = other319.lowValue;
-  highValue = other319.highValue;
-  numNulls = other319.numNulls;
-  numDVs = other319.numDVs;
-  bitVectors = other319.bitVectors;
-  __isset = other319.__isset;
+DecimalColumnStatsData& DecimalColumnStatsData::operator=(const DecimalColumnStatsData& other326) {
+  lowValue = other326.lowValue;
+  highValue = other326.highValue;
+  numNulls = other326.numNulls;
+  numDVs = other326.numDVs;
+  bitVectors = other326.bitVectors;
+  __isset = other326.__isset;
   return *this;
 }
 void DecimalColumnStatsData::printTo(std::ostream& out) const {
@@ -9699,11 +9742,11 @@ void swap(Date &a, Date &b) {
   swap(a.daysSinceEpoch, b.daysSinceEpoch);
 }
 
-Date::Date(const Date& other320) {
-  daysSinceEpoch = other320.daysSinceEpoch;
+Date::Date(const Date& other327) {
+  daysSinceEpoch = other327.daysSinceEpoch;
 }
-Date& Date::operator=(const Date& other321) {
-  daysSinceEpoch = other321.daysSinceEpoch;
+Date& Date::operator=(const Date& other328) {
+  daysSinceEpoch = other328.daysSinceEpoch;
   return *this;
 }
 void Date::printTo(std::ostream& out) const {
@@ -9869,21 +9912,21 @@ void swap(DateColumnStatsData &a, DateColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-DateColumnStatsData::DateColumnStatsData(const DateColumnStatsData& other322) {
-  lowValue = other322.lowValue;
-  highValue = other322.highValue;
-  numNulls = other322.numNulls;
-  numDVs = other322.numDVs;
-  bitVectors = other322.bitVectors;
-  __isset = other322.__isset;
+DateColumnStatsData::DateColumnStatsData(const DateColumnStatsData& other329) {
+  lowValue = other329.lowValue;
+  highValue = other329.highValue;
+  numNulls = other329.numNulls;
+  numDVs = other329.numDVs;
+  bitVectors = other329.bitVectors;
+  __isset = other329.__isset;
 }
-DateColumnStatsData& DateColumnStatsData::operator=(const DateColumnStatsData& other323) {
-  lowValue = other323.lowValue;
-  highValue = other323.highValue;
-  numNulls = other323.numNulls;
-  numDVs = other323.numDVs;
-  bitVectors = other323.bitVectors;
-  __isset = other323.__isset;
+DateColumnStatsData& DateColumnStatsData::operator=(const DateColumnStatsData& other330) {
+  lowValue = other330.lowValue;
+  highValue = other330.highValue;
+  numNulls = other330.numNulls;
+  numDVs = other330.numDVs;
+  bitVectors = other330.bitVectors;
+  __isset = other330.__isset;
   return *this;
 }
 void DateColumnStatsData::printTo(std::ostream& out) const {
@@ -9975,11 +10018,11 @@ void swap(Timestamp &a, Timestamp &b) {
   swap(a.secondsSinceEpoch, b.secondsSinceEpoch);
 }
 
-Timestamp::Timestamp(const Timestamp& other324) {
-  secondsSinceEpoch = other324.secondsSinceEpoch;
+Timestamp::Timestamp(const Timestamp& other331) {
+  secondsSinceEpoch = other331.secondsSinceEpoch;
 }
-Timestamp& Timestamp::operator=(const Timestamp& other325) {
-  secondsSinceEpoch = other325.secondsSinceEpoch;
+Timestamp& Timestamp::operator=(const Timestamp& other332) {
+  secondsSinceEpoch = other332.secondsSinceEpoch;
   return *this;
 }
 void Timestamp::printTo(std::ostream& out) const {
@@ -10145,21 +10188,21 @@ void swap(TimestampColumnStatsData &a, TimestampColumnStatsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-TimestampColumnStatsData::TimestampColumnStatsData(const TimestampColumnStatsData& other326) {
-  lowValue = other326.lowValue;
-  highValue = other326.highValue;
-  numNulls = other326.numNulls;
-  numDVs = other326.numDVs;
-  bitVectors = other326.bitVectors;
-  __isset = other326.__isset;
+TimestampColumnStatsData::TimestampColumnStatsData(const TimestampColumnStatsData& other333) {
+  lowValue = other333.lowValue;
+  highValue = other333.highValue;
+  numNulls = other333.numNulls;
+  numDVs = other333.numDVs;
+  bitVectors = other333.bitVectors;
+  __isset = other333.__isset;
 }
-TimestampColumnStatsData& TimestampColumnStatsData::operator=(const TimestampColumnStatsData& other327) {
-  lowValue = other327.lowValue;
-  highValue = other327.highValue;
-  numNulls = other327.numNulls;
-  numDVs = other327.numDVs;
-  bitVectors = other327.bitVectors;
-  __isset = other327.__isset;
+TimestampColumnStatsData& TimestampColumnStatsData::operator=(const TimestampColumnStatsData& other334) {
+  lowValue = other334.lowValue;
+  highValue = other334.highValue;
+  numNulls = other334.numNulls;
+  numDVs = other334.numDVs;
+  bitVectors = other334.bitVectors;
+  __isset = other334.__isset;
   return *this;
 }
 void TimestampColumnStatsData::printTo(std::ostream& out) const {
@@ -10384,27 +10427,27 @@ void swap(ColumnStatisticsData &a, ColumnStatisticsData &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatisticsData::ColumnStatisticsData(const ColumnStatisticsData& other328) {
-  booleanStats = other328.booleanStats;
-  longStats = other328.longStats;
-  doubleStats = other328.doubleStats;
-  stringStats = other328.stringStats;
-  binaryStats = other328.binaryStats;
-  decimalStats = other328.decimalStats;
-  dateStats = other328.dateStats;
-  timestampStats = other328.timestampStats;
-  __isset = other328.__isset;
+ColumnStatisticsData::ColumnStatisticsData(const ColumnStatisticsData& other335) {
+  booleanStats = other335.booleanStats;
+  longStats = other335.longStats;
+  doubleStats = other335.doubleStats;
+  stringStats = other335.stringStats;
+  binaryStats = other335.binaryStats;
+  decimalStats = other335.decimalStats;
+  dateStats = other335.dateStats;
+  timestampStats = other335.timestampStats;
+  __isset = other335.__isset;
 }
-ColumnStatisticsData& ColumnStatisticsData::operator=(const ColumnStatisticsData& other329) {
-  booleanStats = other329.booleanStats;
-  longStats = other329.longStats;
-  doubleStats = other329.doubleStats;
-  stringStats = other329.stringStats;
-  binaryStats = other329.binaryStats;
-  decimalStats = other329.decimalStats;
-  dateStats = other329.dateStats;
-  timestampStats = other329.timestampStats;
-  __isset = other329.__isset;
+ColumnStatisticsData& ColumnStatisticsData::operator=(const ColumnStatisticsData& other336) {
+  booleanStats = other336.booleanStats;
+  longStats = other336.longStats;
+  doubleStats = other336.doubleStats;
+  stringStats = other336.stringStats;
+  binaryStats = other336.binaryStats;
+  decimalStats = other336.decimalStats;
+  dateStats = other336.dateStats;
+  timestampStats = other336.timestampStats;
+  __isset = other336.__isset;
   return *this;
 }
 void ColumnStatisticsData::printTo(std::ostream& out) const {
@@ -10539,15 +10582,15 @@ void swap(ColumnStatisticsObj &a, ColumnStatisticsObj &b) {
   swap(a.statsData, b.statsData);
 }
 
-ColumnStatisticsObj::ColumnStatisticsObj(const ColumnStatisticsObj& other330) {
-  colName = other330.colName;
-  colType = other330.colType;
-  statsData = other330.statsData;
+ColumnStatisticsObj::ColumnStatisticsObj(const ColumnStatisticsObj& other337) {
+  colName = other337.colName;
+  colType = other337.colType;
+  statsData = other337.statsData;
 }
-ColumnStatisticsObj& ColumnStatisticsObj::operator=(const ColumnStatisticsObj& other331) {
-  colName = other331.colName;
-  colType = other331.colType;
-  statsData = other331.statsData;
+ColumnStatisticsObj& ColumnStatisticsObj::operator=(const ColumnStatisticsObj& other338) {
+  colName = other338.colName;
+  colType = other338.colType;
+  statsData = other338.statsData;
   return *this;
 }
 void ColumnStatisticsObj::printTo(std::ostream& out) const {
@@ -10735,23 +10778,23 @@ void swap(ColumnStatisticsDesc &a, ColumnStatisticsDesc &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatisticsDesc::ColumnStatisticsDesc(const ColumnStatisticsDesc& other332) {
-  isTblLevel = other332.isTblLevel;
-  dbName = other332.dbName;
-  tableName = other332.tableName;
-  partName = other332.partName;
-  lastAnalyzed = other332.lastAnalyzed;
-  catName = other332.catName;
-  __isset = other332.__isset;
+ColumnStatisticsDesc::ColumnStatisticsDesc(const ColumnStatisticsDesc& other339) {
+  isTblLevel = other339.isTblLevel;
+  dbName = other339.dbName;
+  tableName = other339.tableName;
+  partName = other339.partName;
+  lastAnalyzed = other339.lastAnalyzed;
+  catName = other339.catName;
+  __isset = other339.__isset;
 }
-ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc& other333) {
-  isTblLevel = other333.isTblLevel;
-  dbName = other333.dbName;
-  tableName = other333.tableName;
-  partName = other333.partName;
-  lastAnalyzed = other333.lastAnalyzed;
-  catName = other333.catName;
-  __isset = other333.__isset;
+ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc& other340) {
+  isTblLevel = other340.isTblLevel;
+  dbName = other340.dbName;
+  tableName = other340.tableName;
+  partName = other340.partName;
+  lastAnalyzed = other340.lastAnalyzed;
+  catName = other340.catName;
+  __isset = other340.__isset;
   return *this;
 }
 void ColumnStatisticsDesc::printTo(std::ostream& out) const {
@@ -10830,14 +10873,14 @@ uint32_t ColumnStatistics::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->statsObj.clear();
-            uint32_t _size334;
-            ::apache::thrift::protocol::TType _etype337;
-            xfer += iprot->readListBegin(_etype337, _size334);
-            this->statsObj.resize(_size334);
-            uint32_t _i338;
-            for (_i338 = 0; _i338 < _size334; ++_i338)
+            uint32_t _size341;
+            ::apache::thrift::protocol::TType _etype344;
+            xfer += iprot->readListBegin(_etype344, _size341);
+            this->statsObj.resize(_size341);
+            uint32_t _i345;
+            for (_i345 = 0; _i345 < _size341; ++_i345)
             {
-              xfer += this->statsObj[_i338].read(iprot);
+              xfer += this->statsObj[_i345].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -10890,10 +10933,10 @@ uint32_t ColumnStatistics::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("statsObj", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->statsObj.size()));
-    std::vector<ColumnStatisticsObj> ::const_iterator _iter339;
-    for (_iter339 = this->statsObj.begin(); _iter339 != this->statsObj.end(); ++_iter339)
+    std::vector<ColumnStatisticsObj> ::const_iterator _iter346;
+    for (_iter346 = this->statsObj.begin(); _iter346 != this->statsObj.end(); ++_iter346)
     {
-      xfer += (*_iter339).write(oprot);
+      xfer += (*_iter346).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -10923,19 +10966,19 @@ void swap(ColumnStatistics &a, ColumnStatistics &b) {
   swap(a.__isset, b.__isset);
 }
 
-ColumnStatistics::ColumnStatistics(const ColumnStatistics& other340) {
-  statsDesc = other340.statsDesc;
-  statsObj = other340.statsObj;
-  isStatsCompliant = other340.isStatsCompliant;
-  engine = other340.engine;
-  __isset = other340.__isset;
+ColumnStatistics::ColumnStatistics(const ColumnStatistics& other347) {
+  statsDesc = other347.statsDesc;
+  statsObj = other347.statsObj;
+  isStatsCompliant = other347.isStatsCompliant;
+  engine = other347.engine;
+  __isset = other347.__isset;
 }
-ColumnStatistics& ColumnStatistics::operator=(const ColumnStatistics& other341) {
-  statsDesc = other341.statsDesc;
-  statsObj = other341.statsObj;
-  isStatsCompliant = other341.isStatsCompliant;
-  engine = other341.engine;
-  __isset = other341.__isset;
+ColumnStatistics& ColumnStatistics::operator=(const ColumnStatistics& other348) {
+  statsDesc = other348.statsDesc;
+  statsObj = other348.statsObj;
+  isStatsCompliant = other348.isStatsCompliant;
+  engine = other348.engine;
+  __isset = other348.__isset;
   return *this;
 }
 void ColumnStatistics::printTo(std::ostream& out) const {
@@ -11012,14 +11055,14 @@ uint32_t FileMetadata::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->data.clear();
-            uint32_t _size342;
-            ::apache::thrift::protocol::TType _etype345;
-            xfer += iprot->readListBegin(_etype345, _size342);
-            this->data.resize(_size342);
-            uint32_t _i346;
-            for (_i346 = 0; _i346 < _size342; ++_i346)
+            uint32_t _size349;
+            ::apache::thrift::protocol::TType _etype352;
+            xfer += iprot->readListBegin(_etype352, _size349);
+            this->data.resize(_size349);
+            uint32_t _i353;
+            for (_i353 = 0; _i353 < _size349; ++_i353)
             {
-              xfer += iprot->readBinary(this->data[_i346]);
+              xfer += iprot->readBinary(this->data[_i353]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11056,10 +11099,10 @@ uint32_t FileMetadata::write(::apache::thrift::protocol::TProtocol* oprot) const
   xfer += oprot->writeFieldBegin("data", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->data.size()));
-    std::vector<std::string> ::const_iterator _iter347;
-    for (_iter347 = this->data.begin(); _iter347 != this->data.end(); ++_iter347)
+    std::vector<std::string> ::const_iterator _iter354;
+    for (_iter354 = this->data.begin(); _iter354 != this->data.end(); ++_iter354)
     {
-      xfer += oprot->writeBinary((*_iter347));
+      xfer += oprot->writeBinary((*_iter354));
     }
     xfer += oprot->writeListEnd();
   }
@@ -11078,17 +11121,17 @@ void swap(FileMetadata &a, FileMetadata &b) {
   swap(a.__isset, b.__isset);
 }
 
-FileMetadata::FileMetadata(const FileMetadata& other348) {
-  type = other348.type;
-  version = other348.version;
-  data = other348.data;
-  __isset = other348.__isset;
+FileMetadata::FileMetadata(const FileMetadata& other355) {
+  type = other355.type;
+  version = other355.version;
+  data = other355.data;
+  __isset = other355.__isset;
 }
-FileMetadata& FileMetadata::operator=(const FileMetadata& other349) {
-  type = other349.type;
-  version = other349.version;
-  data = other349.data;
-  __isset = other349.__isset;
+FileMetadata& FileMetadata::operator=(const FileMetadata& other356) {
+  type = other356.type;
+  version = other356.version;
+  data = other356.data;
+  __isset = other356.__isset;
   return *this;
 }
 void FileMetadata::printTo(std::ostream& out) const {
@@ -11141,26 +11184,26 @@ uint32_t ObjectDictionary::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->values.clear();
-            uint32_t _size350;
-            ::apache::thrift::protocol::TType _ktype351;
-            ::apache::thrift::protocol::TType _vtype352;
-            xfer += iprot->readMapBegin(_ktype351, _vtype352, _size350);
-            uint32_t _i354;
-            for (_i354 = 0; _i354 < _size350; ++_i354)
+            uint32_t _size357;
+            ::apache::thrift::protocol::TType _ktype358;
+            ::apache::thrift::protocol::TType _vtype359;
+            xfer += iprot->readMapBegin(_ktype358, _vtype359, _size357);
+            uint32_t _i361;
+            for (_i361 = 0; _i361 < _size357; ++_i361)
             {
-              std::string _key355;
-              xfer += iprot->readString(_key355);
-              std::vector<std::string> & _val356 = this->values[_key355];
+              std::string _key362;
+              xfer += iprot->readString(_key362);
+              std::vector<std::string> & _val363 = this->values[_key362];
               {
-                _val356.clear();
-                uint32_t _size357;
-                ::apache::thrift::protocol::TType _etype360;
-                xfer += iprot->readListBegin(_etype360, _size357);
-                _val356.resize(_size357);
-                uint32_t _i361;
-                for (_i361 = 0; _i361 < _size357; ++_i361)
+                _val363.clear();
+                uint32_t _size364;
+                ::apache::thrift::protocol::TType _etype367;
+                xfer += iprot->readListBegin(_etype367, _size364);
+                _val363.resize(_size364);
+                uint32_t _i368;
+                for (_i368 = 0; _i368 < _size364; ++_i368)
                 {
-                  xfer += iprot->readBinary(_val356[_i361]);
+                  xfer += iprot->readBinary(_val363[_i368]);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -11194,16 +11237,16 @@ uint32_t ObjectDictionary::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->values.size()));
-    std::map<std::string, std::vector<std::string> > ::const_iterator _iter362;
-    for (_iter362 = this->values.begin(); _iter362 != this->values.end(); ++_iter362)
+    std::map<std::string, std::vector<std::string> > ::const_iterator _iter369;
+    for (_iter369 = this->values.begin(); _iter369 != this->values.end(); ++_iter369)
     {
-      xfer += oprot->writeString(_iter362->first);
+      xfer += oprot->writeString(_iter369->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter362->second.size()));
-        std::vector<std::string> ::const_iterator _iter363;
-        for (_iter363 = _iter362->second.begin(); _iter363 != _iter362->second.end(); ++_iter363)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(_iter369->second.size()));
+        std::vector<std::string> ::const_iterator _iter370;
+        for (_iter370 = _iter369->second.begin(); _iter370 != _iter369->second.end(); ++_iter370)
         {
-          xfer += oprot->writeBinary((*_iter363));
+          xfer += oprot->writeBinary((*_iter370));
         }
         xfer += oprot->writeListEnd();
       }
@@ -11222,11 +11265,11 @@ void swap(ObjectDictionary &a, ObjectDictionary &b) {
   swap(a.values, b.values);
 }
 
-ObjectDictionary::ObjectDictionary(const ObjectDictionary& other364) {
-  values = other364.values;
+ObjectDictionary::ObjectDictionary(const ObjectDictionary& other371) {
+  values = other371.values;
 }
-ObjectDictionary& ObjectDictionary::operator=(const ObjectDictionary& other365) {
-  values = other365.values;
+ObjectDictionary& ObjectDictionary::operator=(const ObjectDictionary& other372) {
+  values = other372.values;
   return *this;
 }
 void ObjectDictionary::printTo(std::ostream& out) const {
@@ -11451,14 +11494,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionKeys.clear();
-            uint32_t _size366;
-            ::apache::thrift::protocol::TType _etype369;
-            xfer += iprot->readListBegin(_etype369, _size366);
-            this->partitionKeys.resize(_size366);
-            uint32_t _i370;
-            for (_i370 = 0; _i370 < _size366; ++_i370)
+            uint32_t _size373;
+            ::apache::thrift::protocol::TType _etype376;
+            xfer += iprot->readListBegin(_etype376, _size373);
+            this->partitionKeys.resize(_size373);
+            uint32_t _i377;
+            for (_i377 = 0; _i377 < _size373; ++_i377)
             {
-              xfer += this->partitionKeys[_i370].read(iprot);
+              xfer += this->partitionKeys[_i377].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11471,17 +11514,17 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size371;
-            ::apache::thrift::protocol::TType _ktype372;
-            ::apache::thrift::protocol::TType _vtype373;
-            xfer += iprot->readMapBegin(_ktype372, _vtype373, _size371);
-            uint32_t _i375;
-            for (_i375 = 0; _i375 < _size371; ++_i375)
+            uint32_t _size378;
+            ::apache::thrift::protocol::TType _ktype379;
+            ::apache::thrift::protocol::TType _vtype380;
+            xfer += iprot->readMapBegin(_ktype379, _vtype380, _size378);
+            uint32_t _i382;
+            for (_i382 = 0; _i382 < _size378; ++_i382)
             {
-              std::string _key376;
-              xfer += iprot->readString(_key376);
-              std::string& _val377 = this->parameters[_key376];
-              xfer += iprot->readString(_val377);
+              std::string _key383;
+              xfer += iprot->readString(_key383);
+              std::string& _val384 = this->parameters[_key383];
+              xfer += iprot->readString(_val384);
             }
             xfer += iprot->readMapEnd();
           }
@@ -11556,9 +11599,9 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 18:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast378;
-          xfer += iprot->readI32(ecast378);
-          this->ownerType = (PrincipalType::type)ecast378;
+          int32_t ecast385;
+          xfer += iprot->readI32(ecast385);
+          this->ownerType = (PrincipalType::type)ecast385;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -11600,14 +11643,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredReadCapabilities.clear();
-            uint32_t _size379;
-            ::apache::thrift::protocol::TType _etype382;
-            xfer += iprot->readListBegin(_etype382, _size379);
-            this->requiredReadCapabilities.resize(_size379);
-            uint32_t _i383;
-            for (_i383 = 0; _i383 < _size379; ++_i383)
+            uint32_t _size386;
+            ::apache::thrift::protocol::TType _etype389;
+            xfer += iprot->readListBegin(_etype389, _size386);
+            this->requiredReadCapabilities.resize(_size386);
+            uint32_t _i390;
+            for (_i390 = 0; _i390 < _size386; ++_i390)
             {
-              xfer += iprot->readString(this->requiredReadCapabilities[_i383]);
+              xfer += iprot->readString(this->requiredReadCapabilities[_i390]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11620,14 +11663,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredWriteCapabilities.clear();
-            uint32_t _size384;
-            ::apache::thrift::protocol::TType _etype387;
-            xfer += iprot->readListBegin(_etype387, _size384);
-            this->requiredWriteCapabilities.resize(_size384);
-            uint32_t _i388;
-            for (_i388 = 0; _i388 < _size384; ++_i388)
+            uint32_t _size391;
+            ::apache::thrift::protocol::TType _etype394;
+            xfer += iprot->readListBegin(_etype394, _size391);
+            this->requiredWriteCapabilities.resize(_size391);
+            uint32_t _i395;
+            for (_i395 = 0; _i395 < _size391; ++_i395)
             {
-              xfer += iprot->readString(this->requiredWriteCapabilities[_i388]);
+              xfer += iprot->readString(this->requiredWriteCapabilities[_i395]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11708,10 +11751,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("partitionKeys", ::apache::thrift::protocol::T_LIST, 8);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionKeys.size()));
-    std::vector<FieldSchema> ::const_iterator _iter389;
-    for (_iter389 = this->partitionKeys.begin(); _iter389 != this->partitionKeys.end(); ++_iter389)
+    std::vector<FieldSchema> ::const_iterator _iter396;
+    for (_iter396 = this->partitionKeys.begin(); _iter396 != this->partitionKeys.end(); ++_iter396)
     {
-      xfer += (*_iter389).write(oprot);
+      xfer += (*_iter396).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -11720,11 +11763,11 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 9);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter390;
-    for (_iter390 = this->parameters.begin(); _iter390 != this->parameters.end(); ++_iter390)
+    std::map<std::string, std::string> ::const_iterator _iter397;
+    for (_iter397 = this->parameters.begin(); _iter397 != this->parameters.end(); ++_iter397)
     {
-      xfer += oprot->writeString(_iter390->first);
-      xfer += oprot->writeString(_iter390->second);
+      xfer += oprot->writeString(_iter397->first);
+      xfer += oprot->writeString(_iter397->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -11796,10 +11839,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("requiredReadCapabilities", ::apache::thrift::protocol::T_LIST, 23);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredReadCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter391;
-      for (_iter391 = this->requiredReadCapabilities.begin(); _iter391 != this->requiredReadCapabilities.end(); ++_iter391)
+      std::vector<std::string> ::const_iterator _iter398;
+      for (_iter398 = this->requiredReadCapabilities.begin(); _iter398 != this->requiredReadCapabilities.end(); ++_iter398)
       {
-        xfer += oprot->writeString((*_iter391));
+        xfer += oprot->writeString((*_iter398));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11809,10 +11852,10 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("requiredWriteCapabilities", ::apache::thrift::protocol::T_LIST, 24);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredWriteCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter392;
-      for (_iter392 = this->requiredWriteCapabilities.begin(); _iter392 != this->requiredWriteCapabilities.end(); ++_iter392)
+      std::vector<std::string> ::const_iterator _iter399;
+      for (_iter399 = this->requiredWriteCapabilities.begin(); _iter399 != this->requiredWriteCapabilities.end(); ++_iter399)
       {
-        xfer += oprot->writeString((*_iter392));
+        xfer += oprot->writeString((*_iter399));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11870,65 +11913,65 @@ void swap(Table &a, Table &b) {
   swap(a.__isset, b.__isset);
 }
 
-Table::Table(const Table& other393) {
-  tableName = other393.tableName;
-  dbName = other393.dbName;
-  owner = other393.owner;
-  createTime = other393.createTime;
-  lastAccessTime = other393.lastAccessTime;
-  retention = other393.retention;
-  sd = other393.sd;
-  partitionKeys = other393.partitionKeys;
-  parameters = other393.parameters;
-  viewOriginalText = other393.viewOriginalText;
-  viewExpandedText = other393.viewExpandedText;
-  tableType = other393.tableType;
-  privileges = other393.privileges;
-  temporary = other393.temporary;
-  rewriteEnabled = other393.rewriteEnabled;
-  creationMetadata = other393.creationMetadata;
-  catName = other393.catName;
-  ownerType = other393.ownerType;
-  writeId = other393.writeId;
-  isStatsCompliant = other393.isStatsCompliant;
-  colStats = other393.colStats;
-  accessType = other393.accessType;
-  requiredReadCapabilities = other393.requiredReadCapabilities;
-  requiredWriteCapabilities = other393.requiredWriteCapabilities;
-  id = other393.id;
-  fileMetadata = other393.fileMetadata;
-  dictionary = other393.dictionary;
-  __isset = other393.__isset;
+Table::Table(const Table& other400) {
+  tableName = other400.tableName;
+  dbName = other400.dbName;
+  owner = other400.owner;
+  createTime = other400.createTime;
+  lastAccessTime = other400.lastAccessTime;
+  retention = other400.retention;
+  sd = other400.sd;
+  partitionKeys = other400.partitionKeys;
+  parameters = other400.parameters;
+  viewOriginalText = other400.viewOriginalText;
+  viewExpandedText = other400.viewExpandedText;
+  tableType = other400.tableType;
+  privileges = other400.privileges;
+  temporary = other400.temporary;
+  rewriteEnabled = other400.rewriteEnabled;
+  creationMetadata = other400.creationMetadata;
+  catName = other400.catName;
+  ownerType = other400.ownerType;
+  writeId = other400.writeId;
+  isStatsCompliant = other400.isStatsCompliant;
+  colStats = other400.colStats;
+  accessType = other400.accessType;
+  requiredReadCapabilities = other400.requiredReadCapabilities;
+  requiredWriteCapabilities = other400.requiredWriteCapabilities;
+  id = other400.id;
+  fileMetadata = other400.fileMetadata;
+  dictionary = other400.dictionary;
+  __isset = other400.__isset;
 }
-Table& Table::operator=(const Table& other394) {
-  tableName = other394.tableName;
-  dbName = other394.dbName;
-  owner = other394.owner;
-  createTime = other394.createTime;
-  lastAccessTime = other394.lastAccessTime;
-  retention = other394.retention;
-  sd = other394.sd;
-  partitionKeys = other394.partitionKeys;
-  parameters = other394.parameters;
-  viewOriginalText = other394.viewOriginalText;
-  viewExpandedText = other394.viewExpandedText;
-  tableType = other394.tableType;
-  privileges = other394.privileges;
-  temporary = other394.temporary;
-  rewriteEnabled = other394.rewriteEnabled;
-  creationMetadata = other394.creationMetadata;
-  catName = other394.catName;
-  ownerType = other394.ownerType;
-  writeId = other394.writeId;
-  isStatsCompliant = other394.isStatsCompliant;
-  colStats = other394.colStats;
-  accessType = other394.accessType;
-  requiredReadCapabilities = other394.requiredReadCapabilities;
-  requiredWriteCapabilities = other394.requiredWriteCapabilities;
-  id = other394.id;
-  fileMetadata = other394.fileMetadata;
-  dictionary = other394.dictionary;
-  __isset = other394.__isset;
+Table& Table::operator=(const Table& other401) {
+  tableName = other401.tableName;
+  dbName = other401.dbName;
+  owner = other401.owner;
+  createTime = other401.createTime;
+  lastAccessTime = other401.lastAccessTime;
+  retention = other401.retention;
+  sd = other401.sd;
+  partitionKeys = other401.partitionKeys;
+  parameters = other401.parameters;
+  viewOriginalText = other401.viewOriginalText;
+  viewExpandedText = other401.viewExpandedText;
+  tableType = other401.tableType;
+  privileges = other401.privileges;
+  temporary = other401.temporary;
+  rewriteEnabled = other401.rewriteEnabled;
+  creationMetadata = other401.creationMetadata;
+  catName = other401.catName;
+  ownerType = other401.ownerType;
+  writeId = other401.writeId;
+  isStatsCompliant = other401.isStatsCompliant;
+  colStats = other401.colStats;
+  accessType = other401.accessType;
+  requiredReadCapabilities = other401.requiredReadCapabilities;
+  requiredWriteCapabilities = other401.requiredWriteCapabilities;
+  id = other401.id;
+  fileMetadata = other401.fileMetadata;
+  dictionary = other401.dictionary;
+  __isset = other401.__isset;
   return *this;
 }
 void Table::printTo(std::ostream& out) const {
@@ -12058,14 +12101,14 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size395;
-            ::apache::thrift::protocol::TType _etype398;
-            xfer += iprot->readListBegin(_etype398, _size395);
-            this->values.resize(_size395);
-            uint32_t _i399;
-            for (_i399 = 0; _i399 < _size395; ++_i399)
+            uint32_t _size402;
+            ::apache::thrift::protocol::TType _etype405;
+            xfer += iprot->readListBegin(_etype405, _size402);
+            this->values.resize(_size402);
+            uint32_t _i406;
+            for (_i406 = 0; _i406 < _size402; ++_i406)
             {
-              xfer += iprot->readString(this->values[_i399]);
+              xfer += iprot->readString(this->values[_i406]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12118,17 +12161,17 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size400;
-            ::apache::thrift::protocol::TType _ktype401;
-            ::apache::thrift::protocol::TType _vtype402;
-            xfer += iprot->readMapBegin(_ktype401, _vtype402, _size400);
-            uint32_t _i404;
-            for (_i404 = 0; _i404 < _size400; ++_i404)
+            uint32_t _size407;
+            ::apache::thrift::protocol::TType _ktype408;
+            ::apache::thrift::protocol::TType _vtype409;
+            xfer += iprot->readMapBegin(_ktype408, _vtype409, _size407);
+            uint32_t _i411;
+            for (_i411 = 0; _i411 < _size407; ++_i411)
             {
-              std::string _key405;
-              xfer += iprot->readString(_key405);
-              std::string& _val406 = this->parameters[_key405];
-              xfer += iprot->readString(_val406);
+              std::string _key412;
+              xfer += iprot->readString(_key412);
+              std::string& _val413 = this->parameters[_key412];
+              xfer += iprot->readString(_val413);
             }
             xfer += iprot->readMapEnd();
           }
@@ -12205,10 +12248,10 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->values.size()));
-    std::vector<std::string> ::const_iterator _iter407;
-    for (_iter407 = this->values.begin(); _iter407 != this->values.end(); ++_iter407)
+    std::vector<std::string> ::const_iterator _iter414;
+    for (_iter414 = this->values.begin(); _iter414 != this->values.end(); ++_iter414)
     {
-      xfer += oprot->writeString((*_iter407));
+      xfer += oprot->writeString((*_iter414));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12237,11 +12280,11 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 7);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter408;
-    for (_iter408 = this->parameters.begin(); _iter408 != this->parameters.end(); ++_iter408)
+    std::map<std::string, std::string> ::const_iterator _iter415;
+    for (_iter415 = this->parameters.begin(); _iter415 != this->parameters.end(); ++_iter415)
     {
-      xfer += oprot->writeString(_iter408->first);
-      xfer += oprot->writeString(_iter408->second);
+      xfer += oprot->writeString(_iter415->first);
+      xfer += oprot->writeString(_iter415->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -12300,37 +12343,37 @@ void swap(Partition &a, Partition &b) {
   swap(a.__isset, b.__isset);
 }
 
-Partition::Partition(const Partition& other409) {
-  values = other409.values;
-  dbName = other409.dbName;
-  tableName = other409.tableName;
-  createTime = other409.createTime;
-  lastAccessTime = other409.lastAccessTime;
-  sd = other409.sd;
-  parameters = other409.parameters;
-  privileges = other409.privileges;
-  catName = other409.catName;
-  writeId = other409.writeId;
-  isStatsCompliant = other409.isStatsCompliant;
-  colStats = other409.colStats;
-  fileMetadata = other409.fileMetadata;
-  __isset = other409.__isset;
+Partition::Partition(const Partition& other416) {
+  values = other416.values;
+  dbName = other416.dbName;
+  tableName = other416.tableName;
+  createTime = other416.createTime;
+  lastAccessTime = other416.lastAccessTime;
+  sd = other416.sd;
+  parameters = other416.parameters;
+  privileges = other416.privileges;
+  catName = other416.catName;
+  writeId = other416.writeId;
+  isStatsCompliant = other416.isStatsCompliant;
+  colStats = other416.colStats;
+  fileMetadata = other416.fileMetadata;
+  __isset = other416.__isset;
 }
-Partition& Partition::operator=(const Partition& other410) {
-  values = other410.values;
-  dbName = other410.dbName;
-  tableName = other410.tableName;
-  createTime = other410.createTime;
-  lastAccessTime = other410.lastAccessTime;
-  sd = other410.sd;
-  parameters = other410.parameters;
-  privileges = other410.privileges;
-  catName = other410.catName;
-  writeId = other410.writeId;
-  isStatsCompliant = other410.isStatsCompliant;
-  colStats = other410.colStats;
-  fileMetadata = other410.fileMetadata;
-  __isset = other410.__isset;
+Partition& Partition::operator=(const Partition& other417) {
+  values = other417.values;
+  dbName = other417.dbName;
+  tableName = other417.tableName;
+  createTime = other417.createTime;
+  lastAccessTime = other417.lastAccessTime;
+  sd = other417.sd;
+  parameters = other417.parameters;
+  privileges = other417.privileges;
+  catName = other417.catName;
+  writeId = other417.writeId;
+  isStatsCompliant = other417.isStatsCompliant;
+  colStats = other417.colStats;
+  fileMetadata = other417.fileMetadata;
+  __isset = other417.__isset;
   return *this;
 }
 void Partition::printTo(std::ostream& out) const {
@@ -12413,14 +12456,14 @@ uint32_t PartitionWithoutSD::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size411;
-            ::apache::thrift::protocol::TType _etype414;
-            xfer += iprot->readListBegin(_etype414, _size411);
-            this->values.resize(_size411);
-            uint32_t _i415;
-            for (_i415 = 0; _i415 < _size411; ++_i415)
+            uint32_t _size418;
+            ::apache::thrift::protocol::TType _etype421;
+            xfer += iprot->readListBegin(_etype421, _size418);
+            this->values.resize(_size418);
+            uint32_t _i422;
+            for (_i422 = 0; _i422 < _size418; ++_i422)
             {
-              xfer += iprot->readString(this->values[_i415]);
+              xfer += iprot->readString(this->values[_i422]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12457,17 +12500,17 @@ uint32_t PartitionWithoutSD::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size416;
-            ::apache::thrift::protocol::TType _ktype417;
-            ::apache::thrift::protocol::TType _vtype418;
-            xfer += iprot->readMapBegin(_ktype417, _vtype418, _size416);
-            uint32_t _i420;
-            for (_i420 = 0; _i420 < _size416; ++_i420)
+            uint32_t _size423;
+            ::apache::thrift::protocol::TType _ktype424;
+            ::apache::thrift::protocol::TType _vtype425;
+            xfer += iprot->readMapBegin(_ktype424, _vtype425, _size423);
+            uint32_t _i427;
+            for (_i427 = 0; _i427 < _size423; ++_i427)
             {
-              std::string _key421;
-              xfer += iprot->readString(_key421);
-              std::string& _val422 = this->parameters[_key421];
-              xfer += iprot->readString(_val422);
+              std::string _key428;
+              xfer += iprot->readString(_key428);
+              std::string& _val429 = this->parameters[_key428];
+              xfer += iprot->readString(_val429);
             }
             xfer += iprot->readMapEnd();
           }
@@ -12504,10 +12547,10 @@ uint32_t PartitionWithoutSD::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->values.size()));
-    std::vector<std::string> ::const_iterator _iter423;
-    for (_iter423 = this->values.begin(); _iter423 != this->values.end(); ++_iter423)
+    std::vector<std::string> ::const_iterator _iter430;
+    for (_iter430 = this->values.begin(); _iter430 != this->values.end(); ++_iter430)
     {
-      xfer += oprot->writeString((*_iter423));
+      xfer += oprot->writeString((*_iter430));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12528,11 +12571,11 @@ uint32_t PartitionWithoutSD::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 5);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-    std::map<std::string, std::string> ::const_iterator _iter424;
-    for (_iter424 = this->parameters.begin(); _iter424 != this->parameters.end(); ++_iter424)
+    std::map<std::string, std::string> ::const_iterator _iter431;
+    for (_iter431 = this->parameters.begin(); _iter431 != this->parameters.end(); ++_iter431)
     {
-      xfer += oprot->writeString(_iter424->first);
-      xfer += oprot->writeString(_iter424->second);
+      xfer += oprot->writeString(_iter431->first);
+      xfer += oprot->writeString(_iter431->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -12559,23 +12602,23 @@ void swap(PartitionWithoutSD &a, PartitionWithoutSD &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionWithoutSD::PartitionWithoutSD(const PartitionWithoutSD& other425) {
-  values = other425.values;
-  createTime = other425.createTime;
-  lastAccessTime = other425.lastAccessTime;
-  relativePath = other425.relativePath;
-  parameters = other425.parameters;
-  privileges = other425.privileges;
-  __isset = other425.__isset;
+PartitionWithoutSD::PartitionWithoutSD(const PartitionWithoutSD& other432) {
+  values = other432.values;
+  createTime = other432.createTime;
+  lastAccessTime = other432.lastAccessTime;
+  relativePath = other432.relativePath;
+  parameters = other432.parameters;
+  privileges = other432.privileges;
+  __isset = other432.__isset;
 }
-PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& other426) {
-  values = other426.values;
-  createTime = other426.createTime;
-  lastAccessTime = other426.lastAccessTime;
-  relativePath = other426.relativePath;
-  parameters = other426.parameters;
-  privileges = other426.privileges;
-  __isset = other426.__isset;
+PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& other433) {
+  values = other433.values;
+  createTime = other433.createTime;
+  lastAccessTime = other433.lastAccessTime;
+  relativePath = other433.relativePath;
+  parameters = other433.parameters;
+  privileges = other433.privileges;
+  __isset = other433.__isset;
   return *this;
 }
 void PartitionWithoutSD::printTo(std::ostream& out) const {
@@ -12634,14 +12677,14 @@ uint32_t PartitionSpecWithSharedSD::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size427;
-            ::apache::thrift::protocol::TType _etype430;
-            xfer += iprot->readListBegin(_etype430, _size427);
-            this->partitions.resize(_size427);
-            uint32_t _i431;
-            for (_i431 = 0; _i431 < _size427; ++_i431)
+            uint32_t _size434;
+            ::apache::thrift::protocol::TType _etype437;
+            xfer += iprot->readListBegin(_etype437, _size434);
+            this->partitions.resize(_size434);
+            uint32_t _i438;
+            for (_i438 = 0; _i438 < _size434; ++_i438)
             {
-              xfer += this->partitions[_i431].read(iprot);
+              xfer += this->partitions[_i438].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12678,10 +12721,10 @@ uint32_t PartitionSpecWithSharedSD::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<PartitionWithoutSD> ::const_iterator _iter432;
-    for (_iter432 = this->partitions.begin(); _iter432 != this->partitions.end(); ++_iter432)
+    std::vector<PartitionWithoutSD> ::const_iterator _iter439;
+    for (_iter439 = this->partitions.begin(); _iter439 != this->partitions.end(); ++_iter439)
     {
-      xfer += (*_iter432).write(oprot);
+      xfer += (*_iter439).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -12703,15 +12746,15 @@ void swap(PartitionSpecWithSharedSD &a, PartitionSpecWithSharedSD &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionSpecWithSharedSD::PartitionSpecWithSharedSD(const PartitionSpecWithSharedSD& other433) {
-  partitions = other433.partitions;
-  sd = other433.sd;
-  __isset = other433.__isset;
+PartitionSpecWithSharedSD::PartitionSpecWithSharedSD(const PartitionSpecWithSharedSD& other440) {
+  partitions = other440.partitions;
+  sd = other440.sd;
+  __isset = other440.__isset;
 }
-PartitionSpecWithSharedSD& PartitionSpecWithSharedSD::operator=(const PartitionSpecWithSharedSD& other434) {
-  partitions = other434.partitions;
-  sd = other434.sd;
-  __isset = other434.__isset;
+PartitionSpecWithSharedSD& PartitionSpecWithSharedSD::operator=(const PartitionSpecWithSharedSD& other441) {
+  partitions = other441.partitions;
+  sd = other441.sd;
+  __isset = other441.__isset;
   return *this;
 }
 void PartitionSpecWithSharedSD::printTo(std::ostream& out) const {
@@ -12762,14 +12805,14 @@ uint32_t PartitionListComposingSpec::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size435;
-            ::apache::thrift::protocol::TType _etype438;
-            xfer += iprot->readListBegin(_etype438, _size435);
-            this->partitions.resize(_size435);
-            uint32_t _i439;
-            for (_i439 = 0; _i439 < _size435; ++_i439)
+            uint32_t _size442;
+            ::apache::thrift::protocol::TType _etype445;
+            xfer += iprot->readListBegin(_etype445, _size442);
+            this->partitions.resize(_size442);
+            uint32_t _i446;
+            for (_i446 = 0; _i446 < _size442; ++_i446)
             {
-              xfer += this->partitions[_i439].read(iprot);
+              xfer += this->partitions[_i446].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12798,10 +12841,10 @@ uint32_t PartitionListComposingSpec::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter440;
-    for (_iter440 = this->partitions.begin(); _iter440 != this->partitions.end(); ++_iter440)
+    std::vector<Partition> ::const_iterator _iter447;
+    for (_iter447 = this->partitions.begin(); _iter447 != this->partitions.end(); ++_iter447)
     {
-      xfer += (*_iter440).write(oprot);
+      xfer += (*_iter447).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -12818,13 +12861,13 @@ void swap(PartitionListComposingSpec &a, PartitionListComposingSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionListComposingSpec::PartitionListComposingSpec(const PartitionListComposingSpec& other441) {
-  partitions = other441.partitions;
-  __isset = other441.__isset;
+PartitionListComposingSpec::PartitionListComposingSpec(const PartitionListComposingSpec& other448) {
+  partitions = other448.partitions;
+  __isset = other448.__isset;
 }
-PartitionListComposingSpec& PartitionListComposingSpec::operator=(const PartitionListComposingSpec& other442) {
-  partitions = other442.partitions;
-  __isset = other442.__isset;
+PartitionListComposingSpec& PartitionListComposingSpec::operator=(const PartitionListComposingSpec& other449) {
+  partitions = other449.partitions;
+  __isset = other449.__isset;
   return *this;
 }
 void PartitionListComposingSpec::printTo(std::ostream& out) const {
@@ -13039,27 +13082,27 @@ void swap(PartitionSpec &a, PartitionSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionSpec::PartitionSpec(const PartitionSpec& other443) {
-  dbName = other443.dbName;
-  tableName = other443.tableName;
-  rootPath = other443.rootPath;
-  sharedSDPartitionSpec = other443.sharedSDPartitionSpec;
-  partitionList = other443.partitionList;
-  catName = other443.catName;
-  writeId = other443.writeId;
-  isStatsCompliant = other443.isStatsCompliant;
-  __isset = other443.__isset;
+PartitionSpec::PartitionSpec(const PartitionSpec& other450) {
+  dbName = other450.dbName;
+  tableName = other450.tableName;
+  rootPath = other450.rootPath;
+  sharedSDPartitionSpec = other450.sharedSDPartitionSpec;
+  partitionList = other450.partitionList;
+  catName = other450.catName;
+  writeId = other450.writeId;
+  isStatsCompliant = other450.isStatsCompliant;
+  __isset = other450.__isset;
 }
-PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other444) {
-  dbName = other444.dbName;
-  tableName = other444.tableName;
-  rootPath = other444.rootPath;
-  sharedSDPartitionSpec = other444.sharedSDPartitionSpec;
-  partitionList = other444.partitionList;
-  catName = other444.catName;
-  writeId = other444.writeId;
-  isStatsCompliant = other444.isStatsCompliant;
-  __isset = other444.__isset;
+PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other451) {
+  dbName = other451.dbName;
+  tableName = other451.tableName;
+  rootPath = other451.rootPath;
+  sharedSDPartitionSpec = other451.sharedSDPartitionSpec;
+  partitionList = other451.partitionList;
+  catName = other451.catName;
+  writeId = other451.writeId;
+  isStatsCompliant = other451.isStatsCompliant;
+  __isset = other451.__isset;
   return *this;
 }
 void PartitionSpec::printTo(std::ostream& out) const {
@@ -13127,14 +13170,14 @@ uint32_t AggrStats::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colStats.clear();
-            uint32_t _size445;
-            ::apache::thrift::protocol::TType _etype448;
-            xfer += iprot->readListBegin(_etype448, _size445);
-            this->colStats.resize(_size445);
-            uint32_t _i449;
-            for (_i449 = 0; _i449 < _size445; ++_i449)
+            uint32_t _size452;
+            ::apache::thrift::protocol::TType _etype455;
+            xfer += iprot->readListBegin(_etype455, _size452);
+            this->colStats.resize(_size452);
+            uint32_t _i456;
+            for (_i456 = 0; _i456 < _size452; ++_i456)
             {
-              xfer += this->colStats[_i449].read(iprot);
+              xfer += this->colStats[_i456].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13183,10 +13226,10 @@ uint32_t AggrStats::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("colStats", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->colStats.size()));
-    std::vector<ColumnStatisticsObj> ::const_iterator _iter450;
-    for (_iter450 = this->colStats.begin(); _iter450 != this->colStats.end(); ++_iter450)
+    std::vector<ColumnStatisticsObj> ::const_iterator _iter457;
+    for (_iter457 = this->colStats.begin(); _iter457 != this->colStats.end(); ++_iter457)
     {
-      xfer += (*_iter450).write(oprot);
+      xfer += (*_iter457).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -13214,17 +13257,17 @@ void swap(AggrStats &a, AggrStats &b) {
   swap(a.__isset, b.__isset);
 }
 
-AggrStats::AggrStats(const AggrStats& other451) {
-  colStats = other451.colStats;
-  partsFound = other451.partsFound;
-  isStatsCompliant = other451.isStatsCompliant;
-  __isset = other451.__isset;
+AggrStats::AggrStats(const AggrStats& other458) {
+  colStats = other458.colStats;
+  partsFound = other458.partsFound;
+  isStatsCompliant = other458.isStatsCompliant;
+  __isset = other458.__isset;
 }
-AggrStats& AggrStats::operator=(const AggrStats& other452) {
-  colStats = other452.colStats;
-  partsFound = other452.partsFound;
-  isStatsCompliant = other452.isStatsCompliant;
-  __isset = other452.__isset;
+AggrStats& AggrStats::operator=(const AggrStats& other459) {
+  colStats = other459.colStats;
+  partsFound = other459.partsFound;
+  isStatsCompliant = other459.isStatsCompliant;
+  __isset = other459.__isset;
   return *this;
 }
 void AggrStats::printTo(std::ostream& out) const {
@@ -13297,14 +13340,14 @@ uint32_t SetPartitionsStatsRequest::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colStats.clear();
-            uint32_t _size453;
-            ::apache::thrift::protocol::TType _etype456;
-            xfer += iprot->readListBegin(_etype456, _size453);
-            this->colStats.resize(_size453);
-            uint32_t _i457;
-            for (_i457 = 0; _i457 < _size453; ++_i457)
+            uint32_t _size460;
+            ::apache::thrift::protocol::TType _etype463;
+            xfer += iprot->readListBegin(_etype463, _size460);
+            this->colStats.resize(_size460);
+            uint32_t _i464;
+            for (_i464 = 0; _i464 < _size460; ++_i464)
             {
-              xfer += this->colStats[_i457].read(iprot);
+              xfer += this->colStats[_i464].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13369,10 +13412,10 @@ uint32_t SetPartitionsStatsRequest::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("colStats", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->colStats.size()));
-    std::vector<ColumnStatistics> ::const_iterator _iter458;
-    for (_iter458 = this->colStats.begin(); _iter458 != this->colStats.end(); ++_iter458)
+    std::vector<ColumnStatistics> ::const_iterator _iter465;
+    for (_iter465 = this->colStats.begin(); _iter465 != this->colStats.end(); ++_iter465)
     {
-      xfer += (*_iter458).write(oprot);
+      xfer += (*_iter465).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -13412,21 +13455,21 @@ void swap(SetPartitionsStatsRequest &a, SetPartitionsStatsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-SetPartitionsStatsRequest::SetPartitionsStatsRequest(const SetPartitionsStatsRequest& other459) {
-  colStats = other459.colStats;
-  needMerge = other459.needMerge;
-  writeId = other459.writeId;
-  validWriteIdList = other459.validWriteIdList;
-  engine = other459.engine;
-  __isset = other459.__isset;
+SetPartitionsStatsRequest::SetPartitionsStatsRequest(const SetPartitionsStatsRequest& other466) {
+  colStats = other466.colStats;
+  needMerge = other466.needMerge;
+  writeId = other466.writeId;
+  validWriteIdList = other466.validWriteIdList;
+  engine = other466.engine;
+  __isset = other466.__isset;
 }
-SetPartitionsStatsRequest& SetPartitionsStatsRequest::operator=(const SetPartitionsStatsRequest& other460) {
-  colStats = other460.colStats;
-  needMerge = other460.needMerge;
-  writeId = other460.writeId;
-  validWriteIdList = other460.validWriteIdList;
-  engine = other460.engine;
-  __isset = other460.__isset;
+SetPartitionsStatsRequest& SetPartitionsStatsRequest::operator=(const SetPartitionsStatsRequest& other467) {
+  colStats = other467.colStats;
+  needMerge = other467.needMerge;
+  writeId = other467.writeId;
+  validWriteIdList = other467.validWriteIdList;
+  engine = other467.engine;
+  __isset = other467.__isset;
   return *this;
 }
 void SetPartitionsStatsRequest::printTo(std::ostream& out) const {
@@ -13518,11 +13561,11 @@ void swap(SetPartitionsStatsResponse &a, SetPartitionsStatsResponse &b) {
   swap(a.result, b.result);
 }
 
-SetPartitionsStatsResponse::SetPartitionsStatsResponse(const SetPartitionsStatsResponse& other461) {
-  result = other461.result;
+SetPartitionsStatsResponse::SetPartitionsStatsResponse(const SetPartitionsStatsResponse& other468) {
+  result = other468.result;
 }
-SetPartitionsStatsResponse& SetPartitionsStatsResponse::operator=(const SetPartitionsStatsResponse& other462) {
-  result = other462.result;
+SetPartitionsStatsResponse& SetPartitionsStatsResponse::operator=(const SetPartitionsStatsResponse& other469) {
+  result = other469.result;
   return *this;
 }
 void SetPartitionsStatsResponse::printTo(std::ostream& out) const {
@@ -13576,14 +13619,14 @@ uint32_t Schema::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fieldSchemas.clear();
-            uint32_t _size463;
-            ::apache::thrift::protocol::TType _etype466;
-            xfer += iprot->readListBegin(_etype466, _size463);
-            this->fieldSchemas.resize(_size463);
-            uint32_t _i467;
-            for (_i467 = 0; _i467 < _size463; ++_i467)
+            uint32_t _size470;
+            ::apache::thrift::protocol::TType _etype473;
+            xfer += iprot->readListBegin(_etype473, _size470);
+            this->fieldSchemas.resize(_size470);
+            uint32_t _i474;
+            for (_i474 = 0; _i474 < _size470; ++_i474)
             {
-              xfer += this->fieldSchemas[_i467].read(iprot);
+              xfer += this->fieldSchemas[_i474].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13596,17 +13639,17 @@ uint32_t Schema::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->properties.clear();
-            uint32_t _size468;
-            ::apache::thrift::protocol::TType _ktype469;
-            ::apache::thrift::protocol::TType _vtype470;
-            xfer += iprot->readMapBegin(_ktype469, _vtype470, _size468);
-            uint32_t _i472;
-            for (_i472 = 0; _i472 < _size468; ++_i472)
+            uint32_t _size475;
+            ::apache::thrift::protocol::TType _ktype476;
+            ::apache::thrift::protocol::TType _vtype477;
+            xfer += iprot->readMapBegin(_ktype476, _vtype477, _size475);
+            uint32_t _i479;
+            for (_i479 = 0; _i479 < _size475; ++_i479)
             {
-              std::string _key473;
-              xfer += iprot->readString(_key473);
-              std::string& _val474 = this->properties[_key473];
-              xfer += iprot->readString(_val474);
+              std::string _key480;
+              xfer += iprot->readString(_key480);
+              std::string& _val481 = this->properties[_key480];
+              xfer += iprot->readString(_val481);
             }
             xfer += iprot->readMapEnd();
           }
@@ -13635,10 +13678,10 @@ uint32_t Schema::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("fieldSchemas", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fieldSchemas.size()));
-    std::vector<FieldSchema> ::const_iterator _iter475;
-    for (_iter475 = this->fieldSchemas.begin(); _iter475 != this->fieldSchemas.end(); ++_iter475)
+    std::vector<FieldSchema> ::const_iterator _iter482;
+    for (_iter482 = this->fieldSchemas.begin(); _iter482 != this->fieldSchemas.end(); ++_iter482)
     {
-      xfer += (*_iter475).write(oprot);
+      xfer += (*_iter482).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -13647,11 +13690,11 @@ uint32_t Schema::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 2);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
-    std::map<std::string, std::string> ::const_iterator _iter476;
-    for (_iter476 = this->properties.begin(); _iter476 != this->properties.end(); ++_iter476)
+    std::map<std::string, std::string> ::const_iterator _iter483;
+    for (_iter483 = this->properties.begin(); _iter483 != this->properties.end(); ++_iter483)
     {
-      xfer += oprot->writeString(_iter476->first);
-      xfer += oprot->writeString(_iter476->second);
+      xfer += oprot->writeString(_iter483->first);
+      xfer += oprot->writeString(_iter483->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -13669,15 +13712,15 @@ void swap(Schema &a, Schema &b) {
   swap(a.__isset, b.__isset);
 }
 
-Schema::Schema(const Schema& other477) {
-  fieldSchemas = other477.fieldSchemas;
-  properties = other477.properties;
-  __isset = other477.__isset;
+Schema::Schema(const Schema& other484) {
+  fieldSchemas = other484.fieldSchemas;
+  properties = other484.properties;
+  __isset = other484.__isset;
 }
-Schema& Schema::operator=(const Schema& other478) {
-  fieldSchemas = other478.fieldSchemas;
-  properties = other478.properties;
-  __isset = other478.__isset;
+Schema& Schema::operator=(const Schema& other485) {
+  fieldSchemas = other485.fieldSchemas;
+  properties = other485.properties;
+  __isset = other485.__isset;
   return *this;
 }
 void Schema::printTo(std::ostream& out) const {
@@ -13844,21 +13887,21 @@ void swap(PrimaryKeysRequest &a, PrimaryKeysRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PrimaryKeysRequest::PrimaryKeysRequest(const PrimaryKeysRequest& other479) {
-  db_name = other479.db_name;
-  tbl_name = other479.tbl_name;
-  catName = other479.catName;
-  validWriteIdList = other479.validWriteIdList;
-  tableId = other479.tableId;
-  __isset = other479.__isset;
+PrimaryKeysRequest::PrimaryKeysRequest(const PrimaryKeysRequest& other486) {
+  db_name = other486.db_name;
+  tbl_name = other486.tbl_name;
+  catName = other486.catName;
+  validWriteIdList = other486.validWriteIdList;
+  tableId = other486.tableId;
+  __isset = other486.__isset;
 }
-PrimaryKeysRequest& PrimaryKeysRequest::operator=(const PrimaryKeysRequest& other480) {
-  db_name = other480.db_name;
-  tbl_name = other480.tbl_name;
-  catName = other480.catName;
-  validWriteIdList = other480.validWriteIdList;
-  tableId = other480.tableId;
-  __isset = other480.__isset;
+PrimaryKeysRequest& PrimaryKeysRequest::operator=(const PrimaryKeysRequest& other487) {
+  db_name = other487.db_name;
+  tbl_name = other487.tbl_name;
+  catName = other487.catName;
+  validWriteIdList = other487.validWriteIdList;
+  tableId = other487.tableId;
+  __isset = other487.__isset;
   return *this;
 }
 void PrimaryKeysRequest::printTo(std::ostream& out) const {
@@ -13913,14 +13956,14 @@ uint32_t PrimaryKeysResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size481;
-            ::apache::thrift::protocol::TType _etype484;
-            xfer += iprot->readListBegin(_etype484, _size481);
-            this->primaryKeys.resize(_size481);
-            uint32_t _i485;
-            for (_i485 = 0; _i485 < _size481; ++_i485)
+            uint32_t _size488;
+            ::apache::thrift::protocol::TType _etype491;
+            xfer += iprot->readListBegin(_etype491, _size488);
+            this->primaryKeys.resize(_size488);
+            uint32_t _i492;
+            for (_i492 = 0; _i492 < _size488; ++_i492)
             {
-              xfer += this->primaryKeys[_i485].read(iprot);
+              xfer += this->primaryKeys[_i492].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -13951,10 +13994,10 @@ uint32_t PrimaryKeysResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter486;
-    for (_iter486 = this->primaryKeys.begin(); _iter486 != this->primaryKeys.end(); ++_iter486)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter493;
+    for (_iter493 = this->primaryKeys.begin(); _iter493 != this->primaryKeys.end(); ++_iter493)
     {
-      xfer += (*_iter486).write(oprot);
+      xfer += (*_iter493).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -13970,11 +14013,11 @@ void swap(PrimaryKeysResponse &a, PrimaryKeysResponse &b) {
   swap(a.primaryKeys, b.primaryKeys);
 }
 
-PrimaryKeysResponse::PrimaryKeysResponse(const PrimaryKeysResponse& other487) {
-  primaryKeys = other487.primaryKeys;
+PrimaryKeysResponse::PrimaryKeysResponse(const PrimaryKeysResponse& other494) {
+  primaryKeys = other494.primaryKeys;
 }
-PrimaryKeysResponse& PrimaryKeysResponse::operator=(const PrimaryKeysResponse& other488) {
-  primaryKeys = other488.primaryKeys;
+PrimaryKeysResponse& PrimaryKeysResponse::operator=(const PrimaryKeysResponse& other495) {
+  primaryKeys = other495.primaryKeys;
   return *this;
 }
 void PrimaryKeysResponse::printTo(std::ostream& out) const {
@@ -14168,25 +14211,25 @@ void swap(ForeignKeysRequest &a, ForeignKeysRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ForeignKeysRequest::ForeignKeysRequest(const ForeignKeysRequest& other489) {
-  parent_db_name = other489.parent_db_name;
-  parent_tbl_name = other489.parent_tbl_name;
-  foreign_db_name = other489.foreign_db_name;
-  foreign_tbl_name = other489.foreign_tbl_name;
-  catName = other489.catName;
-  validWriteIdList = other489.validWriteIdList;
-  tableId = other489.tableId;
-  __isset = other489.__isset;
+ForeignKeysRequest::ForeignKeysRequest(const ForeignKeysRequest& other496) {
+  parent_db_name = other496.parent_db_name;
+  parent_tbl_name = other496.parent_tbl_name;
+  foreign_db_name = other496.foreign_db_name;
+  foreign_tbl_name = other496.foreign_tbl_name;
+  catName = other496.catName;
+  validWriteIdList = other496.validWriteIdList;
+  tableId = other496.tableId;
+  __isset = other496.__isset;
 }
-ForeignKeysRequest& ForeignKeysRequest::operator=(const ForeignKeysRequest& other490) {
-  parent_db_name = other490.parent_db_name;
-  parent_tbl_name = other490.parent_tbl_name;
-  foreign_db_name = other490.foreign_db_name;
-  foreign_tbl_name = other490.foreign_tbl_name;
-  catName = other490.catName;
-  validWriteIdList = other490.validWriteIdList;
-  tableId = other490.tableId;
-  __isset = other490.__isset;
+ForeignKeysRequest& ForeignKeysRequest::operator=(const ForeignKeysRequest& other497) {
+  parent_db_name = other497.parent_db_name;
+  parent_tbl_name = other497.parent_tbl_name;
+  foreign_db_name = other497.foreign_db_name;
+  foreign_tbl_name = other497.foreign_tbl_name;
+  catName = other497.catName;
+  validWriteIdList = other497.validWriteIdList;
+  tableId = other497.tableId;
+  __isset = other497.__isset;
   return *this;
 }
 void ForeignKeysRequest::printTo(std::ostream& out) const {
@@ -14243,14 +14286,14 @@ uint32_t ForeignKeysResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size491;
-            ::apache::thrift::protocol::TType _etype494;
-            xfer += iprot->readListBegin(_etype494, _size491);
-            this->foreignKeys.resize(_size491);
-            uint32_t _i495;
-            for (_i495 = 0; _i495 < _size491; ++_i495)
+            uint32_t _size498;
+            ::apache::thrift::protocol::TType _etype501;
+            xfer += iprot->readListBegin(_etype501, _size498);
+            this->foreignKeys.resize(_size498);
+            uint32_t _i502;
+            for (_i502 = 0; _i502 < _size498; ++_i502)
             {
-              xfer += this->foreignKeys[_i495].read(iprot);
+              xfer += this->foreignKeys[_i502].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -14281,10 +14324,10 @@ uint32_t ForeignKeysResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter496;
-    for (_iter496 = this->foreignKeys.begin(); _iter496 != this->foreignKeys.end(); ++_iter496)
+    std::vector<SQLForeignKey> ::const_iterator _iter503;
+    for (_iter503 = this->foreignKeys.begin(); _iter503 != this->foreignKeys.end(); ++_iter503)
     {
-      xfer += (*_iter496).write(oprot);
+      xfer += (*_iter503).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -14300,11 +14343,11 @@ void swap(ForeignKeysResponse &a, ForeignKeysResponse &b) {
   swap(a.foreignKeys, b.foreignKeys);
 }
 
-ForeignKeysResponse::ForeignKeysResponse(const ForeignKeysResponse& other497) {
-  foreignKeys = other497.foreignKeys;
+ForeignKeysResponse::ForeignKeysResponse(const ForeignKeysResponse& other504) {
+  foreignKeys = other504.foreignKeys;
 }
-ForeignKeysResponse& ForeignKeysResponse::operator=(const ForeignKeysResponse& other498) {
-  foreignKeys = other498.foreignKeys;
+ForeignKeysResponse& ForeignKeysResponse::operator=(const ForeignKeysResponse& other505) {
+  foreignKeys = other505.foreignKeys;
   return *this;
 }
 void ForeignKeysResponse::printTo(std::ostream& out) const {
@@ -14471,21 +14514,21 @@ void swap(UniqueConstraintsRequest &a, UniqueConstraintsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-UniqueConstraintsRequest::UniqueConstraintsRequest(const UniqueConstraintsRequest& other499) {
-  catName = other499.catName;
-  db_name = other499.db_name;
-  tbl_name = other499.tbl_name;
-  validWriteIdList = other499.validWriteIdList;
-  tableId = other499.tableId;
-  __isset = other499.__isset;
+UniqueConstraintsRequest::UniqueConstraintsRequest(const UniqueConstraintsRequest& other506) {
+  catName = other506.catName;
+  db_name = other506.db_name;
+  tbl_name = other506.tbl_name;
+  validWriteIdList = other506.validWriteIdList;
+  tableId = other506.tableId;
+  __isset = other506.__isset;
 }
-UniqueConstraintsRequest& UniqueConstraintsRequest::operator=(const UniqueConstraintsRequest& other500) {
-  catName = other500.catName;
-  db_name = other500.db_name;
-  tbl_name = other500.tbl_name;
-  validWriteIdList = other500.validWriteIdList;
-  tableId = other500.tableId;
-  __isset = other500.__isset;
+UniqueConstraintsRequest& UniqueConstraintsRequest::operator=(const UniqueConstraintsRequest& other507) {
+  catName = other507.catName;
+  db_name = other507.db_name;
+  tbl_name = other507.tbl_name;
+  validWriteIdList = other507.validWriteIdList;
+  tableId = other507.tableId;
+  __isset = other507.__isset;
   return *this;
 }
 void UniqueConstraintsRequest::printTo(std::ostream& out) const {
@@ -14540,14 +14583,14 @@ uint32_t UniqueConstraintsResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size501;
-            ::apache::thrift::protocol::TType _etype504;
-            xfer += iprot->readListBegin(_etype504, _size501);
-            this->uniqueConstraints.resize(_size501);
-            uint32_t _i505;
-            for (_i505 = 0; _i505 < _size501; ++_i505)
+            uint32_t _size508;
+            ::apache::thrift::protocol::TType _etype511;
+            xfer += iprot->readListBegin(_etype511, _size508);
+            this->uniqueConstraints.resize(_size508);
+            uint32_t _i512;
+            for (_i512 = 0; _i512 < _size508; ++_i512)
             {
-              xfer += this->uniqueConstraints[_i505].read(iprot);
+              xfer += this->uniqueConstraints[_i512].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -14578,10 +14621,10 @@ uint32_t UniqueConstraintsResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter506;
-    for (_iter506 = this->uniqueConstraints.begin(); _iter506 != this->uniqueConstraints.end(); ++_iter506)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter513;
+    for (_iter513 = this->uniqueConstraints.begin(); _iter513 != this->uniqueConstraints.end(); ++_iter513)
     {
-      xfer += (*_iter506).write(oprot);
+      xfer += (*_iter513).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -14597,11 +14640,11 @@ void swap(UniqueConstraintsResponse &a, UniqueConstraintsResponse &b) {
   swap(a.uniqueConstraints, b.uniqueConstraints);
 }
 
-UniqueConstraintsResponse::UniqueConstraintsResponse(const UniqueConstraintsResponse& other507) {
-  uniqueConstraints = other507.uniqueConstraints;
+UniqueConstraintsResponse::UniqueConstraintsResponse(const UniqueConstraintsResponse& other514) {
+  uniqueConstraints = other514.uniqueConstraints;
 }
-UniqueConstraintsResponse& UniqueConstraintsResponse::operator=(const UniqueConstraintsResponse& other508) {
-  uniqueConstraints = other508.uniqueConstraints;
+UniqueConstraintsResponse& UniqueConstraintsResponse::operator=(const UniqueConstraintsResponse& other515) {
+  uniqueConstraints = other515.uniqueConstraints;
   return *this;
 }
 void UniqueConstraintsResponse::printTo(std::ostream& out) const {
@@ -14768,21 +14811,21 @@ void swap(NotNullConstraintsRequest &a, NotNullConstraintsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-NotNullConstraintsRequest::NotNullConstraintsRequest(const NotNullConstraintsRequest& other509) {
-  catName = other509.catName;
-  db_name = other509.db_name;
-  tbl_name = other509.tbl_name;
-  validWriteIdList = other509.validWriteIdList;
-  tableId = other509.tableId;
-  __isset = other509.__isset;
+NotNullConstraintsRequest::NotNullConstraintsRequest(const NotNullConstraintsRequest& other516) {
+  catName = other516.catName;
+  db_name = other516.db_name;
+  tbl_name = other516.tbl_name;
+  validWriteIdList = other516.validWriteIdList;
+  tableId = other516.tableId;
+  __isset = other516.__isset;
 }
-NotNullConstraintsRequest& NotNullConstraintsRequest::operator=(const NotNullConstraintsRequest& other510) {
-  catName = other510.catName;
-  db_name = other510.db_name;
-  tbl_name = other510.tbl_name;
-  validWriteIdList = other510.validWriteIdList;
-  tableId = other510.tableId;
-  __isset = other510.__isset;
+NotNullConstraintsRequest& NotNullConstraintsRequest::operator=(const NotNullConstraintsRequest& other517) {
+  catName = other517.catName;
+  db_name = other517.db_name;
+  tbl_name = other517.tbl_name;
+  validWriteIdList = other517.validWriteIdList;
+  tableId = other517.tableId;
+  __isset = other517.__isset;
   return *this;
 }
 void NotNullConstraintsRequest::printTo(std::ostream& out) const {
@@ -14837,14 +14880,14 @@ uint32_t NotNullConstraintsResponse::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size511;
-            ::apache::thrift::protocol::TType _etype514;
-            xfer += iprot->readListBegin(_etype514, _size511);
-            this->notNullConstraints.resize(_size511);
-            uint32_t _i515;
-            for (_i515 = 0; _i515 < _size511; ++_i515)
+            uint32_t _size518;
+            ::apache::thrift::protocol::TType _etype521;
+            xfer += iprot->readListBegin(_etype521, _size518);
+            this->notNullConstraints.resize(_size518);
+            uint32_t _i522;
+            for (_i522 = 0; _i522 < _size518; ++_i522)
             {
-              xfer += this->notNullConstraints[_i515].read(iprot);
+              xfer += this->notNullConstraints[_i522].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -14875,10 +14918,10 @@ uint32_t NotNullConstraintsResponse::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter516;
-    for (_iter516 = this->notNullConstraints.begin(); _iter516 != this->notNullConstraints.end(); ++_iter516)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter523;
+    for (_iter523 = this->notNullConstraints.begin(); _iter523 != this->notNullConstraints.end(); ++_iter523)
     {
-      xfer += (*_iter516).write(oprot);
+      xfer += (*_iter523).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -14894,11 +14937,11 @@ void swap(NotNullConstraintsResponse &a, NotNullConstraintsResponse &b) {
   swap(a.notNullConstraints, b.notNullConstraints);
 }
 
-NotNullConstraintsResponse::NotNullConstraintsResponse(const NotNullConstraintsResponse& other517) {
-  notNullConstraints = other517.notNullConstraints;
+NotNullConstraintsResponse::NotNullConstraintsResponse(const NotNullConstraintsResponse& other524) {
+  notNullConstraints = other524.notNullConstraints;
 }
-NotNullConstraintsResponse& NotNullConstraintsResponse::operator=(const NotNullConstraintsResponse& other518) {
-  notNullConstraints = other518.notNullConstraints;
+NotNullConstraintsResponse& NotNullConstraintsResponse::operator=(const NotNullConstraintsResponse& other525) {
+  notNullConstraints = other525.notNullConstraints;
   return *this;
 }
 void NotNullConstraintsResponse::printTo(std::ostream& out) const {
@@ -15065,21 +15108,21 @@ void swap(DefaultConstraintsRequest &a, DefaultConstraintsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DefaultConstraintsRequest::DefaultConstraintsRequest(const DefaultConstraintsRequest& other519) {
-  catName = other519.catName;
-  db_name = other519.db_name;
-  tbl_name = other519.tbl_name;
-  validWriteIdList = other519.validWriteIdList;
-  tableId = other519.tableId;
-  __isset = other519.__isset;
+DefaultConstraintsRequest::DefaultConstraintsRequest(const DefaultConstraintsRequest& other526) {
+  catName = other526.catName;
+  db_name = other526.db_name;
+  tbl_name = other526.tbl_name;
+  validWriteIdList = other526.validWriteIdList;
+  tableId = other526.tableId;
+  __isset = other526.__isset;
 }
-DefaultConstraintsRequest& DefaultConstraintsRequest::operator=(const DefaultConstraintsRequest& other520) {
-  catName = other520.catName;
-  db_name = other520.db_name;
-  tbl_name = other520.tbl_name;
-  validWriteIdList = other520.validWriteIdList;
-  tableId = other520.tableId;
-  __isset = other520.__isset;
+DefaultConstraintsRequest& DefaultConstraintsRequest::operator=(const DefaultConstraintsRequest& other527) {
+  catName = other527.catName;
+  db_name = other527.db_name;
+  tbl_name = other527.tbl_name;
+  validWriteIdList = other527.validWriteIdList;
+  tableId = other527.tableId;
+  __isset = other527.__isset;
   return *this;
 }
 void DefaultConstraintsRequest::printTo(std::ostream& out) const {
@@ -15134,14 +15177,14 @@ uint32_t DefaultConstraintsResponse::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size521;
-            ::apache::thrift::protocol::TType _etype524;
-            xfer += iprot->readListBegin(_etype524, _size521);
-            this->defaultConstraints.resize(_size521);
-            uint32_t _i525;
-            for (_i525 = 0; _i525 < _size521; ++_i525)
+            uint32_t _size528;
+            ::apache::thrift::protocol::TType _etype531;
+            xfer += iprot->readListBegin(_etype531, _size528);
+            this->defaultConstraints.resize(_size528);
+            uint32_t _i532;
+            for (_i532 = 0; _i532 < _size528; ++_i532)
             {
-              xfer += this->defaultConstraints[_i525].read(iprot);
+              xfer += this->defaultConstraints[_i532].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -15172,10 +15215,10 @@ uint32_t DefaultConstraintsResponse::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter526;
-    for (_iter526 = this->defaultConstraints.begin(); _iter526 != this->defaultConstraints.end(); ++_iter526)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter533;
+    for (_iter533 = this->defaultConstraints.begin(); _iter533 != this->defaultConstraints.end(); ++_iter533)
     {
-      xfer += (*_iter526).write(oprot);
+      xfer += (*_iter533).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -15191,11 +15234,11 @@ void swap(DefaultConstraintsResponse &a, DefaultConstraintsResponse &b) {
   swap(a.defaultConstraints, b.defaultConstraints);
 }
 
-DefaultConstraintsResponse::DefaultConstraintsResponse(const DefaultConstraintsResponse& other527) {
-  defaultConstraints = other527.defaultConstraints;
+DefaultConstraintsResponse::DefaultConstraintsResponse(const DefaultConstraintsResponse& other534) {
+  defaultConstraints = other534.defaultConstraints;
 }
-DefaultConstraintsResponse& DefaultConstraintsResponse::operator=(const DefaultConstraintsResponse& other528) {
-  defaultConstraints = other528.defaultConstraints;
+DefaultConstraintsResponse& DefaultConstraintsResponse::operator=(const DefaultConstraintsResponse& other535) {
+  defaultConstraints = other535.defaultConstraints;
   return *this;
 }
 void DefaultConstraintsResponse::printTo(std::ostream& out) const {
@@ -15362,21 +15405,21 @@ void swap(CheckConstraintsRequest &a, CheckConstraintsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CheckConstraintsRequest::CheckConstraintsRequest(const CheckConstraintsRequest& other529) {
-  catName = other529.catName;
-  db_name = other529.db_name;
-  tbl_name = other529.tbl_name;
-  validWriteIdList = other529.validWriteIdList;
-  tableId = other529.tableId;
-  __isset = other529.__isset;
+CheckConstraintsRequest::CheckConstraintsRequest(const CheckConstraintsRequest& other536) {
+  catName = other536.catName;
+  db_name = other536.db_name;
+  tbl_name = other536.tbl_name;
+  validWriteIdList = other536.validWriteIdList;
+  tableId = other536.tableId;
+  __isset = other536.__isset;
 }
-CheckConstraintsRequest& CheckConstraintsRequest::operator=(const CheckConstraintsRequest& other530) {
-  catName = other530.catName;
-  db_name = other530.db_name;
-  tbl_name = other530.tbl_name;
-  validWriteIdList = other530.validWriteIdList;
-  tableId = other530.tableId;
-  __isset = other530.__isset;
+CheckConstraintsRequest& CheckConstraintsRequest::operator=(const CheckConstraintsRequest& other537) {
+  catName = other537.catName;
+  db_name = other537.db_name;
+  tbl_name = other537.tbl_name;
+  validWriteIdList = other537.validWriteIdList;
+  tableId = other537.tableId;
+  __isset = other537.__isset;
   return *this;
 }
 void CheckConstraintsRequest::printTo(std::ostream& out) const {
@@ -15431,14 +15474,14 @@ uint32_t CheckConstraintsResponse::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size531;
-            ::apache::thrift::protocol::TType _etype534;
-            xfer += iprot->readListBegin(_etype534, _size531);
-            this->checkConstraints.resize(_size531);
-            uint32_t _i535;
-            for (_i535 = 0; _i535 < _size531; ++_i535)
+            uint32_t _size538;
+            ::apache::thrift::protocol::TType _etype541;
+            xfer += iprot->readListBegin(_etype541, _size538);
+            this->checkConstraints.resize(_size538);
+            uint32_t _i542;
+            for (_i542 = 0; _i542 < _size538; ++_i542)
             {
-              xfer += this->checkConstraints[_i535].read(iprot);
+              xfer += this->checkConstraints[_i542].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -15469,10 +15512,10 @@ uint32_t CheckConstraintsResponse::write(::apache::thrift::protocol::TProtocol* 
   xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter536;
-    for (_iter536 = this->checkConstraints.begin(); _iter536 != this->checkConstraints.end(); ++_iter536)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter543;
+    for (_iter543 = this->checkConstraints.begin(); _iter543 != this->checkConstraints.end(); ++_iter543)
     {
-      xfer += (*_iter536).write(oprot);
+      xfer += (*_iter543).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -15488,11 +15531,11 @@ void swap(CheckConstraintsResponse &a, CheckConstraintsResponse &b) {
   swap(a.checkConstraints, b.checkConstraints);
 }
 
-CheckConstraintsResponse::CheckConstraintsResponse(const CheckConstraintsResponse& other537) {
-  checkConstraints = other537.checkConstraints;
+CheckConstraintsResponse::CheckConstraintsResponse(const CheckConstraintsResponse& other544) {
+  checkConstraints = other544.checkConstraints;
 }
-CheckConstraintsResponse& CheckConstraintsResponse::operator=(const CheckConstraintsResponse& other538) {
-  checkConstraints = other538.checkConstraints;
+CheckConstraintsResponse& CheckConstraintsResponse::operator=(const CheckConstraintsResponse& other545) {
+  checkConstraints = other545.checkConstraints;
   return *this;
 }
 void CheckConstraintsResponse::printTo(std::ostream& out) const {
@@ -15659,21 +15702,21 @@ void swap(AllTableConstraintsRequest &a, AllTableConstraintsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AllTableConstraintsRequest::AllTableConstraintsRequest(const AllTableConstraintsRequest& other539) {
-  dbName = other539.dbName;
-  tblName = other539.tblName;
-  catName = other539.catName;
-  validWriteIdList = other539.validWriteIdList;
-  tableId = other539.tableId;
-  __isset = other539.__isset;
+AllTableConstraintsRequest::AllTableConstraintsRequest(const AllTableConstraintsRequest& other546) {
+  dbName = other546.dbName;
+  tblName = other546.tblName;
+  catName = other546.catName;
+  validWriteIdList = other546.validWriteIdList;
+  tableId = other546.tableId;
+  __isset = other546.__isset;
 }
-AllTableConstraintsRequest& AllTableConstraintsRequest::operator=(const AllTableConstraintsRequest& other540) {
-  dbName = other540.dbName;
-  tblName = other540.tblName;
-  catName = other540.catName;
-  validWriteIdList = other540.validWriteIdList;
-  tableId = other540.tableId;
-  __isset = other540.__isset;
+AllTableConstraintsRequest& AllTableConstraintsRequest::operator=(const AllTableConstraintsRequest& other547) {
+  dbName = other547.dbName;
+  tblName = other547.tblName;
+  catName = other547.catName;
+  validWriteIdList = other547.validWriteIdList;
+  tableId = other547.tableId;
+  __isset = other547.__isset;
   return *this;
 }
 void AllTableConstraintsRequest::printTo(std::ostream& out) const {
@@ -15765,11 +15808,11 @@ void swap(AllTableConstraintsResponse &a, AllTableConstraintsResponse &b) {
   swap(a.allTableConstraints, b.allTableConstraints);
 }
 
-AllTableConstraintsResponse::AllTableConstraintsResponse(const AllTableConstraintsResponse& other541) {
-  allTableConstraints = other541.allTableConstraints;
+AllTableConstraintsResponse::AllTableConstraintsResponse(const AllTableConstraintsResponse& other548) {
+  allTableConstraints = other548.allTableConstraints;
 }
-AllTableConstraintsResponse& AllTableConstraintsResponse::operator=(const AllTableConstraintsResponse& other542) {
-  allTableConstraints = other542.allTableConstraints;
+AllTableConstraintsResponse& AllTableConstraintsResponse::operator=(const AllTableConstraintsResponse& other549) {
+  allTableConstraints = other549.allTableConstraints;
   return *this;
 }
 void AllTableConstraintsResponse::printTo(std::ostream& out) const {
@@ -15917,19 +15960,19 @@ void swap(DropConstraintRequest &a, DropConstraintRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropConstraintRequest::DropConstraintRequest(const DropConstraintRequest& other543) {
-  dbname = other543.dbname;
-  tablename = other543.tablename;
-  constraintname = other543.constraintname;
-  catName = other543.catName;
-  __isset = other543.__isset;
+DropConstraintRequest::DropConstraintRequest(const DropConstraintRequest& other550) {
+  dbname = other550.dbname;
+  tablename = other550.tablename;
+  constraintname = other550.constraintname;
+  catName = other550.catName;
+  __isset = other550.__isset;
 }
-DropConstraintRequest& DropConstraintRequest::operator=(const DropConstraintRequest& other544) {
-  dbname = other544.dbname;
-  tablename = other544.tablename;
-  constraintname = other544.constraintname;
-  catName = other544.catName;
-  __isset = other544.__isset;
+DropConstraintRequest& DropConstraintRequest::operator=(const DropConstraintRequest& other551) {
+  dbname = other551.dbname;
+  tablename = other551.tablename;
+  constraintname = other551.constraintname;
+  catName = other551.catName;
+  __isset = other551.__isset;
   return *this;
 }
 void DropConstraintRequest::printTo(std::ostream& out) const {
@@ -15983,14 +16026,14 @@ uint32_t AddPrimaryKeyRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeyCols.clear();
-            uint32_t _size545;
-            ::apache::thrift::protocol::TType _etype548;
-            xfer += iprot->readListBegin(_etype548, _size545);
-            this->primaryKeyCols.resize(_size545);
-            uint32_t _i549;
-            for (_i549 = 0; _i549 < _size545; ++_i549)
+            uint32_t _size552;
+            ::apache::thrift::protocol::TType _etype555;
+            xfer += iprot->readListBegin(_etype555, _size552);
+            this->primaryKeyCols.resize(_size552);
+            uint32_t _i556;
+            for (_i556 = 0; _i556 < _size552; ++_i556)
             {
-              xfer += this->primaryKeyCols[_i549].read(iprot);
+              xfer += this->primaryKeyCols[_i556].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16021,10 +16064,10 @@ uint32_t AddPrimaryKeyRequest::write(::apache::thrift::protocol::TProtocol* opro
   xfer += oprot->writeFieldBegin("primaryKeyCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeyCols.size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter550;
-    for (_iter550 = this->primaryKeyCols.begin(); _iter550 != this->primaryKeyCols.end(); ++_iter550)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter557;
+    for (_iter557 = this->primaryKeyCols.begin(); _iter557 != this->primaryKeyCols.end(); ++_iter557)
     {
-      xfer += (*_iter550).write(oprot);
+      xfer += (*_iter557).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16040,11 +16083,11 @@ void swap(AddPrimaryKeyRequest &a, AddPrimaryKeyRequest &b) {
   swap(a.primaryKeyCols, b.primaryKeyCols);
 }
 
-AddPrimaryKeyRequest::AddPrimaryKeyRequest(const AddPrimaryKeyRequest& other551) {
-  primaryKeyCols = other551.primaryKeyCols;
+AddPrimaryKeyRequest::AddPrimaryKeyRequest(const AddPrimaryKeyRequest& other558) {
+  primaryKeyCols = other558.primaryKeyCols;
 }
-AddPrimaryKeyRequest& AddPrimaryKeyRequest::operator=(const AddPrimaryKeyRequest& other552) {
-  primaryKeyCols = other552.primaryKeyCols;
+AddPrimaryKeyRequest& AddPrimaryKeyRequest::operator=(const AddPrimaryKeyRequest& other559) {
+  primaryKeyCols = other559.primaryKeyCols;
   return *this;
 }
 void AddPrimaryKeyRequest::printTo(std::ostream& out) const {
@@ -16095,14 +16138,14 @@ uint32_t AddForeignKeyRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeyCols.clear();
-            uint32_t _size553;
-            ::apache::thrift::protocol::TType _etype556;
-            xfer += iprot->readListBegin(_etype556, _size553);
-            this->foreignKeyCols.resize(_size553);
-            uint32_t _i557;
-            for (_i557 = 0; _i557 < _size553; ++_i557)
+            uint32_t _size560;
+            ::apache::thrift::protocol::TType _etype563;
+            xfer += iprot->readListBegin(_etype563, _size560);
+            this->foreignKeyCols.resize(_size560);
+            uint32_t _i564;
+            for (_i564 = 0; _i564 < _size560; ++_i564)
             {
-              xfer += this->foreignKeyCols[_i557].read(iprot);
+              xfer += this->foreignKeyCols[_i564].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16133,10 +16176,10 @@ uint32_t AddForeignKeyRequest::write(::apache::thrift::protocol::TProtocol* opro
   xfer += oprot->writeFieldBegin("foreignKeyCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeyCols.size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter558;
-    for (_iter558 = this->foreignKeyCols.begin(); _iter558 != this->foreignKeyCols.end(); ++_iter558)
+    std::vector<SQLForeignKey> ::const_iterator _iter565;
+    for (_iter565 = this->foreignKeyCols.begin(); _iter565 != this->foreignKeyCols.end(); ++_iter565)
     {
-      xfer += (*_iter558).write(oprot);
+      xfer += (*_iter565).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16152,11 +16195,11 @@ void swap(AddForeignKeyRequest &a, AddForeignKeyRequest &b) {
   swap(a.foreignKeyCols, b.foreignKeyCols);
 }
 
-AddForeignKeyRequest::AddForeignKeyRequest(const AddForeignKeyRequest& other559) {
-  foreignKeyCols = other559.foreignKeyCols;
+AddForeignKeyRequest::AddForeignKeyRequest(const AddForeignKeyRequest& other566) {
+  foreignKeyCols = other566.foreignKeyCols;
 }
-AddForeignKeyRequest& AddForeignKeyRequest::operator=(const AddForeignKeyRequest& other560) {
-  foreignKeyCols = other560.foreignKeyCols;
+AddForeignKeyRequest& AddForeignKeyRequest::operator=(const AddForeignKeyRequest& other567) {
+  foreignKeyCols = other567.foreignKeyCols;
   return *this;
 }
 void AddForeignKeyRequest::printTo(std::ostream& out) const {
@@ -16207,14 +16250,14 @@ uint32_t AddUniqueConstraintRequest::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraintCols.clear();
-            uint32_t _size561;
-            ::apache::thrift::protocol::TType _etype564;
-            xfer += iprot->readListBegin(_etype564, _size561);
-            this->uniqueConstraintCols.resize(_size561);
-            uint32_t _i565;
-            for (_i565 = 0; _i565 < _size561; ++_i565)
+            uint32_t _size568;
+            ::apache::thrift::protocol::TType _etype571;
+            xfer += iprot->readListBegin(_etype571, _size568);
+            this->uniqueConstraintCols.resize(_size568);
+            uint32_t _i572;
+            for (_i572 = 0; _i572 < _size568; ++_i572)
             {
-              xfer += this->uniqueConstraintCols[_i565].read(iprot);
+              xfer += this->uniqueConstraintCols[_i572].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16245,10 +16288,10 @@ uint32_t AddUniqueConstraintRequest::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("uniqueConstraintCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraintCols.size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter566;
-    for (_iter566 = this->uniqueConstraintCols.begin(); _iter566 != this->uniqueConstraintCols.end(); ++_iter566)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter573;
+    for (_iter573 = this->uniqueConstraintCols.begin(); _iter573 != this->uniqueConstraintCols.end(); ++_iter573)
     {
-      xfer += (*_iter566).write(oprot);
+      xfer += (*_iter573).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16264,11 +16307,11 @@ void swap(AddUniqueConstraintRequest &a, AddUniqueConstraintRequest &b) {
   swap(a.uniqueConstraintCols, b.uniqueConstraintCols);
 }
 
-AddUniqueConstraintRequest::AddUniqueConstraintRequest(const AddUniqueConstraintRequest& other567) {
-  uniqueConstraintCols = other567.uniqueConstraintCols;
+AddUniqueConstraintRequest::AddUniqueConstraintRequest(const AddUniqueConstraintRequest& other574) {
+  uniqueConstraintCols = other574.uniqueConstraintCols;
 }
-AddUniqueConstraintRequest& AddUniqueConstraintRequest::operator=(const AddUniqueConstraintRequest& other568) {
-  uniqueConstraintCols = other568.uniqueConstraintCols;
+AddUniqueConstraintRequest& AddUniqueConstraintRequest::operator=(const AddUniqueConstraintRequest& other575) {
+  uniqueConstraintCols = other575.uniqueConstraintCols;
   return *this;
 }
 void AddUniqueConstraintRequest::printTo(std::ostream& out) const {
@@ -16319,14 +16362,14 @@ uint32_t AddNotNullConstraintRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraintCols.clear();
-            uint32_t _size569;
-            ::apache::thrift::protocol::TType _etype572;
-            xfer += iprot->readListBegin(_etype572, _size569);
-            this->notNullConstraintCols.resize(_size569);
-            uint32_t _i573;
-            for (_i573 = 0; _i573 < _size569; ++_i573)
+            uint32_t _size576;
+            ::apache::thrift::protocol::TType _etype579;
+            xfer += iprot->readListBegin(_etype579, _size576);
+            this->notNullConstraintCols.resize(_size576);
+            uint32_t _i580;
+            for (_i580 = 0; _i580 < _size576; ++_i580)
             {
-              xfer += this->notNullConstraintCols[_i573].read(iprot);
+              xfer += this->notNullConstraintCols[_i580].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16357,10 +16400,10 @@ uint32_t AddNotNullConstraintRequest::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("notNullConstraintCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraintCols.size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter574;
-    for (_iter574 = this->notNullConstraintCols.begin(); _iter574 != this->notNullConstraintCols.end(); ++_iter574)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter581;
+    for (_iter581 = this->notNullConstraintCols.begin(); _iter581 != this->notNullConstraintCols.end(); ++_iter581)
     {
-      xfer += (*_iter574).write(oprot);
+      xfer += (*_iter581).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16376,11 +16419,11 @@ void swap(AddNotNullConstraintRequest &a, AddNotNullConstraintRequest &b) {
   swap(a.notNullConstraintCols, b.notNullConstraintCols);
 }
 
-AddNotNullConstraintRequest::AddNotNullConstraintRequest(const AddNotNullConstraintRequest& other575) {
-  notNullConstraintCols = other575.notNullConstraintCols;
+AddNotNullConstraintRequest::AddNotNullConstraintRequest(const AddNotNullConstraintRequest& other582) {
+  notNullConstraintCols = other582.notNullConstraintCols;
 }
-AddNotNullConstraintRequest& AddNotNullConstraintRequest::operator=(const AddNotNullConstraintRequest& other576) {
-  notNullConstraintCols = other576.notNullConstraintCols;
+AddNotNullConstraintRequest& AddNotNullConstraintRequest::operator=(const AddNotNullConstraintRequest& other583) {
+  notNullConstraintCols = other583.notNullConstraintCols;
   return *this;
 }
 void AddNotNullConstraintRequest::printTo(std::ostream& out) const {
@@ -16431,14 +16474,14 @@ uint32_t AddDefaultConstraintRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraintCols.clear();
-            uint32_t _size577;
-            ::apache::thrift::protocol::TType _etype580;
-            xfer += iprot->readListBegin(_etype580, _size577);
-            this->defaultConstraintCols.resize(_size577);
-            uint32_t _i581;
-            for (_i581 = 0; _i581 < _size577; ++_i581)
+            uint32_t _size584;
+            ::apache::thrift::protocol::TType _etype587;
+            xfer += iprot->readListBegin(_etype587, _size584);
+            this->defaultConstraintCols.resize(_size584);
+            uint32_t _i588;
+            for (_i588 = 0; _i588 < _size584; ++_i588)
             {
-              xfer += this->defaultConstraintCols[_i581].read(iprot);
+              xfer += this->defaultConstraintCols[_i588].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16469,10 +16512,10 @@ uint32_t AddDefaultConstraintRequest::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("defaultConstraintCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraintCols.size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter582;
-    for (_iter582 = this->defaultConstraintCols.begin(); _iter582 != this->defaultConstraintCols.end(); ++_iter582)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter589;
+    for (_iter589 = this->defaultConstraintCols.begin(); _iter589 != this->defaultConstraintCols.end(); ++_iter589)
     {
-      xfer += (*_iter582).write(oprot);
+      xfer += (*_iter589).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16488,11 +16531,11 @@ void swap(AddDefaultConstraintRequest &a, AddDefaultConstraintRequest &b) {
   swap(a.defaultConstraintCols, b.defaultConstraintCols);
 }
 
-AddDefaultConstraintRequest::AddDefaultConstraintRequest(const AddDefaultConstraintRequest& other583) {
-  defaultConstraintCols = other583.defaultConstraintCols;
+AddDefaultConstraintRequest::AddDefaultConstraintRequest(const AddDefaultConstraintRequest& other590) {
+  defaultConstraintCols = other590.defaultConstraintCols;
 }
-AddDefaultConstraintRequest& AddDefaultConstraintRequest::operator=(const AddDefaultConstraintRequest& other584) {
-  defaultConstraintCols = other584.defaultConstraintCols;
+AddDefaultConstraintRequest& AddDefaultConstraintRequest::operator=(const AddDefaultConstraintRequest& other591) {
+  defaultConstraintCols = other591.defaultConstraintCols;
   return *this;
 }
 void AddDefaultConstraintRequest::printTo(std::ostream& out) const {
@@ -16543,14 +16586,14 @@ uint32_t AddCheckConstraintRequest::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraintCols.clear();
-            uint32_t _size585;
-            ::apache::thrift::protocol::TType _etype588;
-            xfer += iprot->readListBegin(_etype588, _size585);
-            this->checkConstraintCols.resize(_size585);
-            uint32_t _i589;
-            for (_i589 = 0; _i589 < _size585; ++_i589)
+            uint32_t _size592;
+            ::apache::thrift::protocol::TType _etype595;
+            xfer += iprot->readListBegin(_etype595, _size592);
+            this->checkConstraintCols.resize(_size592);
+            uint32_t _i596;
+            for (_i596 = 0; _i596 < _size592; ++_i596)
             {
-              xfer += this->checkConstraintCols[_i589].read(iprot);
+              xfer += this->checkConstraintCols[_i596].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16581,10 +16624,10 @@ uint32_t AddCheckConstraintRequest::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("checkConstraintCols", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraintCols.size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter590;
-    for (_iter590 = this->checkConstraintCols.begin(); _iter590 != this->checkConstraintCols.end(); ++_iter590)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter597;
+    for (_iter597 = this->checkConstraintCols.begin(); _iter597 != this->checkConstraintCols.end(); ++_iter597)
     {
-      xfer += (*_iter590).write(oprot);
+      xfer += (*_iter597).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16600,11 +16643,11 @@ void swap(AddCheckConstraintRequest &a, AddCheckConstraintRequest &b) {
   swap(a.checkConstraintCols, b.checkConstraintCols);
 }
 
-AddCheckConstraintRequest::AddCheckConstraintRequest(const AddCheckConstraintRequest& other591) {
-  checkConstraintCols = other591.checkConstraintCols;
+AddCheckConstraintRequest::AddCheckConstraintRequest(const AddCheckConstraintRequest& other598) {
+  checkConstraintCols = other598.checkConstraintCols;
 }
-AddCheckConstraintRequest& AddCheckConstraintRequest::operator=(const AddCheckConstraintRequest& other592) {
-  checkConstraintCols = other592.checkConstraintCols;
+AddCheckConstraintRequest& AddCheckConstraintRequest::operator=(const AddCheckConstraintRequest& other599) {
+  checkConstraintCols = other599.checkConstraintCols;
   return *this;
 }
 void AddCheckConstraintRequest::printTo(std::ostream& out) const {
@@ -16660,14 +16703,14 @@ uint32_t PartitionsByExprResult::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size593;
-            ::apache::thrift::protocol::TType _etype596;
-            xfer += iprot->readListBegin(_etype596, _size593);
-            this->partitions.resize(_size593);
-            uint32_t _i597;
-            for (_i597 = 0; _i597 < _size593; ++_i597)
+            uint32_t _size600;
+            ::apache::thrift::protocol::TType _etype603;
+            xfer += iprot->readListBegin(_etype603, _size600);
+            this->partitions.resize(_size600);
+            uint32_t _i604;
+            for (_i604 = 0; _i604 < _size600; ++_i604)
             {
-              xfer += this->partitions[_i597].read(iprot);
+              xfer += this->partitions[_i604].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16708,10 +16751,10 @@ uint32_t PartitionsByExprResult::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter598;
-    for (_iter598 = this->partitions.begin(); _iter598 != this->partitions.end(); ++_iter598)
+    std::vector<Partition> ::const_iterator _iter605;
+    for (_iter605 = this->partitions.begin(); _iter605 != this->partitions.end(); ++_iter605)
     {
-      xfer += (*_iter598).write(oprot);
+      xfer += (*_iter605).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16732,13 +16775,13 @@ void swap(PartitionsByExprResult &a, PartitionsByExprResult &b) {
   swap(a.hasUnknownPartitions, b.hasUnknownPartitions);
 }
 
-PartitionsByExprResult::PartitionsByExprResult(const PartitionsByExprResult& other599) {
-  partitions = other599.partitions;
-  hasUnknownPartitions = other599.hasUnknownPartitions;
+PartitionsByExprResult::PartitionsByExprResult(const PartitionsByExprResult& other606) {
+  partitions = other606.partitions;
+  hasUnknownPartitions = other606.hasUnknownPartitions;
 }
-PartitionsByExprResult& PartitionsByExprResult::operator=(const PartitionsByExprResult& other600) {
-  partitions = other600.partitions;
-  hasUnknownPartitions = other600.hasUnknownPartitions;
+PartitionsByExprResult& PartitionsByExprResult::operator=(const PartitionsByExprResult& other607) {
+  partitions = other607.partitions;
+  hasUnknownPartitions = other607.hasUnknownPartitions;
   return *this;
 }
 void PartitionsByExprResult::printTo(std::ostream& out) const {
@@ -16795,14 +16838,14 @@ uint32_t PartitionsSpecByExprResult::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionsSpec.clear();
-            uint32_t _size601;
-            ::apache::thrift::protocol::TType _etype604;
-            xfer += iprot->readListBegin(_etype604, _size601);
-            this->partitionsSpec.resize(_size601);
-            uint32_t _i605;
-            for (_i605 = 0; _i605 < _size601; ++_i605)
+            uint32_t _size608;
+            ::apache::thrift::protocol::TType _etype611;
+            xfer += iprot->readListBegin(_etype611, _size608);
+            this->partitionsSpec.resize(_size608);
+            uint32_t _i612;
+            for (_i612 = 0; _i612 < _size608; ++_i612)
             {
-              xfer += this->partitionsSpec[_i605].read(iprot);
+              xfer += this->partitionsSpec[_i612].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16843,10 +16886,10 @@ uint32_t PartitionsSpecByExprResult::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("partitionsSpec", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionsSpec.size()));
-    std::vector<PartitionSpec> ::const_iterator _iter606;
-    for (_iter606 = this->partitionsSpec.begin(); _iter606 != this->partitionsSpec.end(); ++_iter606)
+    std::vector<PartitionSpec> ::const_iterator _iter613;
+    for (_iter613 = this->partitionsSpec.begin(); _iter613 != this->partitionsSpec.end(); ++_iter613)
     {
-      xfer += (*_iter606).write(oprot);
+      xfer += (*_iter613).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16867,13 +16910,13 @@ void swap(PartitionsSpecByExprResult &a, PartitionsSpecByExprResult &b) {
   swap(a.hasUnknownPartitions, b.hasUnknownPartitions);
 }
 
-PartitionsSpecByExprResult::PartitionsSpecByExprResult(const PartitionsSpecByExprResult& other607) {
-  partitionsSpec = other607.partitionsSpec;
-  hasUnknownPartitions = other607.hasUnknownPartitions;
+PartitionsSpecByExprResult::PartitionsSpecByExprResult(const PartitionsSpecByExprResult& other614) {
+  partitionsSpec = other614.partitionsSpec;
+  hasUnknownPartitions = other614.hasUnknownPartitions;
 }
-PartitionsSpecByExprResult& PartitionsSpecByExprResult::operator=(const PartitionsSpecByExprResult& other608) {
-  partitionsSpec = other608.partitionsSpec;
-  hasUnknownPartitions = other608.hasUnknownPartitions;
+PartitionsSpecByExprResult& PartitionsSpecByExprResult::operator=(const PartitionsSpecByExprResult& other615) {
+  partitionsSpec = other615.partitionsSpec;
+  hasUnknownPartitions = other615.hasUnknownPartitions;
   return *this;
 }
 void PartitionsSpecByExprResult::printTo(std::ostream& out) const {
@@ -17117,29 +17160,29 @@ void swap(PartitionsByExprRequest &a, PartitionsByExprRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionsByExprRequest::PartitionsByExprRequest(const PartitionsByExprRequest& other609) {
-  dbName = other609.dbName;
-  tblName = other609.tblName;
-  expr = other609.expr;
-  defaultPartitionName = other609.defaultPartitionName;
-  maxParts = other609.maxParts;
-  catName = other609.catName;
-  order = other609.order;
-  validWriteIdList = other609.validWriteIdList;
-  id = other609.id;
-  __isset = other609.__isset;
+PartitionsByExprRequest::PartitionsByExprRequest(const PartitionsByExprRequest& other616) {
+  dbName = other616.dbName;
+  tblName = other616.tblName;
+  expr = other616.expr;
+  defaultPartitionName = other616.defaultPartitionName;
+  maxParts = other616.maxParts;
+  catName = other616.catName;
+  order = other616.order;
+  validWriteIdList = other616.validWriteIdList;
+  id = other616.id;
+  __isset = other616.__isset;
 }
-PartitionsByExprRequest& PartitionsByExprRequest::operator=(const PartitionsByExprRequest& other610) {
-  dbName = other610.dbName;
-  tblName = other610.tblName;
-  expr = other610.expr;
-  defaultPartitionName = other610.defaultPartitionName;
-  maxParts = other610.maxParts;
-  catName = other610.catName;
-  order = other610.order;
-  validWriteIdList = other610.validWriteIdList;
-  id = other610.id;
-  __isset = other610.__isset;
+PartitionsByExprRequest& PartitionsByExprRequest::operator=(const PartitionsByExprRequest& other617) {
+  dbName = other617.dbName;
+  tblName = other617.tblName;
+  expr = other617.expr;
+  defaultPartitionName = other617.defaultPartitionName;
+  maxParts = other617.maxParts;
+  catName = other617.catName;
+  order = other617.order;
+  validWriteIdList = other617.validWriteIdList;
+  id = other617.id;
+  __isset = other617.__isset;
   return *this;
 }
 void PartitionsByExprRequest::printTo(std::ostream& out) const {
@@ -17203,14 +17246,14 @@ uint32_t TableStatsResult::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tableStats.clear();
-            uint32_t _size611;
-            ::apache::thrift::protocol::TType _etype614;
-            xfer += iprot->readListBegin(_etype614, _size611);
-            this->tableStats.resize(_size611);
-            uint32_t _i615;
-            for (_i615 = 0; _i615 < _size611; ++_i615)
+            uint32_t _size618;
+            ::apache::thrift::protocol::TType _etype621;
+            xfer += iprot->readListBegin(_etype621, _size618);
+            this->tableStats.resize(_size618);
+            uint32_t _i622;
+            for (_i622 = 0; _i622 < _size618; ++_i622)
             {
-              xfer += this->tableStats[_i615].read(iprot);
+              xfer += this->tableStats[_i622].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -17249,10 +17292,10 @@ uint32_t TableStatsResult::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("tableStats", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tableStats.size()));
-    std::vector<ColumnStatisticsObj> ::const_iterator _iter616;
-    for (_iter616 = this->tableStats.begin(); _iter616 != this->tableStats.end(); ++_iter616)
+    std::vector<ColumnStatisticsObj> ::const_iterator _iter623;
+    for (_iter623 = this->tableStats.begin(); _iter623 != this->tableStats.end(); ++_iter623)
     {
-      xfer += (*_iter616).write(oprot);
+      xfer += (*_iter623).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -17275,15 +17318,15 @@ void swap(TableStatsResult &a, TableStatsResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableStatsResult::TableStatsResult(const TableStatsResult& other617) {
-  tableStats = other617.tableStats;
-  isStatsCompliant = other617.isStatsCompliant;
-  __isset = other617.__isset;
+TableStatsResult::TableStatsResult(const TableStatsResult& other624) {
+  tableStats = other624.tableStats;
+  isStatsCompliant = other624.isStatsCompliant;
+  __isset = other624.__isset;
 }
-TableStatsResult& TableStatsResult::operator=(const TableStatsResult& other618) {
-  tableStats = other618.tableStats;
-  isStatsCompliant = other618.isStatsCompliant;
-  __isset = other618.__isset;
+TableStatsResult& TableStatsResult::operator=(const TableStatsResult& other625) {
+  tableStats = other625.tableStats;
+  isStatsCompliant = other625.isStatsCompliant;
+  __isset = other625.__isset;
   return *this;
 }
 void TableStatsResult::printTo(std::ostream& out) const {
@@ -17340,26 +17383,26 @@ uint32_t PartitionsStatsResult::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->partStats.clear();
-            uint32_t _size619;
-            ::apache::thrift::protocol::TType _ktype620;
-            ::apache::thrift::protocol::TType _vtype621;
-            xfer += iprot->readMapBegin(_ktype620, _vtype621, _size619);
-            uint32_t _i623;
-            for (_i623 = 0; _i623 < _size619; ++_i623)
+            uint32_t _size626;
+            ::apache::thrift::protocol::TType _ktype627;
+            ::apache::thrift::protocol::TType _vtype628;
+            xfer += iprot->readMapBegin(_ktype627, _vtype628, _size626);
+            uint32_t _i630;
+            for (_i630 = 0; _i630 < _size626; ++_i630)
             {
-              std::string _key624;
-              xfer += iprot->readString(_key624);
-              std::vector<ColumnStatisticsObj> & _val625 = this->partStats[_key624];
+              std::string _key631;
+              xfer += iprot->readString(_key631);
+              std::vector<ColumnStatisticsObj> & _val632 = this->partStats[_key631];
               {
-                _val625.clear();
-                uint32_t _size626;
-                ::apache::thrift::protocol::TType _etype629;
-                xfer += iprot->readListBegin(_etype629, _size626);
-                _val625.resize(_size626);
-                uint32_t _i630;
-                for (_i630 = 0; _i630 < _size626; ++_i630)
+                _val632.clear();
+                uint32_t _size633;
+                ::apache::thrift::protocol::TType _etype636;
+                xfer += iprot->readListBegin(_etype636, _size633);
+                _val632.resize(_size633);
+                uint32_t _i637;
+                for (_i637 = 0; _i637 < _size633; ++_i637)
                 {
-                  xfer += _val625[_i630].read(iprot);
+                  xfer += _val632[_i637].read(iprot);
                 }
                 xfer += iprot->readListEnd();
               }
@@ -17401,16 +17444,16 @@ uint32_t PartitionsStatsResult::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("partStats", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, static_cast<uint32_t>(this->partStats.size()));
-    std::map<std::string, std::vector<ColumnStatisticsObj> > ::const_iterator _iter631;
-    for (_iter631 = this->partStats.begin(); _iter631 != this->partStats.end(); ++_iter631)
+    std::map<std::string, std::vector<ColumnStatisticsObj> > ::const_iterator _iter638;
+    for (_iter638 = this->partStats.begin(); _iter638 != this->partStats.end(); ++_iter638)
     {
-      xfer += oprot->writeString(_iter631->first);
+      xfer += oprot->writeString(_iter638->first);
       {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter631->second.size()));
-        std::vector<ColumnStatisticsObj> ::const_iterator _iter632;
-        for (_iter632 = _iter631->second.begin(); _iter632 != _iter631->second.end(); ++_iter632)
+        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(_iter638->second.size()));
+        std::vector<ColumnStatisticsObj> ::const_iterator _iter639;
+        for (_iter639 = _iter638->second.begin(); _iter639 != _iter638->second.end(); ++_iter639)
         {
-          xfer += (*_iter632).write(oprot);
+          xfer += (*_iter639).write(oprot);
         }
         xfer += oprot->writeListEnd();
       }
@@ -17436,15 +17479,15 @@ void swap(PartitionsStatsResult &a, PartitionsStatsResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionsStatsResult::PartitionsStatsResult(const PartitionsStatsResult& other633) {
-  partStats = other633.partStats;
-  isStatsCompliant = other633.isStatsCompliant;
-  __isset = other633.__isset;
+PartitionsStatsResult::PartitionsStatsResult(const PartitionsStatsResult& other640) {
+  partStats = other640.partStats;
+  isStatsCompliant = other640.isStatsCompliant;
+  __isset = other640.__isset;
 }
-PartitionsStatsResult& PartitionsStatsResult::operator=(const PartitionsStatsResult& other634) {
-  partStats = other634.partStats;
-  isStatsCompliant = other634.isStatsCompliant;
-  __isset = other634.__isset;
+PartitionsStatsResult& PartitionsStatsResult::operator=(const PartitionsStatsResult& other641) {
+  partStats = other641.partStats;
+  isStatsCompliant = other641.isStatsCompliant;
+  __isset = other641.__isset;
   return *this;
 }
 void PartitionsStatsResult::printTo(std::ostream& out) const {
@@ -17542,14 +17585,14 @@ uint32_t TableStatsRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colNames.clear();
-            uint32_t _size635;
-            ::apache::thrift::protocol::TType _etype638;
-            xfer += iprot->readListBegin(_etype638, _size635);
-            this->colNames.resize(_size635);
-            uint32_t _i639;
-            for (_i639 = 0; _i639 < _size635; ++_i639)
+            uint32_t _size642;
+            ::apache::thrift::protocol::TType _etype645;
+            xfer += iprot->readListBegin(_etype645, _size642);
+            this->colNames.resize(_size642);
+            uint32_t _i646;
+            for (_i646 = 0; _i646 < _size642; ++_i646)
             {
-              xfer += iprot->readString(this->colNames[_i639]);
+              xfer += iprot->readString(this->colNames[_i646]);
             }
             xfer += iprot->readListEnd();
           }
@@ -17626,10 +17669,10 @@ uint32_t TableStatsRequest::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("colNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->colNames.size()));
-    std::vector<std::string> ::const_iterator _iter640;
-    for (_iter640 = this->colNames.begin(); _iter640 != this->colNames.end(); ++_iter640)
+    std::vector<std::string> ::const_iterator _iter647;
+    for (_iter647 = this->colNames.begin(); _iter647 != this->colNames.end(); ++_iter647)
     {
-      xfer += oprot->writeString((*_iter640));
+      xfer += oprot->writeString((*_iter647));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17671,25 +17714,25 @@ void swap(TableStatsRequest &a, TableStatsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableStatsRequest::TableStatsRequest(const TableStatsRequest& other641) {
-  dbName = other641.dbName;
-  tblName = other641.tblName;
-  colNames = other641.colNames;
-  catName = other641.catName;
-  validWriteIdList = other641.validWriteIdList;
-  engine = other641.engine;
-  id = other641.id;
-  __isset = other641.__isset;
+TableStatsRequest::TableStatsRequest(const TableStatsRequest& other648) {
+  dbName = other648.dbName;
+  tblName = other648.tblName;
+  colNames = other648.colNames;
+  catName = other648.catName;
+  validWriteIdList = other648.validWriteIdList;
+  engine = other648.engine;
+  id = other648.id;
+  __isset = other648.__isset;
 }
-TableStatsRequest& TableStatsRequest::operator=(const TableStatsRequest& other642) {
-  dbName = other642.dbName;
-  tblName = other642.tblName;
-  colNames = other642.colNames;
-  catName = other642.catName;
-  validWriteIdList = other642.validWriteIdList;
-  engine = other642.engine;
-  id = other642.id;
-  __isset = other642.__isset;
+TableStatsRequest& TableStatsRequest::operator=(const TableStatsRequest& other649) {
+  dbName = other649.dbName;
+  tblName = other649.tblName;
+  colNames = other649.colNames;
+  catName = other649.catName;
+  validWriteIdList = other649.validWriteIdList;
+  engine = other649.engine;
+  id = other649.id;
+  __isset = other649.__isset;
   return *this;
 }
 void TableStatsRequest::printTo(std::ostream& out) const {
@@ -17792,14 +17835,14 @@ uint32_t PartitionsStatsRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->colNames.clear();
-            uint32_t _size643;
-            ::apache::thrift::protocol::TType _etype646;
-            xfer += iprot->readListBegin(_etype646, _size643);
-            this->colNames.resize(_size643);
-            uint32_t _i647;
-            for (_i647 = 0; _i647 < _size643; ++_i647)
+            uint32_t _size650;
+            ::apache::thrift::protocol::TType _etype653;
+            xfer += iprot->readListBegin(_etype653, _size650);
+            this->colNames.resize(_size650);
+            uint32_t _i654;
+            for (_i654 = 0; _i654 < _size650; ++_i654)
             {
-              xfer += iprot->readString(this->colNames[_i647]);
+              xfer += iprot->readString(this->colNames[_i654]);
             }
             xfer += iprot->readListEnd();
           }
@@ -17812,14 +17855,14 @@ uint32_t PartitionsStatsRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size648;
-            ::apache::thrift::protocol::TType _etype651;
-            xfer += iprot->readListBegin(_etype651, _size648);
-            this->partNames.resize(_size648);
-            uint32_t _i652;
-            for (_i652 = 0; _i652 < _size648; ++_i652)
+            uint32_t _size655;
+            ::apache::thrift::protocol::TType _etype658;
+            xfer += iprot->readListBegin(_etype658, _size655);
+            this->partNames.resize(_size655);
+            uint32_t _i659;
+            for (_i659 = 0; _i659 < _size655; ++_i659)
             {
-              xfer += iprot->readString(this->partNames[_i652]);
+              xfer += iprot->readString(this->partNames[_i659]);
             }
             xfer += iprot->readListEnd();
           }
@@ -17890,10 +17933,10 @@ uint32_t PartitionsStatsRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("colNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->colNames.size()));
-    std::vector<std::string> ::const_iterator _iter653;
-    for (_iter653 = this->colNames.begin(); _iter653 != this->colNames.end(); ++_iter653)
+    std::vector<std::string> ::const_iterator _iter660;
+    for (_iter660 = this->colNames.begin(); _iter660 != this->colNames.end(); ++_iter660)
     {
-      xfer += oprot->writeString((*_iter653));
+      xfer += oprot->writeString((*_iter660));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17902,10 +17945,10 @@ uint32_t PartitionsStatsRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-    std::vector<std::string> ::const_iterator _iter654;
-    for (_iter654 = this->partNames.begin(); _iter654 != this->partNames.end(); ++_iter654)
+    std::vector<std::string> ::const_iterator _iter661;
+    for (_iter661 = this->partNames.begin(); _iter661 != this->partNames.end(); ++_iter661)
     {
-      xfer += oprot->writeString((*_iter654));
+      xfer += oprot->writeString((*_iter661));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17942,25 +17985,25 @@ void swap(PartitionsStatsRequest &a, PartitionsStatsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionsStatsRequest::PartitionsStatsRequest(const PartitionsStatsRequest& other655) {
-  dbName = other655.dbName;
-  tblName = other655.tblName;
-  colNames = other655.colNames;
-  partNames = other655.partNames;
-  catName = other655.catName;
-  validWriteIdList = other655.validWriteIdList;
-  engine = other655.engine;
-  __isset = other655.__isset;
+PartitionsStatsRequest::PartitionsStatsRequest(const PartitionsStatsRequest& other662) {
+  dbName = other662.dbName;
+  tblName = other662.tblName;
+  colNames = other662.colNames;
+  partNames = other662.partNames;
+  catName = other662.catName;
+  validWriteIdList = other662.validWriteIdList;
+  engine = other662.engine;
+  __isset = other662.__isset;
 }
-PartitionsStatsRequest& PartitionsStatsRequest::operator=(const PartitionsStatsRequest& other656) {
-  dbName = other656.dbName;
-  tblName = other656.tblName;
-  colNames = other656.colNames;
-  partNames = other656.partNames;
-  catName = other656.catName;
-  validWriteIdList = other656.validWriteIdList;
-  engine = other656.engine;
-  __isset = other656.__isset;
+PartitionsStatsRequest& PartitionsStatsRequest::operator=(const PartitionsStatsRequest& other663) {
+  dbName = other663.dbName;
+  tblName = other663.tblName;
+  colNames = other663.colNames;
+  partNames = other663.partNames;
+  catName = other663.catName;
+  validWriteIdList = other663.validWriteIdList;
+  engine = other663.engine;
+  __isset = other663.__isset;
   return *this;
 }
 void PartitionsStatsRequest::printTo(std::ostream& out) const {
@@ -18022,14 +18065,14 @@ uint32_t AddPartitionsResult::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size657;
-            ::apache::thrift::protocol::TType _etype660;
-            xfer += iprot->readListBegin(_etype660, _size657);
-            this->partitions.resize(_size657);
-            uint32_t _i661;
-            for (_i661 = 0; _i661 < _size657; ++_i661)
+            uint32_t _size664;
+            ::apache::thrift::protocol::TType _etype667;
+            xfer += iprot->readListBegin(_etype667, _size664);
+            this->partitions.resize(_size664);
+            uint32_t _i668;
+            for (_i668 = 0; _i668 < _size664; ++_i668)
             {
-              xfer += this->partitions[_i661].read(iprot);
+              xfer += this->partitions[_i668].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -18067,10 +18110,10 @@ uint32_t AddPartitionsResult::write(::apache::thrift::protocol::TProtocol* oprot
     xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-      std::vector<Partition> ::const_iterator _iter662;
-      for (_iter662 = this->partitions.begin(); _iter662 != this->partitions.end(); ++_iter662)
+      std::vector<Partition> ::const_iterator _iter669;
+      for (_iter669 = this->partitions.begin(); _iter669 != this->partitions.end(); ++_iter669)
       {
-        xfer += (*_iter662).write(oprot);
+        xfer += (*_iter669).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -18093,15 +18136,15 @@ void swap(AddPartitionsResult &a, AddPartitionsResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddPartitionsResult::AddPartitionsResult(const AddPartitionsResult& other663) {
-  partitions = other663.partitions;
-  isStatsCompliant = other663.isStatsCompliant;
-  __isset = other663.__isset;
+AddPartitionsResult::AddPartitionsResult(const AddPartitionsResult& other670) {
+  partitions = other670.partitions;
+  isStatsCompliant = other670.isStatsCompliant;
+  __isset = other670.__isset;
 }
-AddPartitionsResult& AddPartitionsResult::operator=(const AddPartitionsResult& other664) {
-  partitions = other664.partitions;
-  isStatsCompliant = other664.isStatsCompliant;
-  __isset = other664.__isset;
+AddPartitionsResult& AddPartitionsResult::operator=(const AddPartitionsResult& other671) {
+  partitions = other671.partitions;
+  isStatsCompliant = other671.isStatsCompliant;
+  __isset = other671.__isset;
   return *this;
 }
 void AddPartitionsResult::printTo(std::ostream& out) const {
@@ -18199,14 +18242,14 @@ uint32_t AddPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->parts.clear();
-            uint32_t _size665;
-            ::apache::thrift::protocol::TType _etype668;
-            xfer += iprot->readListBegin(_etype668, _size665);
-            this->parts.resize(_size665);
-            uint32_t _i669;
-            for (_i669 = 0; _i669 < _size665; ++_i669)
+            uint32_t _size672;
+            ::apache::thrift::protocol::TType _etype675;
+            xfer += iprot->readListBegin(_etype675, _size672);
+            this->parts.resize(_size672);
+            uint32_t _i676;
+            for (_i676 = 0; _i676 < _size672; ++_i676)
             {
-              xfer += this->parts[_i669].read(iprot);
+              xfer += this->parts[_i676].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -18283,10 +18326,10 @@ uint32_t AddPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
   xfer += oprot->writeFieldBegin("parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->parts.size()));
-    std::vector<Partition> ::const_iterator _iter670;
-    for (_iter670 = this->parts.begin(); _iter670 != this->parts.end(); ++_iter670)
+    std::vector<Partition> ::const_iterator _iter677;
+    for (_iter677 = this->parts.begin(); _iter677 != this->parts.end(); ++_iter677)
     {
-      xfer += (*_iter670).write(oprot);
+      xfer += (*_iter677).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -18328,25 +18371,25 @@ void swap(AddPartitionsRequest &a, AddPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddPartitionsRequest::AddPartitionsRequest(const AddPartitionsRequest& other671) {
-  dbName = other671.dbName;
-  tblName = other671.tblName;
-  parts = other671.parts;
-  ifNotExists = other671.ifNotExists;
-  needResult = other671.needResult;
-  catName = other671.catName;
-  validWriteIdList = other671.validWriteIdList;
-  __isset = other671.__isset;
+AddPartitionsRequest::AddPartitionsRequest(const AddPartitionsRequest& other678) {
+  dbName = other678.dbName;
+  tblName = other678.tblName;
+  parts = other678.parts;
+  ifNotExists = other678.ifNotExists;
+  needResult = other678.needResult;
+  catName = other678.catName;
+  validWriteIdList = other678.validWriteIdList;
+  __isset = other678.__isset;
 }
-AddPartitionsRequest& AddPartitionsRequest::operator=(const AddPartitionsRequest& other672) {
-  dbName = other672.dbName;
-  tblName = other672.tblName;
-  parts = other672.parts;
-  ifNotExists = other672.ifNotExists;
-  needResult = other672.needResult;
-  catName = other672.catName;
-  validWriteIdList = other672.validWriteIdList;
-  __isset = other672.__isset;
+AddPartitionsRequest& AddPartitionsRequest::operator=(const AddPartitionsRequest& other679) {
+  dbName = other679.dbName;
+  tblName = other679.tblName;
+  parts = other679.parts;
+  ifNotExists = other679.ifNotExists;
+  needResult = other679.needResult;
+  catName = other679.catName;
+  validWriteIdList = other679.validWriteIdList;
+  __isset = other679.__isset;
   return *this;
 }
 void AddPartitionsRequest::printTo(std::ostream& out) const {
@@ -18403,14 +18446,14 @@ uint32_t DropPartitionsResult::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size673;
-            ::apache::thrift::protocol::TType _etype676;
-            xfer += iprot->readListBegin(_etype676, _size673);
-            this->partitions.resize(_size673);
-            uint32_t _i677;
-            for (_i677 = 0; _i677 < _size673; ++_i677)
+            uint32_t _size680;
+            ::apache::thrift::protocol::TType _etype683;
+            xfer += iprot->readListBegin(_etype683, _size680);
+            this->partitions.resize(_size680);
+            uint32_t _i684;
+            for (_i684 = 0; _i684 < _size680; ++_i684)
             {
-              xfer += this->partitions[_i677].read(iprot);
+              xfer += this->partitions[_i684].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -18440,10 +18483,10 @@ uint32_t DropPartitionsResult::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-      std::vector<Partition> ::const_iterator _iter678;
-      for (_iter678 = this->partitions.begin(); _iter678 != this->partitions.end(); ++_iter678)
+      std::vector<Partition> ::const_iterator _iter685;
+      for (_iter685 = this->partitions.begin(); _iter685 != this->partitions.end(); ++_iter685)
       {
-        xfer += (*_iter678).write(oprot);
+        xfer += (*_iter685).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -18460,13 +18503,13 @@ void swap(DropPartitionsResult &a, DropPartitionsResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropPartitionsResult::DropPartitionsResult(const DropPartitionsResult& other679) {
-  partitions = other679.partitions;
-  __isset = other679.__isset;
+DropPartitionsResult::DropPartitionsResult(const DropPartitionsResult& other686) {
+  partitions = other686.partitions;
+  __isset = other686.__isset;
 }
-DropPartitionsResult& DropPartitionsResult::operator=(const DropPartitionsResult& other680) {
-  partitions = other680.partitions;
-  __isset = other680.__isset;
+DropPartitionsResult& DropPartitionsResult::operator=(const DropPartitionsResult& other687) {
+  partitions = other687.partitions;
+  __isset = other687.__isset;
   return *this;
 }
 void DropPartitionsResult::printTo(std::ostream& out) const {
@@ -18574,15 +18617,15 @@ void swap(DropPartitionsExpr &a, DropPartitionsExpr &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropPartitionsExpr::DropPartitionsExpr(const DropPartitionsExpr& other681) {
-  expr = other681.expr;
-  partArchiveLevel = other681.partArchiveLevel;
-  __isset = other681.__isset;
+DropPartitionsExpr::DropPartitionsExpr(const DropPartitionsExpr& other688) {
+  expr = other688.expr;
+  partArchiveLevel = other688.partArchiveLevel;
+  __isset = other688.__isset;
 }
-DropPartitionsExpr& DropPartitionsExpr::operator=(const DropPartitionsExpr& other682) {
-  expr = other682.expr;
-  partArchiveLevel = other682.partArchiveLevel;
-  __isset = other682.__isset;
+DropPartitionsExpr& DropPartitionsExpr::operator=(const DropPartitionsExpr& other689) {
+  expr = other689.expr;
+  partArchiveLevel = other689.partArchiveLevel;
+  __isset = other689.__isset;
   return *this;
 }
 void DropPartitionsExpr::printTo(std::ostream& out) const {
@@ -18639,14 +18682,14 @@ uint32_t RequestPartsSpec::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size683;
-            ::apache::thrift::protocol::TType _etype686;
-            xfer += iprot->readListBegin(_etype686, _size683);
-            this->names.resize(_size683);
-            uint32_t _i687;
-            for (_i687 = 0; _i687 < _size683; ++_i687)
+            uint32_t _size690;
+            ::apache::thrift::protocol::TType _etype693;
+            xfer += iprot->readListBegin(_etype693, _size690);
+            this->names.resize(_size690);
+            uint32_t _i694;
+            for (_i694 = 0; _i694 < _size690; ++_i694)
             {
-              xfer += iprot->readString(this->names[_i687]);
+              xfer += iprot->readString(this->names[_i694]);
             }
             xfer += iprot->readListEnd();
           }
@@ -18659,14 +18702,14 @@ uint32_t RequestPartsSpec::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->exprs.clear();
-            uint32_t _size688;
-            ::apache::thrift::protocol::TType _etype691;
-            xfer += iprot->readListBegin(_etype691, _size688);
-            this->exprs.resize(_size688);
-            uint32_t _i692;
-            for (_i692 = 0; _i692 < _size688; ++_i692)
+            uint32_t _size695;
+            ::apache::thrift::protocol::TType _etype698;
+            xfer += iprot->readListBegin(_etype698, _size695);
+            this->exprs.resize(_size695);
+            uint32_t _i699;
+            for (_i699 = 0; _i699 < _size695; ++_i699)
             {
-              xfer += this->exprs[_i692].read(iprot);
+              xfer += this->exprs[_i699].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -18696,10 +18739,10 @@ uint32_t RequestPartsSpec::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-      std::vector<std::string> ::const_iterator _iter693;
-      for (_iter693 = this->names.begin(); _iter693 != this->names.end(); ++_iter693)
+      std::vector<std::string> ::const_iterator _iter700;
+      for (_iter700 = this->names.begin(); _iter700 != this->names.end(); ++_iter700)
       {
-        xfer += oprot->writeString((*_iter693));
+        xfer += oprot->writeString((*_iter700));
       }
       xfer += oprot->writeListEnd();
     }
@@ -18709,10 +18752,10 @@ uint32_t RequestPartsSpec::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("exprs", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->exprs.size()));
-      std::vector<DropPartitionsExpr> ::const_iterator _iter694;
-      for (_iter694 = this->exprs.begin(); _iter694 != this->exprs.end(); ++_iter694)
+      std::vector<DropPartitionsExpr> ::const_iterator _iter701;
+      for (_iter701 = this->exprs.begin(); _iter701 != this->exprs.end(); ++_iter701)
       {
-        xfer += (*_iter694).write(oprot);
+        xfer += (*_iter701).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -18730,15 +18773,15 @@ void swap(RequestPartsSpec &a, RequestPartsSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-RequestPartsSpec::RequestPartsSpec(const RequestPartsSpec& other695) {
-  names = other695.names;
-  exprs = other695.exprs;
-  __isset = other695.__isset;
+RequestPartsSpec::RequestPartsSpec(const RequestPartsSpec& other702) {
+  names = other702.names;
+  exprs = other702.exprs;
+  __isset = other702.__isset;
 }
-RequestPartsSpec& RequestPartsSpec::operator=(const RequestPartsSpec& other696) {
-  names = other696.names;
-  exprs = other696.exprs;
-  __isset = other696.__isset;
+RequestPartsSpec& RequestPartsSpec::operator=(const RequestPartsSpec& other703) {
+  names = other703.names;
+  exprs = other703.exprs;
+  __isset = other703.__isset;
   return *this;
 }
 void RequestPartsSpec::printTo(std::ostream& out) const {
@@ -18982,29 +19025,29 @@ void swap(DropPartitionsRequest &a, DropPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropPartitionsRequest::DropPartitionsRequest(const DropPartitionsRequest& other697) {
-  dbName = other697.dbName;
-  tblName = other697.tblName;
-  parts = other697.parts;
-  deleteData = other697.deleteData;
-  ifExists = other697.ifExists;
-  ignoreProtection = other697.ignoreProtection;
-  environmentContext = other697.environmentContext;
-  needResult = other697.needResult;
-  catName = other697.catName;
-  __isset = other697.__isset;
+DropPartitionsRequest::DropPartitionsRequest(const DropPartitionsRequest& other704) {
+  dbName = other704.dbName;
+  tblName = other704.tblName;
+  parts = other704.parts;
+  deleteData = other704.deleteData;
+  ifExists = other704.ifExists;
+  ignoreProtection = other704.ignoreProtection;
+  environmentContext = other704.environmentContext;
+  needResult = other704.needResult;
+  catName = other704.catName;
+  __isset = other704.__isset;
 }
-DropPartitionsRequest& DropPartitionsRequest::operator=(const DropPartitionsRequest& other698) {
-  dbName = other698.dbName;
-  tblName = other698.tblName;
-  parts = other698.parts;
-  deleteData = other698.deleteData;
-  ifExists = other698.ifExists;
-  ignoreProtection = other698.ignoreProtection;
-  environmentContext = other698.environmentContext;
-  needResult = other698.needResult;
-  catName = other698.catName;
-  __isset = other698.__isset;
+DropPartitionsRequest& DropPartitionsRequest::operator=(const DropPartitionsRequest& other705) {
+  dbName = other705.dbName;
+  tblName = other705.tblName;
+  parts = other705.parts;
+  deleteData = other705.deleteData;
+  ifExists = other705.ifExists;
+  ignoreProtection = other705.ignoreProtection;
+  environmentContext = other705.environmentContext;
+  needResult = other705.needResult;
+  catName = other705.catName;
+  __isset = other705.__isset;
   return *this;
 }
 void DropPartitionsRequest::printTo(std::ostream& out) const {
@@ -19124,14 +19167,14 @@ uint32_t PartitionValuesRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionKeys.clear();
-            uint32_t _size699;
-            ::apache::thrift::protocol::TType _etype702;
-            xfer += iprot->readListBegin(_etype702, _size699);
-            this->partitionKeys.resize(_size699);
-            uint32_t _i703;
-            for (_i703 = 0; _i703 < _size699; ++_i703)
+            uint32_t _size706;
+            ::apache::thrift::protocol::TType _etype709;
+            xfer += iprot->readListBegin(_etype709, _size706);
+            this->partitionKeys.resize(_size706);
+            uint32_t _i710;
+            for (_i710 = 0; _i710 < _size706; ++_i710)
             {
-              xfer += this->partitionKeys[_i703].read(iprot);
+              xfer += this->partitionKeys[_i710].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -19160,14 +19203,14 @@ uint32_t PartitionValuesRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionOrder.clear();
-            uint32_t _size704;
-            ::apache::thrift::protocol::TType _etype707;
-            xfer += iprot->readListBegin(_etype707, _size704);
-            this->partitionOrder.resize(_size704);
-            uint32_t _i708;
-            for (_i708 = 0; _i708 < _size704; ++_i708)
+            uint32_t _size711;
+            ::apache::thrift::protocol::TType _etype714;
+            xfer += iprot->readListBegin(_etype714, _size711);
+            this->partitionOrder.resize(_size711);
+            uint32_t _i715;
+            for (_i715 = 0; _i715 < _size711; ++_i715)
             {
-              xfer += this->partitionOrder[_i708].read(iprot);
+              xfer += this->partitionOrder[_i715].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -19242,10 +19285,10 @@ uint32_t PartitionValuesRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partitionKeys", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionKeys.size()));
-    std::vector<FieldSchema> ::const_iterator _iter709;
-    for (_iter709 = this->partitionKeys.begin(); _iter709 != this->partitionKeys.end(); ++_iter709)
+    std::vector<FieldSchema> ::const_iterator _iter716;
+    for (_iter716 = this->partitionKeys.begin(); _iter716 != this->partitionKeys.end(); ++_iter716)
     {
-      xfer += (*_iter709).write(oprot);
+      xfer += (*_iter716).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -19265,10 +19308,10 @@ uint32_t PartitionValuesRequest::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("partitionOrder", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionOrder.size()));
-      std::vector<FieldSchema> ::const_iterator _iter710;
-      for (_iter710 = this->partitionOrder.begin(); _iter710 != this->partitionOrder.end(); ++_iter710)
+      std::vector<FieldSchema> ::const_iterator _iter717;
+      for (_iter717 = this->partitionOrder.begin(); _iter717 != this->partitionOrder.end(); ++_iter717)
       {
-        xfer += (*_iter710).write(oprot);
+        xfer += (*_iter717).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -19314,31 +19357,31 @@ void swap(PartitionValuesRequest &a, PartitionValuesRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionValuesRequest::PartitionValuesRequest(const PartitionValuesRequest& other711) {
-  dbName = other711.dbName;
-  tblName = other711.tblName;
-  partitionKeys = other711.partitionKeys;
-  applyDistinct = other711.applyDistinct;
-  filter = other711.filter;
-  partitionOrder = other711.partitionOrder;
-  ascending = other711.ascending;
-  maxParts = other711.maxParts;
-  catName = other711.catName;
-  validWriteIdList = other711.validWriteIdList;
-  __isset = other711.__isset;
+PartitionValuesRequest::PartitionValuesRequest(const PartitionValuesRequest& other718) {
+  dbName = other718.dbName;
+  tblName = other718.tblName;
+  partitionKeys = other718.partitionKeys;
+  applyDistinct = other718.applyDistinct;
+  filter = other718.filter;
+  partitionOrder = other718.partitionOrder;
+  ascending = other718.ascending;
+  maxParts = other718.maxParts;
+  catName = other718.catName;
+  validWriteIdList = other718.validWriteIdList;
+  __isset = other718.__isset;
 }
-PartitionValuesRequest& PartitionValuesRequest::operator=(const PartitionValuesRequest& other712) {
-  dbName = other712.dbName;
-  tblName = other712.tblName;
-  partitionKeys = other712.partitionKeys;
-  applyDistinct = other712.applyDistinct;
-  filter = other712.filter;
-  partitionOrder = other712.partitionOrder;
-  ascending = other712.ascending;
-  maxParts = other712.maxParts;
-  catName = other712.catName;
-  validWriteIdList = other712.validWriteIdList;
-  __isset = other712.__isset;
+PartitionValuesRequest& PartitionValuesRequest::operator=(const PartitionValuesRequest& other719) {
+  dbName = other719.dbName;
+  tblName = other719.tblName;
+  partitionKeys = other719.partitionKeys;
+  applyDistinct = other719.applyDistinct;
+  filter = other719.filter;
+  partitionOrder = other719.partitionOrder;
+  ascending = other719.ascending;
+  maxParts = other719.maxParts;
+  catName = other719.catName;
+  validWriteIdList = other719.validWriteIdList;
+  __isset = other719.__isset;
   return *this;
 }
 void PartitionValuesRequest::printTo(std::ostream& out) const {
@@ -19398,14 +19441,14 @@ uint32_t PartitionValuesRow::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->row.clear();
-            uint32_t _size713;
-            ::apache::thrift::protocol::TType _etype716;
-            xfer += iprot->readListBegin(_etype716, _size713);
-            this->row.resize(_size713);
-            uint32_t _i717;
-            for (_i717 = 0; _i717 < _size713; ++_i717)
+            uint32_t _size720;
+            ::apache::thrift::protocol::TType _etype723;
+            xfer += iprot->readListBegin(_etype723, _size720);
+            this->row.resize(_size720);
+            uint32_t _i724;
+            for (_i724 = 0; _i724 < _size720; ++_i724)
             {
-              xfer += iprot->readString(this->row[_i717]);
+              xfer += iprot->readString(this->row[_i724]);
             }
             xfer += iprot->readListEnd();
           }
@@ -19436,10 +19479,10 @@ uint32_t PartitionValuesRow::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("row", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->row.size()));
-    std::vector<std::string> ::const_iterator _iter718;
-    for (_iter718 = this->row.begin(); _iter718 != this->row.end(); ++_iter718)
+    std::vector<std::string> ::const_iterator _iter725;
+    for (_iter725 = this->row.begin(); _iter725 != this->row.end(); ++_iter725)
     {
-      xfer += oprot->writeString((*_iter718));
+      xfer += oprot->writeString((*_iter725));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19455,11 +19498,11 @@ void swap(PartitionValuesRow &a, PartitionValuesRow &b) {
   swap(a.row, b.row);
 }
 
-PartitionValuesRow::PartitionValuesRow(const PartitionValuesRow& other719) {
-  row = other719.row;
+PartitionValuesRow::PartitionValuesRow(const PartitionValuesRow& other726) {
+  row = other726.row;
 }
-PartitionValuesRow& PartitionValuesRow::operator=(const PartitionValuesRow& other720) {
-  row = other720.row;
+PartitionValuesRow& PartitionValuesRow::operator=(const PartitionValuesRow& other727) {
+  row = other727.row;
   return *this;
 }
 void PartitionValuesRow::printTo(std::ostream& out) const {
@@ -19510,14 +19553,14 @@ uint32_t PartitionValuesResponse::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionValues.clear();
-            uint32_t _size721;
-            ::apache::thrift::protocol::TType _etype724;
-            xfer += iprot->readListBegin(_etype724, _size721);
-            this->partitionValues.resize(_size721);
-            uint32_t _i725;
-            for (_i725 = 0; _i725 < _size721; ++_i725)
+            uint32_t _size728;
+            ::apache::thrift::protocol::TType _etype731;
+            xfer += iprot->readListBegin(_etype731, _size728);
+            this->partitionValues.resize(_size728);
+            uint32_t _i732;
+            for (_i732 = 0; _i732 < _size728; ++_i732)
             {
-              xfer += this->partitionValues[_i725].read(iprot);
+              xfer += this->partitionValues[_i732].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -19548,10 +19591,10 @@ uint32_t PartitionValuesResponse::write(::apache::thrift::protocol::TProtocol* o
   xfer += oprot->writeFieldBegin("partitionValues", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionValues.size()));
-    std::vector<PartitionValuesRow> ::const_iterator _iter726;
-    for (_iter726 = this->partitionValues.begin(); _iter726 != this->partitionValues.end(); ++_iter726)
+    std::vector<PartitionValuesRow> ::const_iterator _iter733;
+    for (_iter733 = this->partitionValues.begin(); _iter733 != this->partitionValues.end(); ++_iter733)
     {
-      xfer += (*_iter726).write(oprot);
+      xfer += (*_iter733).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -19567,11 +19610,11 @@ void swap(PartitionValuesResponse &a, PartitionValuesResponse &b) {
   swap(a.partitionValues, b.partitionValues);
 }
 
-PartitionValuesResponse::PartitionValuesResponse(const PartitionValuesResponse& other727) {
-  partitionValues = other727.partitionValues;
+PartitionValuesResponse::PartitionValuesResponse(const PartitionValuesResponse& other734) {
+  partitionValues = other734.partitionValues;
 }
-PartitionValuesResponse& PartitionValuesResponse::operator=(const PartitionValuesResponse& other728) {
-  partitionValues = other728.partitionValues;
+PartitionValuesResponse& PartitionValuesResponse::operator=(const PartitionValuesResponse& other735) {
+  partitionValues = other735.partitionValues;
   return *this;
 }
 void PartitionValuesResponse::printTo(std::ostream& out) const {
@@ -19683,14 +19726,14 @@ uint32_t GetPartitionsByNamesRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size729;
-            ::apache::thrift::protocol::TType _etype732;
-            xfer += iprot->readListBegin(_etype732, _size729);
-            this->names.resize(_size729);
-            uint32_t _i733;
-            for (_i733 = 0; _i733 < _size729; ++_i733)
+            uint32_t _size736;
+            ::apache::thrift::protocol::TType _etype739;
+            xfer += iprot->readListBegin(_etype739, _size736);
+            this->names.resize(_size736);
+            uint32_t _i740;
+            for (_i740 = 0; _i740 < _size736; ++_i740)
             {
-              xfer += iprot->readString(this->names[_i733]);
+              xfer += iprot->readString(this->names[_i740]);
             }
             xfer += iprot->readListEnd();
           }
@@ -19711,14 +19754,14 @@ uint32_t GetPartitionsByNamesRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size734;
-            ::apache::thrift::protocol::TType _etype737;
-            xfer += iprot->readListBegin(_etype737, _size734);
-            this->processorCapabilities.resize(_size734);
-            uint32_t _i738;
-            for (_i738 = 0; _i738 < _size734; ++_i738)
+            uint32_t _size741;
+            ::apache::thrift::protocol::TType _etype744;
+            xfer += iprot->readListBegin(_etype744, _size741);
+            this->processorCapabilities.resize(_size741);
+            uint32_t _i745;
+            for (_i745 = 0; _i745 < _size741; ++_i745)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i738]);
+              xfer += iprot->readString(this->processorCapabilities[_i745]);
             }
             xfer += iprot->readListEnd();
           }
@@ -19800,10 +19843,10 @@ uint32_t GetPartitionsByNamesRequest::write(::apache::thrift::protocol::TProtoco
     xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-      std::vector<std::string> ::const_iterator _iter739;
-      for (_iter739 = this->names.begin(); _iter739 != this->names.end(); ++_iter739)
+      std::vector<std::string> ::const_iterator _iter746;
+      for (_iter746 = this->names.begin(); _iter746 != this->names.end(); ++_iter746)
       {
-        xfer += oprot->writeString((*_iter739));
+        xfer += oprot->writeString((*_iter746));
       }
       xfer += oprot->writeListEnd();
     }
@@ -19818,10 +19861,10 @@ uint32_t GetPartitionsByNamesRequest::write(::apache::thrift::protocol::TProtoco
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter740;
-      for (_iter740 = this->processorCapabilities.begin(); _iter740 != this->processorCapabilities.end(); ++_iter740)
+      std::vector<std::string> ::const_iterator _iter747;
+      for (_iter747 = this->processorCapabilities.begin(); _iter747 != this->processorCapabilities.end(); ++_iter747)
       {
-        xfer += oprot->writeString((*_iter740));
+        xfer += oprot->writeString((*_iter747));
       }
       xfer += oprot->writeListEnd();
     }
@@ -19872,31 +19915,31 @@ void swap(GetPartitionsByNamesRequest &a, GetPartitionsByNamesRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsByNamesRequest::GetPartitionsByNamesRequest(const GetPartitionsByNamesRequest& other741) {
-  db_name = other741.db_name;
-  tbl_name = other741.tbl_name;
-  names = other741.names;
-  get_col_stats = other741.get_col_stats;
-  processorCapabilities = other741.processorCapabilities;
-  processorIdentifier = other741.processorIdentifier;
-  engine = other741.engine;
-  validWriteIdList = other741.validWriteIdList;
-  getFileMetadata = other741.getFileMetadata;
-  id = other741.id;
-  __isset = other741.__isset;
+GetPartitionsByNamesRequest::GetPartitionsByNamesRequest(const GetPartitionsByNamesRequest& other748) {
+  db_name = other748.db_name;
+  tbl_name = other748.tbl_name;
+  names = other748.names;
+  get_col_stats = other748.get_col_stats;
+  processorCapabilities = other748.processorCapabilities;
+  processorIdentifier = other748.processorIdentifier;
+  engine = other748.engine;
+  validWriteIdList = other748.validWriteIdList;
+  getFileMetadata = other748.getFileMetadata;
+  id = other748.id;
+  __isset = other748.__isset;
 }
-GetPartitionsByNamesRequest& GetPartitionsByNamesRequest::operator=(const GetPartitionsByNamesRequest& other742) {
-  db_name = other742.db_name;
-  tbl_name = other742.tbl_name;
-  names = other742.names;
-  get_col_stats = other742.get_col_stats;
-  processorCapabilities = other742.processorCapabilities;
-  processorIdentifier = other742.processorIdentifier;
-  engine = other742.engine;
-  validWriteIdList = other742.validWriteIdList;
-  getFileMetadata = other742.getFileMetadata;
-  id = other742.id;
-  __isset = other742.__isset;
+GetPartitionsByNamesRequest& GetPartitionsByNamesRequest::operator=(const GetPartitionsByNamesRequest& other749) {
+  db_name = other749.db_name;
+  tbl_name = other749.tbl_name;
+  names = other749.names;
+  get_col_stats = other749.get_col_stats;
+  processorCapabilities = other749.processorCapabilities;
+  processorIdentifier = other749.processorIdentifier;
+  engine = other749.engine;
+  validWriteIdList = other749.validWriteIdList;
+  getFileMetadata = other749.getFileMetadata;
+  id = other749.id;
+  __isset = other749.__isset;
   return *this;
 }
 void GetPartitionsByNamesRequest::printTo(std::ostream& out) const {
@@ -19961,14 +20004,14 @@ uint32_t GetPartitionsByNamesResult::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size743;
-            ::apache::thrift::protocol::TType _etype746;
-            xfer += iprot->readListBegin(_etype746, _size743);
-            this->partitions.resize(_size743);
-            uint32_t _i747;
-            for (_i747 = 0; _i747 < _size743; ++_i747)
+            uint32_t _size750;
+            ::apache::thrift::protocol::TType _etype753;
+            xfer += iprot->readListBegin(_etype753, _size750);
+            this->partitions.resize(_size750);
+            uint32_t _i754;
+            for (_i754 = 0; _i754 < _size750; ++_i754)
             {
-              xfer += this->partitions[_i747].read(iprot);
+              xfer += this->partitions[_i754].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20007,10 +20050,10 @@ uint32_t GetPartitionsByNamesResult::write(::apache::thrift::protocol::TProtocol
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter748;
-    for (_iter748 = this->partitions.begin(); _iter748 != this->partitions.end(); ++_iter748)
+    std::vector<Partition> ::const_iterator _iter755;
+    for (_iter755 = this->partitions.begin(); _iter755 != this->partitions.end(); ++_iter755)
     {
-      xfer += (*_iter748).write(oprot);
+      xfer += (*_iter755).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -20033,15 +20076,15 @@ void swap(GetPartitionsByNamesResult &a, GetPartitionsByNamesResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsByNamesResult::GetPartitionsByNamesResult(const GetPartitionsByNamesResult& other749) {
-  partitions = other749.partitions;
-  dictionary = other749.dictionary;
-  __isset = other749.__isset;
+GetPartitionsByNamesResult::GetPartitionsByNamesResult(const GetPartitionsByNamesResult& other756) {
+  partitions = other756.partitions;
+  dictionary = other756.dictionary;
+  __isset = other756.__isset;
 }
-GetPartitionsByNamesResult& GetPartitionsByNamesResult::operator=(const GetPartitionsByNamesResult& other750) {
-  partitions = other750.partitions;
-  dictionary = other750.dictionary;
-  __isset = other750.__isset;
+GetPartitionsByNamesResult& GetPartitionsByNamesResult::operator=(const GetPartitionsByNamesResult& other757) {
+  partitions = other757.partitions;
+  dictionary = other757.dictionary;
+  __isset = other757.__isset;
   return *this;
 }
 void GetPartitionsByNamesResult::printTo(std::ostream& out) const {
@@ -20157,17 +20200,17 @@ uint32_t DataConnector::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size751;
-            ::apache::thrift::protocol::TType _ktype752;
-            ::apache::thrift::protocol::TType _vtype753;
-            xfer += iprot->readMapBegin(_ktype752, _vtype753, _size751);
-            uint32_t _i755;
-            for (_i755 = 0; _i755 < _size751; ++_i755)
+            uint32_t _size758;
+            ::apache::thrift::protocol::TType _ktype759;
+            ::apache::thrift::protocol::TType _vtype760;
+            xfer += iprot->readMapBegin(_ktype759, _vtype760, _size758);
+            uint32_t _i762;
+            for (_i762 = 0; _i762 < _size758; ++_i762)
             {
-              std::string _key756;
-              xfer += iprot->readString(_key756);
-              std::string& _val757 = this->parameters[_key756];
-              xfer += iprot->readString(_val757);
+              std::string _key763;
+              xfer += iprot->readString(_key763);
+              std::string& _val764 = this->parameters[_key763];
+              xfer += iprot->readString(_val764);
             }
             xfer += iprot->readMapEnd();
           }
@@ -20186,9 +20229,9 @@ uint32_t DataConnector::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast758;
-          xfer += iprot->readI32(ecast758);
-          this->ownerType = (PrincipalType::type)ecast758;
+          int32_t ecast765;
+          xfer += iprot->readI32(ecast765);
+          this->ownerType = (PrincipalType::type)ecast765;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -20240,11 +20283,11 @@ uint32_t DataConnector::write(::apache::thrift::protocol::TProtocol* oprot) cons
     xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 5);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-      std::map<std::string, std::string> ::const_iterator _iter759;
-      for (_iter759 = this->parameters.begin(); _iter759 != this->parameters.end(); ++_iter759)
+      std::map<std::string, std::string> ::const_iterator _iter766;
+      for (_iter766 = this->parameters.begin(); _iter766 != this->parameters.end(); ++_iter766)
       {
-        xfer += oprot->writeString(_iter759->first);
-        xfer += oprot->writeString(_iter759->second);
+        xfer += oprot->writeString(_iter766->first);
+        xfer += oprot->writeString(_iter766->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -20283,27 +20326,27 @@ void swap(DataConnector &a, DataConnector &b) {
   swap(a.__isset, b.__isset);
 }
 
-DataConnector::DataConnector(const DataConnector& other760) {
-  name = other760.name;
-  type = other760.type;
-  url = other760.url;
-  description = other760.description;
-  parameters = other760.parameters;
-  ownerName = other760.ownerName;
-  ownerType = other760.ownerType;
-  createTime = other760.createTime;
-  __isset = other760.__isset;
+DataConnector::DataConnector(const DataConnector& other767) {
+  name = other767.name;
+  type = other767.type;
+  url = other767.url;
+  description = other767.description;
+  parameters = other767.parameters;
+  ownerName = other767.ownerName;
+  ownerType = other767.ownerType;
+  createTime = other767.createTime;
+  __isset = other767.__isset;
 }
-DataConnector& DataConnector::operator=(const DataConnector& other761) {
-  name = other761.name;
-  type = other761.type;
-  url = other761.url;
-  description = other761.description;
-  parameters = other761.parameters;
-  ownerName = other761.ownerName;
-  ownerType = other761.ownerType;
-  createTime = other761.createTime;
-  __isset = other761.__isset;
+DataConnector& DataConnector::operator=(const DataConnector& other768) {
+  name = other768.name;
+  type = other768.type;
+  url = other768.url;
+  description = other768.description;
+  parameters = other768.parameters;
+  ownerName = other768.ownerName;
+  ownerType = other768.ownerType;
+  createTime = other768.createTime;
+  __isset = other768.__isset;
   return *this;
 }
 void DataConnector::printTo(std::ostream& out) const {
@@ -20362,9 +20405,9 @@ uint32_t ResourceUri::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast762;
-          xfer += iprot->readI32(ecast762);
-          this->resourceType = (ResourceType::type)ecast762;
+          int32_t ecast769;
+          xfer += iprot->readI32(ecast769);
+          this->resourceType = (ResourceType::type)ecast769;
           this->__isset.resourceType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -20415,15 +20458,15 @@ void swap(ResourceUri &a, ResourceUri &b) {
   swap(a.__isset, b.__isset);
 }
 
-ResourceUri::ResourceUri(const ResourceUri& other763) {
-  resourceType = other763.resourceType;
-  uri = other763.uri;
-  __isset = other763.__isset;
+ResourceUri::ResourceUri(const ResourceUri& other770) {
+  resourceType = other770.resourceType;
+  uri = other770.uri;
+  __isset = other770.__isset;
 }
-ResourceUri& ResourceUri::operator=(const ResourceUri& other764) {
-  resourceType = other764.resourceType;
-  uri = other764.uri;
-  __isset = other764.__isset;
+ResourceUri& ResourceUri::operator=(const ResourceUri& other771) {
+  resourceType = other771.resourceType;
+  uri = other771.uri;
+  __isset = other771.__isset;
   return *this;
 }
 void ResourceUri::printTo(std::ostream& out) const {
@@ -20537,9 +20580,9 @@ uint32_t Function::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast765;
-          xfer += iprot->readI32(ecast765);
-          this->ownerType = (PrincipalType::type)ecast765;
+          int32_t ecast772;
+          xfer += iprot->readI32(ecast772);
+          this->ownerType = (PrincipalType::type)ecast772;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -20555,9 +20598,9 @@ uint32_t Function::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast766;
-          xfer += iprot->readI32(ecast766);
-          this->functionType = (FunctionType::type)ecast766;
+          int32_t ecast773;
+          xfer += iprot->readI32(ecast773);
+          this->functionType = (FunctionType::type)ecast773;
           this->__isset.functionType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -20567,14 +20610,14 @@ uint32_t Function::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->resourceUris.clear();
-            uint32_t _size767;
-            ::apache::thrift::protocol::TType _etype770;
-            xfer += iprot->readListBegin(_etype770, _size767);
-            this->resourceUris.resize(_size767);
-            uint32_t _i771;
-            for (_i771 = 0; _i771 < _size767; ++_i771)
+            uint32_t _size774;
+            ::apache::thrift::protocol::TType _etype777;
+            xfer += iprot->readListBegin(_etype777, _size774);
+            this->resourceUris.resize(_size774);
+            uint32_t _i778;
+            for (_i778 = 0; _i778 < _size774; ++_i778)
             {
-              xfer += this->resourceUris[_i771].read(iprot);
+              xfer += this->resourceUris[_i778].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20639,10 +20682,10 @@ uint32_t Function::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("resourceUris", ::apache::thrift::protocol::T_LIST, 8);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->resourceUris.size()));
-    std::vector<ResourceUri> ::const_iterator _iter772;
-    for (_iter772 = this->resourceUris.begin(); _iter772 != this->resourceUris.end(); ++_iter772)
+    std::vector<ResourceUri> ::const_iterator _iter779;
+    for (_iter779 = this->resourceUris.begin(); _iter779 != this->resourceUris.end(); ++_iter779)
     {
-      xfer += (*_iter772).write(oprot);
+      xfer += (*_iter779).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -20672,29 +20715,29 @@ void swap(Function &a, Function &b) {
   swap(a.__isset, b.__isset);
 }
 
-Function::Function(const Function& other773) {
-  functionName = other773.functionName;
-  dbName = other773.dbName;
-  className = other773.className;
-  ownerName = other773.ownerName;
-  ownerType = other773.ownerType;
-  createTime = other773.createTime;
-  functionType = other773.functionType;
-  resourceUris = other773.resourceUris;
-  catName = other773.catName;
-  __isset = other773.__isset;
+Function::Function(const Function& other780) {
+  functionName = other780.functionName;
+  dbName = other780.dbName;
+  className = other780.className;
+  ownerName = other780.ownerName;
+  ownerType = other780.ownerType;
+  createTime = other780.createTime;
+  functionType = other780.functionType;
+  resourceUris = other780.resourceUris;
+  catName = other780.catName;
+  __isset = other780.__isset;
 }
-Function& Function::operator=(const Function& other774) {
-  functionName = other774.functionName;
-  dbName = other774.dbName;
-  className = other774.className;
-  ownerName = other774.ownerName;
-  ownerType = other774.ownerType;
-  createTime = other774.createTime;
-  functionType = other774.functionType;
-  resourceUris = other774.resourceUris;
-  catName = other774.catName;
-  __isset = other774.__isset;
+Function& Function::operator=(const Function& other781) {
+  functionName = other781.functionName;
+  dbName = other781.dbName;
+  className = other781.className;
+  ownerName = other781.ownerName;
+  ownerType = other781.ownerType;
+  createTime = other781.createTime;
+  functionType = other781.functionType;
+  resourceUris = other781.resourceUris;
+  catName = other781.catName;
+  __isset = other781.__isset;
   return *this;
 }
 void Function::printTo(std::ostream& out) const {
@@ -20799,9 +20842,9 @@ uint32_t TxnInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast775;
-          xfer += iprot->readI32(ecast775);
-          this->state = (TxnState::type)ecast775;
+          int32_t ecast782;
+          xfer += iprot->readI32(ecast782);
+          this->state = (TxnState::type)ecast782;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -20948,29 +20991,29 @@ void swap(TxnInfo &a, TxnInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-TxnInfo::TxnInfo(const TxnInfo& other776) {
-  id = other776.id;
-  state = other776.state;
-  user = other776.user;
-  hostname = other776.hostname;
-  agentInfo = other776.agentInfo;
-  heartbeatCount = other776.heartbeatCount;
-  metaInfo = other776.metaInfo;
-  startedTime = other776.startedTime;
-  lastHeartbeatTime = other776.lastHeartbeatTime;
-  __isset = other776.__isset;
+TxnInfo::TxnInfo(const TxnInfo& other783) {
+  id = other783.id;
+  state = other783.state;
+  user = other783.user;
+  hostname = other783.hostname;
+  agentInfo = other783.agentInfo;
+  heartbeatCount = other783.heartbeatCount;
+  metaInfo = other783.metaInfo;
+  startedTime = other783.startedTime;
+  lastHeartbeatTime = other783.lastHeartbeatTime;
+  __isset = other783.__isset;
 }
-TxnInfo& TxnInfo::operator=(const TxnInfo& other777) {
-  id = other777.id;
-  state = other777.state;
-  user = other777.user;
-  hostname = other777.hostname;
-  agentInfo = other777.agentInfo;
-  heartbeatCount = other777.heartbeatCount;
-  metaInfo = other777.metaInfo;
-  startedTime = other777.startedTime;
-  lastHeartbeatTime = other777.lastHeartbeatTime;
-  __isset = other777.__isset;
+TxnInfo& TxnInfo::operator=(const TxnInfo& other784) {
+  id = other784.id;
+  state = other784.state;
+  user = other784.user;
+  hostname = other784.hostname;
+  agentInfo = other784.agentInfo;
+  heartbeatCount = other784.heartbeatCount;
+  metaInfo = other784.metaInfo;
+  startedTime = other784.startedTime;
+  lastHeartbeatTime = other784.lastHeartbeatTime;
+  __isset = other784.__isset;
   return *this;
 }
 void TxnInfo::printTo(std::ostream& out) const {
@@ -21042,14 +21085,14 @@ uint32_t GetOpenTxnsInfoResponse::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->open_txns.clear();
-            uint32_t _size778;
-            ::apache::thrift::protocol::TType _etype781;
-            xfer += iprot->readListBegin(_etype781, _size778);
-            this->open_txns.resize(_size778);
-            uint32_t _i782;
-            for (_i782 = 0; _i782 < _size778; ++_i782)
+            uint32_t _size785;
+            ::apache::thrift::protocol::TType _etype788;
+            xfer += iprot->readListBegin(_etype788, _size785);
+            this->open_txns.resize(_size785);
+            uint32_t _i789;
+            for (_i789 = 0; _i789 < _size785; ++_i789)
             {
-              xfer += this->open_txns[_i782].read(iprot);
+              xfer += this->open_txns[_i789].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21086,10 +21129,10 @@ uint32_t GetOpenTxnsInfoResponse::write(::apache::thrift::protocol::TProtocol* o
   xfer += oprot->writeFieldBegin("open_txns", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->open_txns.size()));
-    std::vector<TxnInfo> ::const_iterator _iter783;
-    for (_iter783 = this->open_txns.begin(); _iter783 != this->open_txns.end(); ++_iter783)
+    std::vector<TxnInfo> ::const_iterator _iter790;
+    for (_iter790 = this->open_txns.begin(); _iter790 != this->open_txns.end(); ++_iter790)
     {
-      xfer += (*_iter783).write(oprot);
+      xfer += (*_iter790).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -21106,13 +21149,13 @@ void swap(GetOpenTxnsInfoResponse &a, GetOpenTxnsInfoResponse &b) {
   swap(a.open_txns, b.open_txns);
 }
 
-GetOpenTxnsInfoResponse::GetOpenTxnsInfoResponse(const GetOpenTxnsInfoResponse& other784) {
-  txn_high_water_mark = other784.txn_high_water_mark;
-  open_txns = other784.open_txns;
+GetOpenTxnsInfoResponse::GetOpenTxnsInfoResponse(const GetOpenTxnsInfoResponse& other791) {
+  txn_high_water_mark = other791.txn_high_water_mark;
+  open_txns = other791.open_txns;
 }
-GetOpenTxnsInfoResponse& GetOpenTxnsInfoResponse::operator=(const GetOpenTxnsInfoResponse& other785) {
-  txn_high_water_mark = other785.txn_high_water_mark;
-  open_txns = other785.open_txns;
+GetOpenTxnsInfoResponse& GetOpenTxnsInfoResponse::operator=(const GetOpenTxnsInfoResponse& other792) {
+  txn_high_water_mark = other792.txn_high_water_mark;
+  open_txns = other792.open_txns;
   return *this;
 }
 void GetOpenTxnsInfoResponse::printTo(std::ostream& out) const {
@@ -21187,14 +21230,14 @@ uint32_t GetOpenTxnsResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->open_txns.clear();
-            uint32_t _size786;
-            ::apache::thrift::protocol::TType _etype789;
-            xfer += iprot->readListBegin(_etype789, _size786);
-            this->open_txns.resize(_size786);
-            uint32_t _i790;
-            for (_i790 = 0; _i790 < _size786; ++_i790)
+            uint32_t _size793;
+            ::apache::thrift::protocol::TType _etype796;
+            xfer += iprot->readListBegin(_etype796, _size793);
+            this->open_txns.resize(_size793);
+            uint32_t _i797;
+            for (_i797 = 0; _i797 < _size793; ++_i797)
             {
-              xfer += iprot->readI64(this->open_txns[_i790]);
+              xfer += iprot->readI64(this->open_txns[_i797]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21249,10 +21292,10 @@ uint32_t GetOpenTxnsResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("open_txns", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->open_txns.size()));
-    std::vector<int64_t> ::const_iterator _iter791;
-    for (_iter791 = this->open_txns.begin(); _iter791 != this->open_txns.end(); ++_iter791)
+    std::vector<int64_t> ::const_iterator _iter798;
+    for (_iter798 = this->open_txns.begin(); _iter798 != this->open_txns.end(); ++_iter798)
     {
-      xfer += oprot->writeI64((*_iter791));
+      xfer += oprot->writeI64((*_iter798));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21281,19 +21324,19 @@ void swap(GetOpenTxnsResponse &a, GetOpenTxnsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetOpenTxnsResponse::GetOpenTxnsResponse(const GetOpenTxnsResponse& other792) {
-  txn_high_water_mark = other792.txn_high_water_mark;
-  open_txns = other792.open_txns;
-  min_open_txn = other792.min_open_txn;
-  abortedBits = other792.abortedBits;
-  __isset = other792.__isset;
+GetOpenTxnsResponse::GetOpenTxnsResponse(const GetOpenTxnsResponse& other799) {
+  txn_high_water_mark = other799.txn_high_water_mark;
+  open_txns = other799.open_txns;
+  min_open_txn = other799.min_open_txn;
+  abortedBits = other799.abortedBits;
+  __isset = other799.__isset;
 }
-GetOpenTxnsResponse& GetOpenTxnsResponse::operator=(const GetOpenTxnsResponse& other793) {
-  txn_high_water_mark = other793.txn_high_water_mark;
-  open_txns = other793.open_txns;
-  min_open_txn = other793.min_open_txn;
-  abortedBits = other793.abortedBits;
-  __isset = other793.__isset;
+GetOpenTxnsResponse& GetOpenTxnsResponse::operator=(const GetOpenTxnsResponse& other800) {
+  txn_high_water_mark = other800.txn_high_water_mark;
+  open_txns = other800.open_txns;
+  min_open_txn = other800.min_open_txn;
+  abortedBits = other800.abortedBits;
+  __isset = other800.__isset;
   return *this;
 }
 void GetOpenTxnsResponse::printTo(std::ostream& out) const {
@@ -21417,14 +21460,14 @@ uint32_t OpenTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->replSrcTxnIds.clear();
-            uint32_t _size794;
-            ::apache::thrift::protocol::TType _etype797;
-            xfer += iprot->readListBegin(_etype797, _size794);
-            this->replSrcTxnIds.resize(_size794);
-            uint32_t _i798;
-            for (_i798 = 0; _i798 < _size794; ++_i798)
+            uint32_t _size801;
+            ::apache::thrift::protocol::TType _etype804;
+            xfer += iprot->readListBegin(_etype804, _size801);
+            this->replSrcTxnIds.resize(_size801);
+            uint32_t _i805;
+            for (_i805 = 0; _i805 < _size801; ++_i805)
             {
-              xfer += iprot->readI64(this->replSrcTxnIds[_i798]);
+              xfer += iprot->readI64(this->replSrcTxnIds[_i805]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21435,9 +21478,9 @@ uint32_t OpenTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast799;
-          xfer += iprot->readI32(ecast799);
-          this->txn_type = (TxnType::type)ecast799;
+          int32_t ecast806;
+          xfer += iprot->readI32(ecast806);
+          this->txn_type = (TxnType::type)ecast806;
           this->__isset.txn_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -21492,10 +21535,10 @@ uint32_t OpenTxnRequest::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("replSrcTxnIds", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->replSrcTxnIds.size()));
-      std::vector<int64_t> ::const_iterator _iter800;
-      for (_iter800 = this->replSrcTxnIds.begin(); _iter800 != this->replSrcTxnIds.end(); ++_iter800)
+      std::vector<int64_t> ::const_iterator _iter807;
+      for (_iter807 = this->replSrcTxnIds.begin(); _iter807 != this->replSrcTxnIds.end(); ++_iter807)
       {
-        xfer += oprot->writeI64((*_iter800));
+        xfer += oprot->writeI64((*_iter807));
       }
       xfer += oprot->writeListEnd();
     }
@@ -21523,25 +21566,25 @@ void swap(OpenTxnRequest &a, OpenTxnRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-OpenTxnRequest::OpenTxnRequest(const OpenTxnRequest& other801) {
-  num_txns = other801.num_txns;
-  user = other801.user;
-  hostname = other801.hostname;
-  agentInfo = other801.agentInfo;
-  replPolicy = other801.replPolicy;
-  replSrcTxnIds = other801.replSrcTxnIds;
-  txn_type = other801.txn_type;
-  __isset = other801.__isset;
+OpenTxnRequest::OpenTxnRequest(const OpenTxnRequest& other808) {
+  num_txns = other808.num_txns;
+  user = other808.user;
+  hostname = other808.hostname;
+  agentInfo = other808.agentInfo;
+  replPolicy = other808.replPolicy;
+  replSrcTxnIds = other808.replSrcTxnIds;
+  txn_type = other808.txn_type;
+  __isset = other808.__isset;
 }
-OpenTxnRequest& OpenTxnRequest::operator=(const OpenTxnRequest& other802) {
-  num_txns = other802.num_txns;
-  user = other802.user;
-  hostname = other802.hostname;
-  agentInfo = other802.agentInfo;
-  replPolicy = other802.replPolicy;
-  replSrcTxnIds = other802.replSrcTxnIds;
-  txn_type = other802.txn_type;
-  __isset = other802.__isset;
+OpenTxnRequest& OpenTxnRequest::operator=(const OpenTxnRequest& other809) {
+  num_txns = other809.num_txns;
+  user = other809.user;
+  hostname = other809.hostname;
+  agentInfo = other809.agentInfo;
+  replPolicy = other809.replPolicy;
+  replSrcTxnIds = other809.replSrcTxnIds;
+  txn_type = other809.txn_type;
+  __isset = other809.__isset;
   return *this;
 }
 void OpenTxnRequest::printTo(std::ostream& out) const {
@@ -21598,14 +21641,14 @@ uint32_t OpenTxnsResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txn_ids.clear();
-            uint32_t _size803;
-            ::apache::thrift::protocol::TType _etype806;
-            xfer += iprot->readListBegin(_etype806, _size803);
-            this->txn_ids.resize(_size803);
-            uint32_t _i807;
-            for (_i807 = 0; _i807 < _size803; ++_i807)
+            uint32_t _size810;
+            ::apache::thrift::protocol::TType _etype813;
+            xfer += iprot->readListBegin(_etype813, _size810);
+            this->txn_ids.resize(_size810);
+            uint32_t _i814;
+            for (_i814 = 0; _i814 < _size810; ++_i814)
             {
-              xfer += iprot->readI64(this->txn_ids[_i807]);
+              xfer += iprot->readI64(this->txn_ids[_i814]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21636,10 +21679,10 @@ uint32_t OpenTxnsResponse::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("txn_ids", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->txn_ids.size()));
-    std::vector<int64_t> ::const_iterator _iter808;
-    for (_iter808 = this->txn_ids.begin(); _iter808 != this->txn_ids.end(); ++_iter808)
+    std::vector<int64_t> ::const_iterator _iter815;
+    for (_iter815 = this->txn_ids.begin(); _iter815 != this->txn_ids.end(); ++_iter815)
     {
-      xfer += oprot->writeI64((*_iter808));
+      xfer += oprot->writeI64((*_iter815));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21655,11 +21698,11 @@ void swap(OpenTxnsResponse &a, OpenTxnsResponse &b) {
   swap(a.txn_ids, b.txn_ids);
 }
 
-OpenTxnsResponse::OpenTxnsResponse(const OpenTxnsResponse& other809) {
-  txn_ids = other809.txn_ids;
+OpenTxnsResponse::OpenTxnsResponse(const OpenTxnsResponse& other816) {
+  txn_ids = other816.txn_ids;
 }
-OpenTxnsResponse& OpenTxnsResponse::operator=(const OpenTxnsResponse& other810) {
-  txn_ids = other810.txn_ids;
+OpenTxnsResponse& OpenTxnsResponse::operator=(const OpenTxnsResponse& other817) {
+  txn_ids = other817.txn_ids;
   return *this;
 }
 void OpenTxnsResponse::printTo(std::ostream& out) const {
@@ -21734,9 +21777,9 @@ uint32_t AbortTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast811;
-          xfer += iprot->readI32(ecast811);
-          this->txn_type = (TxnType::type)ecast811;
+          int32_t ecast818;
+          xfer += iprot->readI32(ecast818);
+          this->txn_type = (TxnType::type)ecast818;
           this->__isset.txn_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -21788,17 +21831,17 @@ void swap(AbortTxnRequest &a, AbortTxnRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AbortTxnRequest::AbortTxnRequest(const AbortTxnRequest& other812) {
-  txnid = other812.txnid;
-  replPolicy = other812.replPolicy;
-  txn_type = other812.txn_type;
-  __isset = other812.__isset;
+AbortTxnRequest::AbortTxnRequest(const AbortTxnRequest& other819) {
+  txnid = other819.txnid;
+  replPolicy = other819.replPolicy;
+  txn_type = other819.txn_type;
+  __isset = other819.__isset;
 }
-AbortTxnRequest& AbortTxnRequest::operator=(const AbortTxnRequest& other813) {
-  txnid = other813.txnid;
-  replPolicy = other813.replPolicy;
-  txn_type = other813.txn_type;
-  __isset = other813.__isset;
+AbortTxnRequest& AbortTxnRequest::operator=(const AbortTxnRequest& other820) {
+  txnid = other820.txnid;
+  replPolicy = other820.replPolicy;
+  txn_type = other820.txn_type;
+  __isset = other820.__isset;
   return *this;
 }
 void AbortTxnRequest::printTo(std::ostream& out) const {
@@ -21851,14 +21894,14 @@ uint32_t AbortTxnsRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txn_ids.clear();
-            uint32_t _size814;
-            ::apache::thrift::protocol::TType _etype817;
-            xfer += iprot->readListBegin(_etype817, _size814);
-            this->txn_ids.resize(_size814);
-            uint32_t _i818;
-            for (_i818 = 0; _i818 < _size814; ++_i818)
+            uint32_t _size821;
+            ::apache::thrift::protocol::TType _etype824;
+            xfer += iprot->readListBegin(_etype824, _size821);
+            this->txn_ids.resize(_size821);
+            uint32_t _i825;
+            for (_i825 = 0; _i825 < _size821; ++_i825)
             {
-              xfer += iprot->readI64(this->txn_ids[_i818]);
+              xfer += iprot->readI64(this->txn_ids[_i825]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21889,10 +21932,10 @@ uint32_t AbortTxnsRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("txn_ids", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->txn_ids.size()));
-    std::vector<int64_t> ::const_iterator _iter819;
-    for (_iter819 = this->txn_ids.begin(); _iter819 != this->txn_ids.end(); ++_iter819)
+    std::vector<int64_t> ::const_iterator _iter826;
+    for (_iter826 = this->txn_ids.begin(); _iter826 != this->txn_ids.end(); ++_iter826)
     {
-      xfer += oprot->writeI64((*_iter819));
+      xfer += oprot->writeI64((*_iter826));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21908,11 +21951,11 @@ void swap(AbortTxnsRequest &a, AbortTxnsRequest &b) {
   swap(a.txn_ids, b.txn_ids);
 }
 
-AbortTxnsRequest::AbortTxnsRequest(const AbortTxnsRequest& other820) {
-  txn_ids = other820.txn_ids;
+AbortTxnsRequest::AbortTxnsRequest(const AbortTxnsRequest& other827) {
+  txn_ids = other827.txn_ids;
 }
-AbortTxnsRequest& AbortTxnsRequest::operator=(const AbortTxnsRequest& other821) {
-  txn_ids = other821.txn_ids;
+AbortTxnsRequest& AbortTxnsRequest::operator=(const AbortTxnsRequest& other828) {
+  txn_ids = other828.txn_ids;
   return *this;
 }
 void AbortTxnsRequest::printTo(std::ostream& out) const {
@@ -22040,15 +22083,15 @@ void swap(CommitTxnKeyValue &a, CommitTxnKeyValue &b) {
   swap(a.value, b.value);
 }
 
-CommitTxnKeyValue::CommitTxnKeyValue(const CommitTxnKeyValue& other822) {
-  tableId = other822.tableId;
-  key = other822.key;
-  value = other822.value;
+CommitTxnKeyValue::CommitTxnKeyValue(const CommitTxnKeyValue& other829) {
+  tableId = other829.tableId;
+  key = other829.key;
+  value = other829.value;
 }
-CommitTxnKeyValue& CommitTxnKeyValue::operator=(const CommitTxnKeyValue& other823) {
-  tableId = other823.tableId;
-  key = other823.key;
-  value = other823.value;
+CommitTxnKeyValue& CommitTxnKeyValue::operator=(const CommitTxnKeyValue& other830) {
+  tableId = other830.tableId;
+  key = other830.key;
+  value = other830.value;
   return *this;
 }
 void CommitTxnKeyValue::printTo(std::ostream& out) const {
@@ -22256,25 +22299,25 @@ void swap(WriteEventInfo &a, WriteEventInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-WriteEventInfo::WriteEventInfo(const WriteEventInfo& other824) {
-  writeId = other824.writeId;
-  database = other824.database;
-  table = other824.table;
-  files = other824.files;
-  partition = other824.partition;
-  tableObj = other824.tableObj;
-  partitionObj = other824.partitionObj;
-  __isset = other824.__isset;
+WriteEventInfo::WriteEventInfo(const WriteEventInfo& other831) {
+  writeId = other831.writeId;
+  database = other831.database;
+  table = other831.table;
+  files = other831.files;
+  partition = other831.partition;
+  tableObj = other831.tableObj;
+  partitionObj = other831.partitionObj;
+  __isset = other831.__isset;
 }
-WriteEventInfo& WriteEventInfo::operator=(const WriteEventInfo& other825) {
-  writeId = other825.writeId;
-  database = other825.database;
-  table = other825.table;
-  files = other825.files;
-  partition = other825.partition;
-  tableObj = other825.tableObj;
-  partitionObj = other825.partitionObj;
-  __isset = other825.__isset;
+WriteEventInfo& WriteEventInfo::operator=(const WriteEventInfo& other832) {
+  writeId = other832.writeId;
+  database = other832.database;
+  table = other832.table;
+  files = other832.files;
+  partition = other832.partition;
+  tableObj = other832.tableObj;
+  partitionObj = other832.partitionObj;
+  __isset = other832.__isset;
   return *this;
 }
 void WriteEventInfo::printTo(std::ostream& out) const {
@@ -22383,14 +22426,14 @@ uint32_t ReplLastIdInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionList.clear();
-            uint32_t _size826;
-            ::apache::thrift::protocol::TType _etype829;
-            xfer += iprot->readListBegin(_etype829, _size826);
-            this->partitionList.resize(_size826);
-            uint32_t _i830;
-            for (_i830 = 0; _i830 < _size826; ++_i830)
+            uint32_t _size833;
+            ::apache::thrift::protocol::TType _etype836;
+            xfer += iprot->readListBegin(_etype836, _size833);
+            this->partitionList.resize(_size833);
+            uint32_t _i837;
+            for (_i837 = 0; _i837 < _size833; ++_i837)
             {
-              xfer += iprot->readString(this->partitionList[_i830]);
+              xfer += iprot->readString(this->partitionList[_i837]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22442,10 +22485,10 @@ uint32_t ReplLastIdInfo::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("partitionList", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionList.size()));
-      std::vector<std::string> ::const_iterator _iter831;
-      for (_iter831 = this->partitionList.begin(); _iter831 != this->partitionList.end(); ++_iter831)
+      std::vector<std::string> ::const_iterator _iter838;
+      for (_iter838 = this->partitionList.begin(); _iter838 != this->partitionList.end(); ++_iter838)
       {
-        xfer += oprot->writeString((*_iter831));
+        xfer += oprot->writeString((*_iter838));
       }
       xfer += oprot->writeListEnd();
     }
@@ -22466,21 +22509,21 @@ void swap(ReplLastIdInfo &a, ReplLastIdInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplLastIdInfo::ReplLastIdInfo(const ReplLastIdInfo& other832) {
-  database = other832.database;
-  lastReplId = other832.lastReplId;
-  table = other832.table;
-  catalog = other832.catalog;
-  partitionList = other832.partitionList;
-  __isset = other832.__isset;
+ReplLastIdInfo::ReplLastIdInfo(const ReplLastIdInfo& other839) {
+  database = other839.database;
+  lastReplId = other839.lastReplId;
+  table = other839.table;
+  catalog = other839.catalog;
+  partitionList = other839.partitionList;
+  __isset = other839.__isset;
 }
-ReplLastIdInfo& ReplLastIdInfo::operator=(const ReplLastIdInfo& other833) {
-  database = other833.database;
-  lastReplId = other833.lastReplId;
-  table = other833.table;
-  catalog = other833.catalog;
-  partitionList = other833.partitionList;
-  __isset = other833.__isset;
+ReplLastIdInfo& ReplLastIdInfo::operator=(const ReplLastIdInfo& other840) {
+  database = other840.database;
+  lastReplId = other840.lastReplId;
+  table = other840.table;
+  catalog = other840.catalog;
+  partitionList = other840.partitionList;
+  __isset = other840.__isset;
   return *this;
 }
 void ReplLastIdInfo::printTo(std::ostream& out) const {
@@ -22632,17 +22675,17 @@ void swap(UpdateTransactionalStatsRequest &a, UpdateTransactionalStatsRequest &b
   swap(a.deletedCount, b.deletedCount);
 }
 
-UpdateTransactionalStatsRequest::UpdateTransactionalStatsRequest(const UpdateTransactionalStatsRequest& other834) {
-  tableId = other834.tableId;
-  insertCount = other834.insertCount;
-  updatedCount = other834.updatedCount;
-  deletedCount = other834.deletedCount;
+UpdateTransactionalStatsRequest::UpdateTransactionalStatsRequest(const UpdateTransactionalStatsRequest& other841) {
+  tableId = other841.tableId;
+  insertCount = other841.insertCount;
+  updatedCount = other841.updatedCount;
+  deletedCount = other841.deletedCount;
 }
-UpdateTransactionalStatsRequest& UpdateTransactionalStatsRequest::operator=(const UpdateTransactionalStatsRequest& other835) {
-  tableId = other835.tableId;
-  insertCount = other835.insertCount;
-  updatedCount = other835.updatedCount;
-  deletedCount = other835.deletedCount;
+UpdateTransactionalStatsRequest& UpdateTransactionalStatsRequest::operator=(const UpdateTransactionalStatsRequest& other842) {
+  tableId = other842.tableId;
+  insertCount = other842.insertCount;
+  updatedCount = other842.updatedCount;
+  deletedCount = other842.deletedCount;
   return *this;
 }
 void UpdateTransactionalStatsRequest::printTo(std::ostream& out) const {
@@ -22742,14 +22785,14 @@ uint32_t CommitTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->writeEventInfos.clear();
-            uint32_t _size836;
-            ::apache::thrift::protocol::TType _etype839;
-            xfer += iprot->readListBegin(_etype839, _size836);
-            this->writeEventInfos.resize(_size836);
-            uint32_t _i840;
-            for (_i840 = 0; _i840 < _size836; ++_i840)
+            uint32_t _size843;
+            ::apache::thrift::protocol::TType _etype846;
+            xfer += iprot->readListBegin(_etype846, _size843);
+            this->writeEventInfos.resize(_size843);
+            uint32_t _i847;
+            for (_i847 = 0; _i847 < _size843; ++_i847)
             {
-              xfer += this->writeEventInfos[_i840].read(iprot);
+              xfer += this->writeEventInfos[_i847].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22784,9 +22827,9 @@ uint32_t CommitTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast841;
-          xfer += iprot->readI32(ecast841);
-          this->txn_type = (TxnType::type)ecast841;
+          int32_t ecast848;
+          xfer += iprot->readI32(ecast848);
+          this->txn_type = (TxnType::type)ecast848;
           this->__isset.txn_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -22824,10 +22867,10 @@ uint32_t CommitTxnRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("writeEventInfos", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->writeEventInfos.size()));
-      std::vector<WriteEventInfo> ::const_iterator _iter842;
-      for (_iter842 = this->writeEventInfos.begin(); _iter842 != this->writeEventInfos.end(); ++_iter842)
+      std::vector<WriteEventInfo> ::const_iterator _iter849;
+      for (_iter849 = this->writeEventInfos.begin(); _iter849 != this->writeEventInfos.end(); ++_iter849)
       {
-        xfer += (*_iter842).write(oprot);
+        xfer += (*_iter849).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22870,25 +22913,25 @@ void swap(CommitTxnRequest &a, CommitTxnRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CommitTxnRequest::CommitTxnRequest(const CommitTxnRequest& other843) {
-  txnid = other843.txnid;
-  replPolicy = other843.replPolicy;
-  writeEventInfos = other843.writeEventInfos;
-  replLastIdInfo = other843.replLastIdInfo;
-  keyValue = other843.keyValue;
-  exclWriteEnabled = other843.exclWriteEnabled;
-  txn_type = other843.txn_type;
-  __isset = other843.__isset;
+CommitTxnRequest::CommitTxnRequest(const CommitTxnRequest& other850) {
+  txnid = other850.txnid;
+  replPolicy = other850.replPolicy;
+  writeEventInfos = other850.writeEventInfos;
+  replLastIdInfo = other850.replLastIdInfo;
+  keyValue = other850.keyValue;
+  exclWriteEnabled = other850.exclWriteEnabled;
+  txn_type = other850.txn_type;
+  __isset = other850.__isset;
 }
-CommitTxnRequest& CommitTxnRequest::operator=(const CommitTxnRequest& other844) {
-  txnid = other844.txnid;
-  replPolicy = other844.replPolicy;
-  writeEventInfos = other844.writeEventInfos;
-  replLastIdInfo = other844.replLastIdInfo;
-  keyValue = other844.keyValue;
-  exclWriteEnabled = other844.exclWriteEnabled;
-  txn_type = other844.txn_type;
-  __isset = other844.__isset;
+CommitTxnRequest& CommitTxnRequest::operator=(const CommitTxnRequest& other851) {
+  txnid = other851.txnid;
+  replPolicy = other851.replPolicy;
+  writeEventInfos = other851.writeEventInfos;
+  replLastIdInfo = other851.replLastIdInfo;
+  keyValue = other851.keyValue;
+  exclWriteEnabled = other851.exclWriteEnabled;
+  txn_type = other851.txn_type;
+  __isset = other851.__isset;
   return *this;
 }
 void CommitTxnRequest::printTo(std::ostream& out) const {
@@ -23010,14 +23053,14 @@ uint32_t ReplTblWriteIdStateRequest::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size845;
-            ::apache::thrift::protocol::TType _etype848;
-            xfer += iprot->readListBegin(_etype848, _size845);
-            this->partNames.resize(_size845);
-            uint32_t _i849;
-            for (_i849 = 0; _i849 < _size845; ++_i849)
+            uint32_t _size852;
+            ::apache::thrift::protocol::TType _etype855;
+            xfer += iprot->readListBegin(_etype855, _size852);
+            this->partNames.resize(_size852);
+            uint32_t _i856;
+            for (_i856 = 0; _i856 < _size852; ++_i856)
             {
-              xfer += iprot->readString(this->partNames[_i849]);
+              xfer += iprot->readString(this->partNames[_i856]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23077,10 +23120,10 @@ uint32_t ReplTblWriteIdStateRequest::write(::apache::thrift::protocol::TProtocol
     xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-      std::vector<std::string> ::const_iterator _iter850;
-      for (_iter850 = this->partNames.begin(); _iter850 != this->partNames.end(); ++_iter850)
+      std::vector<std::string> ::const_iterator _iter857;
+      for (_iter857 = this->partNames.begin(); _iter857 != this->partNames.end(); ++_iter857)
       {
-        xfer += oprot->writeString((*_iter850));
+        xfer += oprot->writeString((*_iter857));
       }
       xfer += oprot->writeListEnd();
     }
@@ -23102,23 +23145,23 @@ void swap(ReplTblWriteIdStateRequest &a, ReplTblWriteIdStateRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplTblWriteIdStateRequest::ReplTblWriteIdStateRequest(const ReplTblWriteIdStateRequest& other851) {
-  validWriteIdlist = other851.validWriteIdlist;
-  user = other851.user;
-  hostName = other851.hostName;
-  dbName = other851.dbName;
-  tableName = other851.tableName;
-  partNames = other851.partNames;
-  __isset = other851.__isset;
+ReplTblWriteIdStateRequest::ReplTblWriteIdStateRequest(const ReplTblWriteIdStateRequest& other858) {
+  validWriteIdlist = other858.validWriteIdlist;
+  user = other858.user;
+  hostName = other858.hostName;
+  dbName = other858.dbName;
+  tableName = other858.tableName;
+  partNames = other858.partNames;
+  __isset = other858.__isset;
 }
-ReplTblWriteIdStateRequest& ReplTblWriteIdStateRequest::operator=(const ReplTblWriteIdStateRequest& other852) {
-  validWriteIdlist = other852.validWriteIdlist;
-  user = other852.user;
-  hostName = other852.hostName;
-  dbName = other852.dbName;
-  tableName = other852.tableName;
-  partNames = other852.partNames;
-  __isset = other852.__isset;
+ReplTblWriteIdStateRequest& ReplTblWriteIdStateRequest::operator=(const ReplTblWriteIdStateRequest& other859) {
+  validWriteIdlist = other859.validWriteIdlist;
+  user = other859.user;
+  hostName = other859.hostName;
+  dbName = other859.dbName;
+  tableName = other859.tableName;
+  partNames = other859.partNames;
+  __isset = other859.__isset;
   return *this;
 }
 void ReplTblWriteIdStateRequest::printTo(std::ostream& out) const {
@@ -23184,14 +23227,14 @@ uint32_t GetValidWriteIdsRequest::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fullTableNames.clear();
-            uint32_t _size853;
-            ::apache::thrift::protocol::TType _etype856;
-            xfer += iprot->readListBegin(_etype856, _size853);
-            this->fullTableNames.resize(_size853);
-            uint32_t _i857;
-            for (_i857 = 0; _i857 < _size853; ++_i857)
+            uint32_t _size860;
+            ::apache::thrift::protocol::TType _etype863;
+            xfer += iprot->readListBegin(_etype863, _size860);
+            this->fullTableNames.resize(_size860);
+            uint32_t _i864;
+            for (_i864 = 0; _i864 < _size860; ++_i864)
             {
-              xfer += iprot->readString(this->fullTableNames[_i857]);
+              xfer += iprot->readString(this->fullTableNames[_i864]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23238,10 +23281,10 @@ uint32_t GetValidWriteIdsRequest::write(::apache::thrift::protocol::TProtocol* o
   xfer += oprot->writeFieldBegin("fullTableNames", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->fullTableNames.size()));
-    std::vector<std::string> ::const_iterator _iter858;
-    for (_iter858 = this->fullTableNames.begin(); _iter858 != this->fullTableNames.end(); ++_iter858)
+    std::vector<std::string> ::const_iterator _iter865;
+    for (_iter865 = this->fullTableNames.begin(); _iter865 != this->fullTableNames.end(); ++_iter865)
     {
-      xfer += oprot->writeString((*_iter858));
+      xfer += oprot->writeString((*_iter865));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23270,17 +23313,17 @@ void swap(GetValidWriteIdsRequest &a, GetValidWriteIdsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetValidWriteIdsRequest::GetValidWriteIdsRequest(const GetValidWriteIdsRequest& other859) {
-  fullTableNames = other859.fullTableNames;
-  validTxnList = other859.validTxnList;
-  writeId = other859.writeId;
-  __isset = other859.__isset;
+GetValidWriteIdsRequest::GetValidWriteIdsRequest(const GetValidWriteIdsRequest& other866) {
+  fullTableNames = other866.fullTableNames;
+  validTxnList = other866.validTxnList;
+  writeId = other866.writeId;
+  __isset = other866.__isset;
 }
-GetValidWriteIdsRequest& GetValidWriteIdsRequest::operator=(const GetValidWriteIdsRequest& other860) {
-  fullTableNames = other860.fullTableNames;
-  validTxnList = other860.validTxnList;
-  writeId = other860.writeId;
-  __isset = other860.__isset;
+GetValidWriteIdsRequest& GetValidWriteIdsRequest::operator=(const GetValidWriteIdsRequest& other867) {
+  fullTableNames = other867.fullTableNames;
+  validTxnList = other867.validTxnList;
+  writeId = other867.writeId;
+  __isset = other867.__isset;
   return *this;
 }
 void GetValidWriteIdsRequest::printTo(std::ostream& out) const {
@@ -23369,14 +23412,14 @@ uint32_t TableValidWriteIds::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->invalidWriteIds.clear();
-            uint32_t _size861;
-            ::apache::thrift::protocol::TType _etype864;
-            xfer += iprot->readListBegin(_etype864, _size861);
-            this->invalidWriteIds.resize(_size861);
-            uint32_t _i865;
-            for (_i865 = 0; _i865 < _size861; ++_i865)
+            uint32_t _size868;
+            ::apache::thrift::protocol::TType _etype871;
+            xfer += iprot->readListBegin(_etype871, _size868);
+            this->invalidWriteIds.resize(_size868);
+            uint32_t _i872;
+            for (_i872 = 0; _i872 < _size868; ++_i872)
             {
-              xfer += iprot->readI64(this->invalidWriteIds[_i865]);
+              xfer += iprot->readI64(this->invalidWriteIds[_i872]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23437,10 +23480,10 @@ uint32_t TableValidWriteIds::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("invalidWriteIds", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->invalidWriteIds.size()));
-    std::vector<int64_t> ::const_iterator _iter866;
-    for (_iter866 = this->invalidWriteIds.begin(); _iter866 != this->invalidWriteIds.end(); ++_iter866)
+    std::vector<int64_t> ::const_iterator _iter873;
+    for (_iter873 = this->invalidWriteIds.begin(); _iter873 != this->invalidWriteIds.end(); ++_iter873)
     {
-      xfer += oprot->writeI64((*_iter866));
+      xfer += oprot->writeI64((*_iter873));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23470,21 +23513,21 @@ void swap(TableValidWriteIds &a, TableValidWriteIds &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableValidWriteIds::TableValidWriteIds(const TableValidWriteIds& other867) {
-  fullTableName = other867.fullTableName;
-  writeIdHighWaterMark = other867.writeIdHighWaterMark;
-  invalidWriteIds = other867.invalidWriteIds;
-  minOpenWriteId = other867.minOpenWriteId;
-  abortedBits = other867.abortedBits;
-  __isset = other867.__isset;
+TableValidWriteIds::TableValidWriteIds(const TableValidWriteIds& other874) {
+  fullTableName = other874.fullTableName;
+  writeIdHighWaterMark = other874.writeIdHighWaterMark;
+  invalidWriteIds = other874.invalidWriteIds;
+  minOpenWriteId = other874.minOpenWriteId;
+  abortedBits = other874.abortedBits;
+  __isset = other874.__isset;
 }
-TableValidWriteIds& TableValidWriteIds::operator=(const TableValidWriteIds& other868) {
-  fullTableName = other868.fullTableName;
-  writeIdHighWaterMark = other868.writeIdHighWaterMark;
-  invalidWriteIds = other868.invalidWriteIds;
-  minOpenWriteId = other868.minOpenWriteId;
-  abortedBits = other868.abortedBits;
-  __isset = other868.__isset;
+TableValidWriteIds& TableValidWriteIds::operator=(const TableValidWriteIds& other875) {
+  fullTableName = other875.fullTableName;
+  writeIdHighWaterMark = other875.writeIdHighWaterMark;
+  invalidWriteIds = other875.invalidWriteIds;
+  minOpenWriteId = other875.minOpenWriteId;
+  abortedBits = other875.abortedBits;
+  __isset = other875.__isset;
   return *this;
 }
 void TableValidWriteIds::printTo(std::ostream& out) const {
@@ -23539,14 +23582,14 @@ uint32_t GetValidWriteIdsResponse::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tblValidWriteIds.clear();
-            uint32_t _size869;
-            ::apache::thrift::protocol::TType _etype872;
-            xfer += iprot->readListBegin(_etype872, _size869);
-            this->tblValidWriteIds.resize(_size869);
-            uint32_t _i873;
-            for (_i873 = 0; _i873 < _size869; ++_i873)
+            uint32_t _size876;
+            ::apache::thrift::protocol::TType _etype879;
+            xfer += iprot->readListBegin(_etype879, _size876);
+            this->tblValidWriteIds.resize(_size876);
+            uint32_t _i880;
+            for (_i880 = 0; _i880 < _size876; ++_i880)
             {
-              xfer += this->tblValidWriteIds[_i873].read(iprot);
+              xfer += this->tblValidWriteIds[_i880].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23577,10 +23620,10 @@ uint32_t GetValidWriteIdsResponse::write(::apache::thrift::protocol::TProtocol* 
   xfer += oprot->writeFieldBegin("tblValidWriteIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tblValidWriteIds.size()));
-    std::vector<TableValidWriteIds> ::const_iterator _iter874;
-    for (_iter874 = this->tblValidWriteIds.begin(); _iter874 != this->tblValidWriteIds.end(); ++_iter874)
+    std::vector<TableValidWriteIds> ::const_iterator _iter881;
+    for (_iter881 = this->tblValidWriteIds.begin(); _iter881 != this->tblValidWriteIds.end(); ++_iter881)
     {
-      xfer += (*_iter874).write(oprot);
+      xfer += (*_iter881).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -23596,11 +23639,11 @@ void swap(GetValidWriteIdsResponse &a, GetValidWriteIdsResponse &b) {
   swap(a.tblValidWriteIds, b.tblValidWriteIds);
 }
 
-GetValidWriteIdsResponse::GetValidWriteIdsResponse(const GetValidWriteIdsResponse& other875) {
-  tblValidWriteIds = other875.tblValidWriteIds;
+GetValidWriteIdsResponse::GetValidWriteIdsResponse(const GetValidWriteIdsResponse& other882) {
+  tblValidWriteIds = other882.tblValidWriteIds;
 }
-GetValidWriteIdsResponse& GetValidWriteIdsResponse::operator=(const GetValidWriteIdsResponse& other876) {
-  tblValidWriteIds = other876.tblValidWriteIds;
+GetValidWriteIdsResponse& GetValidWriteIdsResponse::operator=(const GetValidWriteIdsResponse& other883) {
+  tblValidWriteIds = other883.tblValidWriteIds;
   return *this;
 }
 void GetValidWriteIdsResponse::printTo(std::ostream& out) const {
@@ -23708,13 +23751,13 @@ void swap(TxnToWriteId &a, TxnToWriteId &b) {
   swap(a.writeId, b.writeId);
 }
 
-TxnToWriteId::TxnToWriteId(const TxnToWriteId& other877) {
-  txnId = other877.txnId;
-  writeId = other877.writeId;
+TxnToWriteId::TxnToWriteId(const TxnToWriteId& other884) {
+  txnId = other884.txnId;
+  writeId = other884.writeId;
 }
-TxnToWriteId& TxnToWriteId::operator=(const TxnToWriteId& other878) {
-  txnId = other878.txnId;
-  writeId = other878.writeId;
+TxnToWriteId& TxnToWriteId::operator=(const TxnToWriteId& other885) {
+  txnId = other885.txnId;
+  writeId = other885.writeId;
   return *this;
 }
 void TxnToWriteId::printTo(std::ostream& out) const {
@@ -23802,14 +23845,14 @@ uint32_t AllocateTableWriteIdsRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txnIds.clear();
-            uint32_t _size879;
-            ::apache::thrift::protocol::TType _etype882;
-            xfer += iprot->readListBegin(_etype882, _size879);
-            this->txnIds.resize(_size879);
-            uint32_t _i883;
-            for (_i883 = 0; _i883 < _size879; ++_i883)
+            uint32_t _size886;
+            ::apache::thrift::protocol::TType _etype889;
+            xfer += iprot->readListBegin(_etype889, _size886);
+            this->txnIds.resize(_size886);
+            uint32_t _i890;
+            for (_i890 = 0; _i890 < _size886; ++_i890)
             {
-              xfer += iprot->readI64(this->txnIds[_i883]);
+              xfer += iprot->readI64(this->txnIds[_i890]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23830,14 +23873,14 @@ uint32_t AllocateTableWriteIdsRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->srcTxnToWriteIdList.clear();
-            uint32_t _size884;
-            ::apache::thrift::protocol::TType _etype887;
-            xfer += iprot->readListBegin(_etype887, _size884);
-            this->srcTxnToWriteIdList.resize(_size884);
-            uint32_t _i888;
-            for (_i888 = 0; _i888 < _size884; ++_i888)
+            uint32_t _size891;
+            ::apache::thrift::protocol::TType _etype894;
+            xfer += iprot->readListBegin(_etype894, _size891);
+            this->srcTxnToWriteIdList.resize(_size891);
+            uint32_t _i895;
+            for (_i895 = 0; _i895 < _size891; ++_i895)
             {
-              xfer += this->srcTxnToWriteIdList[_i888].read(iprot);
+              xfer += this->srcTxnToWriteIdList[_i895].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23879,10 +23922,10 @@ uint32_t AllocateTableWriteIdsRequest::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("txnIds", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->txnIds.size()));
-      std::vector<int64_t> ::const_iterator _iter889;
-      for (_iter889 = this->txnIds.begin(); _iter889 != this->txnIds.end(); ++_iter889)
+      std::vector<int64_t> ::const_iterator _iter896;
+      for (_iter896 = this->txnIds.begin(); _iter896 != this->txnIds.end(); ++_iter896)
       {
-        xfer += oprot->writeI64((*_iter889));
+        xfer += oprot->writeI64((*_iter896));
       }
       xfer += oprot->writeListEnd();
     }
@@ -23897,10 +23940,10 @@ uint32_t AllocateTableWriteIdsRequest::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("srcTxnToWriteIdList", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->srcTxnToWriteIdList.size()));
-      std::vector<TxnToWriteId> ::const_iterator _iter890;
-      for (_iter890 = this->srcTxnToWriteIdList.begin(); _iter890 != this->srcTxnToWriteIdList.end(); ++_iter890)
+      std::vector<TxnToWriteId> ::const_iterator _iter897;
+      for (_iter897 = this->srcTxnToWriteIdList.begin(); _iter897 != this->srcTxnToWriteIdList.end(); ++_iter897)
       {
-        xfer += (*_iter890).write(oprot);
+        xfer += (*_iter897).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -23921,21 +23964,21 @@ void swap(AllocateTableWriteIdsRequest &a, AllocateTableWriteIdsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AllocateTableWriteIdsRequest::AllocateTableWriteIdsRequest(const AllocateTableWriteIdsRequest& other891) {
-  dbName = other891.dbName;
-  tableName = other891.tableName;
-  txnIds = other891.txnIds;
-  replPolicy = other891.replPolicy;
-  srcTxnToWriteIdList = other891.srcTxnToWriteIdList;
-  __isset = other891.__isset;
+AllocateTableWriteIdsRequest::AllocateTableWriteIdsRequest(const AllocateTableWriteIdsRequest& other898) {
+  dbName = other898.dbName;
+  tableName = other898.tableName;
+  txnIds = other898.txnIds;
+  replPolicy = other898.replPolicy;
+  srcTxnToWriteIdList = other898.srcTxnToWriteIdList;
+  __isset = other898.__isset;
 }
-AllocateTableWriteIdsRequest& AllocateTableWriteIdsRequest::operator=(const AllocateTableWriteIdsRequest& other892) {
-  dbName = other892.dbName;
-  tableName = other892.tableName;
-  txnIds = other892.txnIds;
-  replPolicy = other892.replPolicy;
-  srcTxnToWriteIdList = other892.srcTxnToWriteIdList;
-  __isset = other892.__isset;
+AllocateTableWriteIdsRequest& AllocateTableWriteIdsRequest::operator=(const AllocateTableWriteIdsRequest& other899) {
+  dbName = other899.dbName;
+  tableName = other899.tableName;
+  txnIds = other899.txnIds;
+  replPolicy = other899.replPolicy;
+  srcTxnToWriteIdList = other899.srcTxnToWriteIdList;
+  __isset = other899.__isset;
   return *this;
 }
 void AllocateTableWriteIdsRequest::printTo(std::ostream& out) const {
@@ -23990,14 +24033,14 @@ uint32_t AllocateTableWriteIdsResponse::read(::apache::thrift::protocol::TProtoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txnToWriteIds.clear();
-            uint32_t _size893;
-            ::apache::thrift::protocol::TType _etype896;
-            xfer += iprot->readListBegin(_etype896, _size893);
-            this->txnToWriteIds.resize(_size893);
-            uint32_t _i897;
-            for (_i897 = 0; _i897 < _size893; ++_i897)
+            uint32_t _size900;
+            ::apache::thrift::protocol::TType _etype903;
+            xfer += iprot->readListBegin(_etype903, _size900);
+            this->txnToWriteIds.resize(_size900);
+            uint32_t _i904;
+            for (_i904 = 0; _i904 < _size900; ++_i904)
             {
-              xfer += this->txnToWriteIds[_i897].read(iprot);
+              xfer += this->txnToWriteIds[_i904].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24028,10 +24071,10 @@ uint32_t AllocateTableWriteIdsResponse::write(::apache::thrift::protocol::TProto
   xfer += oprot->writeFieldBegin("txnToWriteIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->txnToWriteIds.size()));
-    std::vector<TxnToWriteId> ::const_iterator _iter898;
-    for (_iter898 = this->txnToWriteIds.begin(); _iter898 != this->txnToWriteIds.end(); ++_iter898)
+    std::vector<TxnToWriteId> ::const_iterator _iter905;
+    for (_iter905 = this->txnToWriteIds.begin(); _iter905 != this->txnToWriteIds.end(); ++_iter905)
     {
-      xfer += (*_iter898).write(oprot);
+      xfer += (*_iter905).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -24047,11 +24090,11 @@ void swap(AllocateTableWriteIdsResponse &a, AllocateTableWriteIdsResponse &b) {
   swap(a.txnToWriteIds, b.txnToWriteIds);
 }
 
-AllocateTableWriteIdsResponse::AllocateTableWriteIdsResponse(const AllocateTableWriteIdsResponse& other899) {
-  txnToWriteIds = other899.txnToWriteIds;
+AllocateTableWriteIdsResponse::AllocateTableWriteIdsResponse(const AllocateTableWriteIdsResponse& other906) {
+  txnToWriteIds = other906.txnToWriteIds;
 }
-AllocateTableWriteIdsResponse& AllocateTableWriteIdsResponse::operator=(const AllocateTableWriteIdsResponse& other900) {
-  txnToWriteIds = other900.txnToWriteIds;
+AllocateTableWriteIdsResponse& AllocateTableWriteIdsResponse::operator=(const AllocateTableWriteIdsResponse& other907) {
+  txnToWriteIds = other907.txnToWriteIds;
   return *this;
 }
 void AllocateTableWriteIdsResponse::printTo(std::ostream& out) const {
@@ -24159,13 +24202,13 @@ void swap(MaxAllocatedTableWriteIdRequest &a, MaxAllocatedTableWriteIdRequest &b
   swap(a.tableName, b.tableName);
 }
 
-MaxAllocatedTableWriteIdRequest::MaxAllocatedTableWriteIdRequest(const MaxAllocatedTableWriteIdRequest& other901) {
-  dbName = other901.dbName;
-  tableName = other901.tableName;
+MaxAllocatedTableWriteIdRequest::MaxAllocatedTableWriteIdRequest(const MaxAllocatedTableWriteIdRequest& other908) {
+  dbName = other908.dbName;
+  tableName = other908.tableName;
 }
-MaxAllocatedTableWriteIdRequest& MaxAllocatedTableWriteIdRequest::operator=(const MaxAllocatedTableWriteIdRequest& other902) {
-  dbName = other902.dbName;
-  tableName = other902.tableName;
+MaxAllocatedTableWriteIdRequest& MaxAllocatedTableWriteIdRequest::operator=(const MaxAllocatedTableWriteIdRequest& other909) {
+  dbName = other909.dbName;
+  tableName = other909.tableName;
   return *this;
 }
 void MaxAllocatedTableWriteIdRequest::printTo(std::ostream& out) const {
@@ -24254,11 +24297,11 @@ void swap(MaxAllocatedTableWriteIdResponse &a, MaxAllocatedTableWriteIdResponse 
   swap(a.maxWriteId, b.maxWriteId);
 }
 
-MaxAllocatedTableWriteIdResponse::MaxAllocatedTableWriteIdResponse(const MaxAllocatedTableWriteIdResponse& other903) {
-  maxWriteId = other903.maxWriteId;
+MaxAllocatedTableWriteIdResponse::MaxAllocatedTableWriteIdResponse(const MaxAllocatedTableWriteIdResponse& other910) {
+  maxWriteId = other910.maxWriteId;
 }
-MaxAllocatedTableWriteIdResponse& MaxAllocatedTableWriteIdResponse::operator=(const MaxAllocatedTableWriteIdResponse& other904) {
-  maxWriteId = other904.maxWriteId;
+MaxAllocatedTableWriteIdResponse& MaxAllocatedTableWriteIdResponse::operator=(const MaxAllocatedTableWriteIdResponse& other911) {
+  maxWriteId = other911.maxWriteId;
   return *this;
 }
 void MaxAllocatedTableWriteIdResponse::printTo(std::ostream& out) const {
@@ -24386,15 +24429,15 @@ void swap(SeedTableWriteIdsRequest &a, SeedTableWriteIdsRequest &b) {
   swap(a.seedWriteId, b.seedWriteId);
 }
 
-SeedTableWriteIdsRequest::SeedTableWriteIdsRequest(const SeedTableWriteIdsRequest& other905) {
-  dbName = other905.dbName;
-  tableName = other905.tableName;
-  seedWriteId = other905.seedWriteId;
+SeedTableWriteIdsRequest::SeedTableWriteIdsRequest(const SeedTableWriteIdsRequest& other912) {
+  dbName = other912.dbName;
+  tableName = other912.tableName;
+  seedWriteId = other912.seedWriteId;
 }
-SeedTableWriteIdsRequest& SeedTableWriteIdsRequest::operator=(const SeedTableWriteIdsRequest& other906) {
-  dbName = other906.dbName;
-  tableName = other906.tableName;
-  seedWriteId = other906.seedWriteId;
+SeedTableWriteIdsRequest& SeedTableWriteIdsRequest::operator=(const SeedTableWriteIdsRequest& other913) {
+  dbName = other913.dbName;
+  tableName = other913.tableName;
+  seedWriteId = other913.seedWriteId;
   return *this;
 }
 void SeedTableWriteIdsRequest::printTo(std::ostream& out) const {
@@ -24484,11 +24527,11 @@ void swap(SeedTxnIdRequest &a, SeedTxnIdRequest &b) {
   swap(a.seedTxnId, b.seedTxnId);
 }
 
-SeedTxnIdRequest::SeedTxnIdRequest(const SeedTxnIdRequest& other907) {
-  seedTxnId = other907.seedTxnId;
+SeedTxnIdRequest::SeedTxnIdRequest(const SeedTxnIdRequest& other914) {
+  seedTxnId = other914.seedTxnId;
 }
-SeedTxnIdRequest& SeedTxnIdRequest::operator=(const SeedTxnIdRequest& other908) {
-  seedTxnId = other908.seedTxnId;
+SeedTxnIdRequest& SeedTxnIdRequest::operator=(const SeedTxnIdRequest& other915) {
+  seedTxnId = other915.seedTxnId;
   return *this;
 }
 void SeedTxnIdRequest::printTo(std::ostream& out) const {
@@ -24572,9 +24615,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast909;
-          xfer += iprot->readI32(ecast909);
-          this->type = (LockType::type)ecast909;
+          int32_t ecast916;
+          xfer += iprot->readI32(ecast916);
+          this->type = (LockType::type)ecast916;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24582,9 +24625,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast910;
-          xfer += iprot->readI32(ecast910);
-          this->level = (LockLevel::type)ecast910;
+          int32_t ecast917;
+          xfer += iprot->readI32(ecast917);
+          this->level = (LockLevel::type)ecast917;
           isset_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24616,9 +24659,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast911;
-          xfer += iprot->readI32(ecast911);
-          this->operationType = (DataOperationType::type)ecast911;
+          int32_t ecast918;
+          xfer += iprot->readI32(ecast918);
+          this->operationType = (DataOperationType::type)ecast918;
           this->__isset.operationType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24718,27 +24761,27 @@ void swap(LockComponent &a, LockComponent &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockComponent::LockComponent(const LockComponent& other912) {
-  type = other912.type;
-  level = other912.level;
-  dbname = other912.dbname;
-  tablename = other912.tablename;
-  partitionname = other912.partitionname;
-  operationType = other912.operationType;
-  isTransactional = other912.isTransactional;
-  isDynamicPartitionWrite = other912.isDynamicPartitionWrite;
-  __isset = other912.__isset;
+LockComponent::LockComponent(const LockComponent& other919) {
+  type = other919.type;
+  level = other919.level;
+  dbname = other919.dbname;
+  tablename = other919.tablename;
+  partitionname = other919.partitionname;
+  operationType = other919.operationType;
+  isTransactional = other919.isTransactional;
+  isDynamicPartitionWrite = other919.isDynamicPartitionWrite;
+  __isset = other919.__isset;
 }
-LockComponent& LockComponent::operator=(const LockComponent& other913) {
-  type = other913.type;
-  level = other913.level;
-  dbname = other913.dbname;
-  tablename = other913.tablename;
-  partitionname = other913.partitionname;
-  operationType = other913.operationType;
-  isTransactional = other913.isTransactional;
-  isDynamicPartitionWrite = other913.isDynamicPartitionWrite;
-  __isset = other913.__isset;
+LockComponent& LockComponent::operator=(const LockComponent& other920) {
+  type = other920.type;
+  level = other920.level;
+  dbname = other920.dbname;
+  tablename = other920.tablename;
+  partitionname = other920.partitionname;
+  operationType = other920.operationType;
+  isTransactional = other920.isTransactional;
+  isDynamicPartitionWrite = other920.isDynamicPartitionWrite;
+  __isset = other920.__isset;
   return *this;
 }
 void LockComponent::printTo(std::ostream& out) const {
@@ -24821,14 +24864,14 @@ uint32_t LockRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->component.clear();
-            uint32_t _size914;
-            ::apache::thrift::protocol::TType _etype917;
-            xfer += iprot->readListBegin(_etype917, _size914);
-            this->component.resize(_size914);
-            uint32_t _i918;
-            for (_i918 = 0; _i918 < _size914; ++_i918)
+            uint32_t _size921;
+            ::apache::thrift::protocol::TType _etype924;
+            xfer += iprot->readListBegin(_etype924, _size921);
+            this->component.resize(_size921);
+            uint32_t _i925;
+            for (_i925 = 0; _i925 < _size921; ++_i925)
             {
-              xfer += this->component[_i918].read(iprot);
+              xfer += this->component[_i925].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24903,10 +24946,10 @@ uint32_t LockRequest::write(::apache::thrift::protocol::TProtocol* oprot) const 
   xfer += oprot->writeFieldBegin("component", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->component.size()));
-    std::vector<LockComponent> ::const_iterator _iter919;
-    for (_iter919 = this->component.begin(); _iter919 != this->component.end(); ++_iter919)
+    std::vector<LockComponent> ::const_iterator _iter926;
+    for (_iter926 = this->component.begin(); _iter926 != this->component.end(); ++_iter926)
     {
-      xfer += (*_iter919).write(oprot);
+      xfer += (*_iter926).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -24951,23 +24994,23 @@ void swap(LockRequest &a, LockRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockRequest::LockRequest(const LockRequest& other920) {
-  component = other920.component;
-  txnid = other920.txnid;
-  user = other920.user;
-  hostname = other920.hostname;
-  agentInfo = other920.agentInfo;
-  zeroWaitReadEnabled = other920.zeroWaitReadEnabled;
-  __isset = other920.__isset;
+LockRequest::LockRequest(const LockRequest& other927) {
+  component = other927.component;
+  txnid = other927.txnid;
+  user = other927.user;
+  hostname = other927.hostname;
+  agentInfo = other927.agentInfo;
+  zeroWaitReadEnabled = other927.zeroWaitReadEnabled;
+  __isset = other927.__isset;
 }
-LockRequest& LockRequest::operator=(const LockRequest& other921) {
-  component = other921.component;
-  txnid = other921.txnid;
-  user = other921.user;
-  hostname = other921.hostname;
-  agentInfo = other921.agentInfo;
-  zeroWaitReadEnabled = other921.zeroWaitReadEnabled;
-  __isset = other921.__isset;
+LockRequest& LockRequest::operator=(const LockRequest& other928) {
+  component = other928.component;
+  txnid = other928.txnid;
+  user = other928.user;
+  hostname = other928.hostname;
+  agentInfo = other928.agentInfo;
+  zeroWaitReadEnabled = other928.zeroWaitReadEnabled;
+  __isset = other928.__isset;
   return *this;
 }
 void LockRequest::printTo(std::ostream& out) const {
@@ -25039,9 +25082,9 @@ uint32_t LockResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast922;
-          xfer += iprot->readI32(ecast922);
-          this->state = (LockState::type)ecast922;
+          int32_t ecast929;
+          xfer += iprot->readI32(ecast929);
+          this->state = (LockState::type)ecast929;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -25102,17 +25145,17 @@ void swap(LockResponse &a, LockResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockResponse::LockResponse(const LockResponse& other923) {
-  lockid = other923.lockid;
-  state = other923.state;
-  errorMessage = other923.errorMessage;
-  __isset = other923.__isset;
+LockResponse::LockResponse(const LockResponse& other930) {
+  lockid = other930.lockid;
+  state = other930.state;
+  errorMessage = other930.errorMessage;
+  __isset = other930.__isset;
 }
-LockResponse& LockResponse::operator=(const LockResponse& other924) {
-  lockid = other924.lockid;
-  state = other924.state;
-  errorMessage = other924.errorMessage;
-  __isset = other924.__isset;
+LockResponse& LockResponse::operator=(const LockResponse& other931) {
+  lockid = other931.lockid;
+  state = other931.state;
+  errorMessage = other931.errorMessage;
+  __isset = other931.__isset;
   return *this;
 }
 void LockResponse::printTo(std::ostream& out) const {
@@ -25241,17 +25284,17 @@ void swap(CheckLockRequest &a, CheckLockRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CheckLockRequest::CheckLockRequest(const CheckLockRequest& other925) {
-  lockid = other925.lockid;
-  txnid = other925.txnid;
-  elapsed_ms = other925.elapsed_ms;
-  __isset = other925.__isset;
+CheckLockRequest::CheckLockRequest(const CheckLockRequest& other932) {
+  lockid = other932.lockid;
+  txnid = other932.txnid;
+  elapsed_ms = other932.elapsed_ms;
+  __isset = other932.__isset;
 }
-CheckLockRequest& CheckLockRequest::operator=(const CheckLockRequest& other926) {
-  lockid = other926.lockid;
-  txnid = other926.txnid;
-  elapsed_ms = other926.elapsed_ms;
-  __isset = other926.__isset;
+CheckLockRequest& CheckLockRequest::operator=(const CheckLockRequest& other933) {
+  lockid = other933.lockid;
+  txnid = other933.txnid;
+  elapsed_ms = other933.elapsed_ms;
+  __isset = other933.__isset;
   return *this;
 }
 void CheckLockRequest::printTo(std::ostream& out) const {
@@ -25341,11 +25384,11 @@ void swap(UnlockRequest &a, UnlockRequest &b) {
   swap(a.lockid, b.lockid);
 }
 
-UnlockRequest::UnlockRequest(const UnlockRequest& other927) {
-  lockid = other927.lockid;
+UnlockRequest::UnlockRequest(const UnlockRequest& other934) {
+  lockid = other934.lockid;
 }
-UnlockRequest& UnlockRequest::operator=(const UnlockRequest& other928) {
-  lockid = other928.lockid;
+UnlockRequest& UnlockRequest::operator=(const UnlockRequest& other935) {
+  lockid = other935.lockid;
   return *this;
 }
 void UnlockRequest::printTo(std::ostream& out) const {
@@ -25509,21 +25552,21 @@ void swap(ShowLocksRequest &a, ShowLocksRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksRequest::ShowLocksRequest(const ShowLocksRequest& other929) {
-  dbname = other929.dbname;
-  tablename = other929.tablename;
-  partname = other929.partname;
-  isExtended = other929.isExtended;
-  txnid = other929.txnid;
-  __isset = other929.__isset;
+ShowLocksRequest::ShowLocksRequest(const ShowLocksRequest& other936) {
+  dbname = other936.dbname;
+  tablename = other936.tablename;
+  partname = other936.partname;
+  isExtended = other936.isExtended;
+  txnid = other936.txnid;
+  __isset = other936.__isset;
 }
-ShowLocksRequest& ShowLocksRequest::operator=(const ShowLocksRequest& other930) {
-  dbname = other930.dbname;
-  tablename = other930.tablename;
-  partname = other930.partname;
-  isExtended = other930.isExtended;
-  txnid = other930.txnid;
-  __isset = other930.__isset;
+ShowLocksRequest& ShowLocksRequest::operator=(const ShowLocksRequest& other937) {
+  dbname = other937.dbname;
+  tablename = other937.tablename;
+  partname = other937.partname;
+  isExtended = other937.isExtended;
+  txnid = other937.txnid;
+  __isset = other937.__isset;
   return *this;
 }
 void ShowLocksRequest::printTo(std::ostream& out) const {
@@ -25683,9 +25726,9 @@ uint32_t ShowLocksResponseElement::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast931;
-          xfer += iprot->readI32(ecast931);
-          this->state = (LockState::type)ecast931;
+          int32_t ecast938;
+          xfer += iprot->readI32(ecast938);
+          this->state = (LockState::type)ecast938;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -25693,9 +25736,9 @@ uint32_t ShowLocksResponseElement::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast932;
-          xfer += iprot->readI32(ecast932);
-          this->type = (LockType::type)ecast932;
+          int32_t ecast939;
+          xfer += iprot->readI32(ecast939);
+          this->type = (LockType::type)ecast939;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -25911,43 +25954,43 @@ void swap(ShowLocksResponseElement &a, ShowLocksResponseElement &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksResponseElement::ShowLocksResponseElement(const ShowLocksResponseElement& other933) {
-  lockid = other933.lockid;
-  dbname = other933.dbname;
-  tablename = other933.tablename;
-  partname = other933.partname;
-  state = other933.state;
-  type = other933.type;
-  txnid = other933.txnid;
-  lastheartbeat = other933.lastheartbeat;
-  acquiredat = other933.acquiredat;
-  user = other933.user;
-  hostname = other933.hostname;
-  heartbeatCount = other933.heartbeatCount;
-  agentInfo = other933.agentInfo;
-  blockedByExtId = other933.blockedByExtId;
-  blockedByIntId = other933.blockedByIntId;
-  lockIdInternal = other933.lockIdInternal;
-  __isset = other933.__isset;
+ShowLocksResponseElement::ShowLocksResponseElement(const ShowLocksResponseElement& other940) {
+  lockid = other940.lockid;
+  dbname = other940.dbname;
+  tablename = other940.tablename;
+  partname = other940.partname;
+  state = other940.state;
+  type = other940.type;
+  txnid = other940.txnid;
+  lastheartbeat = other940.lastheartbeat;
+  acquiredat = other940.acquiredat;
+  user = other940.user;
+  hostname = other940.hostname;
+  heartbeatCount = other940.heartbeatCount;
+  agentInfo = other940.agentInfo;
+  blockedByExtId = other940.blockedByExtId;
+  blockedByIntId = other940.blockedByIntId;
+  lockIdInternal = other940.lockIdInternal;
+  __isset = other940.__isset;
 }
-ShowLocksResponseElement& ShowLocksResponseElement::operator=(const ShowLocksResponseElement& other934) {
-  lockid = other934.lockid;
-  dbname = other934.dbname;
-  tablename = other934.tablename;
-  partname = other934.partname;
-  state = other934.state;
-  type = other934.type;
-  txnid = other934.txnid;
-  lastheartbeat = other934.lastheartbeat;
-  acquiredat = other934.acquiredat;
-  user = other934.user;
-  hostname = other934.hostname;
-  heartbeatCount = other934.heartbeatCount;
-  agentInfo = other934.agentInfo;
-  blockedByExtId = other934.blockedByExtId;
-  blockedByIntId = other934.blockedByIntId;
-  lockIdInternal = other934.lockIdInternal;
-  __isset = other934.__isset;
+ShowLocksResponseElement& ShowLocksResponseElement::operator=(const ShowLocksResponseElement& other941) {
+  lockid = other941.lockid;
+  dbname = other941.dbname;
+  tablename = other941.tablename;
+  partname = other941.partname;
+  state = other941.state;
+  type = other941.type;
+  txnid = other941.txnid;
+  lastheartbeat = other941.lastheartbeat;
+  acquiredat = other941.acquiredat;
+  user = other941.user;
+  hostname = other941.hostname;
+  heartbeatCount = other941.heartbeatCount;
+  agentInfo = other941.agentInfo;
+  blockedByExtId = other941.blockedByExtId;
+  blockedByIntId = other941.blockedByIntId;
+  lockIdInternal = other941.lockIdInternal;
+  __isset = other941.__isset;
   return *this;
 }
 void ShowLocksResponseElement::printTo(std::ostream& out) const {
@@ -26012,14 +26055,14 @@ uint32_t ShowLocksResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->locks.clear();
-            uint32_t _size935;
-            ::apache::thrift::protocol::TType _etype938;
-            xfer += iprot->readListBegin(_etype938, _size935);
-            this->locks.resize(_size935);
-            uint32_t _i939;
-            for (_i939 = 0; _i939 < _size935; ++_i939)
+            uint32_t _size942;
+            ::apache::thrift::protocol::TType _etype945;
+            xfer += iprot->readListBegin(_etype945, _size942);
+            this->locks.resize(_size942);
+            uint32_t _i946;
+            for (_i946 = 0; _i946 < _size942; ++_i946)
             {
-              xfer += this->locks[_i939].read(iprot);
+              xfer += this->locks[_i946].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26048,10 +26091,10 @@ uint32_t ShowLocksResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("locks", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->locks.size()));
-    std::vector<ShowLocksResponseElement> ::const_iterator _iter940;
-    for (_iter940 = this->locks.begin(); _iter940 != this->locks.end(); ++_iter940)
+    std::vector<ShowLocksResponseElement> ::const_iterator _iter947;
+    for (_iter947 = this->locks.begin(); _iter947 != this->locks.end(); ++_iter947)
     {
-      xfer += (*_iter940).write(oprot);
+      xfer += (*_iter947).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26068,13 +26111,13 @@ void swap(ShowLocksResponse &a, ShowLocksResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksResponse::ShowLocksResponse(const ShowLocksResponse& other941) {
-  locks = other941.locks;
-  __isset = other941.__isset;
+ShowLocksResponse::ShowLocksResponse(const ShowLocksResponse& other948) {
+  locks = other948.locks;
+  __isset = other948.__isset;
 }
-ShowLocksResponse& ShowLocksResponse::operator=(const ShowLocksResponse& other942) {
-  locks = other942.locks;
-  __isset = other942.__isset;
+ShowLocksResponse& ShowLocksResponse::operator=(const ShowLocksResponse& other949) {
+  locks = other949.locks;
+  __isset = other949.__isset;
   return *this;
 }
 void ShowLocksResponse::printTo(std::ostream& out) const {
@@ -26181,15 +26224,15 @@ void swap(HeartbeatRequest &a, HeartbeatRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-HeartbeatRequest::HeartbeatRequest(const HeartbeatRequest& other943) {
-  lockid = other943.lockid;
-  txnid = other943.txnid;
-  __isset = other943.__isset;
+HeartbeatRequest::HeartbeatRequest(const HeartbeatRequest& other950) {
+  lockid = other950.lockid;
+  txnid = other950.txnid;
+  __isset = other950.__isset;
 }
-HeartbeatRequest& HeartbeatRequest::operator=(const HeartbeatRequest& other944) {
-  lockid = other944.lockid;
-  txnid = other944.txnid;
-  __isset = other944.__isset;
+HeartbeatRequest& HeartbeatRequest::operator=(const HeartbeatRequest& other951) {
+  lockid = other951.lockid;
+  txnid = other951.txnid;
+  __isset = other951.__isset;
   return *this;
 }
 void HeartbeatRequest::printTo(std::ostream& out) const {
@@ -26298,13 +26341,13 @@ void swap(HeartbeatTxnRangeRequest &a, HeartbeatTxnRangeRequest &b) {
   swap(a.max, b.max);
 }
 
-HeartbeatTxnRangeRequest::HeartbeatTxnRangeRequest(const HeartbeatTxnRangeRequest& other945) {
-  min = other945.min;
-  max = other945.max;
+HeartbeatTxnRangeRequest::HeartbeatTxnRangeRequest(const HeartbeatTxnRangeRequest& other952) {
+  min = other952.min;
+  max = other952.max;
 }
-HeartbeatTxnRangeRequest& HeartbeatTxnRangeRequest::operator=(const HeartbeatTxnRangeRequest& other946) {
-  min = other946.min;
-  max = other946.max;
+HeartbeatTxnRangeRequest& HeartbeatTxnRangeRequest::operator=(const HeartbeatTxnRangeRequest& other953) {
+  min = other953.min;
+  max = other953.max;
   return *this;
 }
 void HeartbeatTxnRangeRequest::printTo(std::ostream& out) const {
@@ -26361,15 +26404,15 @@ uint32_t HeartbeatTxnRangeResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_SET) {
           {
             this->aborted.clear();
-            uint32_t _size947;
-            ::apache::thrift::protocol::TType _etype950;
-            xfer += iprot->readSetBegin(_etype950, _size947);
-            uint32_t _i951;
-            for (_i951 = 0; _i951 < _size947; ++_i951)
+            uint32_t _size954;
+            ::apache::thrift::protocol::TType _etype957;
+            xfer += iprot->readSetBegin(_etype957, _size954);
+            uint32_t _i958;
+            for (_i958 = 0; _i958 < _size954; ++_i958)
             {
-              int64_t _elem952;
-              xfer += iprot->readI64(_elem952);
-              this->aborted.insert(_elem952);
+              int64_t _elem959;
+              xfer += iprot->readI64(_elem959);
+              this->aborted.insert(_elem959);
             }
             xfer += iprot->readSetEnd();
           }
@@ -26382,15 +26425,15 @@ uint32_t HeartbeatTxnRangeResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_SET) {
           {
             this->nosuch.clear();
-            uint32_t _size953;
-            ::apache::thrift::protocol::TType _etype956;
-            xfer += iprot->readSetBegin(_etype956, _size953);
-            uint32_t _i957;
-            for (_i957 = 0; _i957 < _size953; ++_i957)
+            uint32_t _size960;
+            ::apache::thrift::protocol::TType _etype963;
+            xfer += iprot->readSetBegin(_etype963, _size960);
+            uint32_t _i964;
+            for (_i964 = 0; _i964 < _size960; ++_i964)
             {
-              int64_t _elem958;
-              xfer += iprot->readI64(_elem958);
-              this->nosuch.insert(_elem958);
+              int64_t _elem965;
+              xfer += iprot->readI64(_elem965);
+              this->nosuch.insert(_elem965);
             }
             xfer += iprot->readSetEnd();
           }
@@ -26423,10 +26466,10 @@ uint32_t HeartbeatTxnRangeResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("aborted", ::apache::thrift::protocol::T_SET, 1);
   {
     xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->aborted.size()));
-    std::set<int64_t> ::const_iterator _iter959;
-    for (_iter959 = this->aborted.begin(); _iter959 != this->aborted.end(); ++_iter959)
+    std::set<int64_t> ::const_iterator _iter966;
+    for (_iter966 = this->aborted.begin(); _iter966 != this->aborted.end(); ++_iter966)
     {
-      xfer += oprot->writeI64((*_iter959));
+      xfer += oprot->writeI64((*_iter966));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -26435,10 +26478,10 @@ uint32_t HeartbeatTxnRangeResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("nosuch", ::apache::thrift::protocol::T_SET, 2);
   {
     xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->nosuch.size()));
-    std::set<int64_t> ::const_iterator _iter960;
-    for (_iter960 = this->nosuch.begin(); _iter960 != this->nosuch.end(); ++_iter960)
+    std::set<int64_t> ::const_iterator _iter967;
+    for (_iter967 = this->nosuch.begin(); _iter967 != this->nosuch.end(); ++_iter967)
     {
-      xfer += oprot->writeI64((*_iter960));
+      xfer += oprot->writeI64((*_iter967));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -26455,13 +26498,13 @@ void swap(HeartbeatTxnRangeResponse &a, HeartbeatTxnRangeResponse &b) {
   swap(a.nosuch, b.nosuch);
 }
 
-HeartbeatTxnRangeResponse::HeartbeatTxnRangeResponse(const HeartbeatTxnRangeResponse& other961) {
-  aborted = other961.aborted;
-  nosuch = other961.nosuch;
+HeartbeatTxnRangeResponse::HeartbeatTxnRangeResponse(const HeartbeatTxnRangeResponse& other968) {
+  aborted = other968.aborted;
+  nosuch = other968.nosuch;
 }
-HeartbeatTxnRangeResponse& HeartbeatTxnRangeResponse::operator=(const HeartbeatTxnRangeResponse& other962) {
-  aborted = other962.aborted;
-  nosuch = other962.nosuch;
+HeartbeatTxnRangeResponse& HeartbeatTxnRangeResponse::operator=(const HeartbeatTxnRangeResponse& other969) {
+  aborted = other969.aborted;
+  nosuch = other969.nosuch;
   return *this;
 }
 void HeartbeatTxnRangeResponse::printTo(std::ostream& out) const {
@@ -26570,9 +26613,9 @@ uint32_t CompactionRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast963;
-          xfer += iprot->readI32(ecast963);
-          this->type = (CompactionType::type)ecast963;
+          int32_t ecast970;
+          xfer += iprot->readI32(ecast970);
+          this->type = (CompactionType::type)ecast970;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -26590,17 +26633,17 @@ uint32_t CompactionRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->properties.clear();
-            uint32_t _size964;
-            ::apache::thrift::protocol::TType _ktype965;
-            ::apache::thrift::protocol::TType _vtype966;
-            xfer += iprot->readMapBegin(_ktype965, _vtype966, _size964);
-            uint32_t _i968;
-            for (_i968 = 0; _i968 < _size964; ++_i968)
+            uint32_t _size971;
+            ::apache::thrift::protocol::TType _ktype972;
+            ::apache::thrift::protocol::TType _vtype973;
+            xfer += iprot->readMapBegin(_ktype972, _vtype973, _size971);
+            uint32_t _i975;
+            for (_i975 = 0; _i975 < _size971; ++_i975)
             {
-              std::string _key969;
-              xfer += iprot->readString(_key969);
-              std::string& _val970 = this->properties[_key969];
-              xfer += iprot->readString(_val970);
+              std::string _key976;
+              xfer += iprot->readString(_key976);
+              std::string& _val977 = this->properties[_key976];
+              xfer += iprot->readString(_val977);
             }
             xfer += iprot->readMapEnd();
           }
@@ -26674,11 +26717,11 @@ uint32_t CompactionRequest::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 6);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
-      std::map<std::string, std::string> ::const_iterator _iter971;
-      for (_iter971 = this->properties.begin(); _iter971 != this->properties.end(); ++_iter971)
+      std::map<std::string, std::string> ::const_iterator _iter978;
+      for (_iter978 = this->properties.begin(); _iter978 != this->properties.end(); ++_iter978)
       {
-        xfer += oprot->writeString(_iter971->first);
-        xfer += oprot->writeString(_iter971->second);
+        xfer += oprot->writeString(_iter978->first);
+        xfer += oprot->writeString(_iter978->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -26712,27 +26755,27 @@ void swap(CompactionRequest &a, CompactionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CompactionRequest::CompactionRequest(const CompactionRequest& other972) {
-  dbname = other972.dbname;
-  tablename = other972.tablename;
-  partitionname = other972.partitionname;
-  type = other972.type;
-  runas = other972.runas;
-  properties = other972.properties;
-  initiatorId = other972.initiatorId;
-  initiatorVersion = other972.initiatorVersion;
-  __isset = other972.__isset;
+CompactionRequest::CompactionRequest(const CompactionRequest& other979) {
+  dbname = other979.dbname;
+  tablename = other979.tablename;
+  partitionname = other979.partitionname;
+  type = other979.type;
+  runas = other979.runas;
+  properties = other979.properties;
+  initiatorId = other979.initiatorId;
+  initiatorVersion = other979.initiatorVersion;
+  __isset = other979.__isset;
 }
-CompactionRequest& CompactionRequest::operator=(const CompactionRequest& other973) {
-  dbname = other973.dbname;
-  tablename = other973.tablename;
-  partitionname = other973.partitionname;
-  type = other973.type;
-  runas = other973.runas;
-  properties = other973.properties;
-  initiatorId = other973.initiatorId;
-  initiatorVersion = other973.initiatorVersion;
-  __isset = other973.__isset;
+CompactionRequest& CompactionRequest::operator=(const CompactionRequest& other980) {
+  dbname = other980.dbname;
+  tablename = other980.tablename;
+  partitionname = other980.partitionname;
+  type = other980.type;
+  runas = other980.runas;
+  properties = other980.properties;
+  initiatorId = other980.initiatorId;
+  initiatorVersion = other980.initiatorVersion;
+  __isset = other980.__isset;
   return *this;
 }
 void CompactionRequest::printTo(std::ostream& out) const {
@@ -26890,9 +26933,9 @@ uint32_t CompactionInfoStruct::read(::apache::thrift::protocol::TProtocol* iprot
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast974;
-          xfer += iprot->readI32(ecast974);
-          this->type = (CompactionType::type)ecast974;
+          int32_t ecast981;
+          xfer += iprot->readI32(ecast981);
+          this->type = (CompactionType::type)ecast981;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -27099,41 +27142,41 @@ void swap(CompactionInfoStruct &a, CompactionInfoStruct &b) {
   swap(a.__isset, b.__isset);
 }
 
-CompactionInfoStruct::CompactionInfoStruct(const CompactionInfoStruct& other975) {
-  id = other975.id;
-  dbname = other975.dbname;
-  tablename = other975.tablename;
-  partitionname = other975.partitionname;
-  type = other975.type;
-  runas = other975.runas;
-  properties = other975.properties;
-  toomanyaborts = other975.toomanyaborts;
-  state = other975.state;
-  workerId = other975.workerId;
-  start = other975.start;
-  highestWriteId = other975.highestWriteId;
-  errorMessage = other975.errorMessage;
-  hasoldabort = other975.hasoldabort;
-  enqueueTime = other975.enqueueTime;
-  __isset = other975.__isset;
+CompactionInfoStruct::CompactionInfoStruct(const CompactionInfoStruct& other982) {
+  id = other982.id;
+  dbname = other982.dbname;
+  tablename = other982.tablename;
+  partitionname = other982.partitionname;
+  type = other982.type;
+  runas = other982.runas;
+  properties = other982.properties;
+  toomanyaborts = other982.toomanyaborts;
+  state = other982.state;
+  workerId = other982.workerId;
+  start = other982.start;
+  highestWriteId = other982.highestWriteId;
+  errorMessage = other982.errorMessage;
+  hasoldabort = other982.hasoldabort;
+  enqueueTime = other982.enqueueTime;
+  __isset = other982.__isset;
 }
-CompactionInfoStruct& CompactionInfoStruct::operator=(const CompactionInfoStruct& other976) {
-  id = other976.id;
-  dbname = other976.dbname;
-  tablename = other976.tablename;
-  partitionname = other976.partitionname;
-  type = other976.type;
-  runas = other976.runas;
-  properties = other976.properties;
-  toomanyaborts = other976.toomanyaborts;
-  state = other976.state;
-  workerId = other976.workerId;
-  start = other976.start;
-  highestWriteId = other976.highestWriteId;
-  errorMessage = other976.errorMessage;
-  hasoldabort = other976.hasoldabort;
-  enqueueTime = other976.enqueueTime;
-  __isset = other976.__isset;
+CompactionInfoStruct& CompactionInfoStruct::operator=(const CompactionInfoStruct& other983) {
+  id = other983.id;
+  dbname = other983.dbname;
+  tablename = other983.tablename;
+  partitionname = other983.partitionname;
+  type = other983.type;
+  runas = other983.runas;
+  properties = other983.properties;
+  toomanyaborts = other983.toomanyaborts;
+  state = other983.state;
+  workerId = other983.workerId;
+  start = other983.start;
+  highestWriteId = other983.highestWriteId;
+  errorMessage = other983.errorMessage;
+  hasoldabort = other983.hasoldabort;
+  enqueueTime = other983.enqueueTime;
+  __isset = other983.__isset;
   return *this;
 }
 void CompactionInfoStruct::printTo(std::ostream& out) const {
@@ -27235,13 +27278,13 @@ void swap(OptionalCompactionInfoStruct &a, OptionalCompactionInfoStruct &b) {
   swap(a.__isset, b.__isset);
 }
 
-OptionalCompactionInfoStruct::OptionalCompactionInfoStruct(const OptionalCompactionInfoStruct& other977) {
-  ci = other977.ci;
-  __isset = other977.__isset;
+OptionalCompactionInfoStruct::OptionalCompactionInfoStruct(const OptionalCompactionInfoStruct& other984) {
+  ci = other984.ci;
+  __isset = other984.__isset;
 }
-OptionalCompactionInfoStruct& OptionalCompactionInfoStruct::operator=(const OptionalCompactionInfoStruct& other978) {
-  ci = other978.ci;
-  __isset = other978.__isset;
+OptionalCompactionInfoStruct& OptionalCompactionInfoStruct::operator=(const OptionalCompactionInfoStruct& other985) {
+  ci = other985.ci;
+  __isset = other985.__isset;
   return *this;
 }
 void OptionalCompactionInfoStruct::printTo(std::ostream& out) const {
@@ -27369,15 +27412,15 @@ void swap(CompactionResponse &a, CompactionResponse &b) {
   swap(a.accepted, b.accepted);
 }
 
-CompactionResponse::CompactionResponse(const CompactionResponse& other979) {
-  id = other979.id;
-  state = other979.state;
-  accepted = other979.accepted;
+CompactionResponse::CompactionResponse(const CompactionResponse& other986) {
+  id = other986.id;
+  state = other986.state;
+  accepted = other986.accepted;
 }
-CompactionResponse& CompactionResponse::operator=(const CompactionResponse& other980) {
-  id = other980.id;
-  state = other980.state;
-  accepted = other980.accepted;
+CompactionResponse& CompactionResponse::operator=(const CompactionResponse& other987) {
+  id = other987.id;
+  state = other987.state;
+  accepted = other987.accepted;
   return *this;
 }
 void CompactionResponse::printTo(std::ostream& out) const {
@@ -27444,11 +27487,11 @@ void swap(ShowCompactRequest &a, ShowCompactRequest &b) {
   (void) b;
 }
 
-ShowCompactRequest::ShowCompactRequest(const ShowCompactRequest& other981) {
-  (void) other981;
+ShowCompactRequest::ShowCompactRequest(const ShowCompactRequest& other988) {
+  (void) other988;
 }
-ShowCompactRequest& ShowCompactRequest::operator=(const ShowCompactRequest& other982) {
-  (void) other982;
+ShowCompactRequest& ShowCompactRequest::operator=(const ShowCompactRequest& other989) {
+  (void) other989;
   return *this;
 }
 void ShowCompactRequest::printTo(std::ostream& out) const {
@@ -27610,9 +27653,9 @@ uint32_t ShowCompactResponseElement::read(::apache::thrift::protocol::TProtocol*
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast983;
-          xfer += iprot->readI32(ecast983);
-          this->type = (CompactionType::type)ecast983;
+          int32_t ecast990;
+          xfer += iprot->readI32(ecast990);
+          this->type = (CompactionType::type)ecast990;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -27883,6 +27926,7 @@ void swap(ShowCompactResponseElement &a, ShowCompactResponseElement &b) {
   swap(a.__isset, b.__isset);
 }
 
+<<<<<<< HEAD
 ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other984) {
   dbname = other984.dbname;
   tablename = other984.tablename;
@@ -27926,6 +27970,49 @@ ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowComp
   initiatorVersion = other985.initiatorVersion;
   cleanerStart = other985.cleanerStart;
   __isset = other985.__isset;
+=======
+ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other991) {
+  dbname = other991.dbname;
+  tablename = other991.tablename;
+  partitionname = other991.partitionname;
+  type = other991.type;
+  state = other991.state;
+  workerid = other991.workerid;
+  start = other991.start;
+  runAs = other991.runAs;
+  hightestTxnId = other991.hightestTxnId;
+  metaInfo = other991.metaInfo;
+  endTime = other991.endTime;
+  hadoopJobId = other991.hadoopJobId;
+  id = other991.id;
+  errorMessage = other991.errorMessage;
+  enqueueTime = other991.enqueueTime;
+  workerVersion = other991.workerVersion;
+  initiatorId = other991.initiatorId;
+  initiatorVersion = other991.initiatorVersion;
+  __isset = other991.__isset;
+}
+ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowCompactResponseElement& other992) {
+  dbname = other992.dbname;
+  tablename = other992.tablename;
+  partitionname = other992.partitionname;
+  type = other992.type;
+  state = other992.state;
+  workerid = other992.workerid;
+  start = other992.start;
+  runAs = other992.runAs;
+  hightestTxnId = other992.hightestTxnId;
+  metaInfo = other992.metaInfo;
+  endTime = other992.endTime;
+  hadoopJobId = other992.hadoopJobId;
+  id = other992.id;
+  errorMessage = other992.errorMessage;
+  enqueueTime = other992.enqueueTime;
+  workerVersion = other992.workerVersion;
+  initiatorId = other992.initiatorId;
+  initiatorVersion = other992.initiatorVersion;
+  __isset = other992.__isset;
+>>>>>>> HIVE-25744: Support backward compatibility of thrift struct CreationMetadata
   return *this;
 }
 void ShowCompactResponseElement::printTo(std::ostream& out) const {
@@ -27994,14 +28081,14 @@ uint32_t ShowCompactResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->compacts.clear();
-            uint32_t _size986;
-            ::apache::thrift::protocol::TType _etype989;
-            xfer += iprot->readListBegin(_etype989, _size986);
-            this->compacts.resize(_size986);
-            uint32_t _i990;
-            for (_i990 = 0; _i990 < _size986; ++_i990)
+            uint32_t _size993;
+            ::apache::thrift::protocol::TType _etype996;
+            xfer += iprot->readListBegin(_etype996, _size993);
+            this->compacts.resize(_size993);
+            uint32_t _i997;
+            for (_i997 = 0; _i997 < _size993; ++_i997)
             {
-              xfer += this->compacts[_i990].read(iprot);
+              xfer += this->compacts[_i997].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -28032,10 +28119,10 @@ uint32_t ShowCompactResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("compacts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->compacts.size()));
-    std::vector<ShowCompactResponseElement> ::const_iterator _iter991;
-    for (_iter991 = this->compacts.begin(); _iter991 != this->compacts.end(); ++_iter991)
+    std::vector<ShowCompactResponseElement> ::const_iterator _iter998;
+    for (_iter998 = this->compacts.begin(); _iter998 != this->compacts.end(); ++_iter998)
     {
-      xfer += (*_iter991).write(oprot);
+      xfer += (*_iter998).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -28051,11 +28138,11 @@ void swap(ShowCompactResponse &a, ShowCompactResponse &b) {
   swap(a.compacts, b.compacts);
 }
 
-ShowCompactResponse::ShowCompactResponse(const ShowCompactResponse& other992) {
-  compacts = other992.compacts;
+ShowCompactResponse::ShowCompactResponse(const ShowCompactResponse& other999) {
+  compacts = other999.compacts;
 }
-ShowCompactResponse& ShowCompactResponse::operator=(const ShowCompactResponse& other993) {
-  compacts = other993.compacts;
+ShowCompactResponse& ShowCompactResponse::operator=(const ShowCompactResponse& other1000) {
+  compacts = other1000.compacts;
   return *this;
 }
 void ShowCompactResponse::printTo(std::ostream& out) const {
@@ -28132,14 +28219,14 @@ uint32_t GetLatestCommittedCompactionInfoRequest::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionnames.clear();
-            uint32_t _size994;
-            ::apache::thrift::protocol::TType _etype997;
-            xfer += iprot->readListBegin(_etype997, _size994);
-            this->partitionnames.resize(_size994);
-            uint32_t _i998;
-            for (_i998 = 0; _i998 < _size994; ++_i998)
+            uint32_t _size1001;
+            ::apache::thrift::protocol::TType _etype1004;
+            xfer += iprot->readListBegin(_etype1004, _size1001);
+            this->partitionnames.resize(_size1001);
+            uint32_t _i1005;
+            for (_i1005 = 0; _i1005 < _size1001; ++_i1005)
             {
-              xfer += iprot->readString(this->partitionnames[_i998]);
+              xfer += iprot->readString(this->partitionnames[_i1005]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28181,10 +28268,10 @@ uint32_t GetLatestCommittedCompactionInfoRequest::write(::apache::thrift::protoc
     xfer += oprot->writeFieldBegin("partitionnames", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionnames.size()));
-      std::vector<std::string> ::const_iterator _iter999;
-      for (_iter999 = this->partitionnames.begin(); _iter999 != this->partitionnames.end(); ++_iter999)
+      std::vector<std::string> ::const_iterator _iter1006;
+      for (_iter1006 = this->partitionnames.begin(); _iter1006 != this->partitionnames.end(); ++_iter1006)
       {
-        xfer += oprot->writeString((*_iter999));
+        xfer += oprot->writeString((*_iter1006));
       }
       xfer += oprot->writeListEnd();
     }
@@ -28203,17 +28290,17 @@ void swap(GetLatestCommittedCompactionInfoRequest &a, GetLatestCommittedCompacti
   swap(a.__isset, b.__isset);
 }
 
-GetLatestCommittedCompactionInfoRequest::GetLatestCommittedCompactionInfoRequest(const GetLatestCommittedCompactionInfoRequest& other1000) {
-  dbname = other1000.dbname;
-  tablename = other1000.tablename;
-  partitionnames = other1000.partitionnames;
-  __isset = other1000.__isset;
+GetLatestCommittedCompactionInfoRequest::GetLatestCommittedCompactionInfoRequest(const GetLatestCommittedCompactionInfoRequest& other1007) {
+  dbname = other1007.dbname;
+  tablename = other1007.tablename;
+  partitionnames = other1007.partitionnames;
+  __isset = other1007.__isset;
 }
-GetLatestCommittedCompactionInfoRequest& GetLatestCommittedCompactionInfoRequest::operator=(const GetLatestCommittedCompactionInfoRequest& other1001) {
-  dbname = other1001.dbname;
-  tablename = other1001.tablename;
-  partitionnames = other1001.partitionnames;
-  __isset = other1001.__isset;
+GetLatestCommittedCompactionInfoRequest& GetLatestCommittedCompactionInfoRequest::operator=(const GetLatestCommittedCompactionInfoRequest& other1008) {
+  dbname = other1008.dbname;
+  tablename = other1008.tablename;
+  partitionnames = other1008.partitionnames;
+  __isset = other1008.__isset;
   return *this;
 }
 void GetLatestCommittedCompactionInfoRequest::printTo(std::ostream& out) const {
@@ -28266,14 +28353,14 @@ uint32_t GetLatestCommittedCompactionInfoResponse::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->compactions.clear();
-            uint32_t _size1002;
-            ::apache::thrift::protocol::TType _etype1005;
-            xfer += iprot->readListBegin(_etype1005, _size1002);
-            this->compactions.resize(_size1002);
-            uint32_t _i1006;
-            for (_i1006 = 0; _i1006 < _size1002; ++_i1006)
+            uint32_t _size1009;
+            ::apache::thrift::protocol::TType _etype1012;
+            xfer += iprot->readListBegin(_etype1012, _size1009);
+            this->compactions.resize(_size1009);
+            uint32_t _i1013;
+            for (_i1013 = 0; _i1013 < _size1009; ++_i1013)
             {
-              xfer += this->compactions[_i1006].read(iprot);
+              xfer += this->compactions[_i1013].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -28304,10 +28391,10 @@ uint32_t GetLatestCommittedCompactionInfoResponse::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("compactions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->compactions.size()));
-    std::vector<CompactionInfoStruct> ::const_iterator _iter1007;
-    for (_iter1007 = this->compactions.begin(); _iter1007 != this->compactions.end(); ++_iter1007)
+    std::vector<CompactionInfoStruct> ::const_iterator _iter1014;
+    for (_iter1014 = this->compactions.begin(); _iter1014 != this->compactions.end(); ++_iter1014)
     {
-      xfer += (*_iter1007).write(oprot);
+      xfer += (*_iter1014).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -28323,11 +28410,11 @@ void swap(GetLatestCommittedCompactionInfoResponse &a, GetLatestCommittedCompact
   swap(a.compactions, b.compactions);
 }
 
-GetLatestCommittedCompactionInfoResponse::GetLatestCommittedCompactionInfoResponse(const GetLatestCommittedCompactionInfoResponse& other1008) {
-  compactions = other1008.compactions;
+GetLatestCommittedCompactionInfoResponse::GetLatestCommittedCompactionInfoResponse(const GetLatestCommittedCompactionInfoResponse& other1015) {
+  compactions = other1015.compactions;
 }
-GetLatestCommittedCompactionInfoResponse& GetLatestCommittedCompactionInfoResponse::operator=(const GetLatestCommittedCompactionInfoResponse& other1009) {
-  compactions = other1009.compactions;
+GetLatestCommittedCompactionInfoResponse& GetLatestCommittedCompactionInfoResponse::operator=(const GetLatestCommittedCompactionInfoResponse& other1016) {
+  compactions = other1016.compactions;
   return *this;
 }
 void GetLatestCommittedCompactionInfoResponse::printTo(std::ostream& out) const {
@@ -28434,15 +28521,15 @@ void swap(FindNextCompactRequest &a, FindNextCompactRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-FindNextCompactRequest::FindNextCompactRequest(const FindNextCompactRequest& other1010) {
-  workerId = other1010.workerId;
-  workerVersion = other1010.workerVersion;
-  __isset = other1010.__isset;
+FindNextCompactRequest::FindNextCompactRequest(const FindNextCompactRequest& other1017) {
+  workerId = other1017.workerId;
+  workerVersion = other1017.workerVersion;
+  __isset = other1017.__isset;
 }
-FindNextCompactRequest& FindNextCompactRequest::operator=(const FindNextCompactRequest& other1011) {
-  workerId = other1011.workerId;
-  workerVersion = other1011.workerVersion;
-  __isset = other1011.__isset;
+FindNextCompactRequest& FindNextCompactRequest::operator=(const FindNextCompactRequest& other1018) {
+  workerId = other1018.workerId;
+  workerVersion = other1018.workerVersion;
+  __isset = other1018.__isset;
   return *this;
 }
 void FindNextCompactRequest::printTo(std::ostream& out) const {
@@ -28551,14 +28638,14 @@ uint32_t AddDynamicPartitions::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionnames.clear();
-            uint32_t _size1012;
-            ::apache::thrift::protocol::TType _etype1015;
-            xfer += iprot->readListBegin(_etype1015, _size1012);
-            this->partitionnames.resize(_size1012);
-            uint32_t _i1016;
-            for (_i1016 = 0; _i1016 < _size1012; ++_i1016)
+            uint32_t _size1019;
+            ::apache::thrift::protocol::TType _etype1022;
+            xfer += iprot->readListBegin(_etype1022, _size1019);
+            this->partitionnames.resize(_size1019);
+            uint32_t _i1023;
+            for (_i1023 = 0; _i1023 < _size1019; ++_i1023)
             {
-              xfer += iprot->readString(this->partitionnames[_i1016]);
+              xfer += iprot->readString(this->partitionnames[_i1023]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28569,9 +28656,9 @@ uint32_t AddDynamicPartitions::read(::apache::thrift::protocol::TProtocol* iprot
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1017;
-          xfer += iprot->readI32(ecast1017);
-          this->operationType = (DataOperationType::type)ecast1017;
+          int32_t ecast1024;
+          xfer += iprot->readI32(ecast1024);
+          this->operationType = (DataOperationType::type)ecast1024;
           this->__isset.operationType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -28623,10 +28710,10 @@ uint32_t AddDynamicPartitions::write(::apache::thrift::protocol::TProtocol* opro
   xfer += oprot->writeFieldBegin("partitionnames", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionnames.size()));
-    std::vector<std::string> ::const_iterator _iter1018;
-    for (_iter1018 = this->partitionnames.begin(); _iter1018 != this->partitionnames.end(); ++_iter1018)
+    std::vector<std::string> ::const_iterator _iter1025;
+    for (_iter1025 = this->partitionnames.begin(); _iter1025 != this->partitionnames.end(); ++_iter1025)
     {
-      xfer += oprot->writeString((*_iter1018));
+      xfer += oprot->writeString((*_iter1025));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28653,23 +28740,23 @@ void swap(AddDynamicPartitions &a, AddDynamicPartitions &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddDynamicPartitions::AddDynamicPartitions(const AddDynamicPartitions& other1019) {
-  txnid = other1019.txnid;
-  writeid = other1019.writeid;
-  dbname = other1019.dbname;
-  tablename = other1019.tablename;
-  partitionnames = other1019.partitionnames;
-  operationType = other1019.operationType;
-  __isset = other1019.__isset;
+AddDynamicPartitions::AddDynamicPartitions(const AddDynamicPartitions& other1026) {
+  txnid = other1026.txnid;
+  writeid = other1026.writeid;
+  dbname = other1026.dbname;
+  tablename = other1026.tablename;
+  partitionnames = other1026.partitionnames;
+  operationType = other1026.operationType;
+  __isset = other1026.__isset;
 }
-AddDynamicPartitions& AddDynamicPartitions::operator=(const AddDynamicPartitions& other1020) {
-  txnid = other1020.txnid;
-  writeid = other1020.writeid;
-  dbname = other1020.dbname;
-  tablename = other1020.tablename;
-  partitionnames = other1020.partitionnames;
-  operationType = other1020.operationType;
-  __isset = other1020.__isset;
+AddDynamicPartitions& AddDynamicPartitions::operator=(const AddDynamicPartitions& other1027) {
+  txnid = other1027.txnid;
+  writeid = other1027.writeid;
+  dbname = other1027.dbname;
+  tablename = other1027.tablename;
+  partitionnames = other1027.partitionnames;
+  operationType = other1027.operationType;
+  __isset = other1027.__isset;
   return *this;
 }
 void AddDynamicPartitions::printTo(std::ostream& out) const {
@@ -28858,23 +28945,23 @@ void swap(BasicTxnInfo &a, BasicTxnInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-BasicTxnInfo::BasicTxnInfo(const BasicTxnInfo& other1021) {
-  isnull = other1021.isnull;
-  time = other1021.time;
-  txnid = other1021.txnid;
-  dbname = other1021.dbname;
-  tablename = other1021.tablename;
-  partitionname = other1021.partitionname;
-  __isset = other1021.__isset;
+BasicTxnInfo::BasicTxnInfo(const BasicTxnInfo& other1028) {
+  isnull = other1028.isnull;
+  time = other1028.time;
+  txnid = other1028.txnid;
+  dbname = other1028.dbname;
+  tablename = other1028.tablename;
+  partitionname = other1028.partitionname;
+  __isset = other1028.__isset;
 }
-BasicTxnInfo& BasicTxnInfo::operator=(const BasicTxnInfo& other1022) {
-  isnull = other1022.isnull;
-  time = other1022.time;
-  txnid = other1022.txnid;
-  dbname = other1022.dbname;
-  tablename = other1022.tablename;
-  partitionname = other1022.partitionname;
-  __isset = other1022.__isset;
+BasicTxnInfo& BasicTxnInfo::operator=(const BasicTxnInfo& other1029) {
+  isnull = other1029.isnull;
+  time = other1029.time;
+  txnid = other1029.txnid;
+  dbname = other1029.dbname;
+  tablename = other1029.tablename;
+  partitionname = other1029.partitionname;
+  __isset = other1029.__isset;
   return *this;
 }
 void BasicTxnInfo::printTo(std::ostream& out) const {
@@ -28956,14 +29043,14 @@ uint32_t NotificationEventRequest::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->eventTypeSkipList.clear();
-            uint32_t _size1023;
-            ::apache::thrift::protocol::TType _etype1026;
-            xfer += iprot->readListBegin(_etype1026, _size1023);
-            this->eventTypeSkipList.resize(_size1023);
-            uint32_t _i1027;
-            for (_i1027 = 0; _i1027 < _size1023; ++_i1027)
+            uint32_t _size1030;
+            ::apache::thrift::protocol::TType _etype1033;
+            xfer += iprot->readListBegin(_etype1033, _size1030);
+            this->eventTypeSkipList.resize(_size1030);
+            uint32_t _i1034;
+            for (_i1034 = 0; _i1034 < _size1030; ++_i1034)
             {
-              xfer += iprot->readString(this->eventTypeSkipList[_i1027]);
+              xfer += iprot->readString(this->eventTypeSkipList[_i1034]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29004,10 +29091,10 @@ uint32_t NotificationEventRequest::write(::apache::thrift::protocol::TProtocol* 
     xfer += oprot->writeFieldBegin("eventTypeSkipList", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->eventTypeSkipList.size()));
-      std::vector<std::string> ::const_iterator _iter1028;
-      for (_iter1028 = this->eventTypeSkipList.begin(); _iter1028 != this->eventTypeSkipList.end(); ++_iter1028)
+      std::vector<std::string> ::const_iterator _iter1035;
+      for (_iter1035 = this->eventTypeSkipList.begin(); _iter1035 != this->eventTypeSkipList.end(); ++_iter1035)
       {
-        xfer += oprot->writeString((*_iter1028));
+        xfer += oprot->writeString((*_iter1035));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29026,17 +29113,17 @@ void swap(NotificationEventRequest &a, NotificationEventRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-NotificationEventRequest::NotificationEventRequest(const NotificationEventRequest& other1029) {
-  lastEvent = other1029.lastEvent;
-  maxEvents = other1029.maxEvents;
-  eventTypeSkipList = other1029.eventTypeSkipList;
-  __isset = other1029.__isset;
+NotificationEventRequest::NotificationEventRequest(const NotificationEventRequest& other1036) {
+  lastEvent = other1036.lastEvent;
+  maxEvents = other1036.maxEvents;
+  eventTypeSkipList = other1036.eventTypeSkipList;
+  __isset = other1036.__isset;
 }
-NotificationEventRequest& NotificationEventRequest::operator=(const NotificationEventRequest& other1030) {
-  lastEvent = other1030.lastEvent;
-  maxEvents = other1030.maxEvents;
-  eventTypeSkipList = other1030.eventTypeSkipList;
-  __isset = other1030.__isset;
+NotificationEventRequest& NotificationEventRequest::operator=(const NotificationEventRequest& other1037) {
+  lastEvent = other1037.lastEvent;
+  maxEvents = other1037.maxEvents;
+  eventTypeSkipList = other1037.eventTypeSkipList;
+  __isset = other1037.__isset;
   return *this;
 }
 void NotificationEventRequest::printTo(std::ostream& out) const {
@@ -29263,27 +29350,27 @@ void swap(NotificationEvent &a, NotificationEvent &b) {
   swap(a.__isset, b.__isset);
 }
 
-NotificationEvent::NotificationEvent(const NotificationEvent& other1031) {
-  eventId = other1031.eventId;
-  eventTime = other1031.eventTime;
-  eventType = other1031.eventType;
-  dbName = other1031.dbName;
-  tableName = other1031.tableName;
-  message = other1031.message;
-  messageFormat = other1031.messageFormat;
-  catName = other1031.catName;
-  __isset = other1031.__isset;
+NotificationEvent::NotificationEvent(const NotificationEvent& other1038) {
+  eventId = other1038.eventId;
+  eventTime = other1038.eventTime;
+  eventType = other1038.eventType;
+  dbName = other1038.dbName;
+  tableName = other1038.tableName;
+  message = other1038.message;
+  messageFormat = other1038.messageFormat;
+  catName = other1038.catName;
+  __isset = other1038.__isset;
 }
-NotificationEvent& NotificationEvent::operator=(const NotificationEvent& other1032) {
-  eventId = other1032.eventId;
-  eventTime = other1032.eventTime;
-  eventType = other1032.eventType;
-  dbName = other1032.dbName;
-  tableName = other1032.tableName;
-  message = other1032.message;
-  messageFormat = other1032.messageFormat;
-  catName = other1032.catName;
-  __isset = other1032.__isset;
+NotificationEvent& NotificationEvent::operator=(const NotificationEvent& other1039) {
+  eventId = other1039.eventId;
+  eventTime = other1039.eventTime;
+  eventType = other1039.eventType;
+  dbName = other1039.dbName;
+  tableName = other1039.tableName;
+  message = other1039.message;
+  messageFormat = other1039.messageFormat;
+  catName = other1039.catName;
+  __isset = other1039.__isset;
   return *this;
 }
 void NotificationEvent::printTo(std::ostream& out) const {
@@ -29341,14 +29428,14 @@ uint32_t NotificationEventResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->events.clear();
-            uint32_t _size1033;
-            ::apache::thrift::protocol::TType _etype1036;
-            xfer += iprot->readListBegin(_etype1036, _size1033);
-            this->events.resize(_size1033);
-            uint32_t _i1037;
-            for (_i1037 = 0; _i1037 < _size1033; ++_i1037)
+            uint32_t _size1040;
+            ::apache::thrift::protocol::TType _etype1043;
+            xfer += iprot->readListBegin(_etype1043, _size1040);
+            this->events.resize(_size1040);
+            uint32_t _i1044;
+            for (_i1044 = 0; _i1044 < _size1040; ++_i1044)
             {
-              xfer += this->events[_i1037].read(iprot);
+              xfer += this->events[_i1044].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -29379,10 +29466,10 @@ uint32_t NotificationEventResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("events", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->events.size()));
-    std::vector<NotificationEvent> ::const_iterator _iter1038;
-    for (_iter1038 = this->events.begin(); _iter1038 != this->events.end(); ++_iter1038)
+    std::vector<NotificationEvent> ::const_iterator _iter1045;
+    for (_iter1045 = this->events.begin(); _iter1045 != this->events.end(); ++_iter1045)
     {
-      xfer += (*_iter1038).write(oprot);
+      xfer += (*_iter1045).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -29398,11 +29485,11 @@ void swap(NotificationEventResponse &a, NotificationEventResponse &b) {
   swap(a.events, b.events);
 }
 
-NotificationEventResponse::NotificationEventResponse(const NotificationEventResponse& other1039) {
-  events = other1039.events;
+NotificationEventResponse::NotificationEventResponse(const NotificationEventResponse& other1046) {
+  events = other1046.events;
 }
-NotificationEventResponse& NotificationEventResponse::operator=(const NotificationEventResponse& other1040) {
-  events = other1040.events;
+NotificationEventResponse& NotificationEventResponse::operator=(const NotificationEventResponse& other1047) {
+  events = other1047.events;
   return *this;
 }
 void NotificationEventResponse::printTo(std::ostream& out) const {
@@ -29490,11 +29577,11 @@ void swap(CurrentNotificationEventId &a, CurrentNotificationEventId &b) {
   swap(a.eventId, b.eventId);
 }
 
-CurrentNotificationEventId::CurrentNotificationEventId(const CurrentNotificationEventId& other1041) {
-  eventId = other1041.eventId;
+CurrentNotificationEventId::CurrentNotificationEventId(const CurrentNotificationEventId& other1048) {
+  eventId = other1048.eventId;
 }
-CurrentNotificationEventId& CurrentNotificationEventId::operator=(const CurrentNotificationEventId& other1042) {
-  eventId = other1042.eventId;
+CurrentNotificationEventId& CurrentNotificationEventId::operator=(const CurrentNotificationEventId& other1049) {
+  eventId = other1049.eventId;
   return *this;
 }
 void CurrentNotificationEventId::printTo(std::ostream& out) const {
@@ -29660,21 +29747,21 @@ void swap(NotificationEventsCountRequest &a, NotificationEventsCountRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-NotificationEventsCountRequest::NotificationEventsCountRequest(const NotificationEventsCountRequest& other1043) {
-  fromEventId = other1043.fromEventId;
-  dbName = other1043.dbName;
-  catName = other1043.catName;
-  toEventId = other1043.toEventId;
-  limit = other1043.limit;
-  __isset = other1043.__isset;
+NotificationEventsCountRequest::NotificationEventsCountRequest(const NotificationEventsCountRequest& other1050) {
+  fromEventId = other1050.fromEventId;
+  dbName = other1050.dbName;
+  catName = other1050.catName;
+  toEventId = other1050.toEventId;
+  limit = other1050.limit;
+  __isset = other1050.__isset;
 }
-NotificationEventsCountRequest& NotificationEventsCountRequest::operator=(const NotificationEventsCountRequest& other1044) {
-  fromEventId = other1044.fromEventId;
-  dbName = other1044.dbName;
-  catName = other1044.catName;
-  toEventId = other1044.toEventId;
-  limit = other1044.limit;
-  __isset = other1044.__isset;
+NotificationEventsCountRequest& NotificationEventsCountRequest::operator=(const NotificationEventsCountRequest& other1051) {
+  fromEventId = other1051.fromEventId;
+  dbName = other1051.dbName;
+  catName = other1051.catName;
+  toEventId = other1051.toEventId;
+  limit = other1051.limit;
+  __isset = other1051.__isset;
   return *this;
 }
 void NotificationEventsCountRequest::printTo(std::ostream& out) const {
@@ -29766,11 +29853,11 @@ void swap(NotificationEventsCountResponse &a, NotificationEventsCountResponse &b
   swap(a.eventsCount, b.eventsCount);
 }
 
-NotificationEventsCountResponse::NotificationEventsCountResponse(const NotificationEventsCountResponse& other1045) {
-  eventsCount = other1045.eventsCount;
+NotificationEventsCountResponse::NotificationEventsCountResponse(const NotificationEventsCountResponse& other1052) {
+  eventsCount = other1052.eventsCount;
 }
-NotificationEventsCountResponse& NotificationEventsCountResponse::operator=(const NotificationEventsCountResponse& other1046) {
-  eventsCount = other1046.eventsCount;
+NotificationEventsCountResponse& NotificationEventsCountResponse::operator=(const NotificationEventsCountResponse& other1053) {
+  eventsCount = other1053.eventsCount;
   return *this;
 }
 void NotificationEventsCountResponse::printTo(std::ostream& out) const {
@@ -29849,14 +29936,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filesAdded.clear();
-            uint32_t _size1047;
-            ::apache::thrift::protocol::TType _etype1050;
-            xfer += iprot->readListBegin(_etype1050, _size1047);
-            this->filesAdded.resize(_size1047);
-            uint32_t _i1051;
-            for (_i1051 = 0; _i1051 < _size1047; ++_i1051)
+            uint32_t _size1054;
+            ::apache::thrift::protocol::TType _etype1057;
+            xfer += iprot->readListBegin(_etype1057, _size1054);
+            this->filesAdded.resize(_size1054);
+            uint32_t _i1058;
+            for (_i1058 = 0; _i1058 < _size1054; ++_i1058)
             {
-              xfer += iprot->readString(this->filesAdded[_i1051]);
+              xfer += iprot->readString(this->filesAdded[_i1058]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29869,14 +29956,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filesAddedChecksum.clear();
-            uint32_t _size1052;
-            ::apache::thrift::protocol::TType _etype1055;
-            xfer += iprot->readListBegin(_etype1055, _size1052);
-            this->filesAddedChecksum.resize(_size1052);
-            uint32_t _i1056;
-            for (_i1056 = 0; _i1056 < _size1052; ++_i1056)
+            uint32_t _size1059;
+            ::apache::thrift::protocol::TType _etype1062;
+            xfer += iprot->readListBegin(_etype1062, _size1059);
+            this->filesAddedChecksum.resize(_size1059);
+            uint32_t _i1063;
+            for (_i1063 = 0; _i1063 < _size1059; ++_i1063)
             {
-              xfer += iprot->readString(this->filesAddedChecksum[_i1056]);
+              xfer += iprot->readString(this->filesAddedChecksum[_i1063]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29889,14 +29976,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->subDirectoryList.clear();
-            uint32_t _size1057;
-            ::apache::thrift::protocol::TType _etype1060;
-            xfer += iprot->readListBegin(_etype1060, _size1057);
-            this->subDirectoryList.resize(_size1057);
-            uint32_t _i1061;
-            for (_i1061 = 0; _i1061 < _size1057; ++_i1061)
+            uint32_t _size1064;
+            ::apache::thrift::protocol::TType _etype1067;
+            xfer += iprot->readListBegin(_etype1067, _size1064);
+            this->subDirectoryList.resize(_size1064);
+            uint32_t _i1068;
+            for (_i1068 = 0; _i1068 < _size1064; ++_i1068)
             {
-              xfer += iprot->readString(this->subDirectoryList[_i1061]);
+              xfer += iprot->readString(this->subDirectoryList[_i1068]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29909,14 +29996,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVal.clear();
-            uint32_t _size1062;
-            ::apache::thrift::protocol::TType _etype1065;
-            xfer += iprot->readListBegin(_etype1065, _size1062);
-            this->partitionVal.resize(_size1062);
-            uint32_t _i1066;
-            for (_i1066 = 0; _i1066 < _size1062; ++_i1066)
+            uint32_t _size1069;
+            ::apache::thrift::protocol::TType _etype1072;
+            xfer += iprot->readListBegin(_etype1072, _size1069);
+            this->partitionVal.resize(_size1069);
+            uint32_t _i1073;
+            for (_i1073 = 0; _i1073 < _size1069; ++_i1073)
             {
-              xfer += iprot->readString(this->partitionVal[_i1066]);
+              xfer += iprot->readString(this->partitionVal[_i1073]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29952,10 +30039,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("filesAdded", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filesAdded.size()));
-    std::vector<std::string> ::const_iterator _iter1067;
-    for (_iter1067 = this->filesAdded.begin(); _iter1067 != this->filesAdded.end(); ++_iter1067)
+    std::vector<std::string> ::const_iterator _iter1074;
+    for (_iter1074 = this->filesAdded.begin(); _iter1074 != this->filesAdded.end(); ++_iter1074)
     {
-      xfer += oprot->writeString((*_iter1067));
+      xfer += oprot->writeString((*_iter1074));
     }
     xfer += oprot->writeListEnd();
   }
@@ -29965,10 +30052,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("filesAddedChecksum", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filesAddedChecksum.size()));
-      std::vector<std::string> ::const_iterator _iter1068;
-      for (_iter1068 = this->filesAddedChecksum.begin(); _iter1068 != this->filesAddedChecksum.end(); ++_iter1068)
+      std::vector<std::string> ::const_iterator _iter1075;
+      for (_iter1075 = this->filesAddedChecksum.begin(); _iter1075 != this->filesAddedChecksum.end(); ++_iter1075)
       {
-        xfer += oprot->writeString((*_iter1068));
+        xfer += oprot->writeString((*_iter1075));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29978,10 +30065,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("subDirectoryList", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->subDirectoryList.size()));
-      std::vector<std::string> ::const_iterator _iter1069;
-      for (_iter1069 = this->subDirectoryList.begin(); _iter1069 != this->subDirectoryList.end(); ++_iter1069)
+      std::vector<std::string> ::const_iterator _iter1076;
+      for (_iter1076 = this->subDirectoryList.begin(); _iter1076 != this->subDirectoryList.end(); ++_iter1076)
       {
-        xfer += oprot->writeString((*_iter1069));
+        xfer += oprot->writeString((*_iter1076));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29991,10 +30078,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("partitionVal", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVal.size()));
-      std::vector<std::string> ::const_iterator _iter1070;
-      for (_iter1070 = this->partitionVal.begin(); _iter1070 != this->partitionVal.end(); ++_iter1070)
+      std::vector<std::string> ::const_iterator _iter1077;
+      for (_iter1077 = this->partitionVal.begin(); _iter1077 != this->partitionVal.end(); ++_iter1077)
       {
-        xfer += oprot->writeString((*_iter1070));
+        xfer += oprot->writeString((*_iter1077));
       }
       xfer += oprot->writeListEnd();
     }
@@ -30015,21 +30102,21 @@ void swap(InsertEventRequestData &a, InsertEventRequestData &b) {
   swap(a.__isset, b.__isset);
 }
 
-InsertEventRequestData::InsertEventRequestData(const InsertEventRequestData& other1071) {
-  replace = other1071.replace;
-  filesAdded = other1071.filesAdded;
-  filesAddedChecksum = other1071.filesAddedChecksum;
-  subDirectoryList = other1071.subDirectoryList;
-  partitionVal = other1071.partitionVal;
-  __isset = other1071.__isset;
+InsertEventRequestData::InsertEventRequestData(const InsertEventRequestData& other1078) {
+  replace = other1078.replace;
+  filesAdded = other1078.filesAdded;
+  filesAddedChecksum = other1078.filesAddedChecksum;
+  subDirectoryList = other1078.subDirectoryList;
+  partitionVal = other1078.partitionVal;
+  __isset = other1078.__isset;
 }
-InsertEventRequestData& InsertEventRequestData::operator=(const InsertEventRequestData& other1072) {
-  replace = other1072.replace;
-  filesAdded = other1072.filesAdded;
-  filesAddedChecksum = other1072.filesAddedChecksum;
-  subDirectoryList = other1072.subDirectoryList;
-  partitionVal = other1072.partitionVal;
-  __isset = other1072.__isset;
+InsertEventRequestData& InsertEventRequestData::operator=(const InsertEventRequestData& other1079) {
+  replace = other1079.replace;
+  filesAdded = other1079.filesAdded;
+  filesAddedChecksum = other1079.filesAddedChecksum;
+  subDirectoryList = other1079.subDirectoryList;
+  partitionVal = other1079.partitionVal;
+  __isset = other1079.__isset;
   return *this;
 }
 void InsertEventRequestData::printTo(std::ostream& out) const {
@@ -30097,14 +30184,14 @@ uint32_t FireEventRequestData::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->insertDatas.clear();
-            uint32_t _size1073;
-            ::apache::thrift::protocol::TType _etype1076;
-            xfer += iprot->readListBegin(_etype1076, _size1073);
-            this->insertDatas.resize(_size1073);
-            uint32_t _i1077;
-            for (_i1077 = 0; _i1077 < _size1073; ++_i1077)
+            uint32_t _size1080;
+            ::apache::thrift::protocol::TType _etype1083;
+            xfer += iprot->readListBegin(_etype1083, _size1080);
+            this->insertDatas.resize(_size1080);
+            uint32_t _i1084;
+            for (_i1084 = 0; _i1084 < _size1080; ++_i1084)
             {
-              xfer += this->insertDatas[_i1077].read(iprot);
+              xfer += this->insertDatas[_i1084].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -30139,10 +30226,10 @@ uint32_t FireEventRequestData::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("insertDatas", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->insertDatas.size()));
-      std::vector<InsertEventRequestData> ::const_iterator _iter1078;
-      for (_iter1078 = this->insertDatas.begin(); _iter1078 != this->insertDatas.end(); ++_iter1078)
+      std::vector<InsertEventRequestData> ::const_iterator _iter1085;
+      for (_iter1085 = this->insertDatas.begin(); _iter1085 != this->insertDatas.end(); ++_iter1085)
       {
-        xfer += (*_iter1078).write(oprot);
+        xfer += (*_iter1085).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -30160,15 +30247,15 @@ void swap(FireEventRequestData &a, FireEventRequestData &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventRequestData::FireEventRequestData(const FireEventRequestData& other1079) {
-  insertData = other1079.insertData;
-  insertDatas = other1079.insertDatas;
-  __isset = other1079.__isset;
+FireEventRequestData::FireEventRequestData(const FireEventRequestData& other1086) {
+  insertData = other1086.insertData;
+  insertDatas = other1086.insertDatas;
+  __isset = other1086.__isset;
 }
-FireEventRequestData& FireEventRequestData::operator=(const FireEventRequestData& other1080) {
-  insertData = other1080.insertData;
-  insertDatas = other1080.insertDatas;
-  __isset = other1080.__isset;
+FireEventRequestData& FireEventRequestData::operator=(const FireEventRequestData& other1087) {
+  insertData = other1087.insertData;
+  insertDatas = other1087.insertDatas;
+  __isset = other1087.__isset;
   return *this;
 }
 void FireEventRequestData::printTo(std::ostream& out) const {
@@ -30277,14 +30364,14 @@ uint32_t FireEventRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVals.clear();
-            uint32_t _size1081;
-            ::apache::thrift::protocol::TType _etype1084;
-            xfer += iprot->readListBegin(_etype1084, _size1081);
-            this->partitionVals.resize(_size1081);
-            uint32_t _i1085;
-            for (_i1085 = 0; _i1085 < _size1081; ++_i1085)
+            uint32_t _size1088;
+            ::apache::thrift::protocol::TType _etype1091;
+            xfer += iprot->readListBegin(_etype1091, _size1088);
+            this->partitionVals.resize(_size1088);
+            uint32_t _i1092;
+            for (_i1092 = 0; _i1092 < _size1088; ++_i1092)
             {
-              xfer += iprot->readString(this->partitionVals[_i1085]);
+              xfer += iprot->readString(this->partitionVals[_i1092]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30344,10 +30431,10 @@ uint32_t FireEventRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("partitionVals", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVals.size()));
-      std::vector<std::string> ::const_iterator _iter1086;
-      for (_iter1086 = this->partitionVals.begin(); _iter1086 != this->partitionVals.end(); ++_iter1086)
+      std::vector<std::string> ::const_iterator _iter1093;
+      for (_iter1093 = this->partitionVals.begin(); _iter1093 != this->partitionVals.end(); ++_iter1093)
       {
-        xfer += oprot->writeString((*_iter1086));
+        xfer += oprot->writeString((*_iter1093));
       }
       xfer += oprot->writeListEnd();
     }
@@ -30374,23 +30461,23 @@ void swap(FireEventRequest &a, FireEventRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventRequest::FireEventRequest(const FireEventRequest& other1087) {
-  successful = other1087.successful;
-  data = other1087.data;
-  dbName = other1087.dbName;
-  tableName = other1087.tableName;
-  partitionVals = other1087.partitionVals;
-  catName = other1087.catName;
-  __isset = other1087.__isset;
+FireEventRequest::FireEventRequest(const FireEventRequest& other1094) {
+  successful = other1094.successful;
+  data = other1094.data;
+  dbName = other1094.dbName;
+  tableName = other1094.tableName;
+  partitionVals = other1094.partitionVals;
+  catName = other1094.catName;
+  __isset = other1094.__isset;
 }
-FireEventRequest& FireEventRequest::operator=(const FireEventRequest& other1088) {
-  successful = other1088.successful;
-  data = other1088.data;
-  dbName = other1088.dbName;
-  tableName = other1088.tableName;
-  partitionVals = other1088.partitionVals;
-  catName = other1088.catName;
-  __isset = other1088.__isset;
+FireEventRequest& FireEventRequest::operator=(const FireEventRequest& other1095) {
+  successful = other1095.successful;
+  data = other1095.data;
+  dbName = other1095.dbName;
+  tableName = other1095.tableName;
+  partitionVals = other1095.partitionVals;
+  catName = other1095.catName;
+  __isset = other1095.__isset;
   return *this;
 }
 void FireEventRequest::printTo(std::ostream& out) const {
@@ -30445,14 +30532,14 @@ uint32_t FireEventResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->eventIds.clear();
-            uint32_t _size1089;
-            ::apache::thrift::protocol::TType _etype1092;
-            xfer += iprot->readListBegin(_etype1092, _size1089);
-            this->eventIds.resize(_size1089);
-            uint32_t _i1093;
-            for (_i1093 = 0; _i1093 < _size1089; ++_i1093)
+            uint32_t _size1096;
+            ::apache::thrift::protocol::TType _etype1099;
+            xfer += iprot->readListBegin(_etype1099, _size1096);
+            this->eventIds.resize(_size1096);
+            uint32_t _i1100;
+            for (_i1100 = 0; _i1100 < _size1096; ++_i1100)
             {
-              xfer += iprot->readI64(this->eventIds[_i1093]);
+              xfer += iprot->readI64(this->eventIds[_i1100]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30481,10 +30568,10 @@ uint32_t FireEventResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("eventIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->eventIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1094;
-    for (_iter1094 = this->eventIds.begin(); _iter1094 != this->eventIds.end(); ++_iter1094)
+    std::vector<int64_t> ::const_iterator _iter1101;
+    for (_iter1101 = this->eventIds.begin(); _iter1101 != this->eventIds.end(); ++_iter1101)
     {
-      xfer += oprot->writeI64((*_iter1094));
+      xfer += oprot->writeI64((*_iter1101));
     }
     xfer += oprot->writeListEnd();
   }
@@ -30501,13 +30588,13 @@ void swap(FireEventResponse &a, FireEventResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventResponse::FireEventResponse(const FireEventResponse& other1095) {
-  eventIds = other1095.eventIds;
-  __isset = other1095.__isset;
+FireEventResponse::FireEventResponse(const FireEventResponse& other1102) {
+  eventIds = other1102.eventIds;
+  __isset = other1102.__isset;
 }
-FireEventResponse& FireEventResponse::operator=(const FireEventResponse& other1096) {
-  eventIds = other1096.eventIds;
-  __isset = other1096.__isset;
+FireEventResponse& FireEventResponse::operator=(const FireEventResponse& other1103) {
+  eventIds = other1103.eventIds;
+  __isset = other1103.__isset;
   return *this;
 }
 void FireEventResponse::printTo(std::ostream& out) const {
@@ -30623,14 +30710,14 @@ uint32_t WriteNotificationLogRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVals.clear();
-            uint32_t _size1097;
-            ::apache::thrift::protocol::TType _etype1100;
-            xfer += iprot->readListBegin(_etype1100, _size1097);
-            this->partitionVals.resize(_size1097);
-            uint32_t _i1101;
-            for (_i1101 = 0; _i1101 < _size1097; ++_i1101)
+            uint32_t _size1104;
+            ::apache::thrift::protocol::TType _etype1107;
+            xfer += iprot->readListBegin(_etype1107, _size1104);
+            this->partitionVals.resize(_size1104);
+            uint32_t _i1108;
+            for (_i1108 = 0; _i1108 < _size1104; ++_i1108)
             {
-              xfer += iprot->readString(this->partitionVals[_i1101]);
+              xfer += iprot->readString(this->partitionVals[_i1108]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30690,10 +30777,10 @@ uint32_t WriteNotificationLogRequest::write(::apache::thrift::protocol::TProtoco
     xfer += oprot->writeFieldBegin("partitionVals", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVals.size()));
-      std::vector<std::string> ::const_iterator _iter1102;
-      for (_iter1102 = this->partitionVals.begin(); _iter1102 != this->partitionVals.end(); ++_iter1102)
+      std::vector<std::string> ::const_iterator _iter1109;
+      for (_iter1109 = this->partitionVals.begin(); _iter1109 != this->partitionVals.end(); ++_iter1109)
       {
-        xfer += oprot->writeString((*_iter1102));
+        xfer += oprot->writeString((*_iter1109));
       }
       xfer += oprot->writeListEnd();
     }
@@ -30715,23 +30802,23 @@ void swap(WriteNotificationLogRequest &a, WriteNotificationLogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WriteNotificationLogRequest::WriteNotificationLogRequest(const WriteNotificationLogRequest& other1103) {
-  txnId = other1103.txnId;
-  writeId = other1103.writeId;
-  db = other1103.db;
-  table = other1103.table;
-  fileInfo = other1103.fileInfo;
-  partitionVals = other1103.partitionVals;
-  __isset = other1103.__isset;
+WriteNotificationLogRequest::WriteNotificationLogRequest(const WriteNotificationLogRequest& other1110) {
+  txnId = other1110.txnId;
+  writeId = other1110.writeId;
+  db = other1110.db;
+  table = other1110.table;
+  fileInfo = other1110.fileInfo;
+  partitionVals = other1110.partitionVals;
+  __isset = other1110.__isset;
 }
-WriteNotificationLogRequest& WriteNotificationLogRequest::operator=(const WriteNotificationLogRequest& other1104) {
-  txnId = other1104.txnId;
-  writeId = other1104.writeId;
-  db = other1104.db;
-  table = other1104.table;
-  fileInfo = other1104.fileInfo;
-  partitionVals = other1104.partitionVals;
-  __isset = other1104.__isset;
+WriteNotificationLogRequest& WriteNotificationLogRequest::operator=(const WriteNotificationLogRequest& other1111) {
+  txnId = other1111.txnId;
+  writeId = other1111.writeId;
+  db = other1111.db;
+  table = other1111.table;
+  fileInfo = other1111.fileInfo;
+  partitionVals = other1111.partitionVals;
+  __isset = other1111.__isset;
   return *this;
 }
 void WriteNotificationLogRequest::printTo(std::ostream& out) const {
@@ -30801,11 +30888,11 @@ void swap(WriteNotificationLogResponse &a, WriteNotificationLogResponse &b) {
   (void) b;
 }
 
-WriteNotificationLogResponse::WriteNotificationLogResponse(const WriteNotificationLogResponse& other1105) {
-  (void) other1105;
+WriteNotificationLogResponse::WriteNotificationLogResponse(const WriteNotificationLogResponse& other1112) {
+  (void) other1112;
 }
-WriteNotificationLogResponse& WriteNotificationLogResponse::operator=(const WriteNotificationLogResponse& other1106) {
-  (void) other1106;
+WriteNotificationLogResponse& WriteNotificationLogResponse::operator=(const WriteNotificationLogResponse& other1113) {
+  (void) other1113;
   return *this;
 }
 void WriteNotificationLogResponse::printTo(std::ostream& out) const {
@@ -30894,14 +30981,14 @@ uint32_t WriteNotificationLogBatchRequest::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requestList.clear();
-            uint32_t _size1107;
-            ::apache::thrift::protocol::TType _etype1110;
-            xfer += iprot->readListBegin(_etype1110, _size1107);
-            this->requestList.resize(_size1107);
-            uint32_t _i1111;
-            for (_i1111 = 0; _i1111 < _size1107; ++_i1111)
+            uint32_t _size1114;
+            ::apache::thrift::protocol::TType _etype1117;
+            xfer += iprot->readListBegin(_etype1117, _size1114);
+            this->requestList.resize(_size1114);
+            uint32_t _i1118;
+            for (_i1118 = 0; _i1118 < _size1114; ++_i1118)
             {
-              xfer += this->requestList[_i1111].read(iprot);
+              xfer += this->requestList[_i1118].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -30950,10 +31037,10 @@ uint32_t WriteNotificationLogBatchRequest::write(::apache::thrift::protocol::TPr
   xfer += oprot->writeFieldBegin("requestList", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->requestList.size()));
-    std::vector<WriteNotificationLogRequest> ::const_iterator _iter1112;
-    for (_iter1112 = this->requestList.begin(); _iter1112 != this->requestList.end(); ++_iter1112)
+    std::vector<WriteNotificationLogRequest> ::const_iterator _iter1119;
+    for (_iter1119 = this->requestList.begin(); _iter1119 != this->requestList.end(); ++_iter1119)
     {
-      xfer += (*_iter1112).write(oprot);
+      xfer += (*_iter1119).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -30972,17 +31059,17 @@ void swap(WriteNotificationLogBatchRequest &a, WriteNotificationLogBatchRequest 
   swap(a.requestList, b.requestList);
 }
 
-WriteNotificationLogBatchRequest::WriteNotificationLogBatchRequest(const WriteNotificationLogBatchRequest& other1113) {
-  catalog = other1113.catalog;
-  db = other1113.db;
-  table = other1113.table;
-  requestList = other1113.requestList;
+WriteNotificationLogBatchRequest::WriteNotificationLogBatchRequest(const WriteNotificationLogBatchRequest& other1120) {
+  catalog = other1120.catalog;
+  db = other1120.db;
+  table = other1120.table;
+  requestList = other1120.requestList;
 }
-WriteNotificationLogBatchRequest& WriteNotificationLogBatchRequest::operator=(const WriteNotificationLogBatchRequest& other1114) {
-  catalog = other1114.catalog;
-  db = other1114.db;
-  table = other1114.table;
-  requestList = other1114.requestList;
+WriteNotificationLogBatchRequest& WriteNotificationLogBatchRequest::operator=(const WriteNotificationLogBatchRequest& other1121) {
+  catalog = other1121.catalog;
+  db = other1121.db;
+  table = other1121.table;
+  requestList = other1121.requestList;
   return *this;
 }
 void WriteNotificationLogBatchRequest::printTo(std::ostream& out) const {
@@ -31050,11 +31137,11 @@ void swap(WriteNotificationLogBatchResponse &a, WriteNotificationLogBatchRespons
   (void) b;
 }
 
-WriteNotificationLogBatchResponse::WriteNotificationLogBatchResponse(const WriteNotificationLogBatchResponse& other1115) {
-  (void) other1115;
+WriteNotificationLogBatchResponse::WriteNotificationLogBatchResponse(const WriteNotificationLogBatchResponse& other1122) {
+  (void) other1122;
 }
-WriteNotificationLogBatchResponse& WriteNotificationLogBatchResponse::operator=(const WriteNotificationLogBatchResponse& other1116) {
-  (void) other1116;
+WriteNotificationLogBatchResponse& WriteNotificationLogBatchResponse::operator=(const WriteNotificationLogBatchResponse& other1123) {
+  (void) other1123;
   return *this;
 }
 void WriteNotificationLogBatchResponse::printTo(std::ostream& out) const {
@@ -31160,15 +31247,15 @@ void swap(MetadataPpdResult &a, MetadataPpdResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-MetadataPpdResult::MetadataPpdResult(const MetadataPpdResult& other1117) {
-  metadata = other1117.metadata;
-  includeBitset = other1117.includeBitset;
-  __isset = other1117.__isset;
+MetadataPpdResult::MetadataPpdResult(const MetadataPpdResult& other1124) {
+  metadata = other1124.metadata;
+  includeBitset = other1124.includeBitset;
+  __isset = other1124.__isset;
 }
-MetadataPpdResult& MetadataPpdResult::operator=(const MetadataPpdResult& other1118) {
-  metadata = other1118.metadata;
-  includeBitset = other1118.includeBitset;
-  __isset = other1118.__isset;
+MetadataPpdResult& MetadataPpdResult::operator=(const MetadataPpdResult& other1125) {
+  metadata = other1125.metadata;
+  includeBitset = other1125.includeBitset;
+  __isset = other1125.__isset;
   return *this;
 }
 void MetadataPpdResult::printTo(std::ostream& out) const {
@@ -31225,17 +31312,17 @@ uint32_t GetFileMetadataByExprResult::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->metadata.clear();
-            uint32_t _size1119;
-            ::apache::thrift::protocol::TType _ktype1120;
-            ::apache::thrift::protocol::TType _vtype1121;
-            xfer += iprot->readMapBegin(_ktype1120, _vtype1121, _size1119);
-            uint32_t _i1123;
-            for (_i1123 = 0; _i1123 < _size1119; ++_i1123)
+            uint32_t _size1126;
+            ::apache::thrift::protocol::TType _ktype1127;
+            ::apache::thrift::protocol::TType _vtype1128;
+            xfer += iprot->readMapBegin(_ktype1127, _vtype1128, _size1126);
+            uint32_t _i1130;
+            for (_i1130 = 0; _i1130 < _size1126; ++_i1130)
             {
-              int64_t _key1124;
-              xfer += iprot->readI64(_key1124);
-              MetadataPpdResult& _val1125 = this->metadata[_key1124];
-              xfer += _val1125.read(iprot);
+              int64_t _key1131;
+              xfer += iprot->readI64(_key1131);
+              MetadataPpdResult& _val1132 = this->metadata[_key1131];
+              xfer += _val1132.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -31276,11 +31363,11 @@ uint32_t GetFileMetadataByExprResult::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_I64, ::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->metadata.size()));
-    std::map<int64_t, MetadataPpdResult> ::const_iterator _iter1126;
-    for (_iter1126 = this->metadata.begin(); _iter1126 != this->metadata.end(); ++_iter1126)
+    std::map<int64_t, MetadataPpdResult> ::const_iterator _iter1133;
+    for (_iter1133 = this->metadata.begin(); _iter1133 != this->metadata.end(); ++_iter1133)
     {
-      xfer += oprot->writeI64(_iter1126->first);
-      xfer += _iter1126->second.write(oprot);
+      xfer += oprot->writeI64(_iter1133->first);
+      xfer += _iter1133->second.write(oprot);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -31301,13 +31388,13 @@ void swap(GetFileMetadataByExprResult &a, GetFileMetadataByExprResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-GetFileMetadataByExprResult::GetFileMetadataByExprResult(const GetFileMetadataByExprResult& other1127) {
-  metadata = other1127.metadata;
-  isSupported = other1127.isSupported;
+GetFileMetadataByExprResult::GetFileMetadataByExprResult(const GetFileMetadataByExprResult& other1134) {
+  metadata = other1134.metadata;
+  isSupported = other1134.isSupported;
 }
-GetFileMetadataByExprResult& GetFileMetadataByExprResult::operator=(const GetFileMetadataByExprResult& other1128) {
-  metadata = other1128.metadata;
-  isSupported = other1128.isSupported;
+GetFileMetadataByExprResult& GetFileMetadataByExprResult::operator=(const GetFileMetadataByExprResult& other1135) {
+  metadata = other1135.metadata;
+  isSupported = other1135.isSupported;
   return *this;
 }
 void GetFileMetadataByExprResult::printTo(std::ostream& out) const {
@@ -31374,14 +31461,14 @@ uint32_t GetFileMetadataByExprRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1129;
-            ::apache::thrift::protocol::TType _etype1132;
-            xfer += iprot->readListBegin(_etype1132, _size1129);
-            this->fileIds.resize(_size1129);
-            uint32_t _i1133;
-            for (_i1133 = 0; _i1133 < _size1129; ++_i1133)
+            uint32_t _size1136;
+            ::apache::thrift::protocol::TType _etype1139;
+            xfer += iprot->readListBegin(_etype1139, _size1136);
+            this->fileIds.resize(_size1136);
+            uint32_t _i1140;
+            for (_i1140 = 0; _i1140 < _size1136; ++_i1140)
             {
-              xfer += iprot->readI64(this->fileIds[_i1133]);
+              xfer += iprot->readI64(this->fileIds[_i1140]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31408,9 +31495,9 @@ uint32_t GetFileMetadataByExprRequest::read(::apache::thrift::protocol::TProtoco
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1134;
-          xfer += iprot->readI32(ecast1134);
-          this->type = (FileMetadataExprType::type)ecast1134;
+          int32_t ecast1141;
+          xfer += iprot->readI32(ecast1141);
+          this->type = (FileMetadataExprType::type)ecast1141;
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -31440,10 +31527,10 @@ uint32_t GetFileMetadataByExprRequest::write(::apache::thrift::protocol::TProtoc
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1135;
-    for (_iter1135 = this->fileIds.begin(); _iter1135 != this->fileIds.end(); ++_iter1135)
+    std::vector<int64_t> ::const_iterator _iter1142;
+    for (_iter1142 = this->fileIds.begin(); _iter1142 != this->fileIds.end(); ++_iter1142)
     {
-      xfer += oprot->writeI64((*_iter1135));
+      xfer += oprot->writeI64((*_iter1142));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31477,19 +31564,19 @@ void swap(GetFileMetadataByExprRequest &a, GetFileMetadataByExprRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetFileMetadataByExprRequest::GetFileMetadataByExprRequest(const GetFileMetadataByExprRequest& other1136) {
-  fileIds = other1136.fileIds;
-  expr = other1136.expr;
-  doGetFooters = other1136.doGetFooters;
-  type = other1136.type;
-  __isset = other1136.__isset;
+GetFileMetadataByExprRequest::GetFileMetadataByExprRequest(const GetFileMetadataByExprRequest& other1143) {
+  fileIds = other1143.fileIds;
+  expr = other1143.expr;
+  doGetFooters = other1143.doGetFooters;
+  type = other1143.type;
+  __isset = other1143.__isset;
 }
-GetFileMetadataByExprRequest& GetFileMetadataByExprRequest::operator=(const GetFileMetadataByExprRequest& other1137) {
-  fileIds = other1137.fileIds;
-  expr = other1137.expr;
-  doGetFooters = other1137.doGetFooters;
-  type = other1137.type;
-  __isset = other1137.__isset;
+GetFileMetadataByExprRequest& GetFileMetadataByExprRequest::operator=(const GetFileMetadataByExprRequest& other1144) {
+  fileIds = other1144.fileIds;
+  expr = other1144.expr;
+  doGetFooters = other1144.doGetFooters;
+  type = other1144.type;
+  __isset = other1144.__isset;
   return *this;
 }
 void GetFileMetadataByExprRequest::printTo(std::ostream& out) const {
@@ -31548,17 +31635,17 @@ uint32_t GetFileMetadataResult::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->metadata.clear();
-            uint32_t _size1138;
-            ::apache::thrift::protocol::TType _ktype1139;
-            ::apache::thrift::protocol::TType _vtype1140;
-            xfer += iprot->readMapBegin(_ktype1139, _vtype1140, _size1138);
-            uint32_t _i1142;
-            for (_i1142 = 0; _i1142 < _size1138; ++_i1142)
+            uint32_t _size1145;
+            ::apache::thrift::protocol::TType _ktype1146;
+            ::apache::thrift::protocol::TType _vtype1147;
+            xfer += iprot->readMapBegin(_ktype1146, _vtype1147, _size1145);
+            uint32_t _i1149;
+            for (_i1149 = 0; _i1149 < _size1145; ++_i1149)
             {
-              int64_t _key1143;
-              xfer += iprot->readI64(_key1143);
-              std::string& _val1144 = this->metadata[_key1143];
-              xfer += iprot->readBinary(_val1144);
+              int64_t _key1150;
+              xfer += iprot->readI64(_key1150);
+              std::string& _val1151 = this->metadata[_key1150];
+              xfer += iprot->readBinary(_val1151);
             }
             xfer += iprot->readMapEnd();
           }
@@ -31599,11 +31686,11 @@ uint32_t GetFileMetadataResult::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_I64, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->metadata.size()));
-    std::map<int64_t, std::string> ::const_iterator _iter1145;
-    for (_iter1145 = this->metadata.begin(); _iter1145 != this->metadata.end(); ++_iter1145)
+    std::map<int64_t, std::string> ::const_iterator _iter1152;
+    for (_iter1152 = this->metadata.begin(); _iter1152 != this->metadata.end(); ++_iter1152)
     {
-      xfer += oprot->writeI64(_iter1145->first);
-      xfer += oprot->writeBinary(_iter1145->second);
+      xfer += oprot->writeI64(_iter1152->first);
+      xfer += oprot->writeBinary(_iter1152->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -31624,13 +31711,13 @@ void swap(GetFileMetadataResult &a, GetFileMetadataResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-GetFileMetadataResult::GetFileMetadataResult(const GetFileMetadataResult& other1146) {
-  metadata = other1146.metadata;
-  isSupported = other1146.isSupported;
+GetFileMetadataResult::GetFileMetadataResult(const GetFileMetadataResult& other1153) {
+  metadata = other1153.metadata;
+  isSupported = other1153.isSupported;
 }
-GetFileMetadataResult& GetFileMetadataResult::operator=(const GetFileMetadataResult& other1147) {
-  metadata = other1147.metadata;
-  isSupported = other1147.isSupported;
+GetFileMetadataResult& GetFileMetadataResult::operator=(const GetFileMetadataResult& other1154) {
+  metadata = other1154.metadata;
+  isSupported = other1154.isSupported;
   return *this;
 }
 void GetFileMetadataResult::printTo(std::ostream& out) const {
@@ -31682,14 +31769,14 @@ uint32_t GetFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1148;
-            ::apache::thrift::protocol::TType _etype1151;
-            xfer += iprot->readListBegin(_etype1151, _size1148);
-            this->fileIds.resize(_size1148);
-            uint32_t _i1152;
-            for (_i1152 = 0; _i1152 < _size1148; ++_i1152)
+            uint32_t _size1155;
+            ::apache::thrift::protocol::TType _etype1158;
+            xfer += iprot->readListBegin(_etype1158, _size1155);
+            this->fileIds.resize(_size1155);
+            uint32_t _i1159;
+            for (_i1159 = 0; _i1159 < _size1155; ++_i1159)
             {
-              xfer += iprot->readI64(this->fileIds[_i1152]);
+              xfer += iprot->readI64(this->fileIds[_i1159]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31720,10 +31807,10 @@ uint32_t GetFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1153;
-    for (_iter1153 = this->fileIds.begin(); _iter1153 != this->fileIds.end(); ++_iter1153)
+    std::vector<int64_t> ::const_iterator _iter1160;
+    for (_iter1160 = this->fileIds.begin(); _iter1160 != this->fileIds.end(); ++_iter1160)
     {
-      xfer += oprot->writeI64((*_iter1153));
+      xfer += oprot->writeI64((*_iter1160));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31739,11 +31826,11 @@ void swap(GetFileMetadataRequest &a, GetFileMetadataRequest &b) {
   swap(a.fileIds, b.fileIds);
 }
 
-GetFileMetadataRequest::GetFileMetadataRequest(const GetFileMetadataRequest& other1154) {
-  fileIds = other1154.fileIds;
+GetFileMetadataRequest::GetFileMetadataRequest(const GetFileMetadataRequest& other1161) {
+  fileIds = other1161.fileIds;
 }
-GetFileMetadataRequest& GetFileMetadataRequest::operator=(const GetFileMetadataRequest& other1155) {
-  fileIds = other1155.fileIds;
+GetFileMetadataRequest& GetFileMetadataRequest::operator=(const GetFileMetadataRequest& other1162) {
+  fileIds = other1162.fileIds;
   return *this;
 }
 void GetFileMetadataRequest::printTo(std::ostream& out) const {
@@ -31808,11 +31895,11 @@ void swap(PutFileMetadataResult &a, PutFileMetadataResult &b) {
   (void) b;
 }
 
-PutFileMetadataResult::PutFileMetadataResult(const PutFileMetadataResult& other1156) {
-  (void) other1156;
+PutFileMetadataResult::PutFileMetadataResult(const PutFileMetadataResult& other1163) {
+  (void) other1163;
 }
-PutFileMetadataResult& PutFileMetadataResult::operator=(const PutFileMetadataResult& other1157) {
-  (void) other1157;
+PutFileMetadataResult& PutFileMetadataResult::operator=(const PutFileMetadataResult& other1164) {
+  (void) other1164;
   return *this;
 }
 void PutFileMetadataResult::printTo(std::ostream& out) const {
@@ -31872,14 +31959,14 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1158;
-            ::apache::thrift::protocol::TType _etype1161;
-            xfer += iprot->readListBegin(_etype1161, _size1158);
-            this->fileIds.resize(_size1158);
-            uint32_t _i1162;
-            for (_i1162 = 0; _i1162 < _size1158; ++_i1162)
+            uint32_t _size1165;
+            ::apache::thrift::protocol::TType _etype1168;
+            xfer += iprot->readListBegin(_etype1168, _size1165);
+            this->fileIds.resize(_size1165);
+            uint32_t _i1169;
+            for (_i1169 = 0; _i1169 < _size1165; ++_i1169)
             {
-              xfer += iprot->readI64(this->fileIds[_i1162]);
+              xfer += iprot->readI64(this->fileIds[_i1169]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31892,14 +31979,14 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->metadata.clear();
-            uint32_t _size1163;
-            ::apache::thrift::protocol::TType _etype1166;
-            xfer += iprot->readListBegin(_etype1166, _size1163);
-            this->metadata.resize(_size1163);
-            uint32_t _i1167;
-            for (_i1167 = 0; _i1167 < _size1163; ++_i1167)
+            uint32_t _size1170;
+            ::apache::thrift::protocol::TType _etype1173;
+            xfer += iprot->readListBegin(_etype1173, _size1170);
+            this->metadata.resize(_size1170);
+            uint32_t _i1174;
+            for (_i1174 = 0; _i1174 < _size1170; ++_i1174)
             {
-              xfer += iprot->readBinary(this->metadata[_i1167]);
+              xfer += iprot->readBinary(this->metadata[_i1174]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31910,9 +31997,9 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1168;
-          xfer += iprot->readI32(ecast1168);
-          this->type = (FileMetadataExprType::type)ecast1168;
+          int32_t ecast1175;
+          xfer += iprot->readI32(ecast1175);
+          this->type = (FileMetadataExprType::type)ecast1175;
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -31942,10 +32029,10 @@ uint32_t PutFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1169;
-    for (_iter1169 = this->fileIds.begin(); _iter1169 != this->fileIds.end(); ++_iter1169)
+    std::vector<int64_t> ::const_iterator _iter1176;
+    for (_iter1176 = this->fileIds.begin(); _iter1176 != this->fileIds.end(); ++_iter1176)
     {
-      xfer += oprot->writeI64((*_iter1169));
+      xfer += oprot->writeI64((*_iter1176));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31954,10 +32041,10 @@ uint32_t PutFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->metadata.size()));
-    std::vector<std::string> ::const_iterator _iter1170;
-    for (_iter1170 = this->metadata.begin(); _iter1170 != this->metadata.end(); ++_iter1170)
+    std::vector<std::string> ::const_iterator _iter1177;
+    for (_iter1177 = this->metadata.begin(); _iter1177 != this->metadata.end(); ++_iter1177)
     {
-      xfer += oprot->writeBinary((*_iter1170));
+      xfer += oprot->writeBinary((*_iter1177));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31981,17 +32068,17 @@ void swap(PutFileMetadataRequest &a, PutFileMetadataRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PutFileMetadataRequest::PutFileMetadataRequest(const PutFileMetadataRequest& other1171) {
-  fileIds = other1171.fileIds;
-  metadata = other1171.metadata;
-  type = other1171.type;
-  __isset = other1171.__isset;
+PutFileMetadataRequest::PutFileMetadataRequest(const PutFileMetadataRequest& other1178) {
+  fileIds = other1178.fileIds;
+  metadata = other1178.metadata;
+  type = other1178.type;
+  __isset = other1178.__isset;
 }
-PutFileMetadataRequest& PutFileMetadataRequest::operator=(const PutFileMetadataRequest& other1172) {
-  fileIds = other1172.fileIds;
-  metadata = other1172.metadata;
-  type = other1172.type;
-  __isset = other1172.__isset;
+PutFileMetadataRequest& PutFileMetadataRequest::operator=(const PutFileMetadataRequest& other1179) {
+  fileIds = other1179.fileIds;
+  metadata = other1179.metadata;
+  type = other1179.type;
+  __isset = other1179.__isset;
   return *this;
 }
 void PutFileMetadataRequest::printTo(std::ostream& out) const {
@@ -32058,11 +32145,11 @@ void swap(ClearFileMetadataResult &a, ClearFileMetadataResult &b) {
   (void) b;
 }
 
-ClearFileMetadataResult::ClearFileMetadataResult(const ClearFileMetadataResult& other1173) {
-  (void) other1173;
+ClearFileMetadataResult::ClearFileMetadataResult(const ClearFileMetadataResult& other1180) {
+  (void) other1180;
 }
-ClearFileMetadataResult& ClearFileMetadataResult::operator=(const ClearFileMetadataResult& other1174) {
-  (void) other1174;
+ClearFileMetadataResult& ClearFileMetadataResult::operator=(const ClearFileMetadataResult& other1181) {
+  (void) other1181;
   return *this;
 }
 void ClearFileMetadataResult::printTo(std::ostream& out) const {
@@ -32112,14 +32199,14 @@ uint32_t ClearFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1175;
-            ::apache::thrift::protocol::TType _etype1178;
-            xfer += iprot->readListBegin(_etype1178, _size1175);
-            this->fileIds.resize(_size1175);
-            uint32_t _i1179;
-            for (_i1179 = 0; _i1179 < _size1175; ++_i1179)
+            uint32_t _size1182;
+            ::apache::thrift::protocol::TType _etype1185;
+            xfer += iprot->readListBegin(_etype1185, _size1182);
+            this->fileIds.resize(_size1182);
+            uint32_t _i1186;
+            for (_i1186 = 0; _i1186 < _size1182; ++_i1186)
             {
-              xfer += iprot->readI64(this->fileIds[_i1179]);
+              xfer += iprot->readI64(this->fileIds[_i1186]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32150,10 +32237,10 @@ uint32_t ClearFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* 
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1180;
-    for (_iter1180 = this->fileIds.begin(); _iter1180 != this->fileIds.end(); ++_iter1180)
+    std::vector<int64_t> ::const_iterator _iter1187;
+    for (_iter1187 = this->fileIds.begin(); _iter1187 != this->fileIds.end(); ++_iter1187)
     {
-      xfer += oprot->writeI64((*_iter1180));
+      xfer += oprot->writeI64((*_iter1187));
     }
     xfer += oprot->writeListEnd();
   }
@@ -32169,11 +32256,11 @@ void swap(ClearFileMetadataRequest &a, ClearFileMetadataRequest &b) {
   swap(a.fileIds, b.fileIds);
 }
 
-ClearFileMetadataRequest::ClearFileMetadataRequest(const ClearFileMetadataRequest& other1181) {
-  fileIds = other1181.fileIds;
+ClearFileMetadataRequest::ClearFileMetadataRequest(const ClearFileMetadataRequest& other1188) {
+  fileIds = other1188.fileIds;
 }
-ClearFileMetadataRequest& ClearFileMetadataRequest::operator=(const ClearFileMetadataRequest& other1182) {
-  fileIds = other1182.fileIds;
+ClearFileMetadataRequest& ClearFileMetadataRequest::operator=(const ClearFileMetadataRequest& other1189) {
+  fileIds = other1189.fileIds;
   return *this;
 }
 void ClearFileMetadataRequest::printTo(std::ostream& out) const {
@@ -32261,11 +32348,11 @@ void swap(CacheFileMetadataResult &a, CacheFileMetadataResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-CacheFileMetadataResult::CacheFileMetadataResult(const CacheFileMetadataResult& other1183) {
-  isSupported = other1183.isSupported;
+CacheFileMetadataResult::CacheFileMetadataResult(const CacheFileMetadataResult& other1190) {
+  isSupported = other1190.isSupported;
 }
-CacheFileMetadataResult& CacheFileMetadataResult::operator=(const CacheFileMetadataResult& other1184) {
-  isSupported = other1184.isSupported;
+CacheFileMetadataResult& CacheFileMetadataResult::operator=(const CacheFileMetadataResult& other1191) {
+  isSupported = other1191.isSupported;
   return *this;
 }
 void CacheFileMetadataResult::printTo(std::ostream& out) const {
@@ -32412,19 +32499,19 @@ void swap(CacheFileMetadataRequest &a, CacheFileMetadataRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CacheFileMetadataRequest::CacheFileMetadataRequest(const CacheFileMetadataRequest& other1185) {
-  dbName = other1185.dbName;
-  tblName = other1185.tblName;
-  partName = other1185.partName;
-  isAllParts = other1185.isAllParts;
-  __isset = other1185.__isset;
+CacheFileMetadataRequest::CacheFileMetadataRequest(const CacheFileMetadataRequest& other1192) {
+  dbName = other1192.dbName;
+  tblName = other1192.tblName;
+  partName = other1192.partName;
+  isAllParts = other1192.isAllParts;
+  __isset = other1192.__isset;
 }
-CacheFileMetadataRequest& CacheFileMetadataRequest::operator=(const CacheFileMetadataRequest& other1186) {
-  dbName = other1186.dbName;
-  tblName = other1186.tblName;
-  partName = other1186.partName;
-  isAllParts = other1186.isAllParts;
-  __isset = other1186.__isset;
+CacheFileMetadataRequest& CacheFileMetadataRequest::operator=(const CacheFileMetadataRequest& other1193) {
+  dbName = other1193.dbName;
+  tblName = other1193.tblName;
+  partName = other1193.partName;
+  isAllParts = other1193.isAllParts;
+  __isset = other1193.__isset;
   return *this;
 }
 void CacheFileMetadataRequest::printTo(std::ostream& out) const {
@@ -32478,14 +32565,14 @@ uint32_t GetAllFunctionsResponse::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->functions.clear();
-            uint32_t _size1187;
-            ::apache::thrift::protocol::TType _etype1190;
-            xfer += iprot->readListBegin(_etype1190, _size1187);
-            this->functions.resize(_size1187);
-            uint32_t _i1191;
-            for (_i1191 = 0; _i1191 < _size1187; ++_i1191)
+            uint32_t _size1194;
+            ::apache::thrift::protocol::TType _etype1197;
+            xfer += iprot->readListBegin(_etype1197, _size1194);
+            this->functions.resize(_size1194);
+            uint32_t _i1198;
+            for (_i1198 = 0; _i1198 < _size1194; ++_i1198)
             {
-              xfer += this->functions[_i1191].read(iprot);
+              xfer += this->functions[_i1198].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -32515,10 +32602,10 @@ uint32_t GetAllFunctionsResponse::write(::apache::thrift::protocol::TProtocol* o
     xfer += oprot->writeFieldBegin("functions", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->functions.size()));
-      std::vector<Function> ::const_iterator _iter1192;
-      for (_iter1192 = this->functions.begin(); _iter1192 != this->functions.end(); ++_iter1192)
+      std::vector<Function> ::const_iterator _iter1199;
+      for (_iter1199 = this->functions.begin(); _iter1199 != this->functions.end(); ++_iter1199)
       {
-        xfer += (*_iter1192).write(oprot);
+        xfer += (*_iter1199).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -32535,13 +32622,13 @@ void swap(GetAllFunctionsResponse &a, GetAllFunctionsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetAllFunctionsResponse::GetAllFunctionsResponse(const GetAllFunctionsResponse& other1193) {
-  functions = other1193.functions;
-  __isset = other1193.__isset;
+GetAllFunctionsResponse::GetAllFunctionsResponse(const GetAllFunctionsResponse& other1200) {
+  functions = other1200.functions;
+  __isset = other1200.__isset;
 }
-GetAllFunctionsResponse& GetAllFunctionsResponse::operator=(const GetAllFunctionsResponse& other1194) {
-  functions = other1194.functions;
-  __isset = other1194.__isset;
+GetAllFunctionsResponse& GetAllFunctionsResponse::operator=(const GetAllFunctionsResponse& other1201) {
+  functions = other1201.functions;
+  __isset = other1201.__isset;
   return *this;
 }
 void GetAllFunctionsResponse::printTo(std::ostream& out) const {
@@ -32592,16 +32679,16 @@ uint32_t ClientCapabilities::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size1195;
-            ::apache::thrift::protocol::TType _etype1198;
-            xfer += iprot->readListBegin(_etype1198, _size1195);
-            this->values.resize(_size1195);
-            uint32_t _i1199;
-            for (_i1199 = 0; _i1199 < _size1195; ++_i1199)
+            uint32_t _size1202;
+            ::apache::thrift::protocol::TType _etype1205;
+            xfer += iprot->readListBegin(_etype1205, _size1202);
+            this->values.resize(_size1202);
+            uint32_t _i1206;
+            for (_i1206 = 0; _i1206 < _size1202; ++_i1206)
             {
-              int32_t ecast1200;
-              xfer += iprot->readI32(ecast1200);
-              this->values[_i1199] = (ClientCapability::type)ecast1200;
+              int32_t ecast1207;
+              xfer += iprot->readI32(ecast1207);
+              this->values[_i1206] = (ClientCapability::type)ecast1207;
             }
             xfer += iprot->readListEnd();
           }
@@ -32632,10 +32719,10 @@ uint32_t ClientCapabilities::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->values.size()));
-    std::vector<ClientCapability::type> ::const_iterator _iter1201;
-    for (_iter1201 = this->values.begin(); _iter1201 != this->values.end(); ++_iter1201)
+    std::vector<ClientCapability::type> ::const_iterator _iter1208;
+    for (_iter1208 = this->values.begin(); _iter1208 != this->values.end(); ++_iter1208)
     {
-      xfer += oprot->writeI32((int32_t)(*_iter1201));
+      xfer += oprot->writeI32((int32_t)(*_iter1208));
     }
     xfer += oprot->writeListEnd();
   }
@@ -32651,11 +32738,11 @@ void swap(ClientCapabilities &a, ClientCapabilities &b) {
   swap(a.values, b.values);
 }
 
-ClientCapabilities::ClientCapabilities(const ClientCapabilities& other1202) {
-  values = other1202.values;
+ClientCapabilities::ClientCapabilities(const ClientCapabilities& other1209) {
+  values = other1209.values;
 }
-ClientCapabilities& ClientCapabilities::operator=(const ClientCapabilities& other1203) {
-  values = other1203.values;
+ClientCapabilities& ClientCapabilities::operator=(const ClientCapabilities& other1210) {
+  values = other1210.values;
   return *this;
 }
 void ClientCapabilities::printTo(std::ostream& out) const {
@@ -32713,14 +32800,14 @@ uint32_t GetProjectionsSpec::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fieldList.clear();
-            uint32_t _size1204;
-            ::apache::thrift::protocol::TType _etype1207;
-            xfer += iprot->readListBegin(_etype1207, _size1204);
-            this->fieldList.resize(_size1204);
-            uint32_t _i1208;
-            for (_i1208 = 0; _i1208 < _size1204; ++_i1208)
+            uint32_t _size1211;
+            ::apache::thrift::protocol::TType _etype1214;
+            xfer += iprot->readListBegin(_etype1214, _size1211);
+            this->fieldList.resize(_size1211);
+            uint32_t _i1215;
+            for (_i1215 = 0; _i1215 < _size1211; ++_i1215)
             {
-              xfer += iprot->readString(this->fieldList[_i1208]);
+              xfer += iprot->readString(this->fieldList[_i1215]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32765,10 +32852,10 @@ uint32_t GetProjectionsSpec::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("fieldList", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->fieldList.size()));
-    std::vector<std::string> ::const_iterator _iter1209;
-    for (_iter1209 = this->fieldList.begin(); _iter1209 != this->fieldList.end(); ++_iter1209)
+    std::vector<std::string> ::const_iterator _iter1216;
+    for (_iter1216 = this->fieldList.begin(); _iter1216 != this->fieldList.end(); ++_iter1216)
     {
-      xfer += oprot->writeString((*_iter1209));
+      xfer += oprot->writeString((*_iter1216));
     }
     xfer += oprot->writeListEnd();
   }
@@ -32795,17 +32882,17 @@ void swap(GetProjectionsSpec &a, GetProjectionsSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetProjectionsSpec::GetProjectionsSpec(const GetProjectionsSpec& other1210) {
-  fieldList = other1210.fieldList;
-  includeParamKeyPattern = other1210.includeParamKeyPattern;
-  excludeParamKeyPattern = other1210.excludeParamKeyPattern;
-  __isset = other1210.__isset;
+GetProjectionsSpec::GetProjectionsSpec(const GetProjectionsSpec& other1217) {
+  fieldList = other1217.fieldList;
+  includeParamKeyPattern = other1217.includeParamKeyPattern;
+  excludeParamKeyPattern = other1217.excludeParamKeyPattern;
+  __isset = other1217.__isset;
 }
-GetProjectionsSpec& GetProjectionsSpec::operator=(const GetProjectionsSpec& other1211) {
-  fieldList = other1211.fieldList;
-  includeParamKeyPattern = other1211.includeParamKeyPattern;
-  excludeParamKeyPattern = other1211.excludeParamKeyPattern;
-  __isset = other1211.__isset;
+GetProjectionsSpec& GetProjectionsSpec::operator=(const GetProjectionsSpec& other1218) {
+  fieldList = other1218.fieldList;
+  includeParamKeyPattern = other1218.includeParamKeyPattern;
+  excludeParamKeyPattern = other1218.excludeParamKeyPattern;
+  __isset = other1218.__isset;
   return *this;
 }
 void GetProjectionsSpec::printTo(std::ostream& out) const {
@@ -32951,14 +33038,14 @@ uint32_t GetTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1212;
-            ::apache::thrift::protocol::TType _etype1215;
-            xfer += iprot->readListBegin(_etype1215, _size1212);
-            this->processorCapabilities.resize(_size1212);
-            uint32_t _i1216;
-            for (_i1216 = 0; _i1216 < _size1212; ++_i1216)
+            uint32_t _size1219;
+            ::apache::thrift::protocol::TType _etype1222;
+            xfer += iprot->readListBegin(_etype1222, _size1219);
+            this->processorCapabilities.resize(_size1219);
+            uint32_t _i1223;
+            for (_i1223 = 0; _i1223 < _size1219; ++_i1223)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1216]);
+              xfer += iprot->readString(this->processorCapabilities[_i1223]);
             }
             xfer += iprot->readListEnd();
           }
@@ -33044,10 +33131,10 @@ uint32_t GetTableRequest::write(::apache::thrift::protocol::TProtocol* oprot) co
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1217;
-      for (_iter1217 = this->processorCapabilities.begin(); _iter1217 != this->processorCapabilities.end(); ++_iter1217)
+      std::vector<std::string> ::const_iterator _iter1224;
+      for (_iter1224 = this->processorCapabilities.begin(); _iter1224 != this->processorCapabilities.end(); ++_iter1224)
       {
-        xfer += oprot->writeString((*_iter1217));
+        xfer += oprot->writeString((*_iter1224));
       }
       xfer += oprot->writeListEnd();
     }
@@ -33088,31 +33175,31 @@ void swap(GetTableRequest &a, GetTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTableRequest::GetTableRequest(const GetTableRequest& other1218) {
-  dbName = other1218.dbName;
-  tblName = other1218.tblName;
-  capabilities = other1218.capabilities;
-  catName = other1218.catName;
-  validWriteIdList = other1218.validWriteIdList;
-  getColumnStats = other1218.getColumnStats;
-  processorCapabilities = other1218.processorCapabilities;
-  processorIdentifier = other1218.processorIdentifier;
-  engine = other1218.engine;
-  id = other1218.id;
-  __isset = other1218.__isset;
+GetTableRequest::GetTableRequest(const GetTableRequest& other1225) {
+  dbName = other1225.dbName;
+  tblName = other1225.tblName;
+  capabilities = other1225.capabilities;
+  catName = other1225.catName;
+  validWriteIdList = other1225.validWriteIdList;
+  getColumnStats = other1225.getColumnStats;
+  processorCapabilities = other1225.processorCapabilities;
+  processorIdentifier = other1225.processorIdentifier;
+  engine = other1225.engine;
+  id = other1225.id;
+  __isset = other1225.__isset;
 }
-GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other1219) {
-  dbName = other1219.dbName;
-  tblName = other1219.tblName;
-  capabilities = other1219.capabilities;
-  catName = other1219.catName;
-  validWriteIdList = other1219.validWriteIdList;
-  getColumnStats = other1219.getColumnStats;
-  processorCapabilities = other1219.processorCapabilities;
-  processorIdentifier = other1219.processorIdentifier;
-  engine = other1219.engine;
-  id = other1219.id;
-  __isset = other1219.__isset;
+GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other1226) {
+  dbName = other1226.dbName;
+  tblName = other1226.tblName;
+  capabilities = other1226.capabilities;
+  catName = other1226.catName;
+  validWriteIdList = other1226.validWriteIdList;
+  getColumnStats = other1226.getColumnStats;
+  processorCapabilities = other1226.processorCapabilities;
+  processorIdentifier = other1226.processorIdentifier;
+  engine = other1226.engine;
+  id = other1226.id;
+  __isset = other1226.__isset;
   return *this;
 }
 void GetTableRequest::printTo(std::ostream& out) const {
@@ -33229,15 +33316,15 @@ void swap(GetTableResult &a, GetTableResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTableResult::GetTableResult(const GetTableResult& other1220) {
-  table = other1220.table;
-  isStatsCompliant = other1220.isStatsCompliant;
-  __isset = other1220.__isset;
+GetTableResult::GetTableResult(const GetTableResult& other1227) {
+  table = other1227.table;
+  isStatsCompliant = other1227.isStatsCompliant;
+  __isset = other1227.__isset;
 }
-GetTableResult& GetTableResult::operator=(const GetTableResult& other1221) {
-  table = other1221.table;
-  isStatsCompliant = other1221.isStatsCompliant;
-  __isset = other1221.__isset;
+GetTableResult& GetTableResult::operator=(const GetTableResult& other1228) {
+  table = other1228.table;
+  isStatsCompliant = other1228.isStatsCompliant;
+  __isset = other1228.__isset;
   return *this;
 }
 void GetTableResult::printTo(std::ostream& out) const {
@@ -33332,14 +33419,14 @@ uint32_t GetTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tblNames.clear();
-            uint32_t _size1222;
-            ::apache::thrift::protocol::TType _etype1225;
-            xfer += iprot->readListBegin(_etype1225, _size1222);
-            this->tblNames.resize(_size1222);
-            uint32_t _i1226;
-            for (_i1226 = 0; _i1226 < _size1222; ++_i1226)
+            uint32_t _size1229;
+            ::apache::thrift::protocol::TType _etype1232;
+            xfer += iprot->readListBegin(_etype1232, _size1229);
+            this->tblNames.resize(_size1229);
+            uint32_t _i1233;
+            for (_i1233 = 0; _i1233 < _size1229; ++_i1233)
             {
-              xfer += iprot->readString(this->tblNames[_i1226]);
+              xfer += iprot->readString(this->tblNames[_i1233]);
             }
             xfer += iprot->readListEnd();
           }
@@ -33368,14 +33455,14 @@ uint32_t GetTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1227;
-            ::apache::thrift::protocol::TType _etype1230;
-            xfer += iprot->readListBegin(_etype1230, _size1227);
-            this->processorCapabilities.resize(_size1227);
-            uint32_t _i1231;
-            for (_i1231 = 0; _i1231 < _size1227; ++_i1231)
+            uint32_t _size1234;
+            ::apache::thrift::protocol::TType _etype1237;
+            xfer += iprot->readListBegin(_etype1237, _size1234);
+            this->processorCapabilities.resize(_size1234);
+            uint32_t _i1238;
+            for (_i1238 = 0; _i1238 < _size1234; ++_i1238)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1231]);
+              xfer += iprot->readString(this->processorCapabilities[_i1238]);
             }
             xfer += iprot->readListEnd();
           }
@@ -33435,10 +33522,10 @@ uint32_t GetTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("tblNames", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tblNames.size()));
-      std::vector<std::string> ::const_iterator _iter1232;
-      for (_iter1232 = this->tblNames.begin(); _iter1232 != this->tblNames.end(); ++_iter1232)
+      std::vector<std::string> ::const_iterator _iter1239;
+      for (_iter1239 = this->tblNames.begin(); _iter1239 != this->tblNames.end(); ++_iter1239)
       {
-        xfer += oprot->writeString((*_iter1232));
+        xfer += oprot->writeString((*_iter1239));
       }
       xfer += oprot->writeListEnd();
     }
@@ -33458,10 +33545,10 @@ uint32_t GetTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1233;
-      for (_iter1233 = this->processorCapabilities.begin(); _iter1233 != this->processorCapabilities.end(); ++_iter1233)
+      std::vector<std::string> ::const_iterator _iter1240;
+      for (_iter1240 = this->processorCapabilities.begin(); _iter1240 != this->processorCapabilities.end(); ++_iter1240)
       {
-        xfer += oprot->writeString((*_iter1233));
+        xfer += oprot->writeString((*_iter1240));
       }
       xfer += oprot->writeListEnd();
     }
@@ -33500,27 +33587,27 @@ void swap(GetTablesRequest &a, GetTablesRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTablesRequest::GetTablesRequest(const GetTablesRequest& other1234) {
-  dbName = other1234.dbName;
-  tblNames = other1234.tblNames;
-  capabilities = other1234.capabilities;
-  catName = other1234.catName;
-  processorCapabilities = other1234.processorCapabilities;
-  processorIdentifier = other1234.processorIdentifier;
-  projectionSpec = other1234.projectionSpec;
-  tablesPattern = other1234.tablesPattern;
-  __isset = other1234.__isset;
+GetTablesRequest::GetTablesRequest(const GetTablesRequest& other1241) {
+  dbName = other1241.dbName;
+  tblNames = other1241.tblNames;
+  capabilities = other1241.capabilities;
+  catName = other1241.catName;
+  processorCapabilities = other1241.processorCapabilities;
+  processorIdentifier = other1241.processorIdentifier;
+  projectionSpec = other1241.projectionSpec;
+  tablesPattern = other1241.tablesPattern;
+  __isset = other1241.__isset;
 }
-GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1235) {
-  dbName = other1235.dbName;
-  tblNames = other1235.tblNames;
-  capabilities = other1235.capabilities;
-  catName = other1235.catName;
-  processorCapabilities = other1235.processorCapabilities;
-  processorIdentifier = other1235.processorIdentifier;
-  projectionSpec = other1235.projectionSpec;
-  tablesPattern = other1235.tablesPattern;
-  __isset = other1235.__isset;
+GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1242) {
+  dbName = other1242.dbName;
+  tblNames = other1242.tblNames;
+  capabilities = other1242.capabilities;
+  catName = other1242.catName;
+  processorCapabilities = other1242.processorCapabilities;
+  processorIdentifier = other1242.processorIdentifier;
+  projectionSpec = other1242.projectionSpec;
+  tablesPattern = other1242.tablesPattern;
+  __isset = other1242.__isset;
   return *this;
 }
 void GetTablesRequest::printTo(std::ostream& out) const {
@@ -33578,14 +33665,14 @@ uint32_t GetTablesResult::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tables.clear();
-            uint32_t _size1236;
-            ::apache::thrift::protocol::TType _etype1239;
-            xfer += iprot->readListBegin(_etype1239, _size1236);
-            this->tables.resize(_size1236);
-            uint32_t _i1240;
-            for (_i1240 = 0; _i1240 < _size1236; ++_i1240)
+            uint32_t _size1243;
+            ::apache::thrift::protocol::TType _etype1246;
+            xfer += iprot->readListBegin(_etype1246, _size1243);
+            this->tables.resize(_size1243);
+            uint32_t _i1247;
+            for (_i1247 = 0; _i1247 < _size1243; ++_i1247)
             {
-              xfer += this->tables[_i1240].read(iprot);
+              xfer += this->tables[_i1247].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -33616,10 +33703,10 @@ uint32_t GetTablesResult::write(::apache::thrift::protocol::TProtocol* oprot) co
   xfer += oprot->writeFieldBegin("tables", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tables.size()));
-    std::vector<Table> ::const_iterator _iter1241;
-    for (_iter1241 = this->tables.begin(); _iter1241 != this->tables.end(); ++_iter1241)
+    std::vector<Table> ::const_iterator _iter1248;
+    for (_iter1248 = this->tables.begin(); _iter1248 != this->tables.end(); ++_iter1248)
     {
-      xfer += (*_iter1241).write(oprot);
+      xfer += (*_iter1248).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -33635,11 +33722,11 @@ void swap(GetTablesResult &a, GetTablesResult &b) {
   swap(a.tables, b.tables);
 }
 
-GetTablesResult::GetTablesResult(const GetTablesResult& other1242) {
-  tables = other1242.tables;
+GetTablesResult::GetTablesResult(const GetTablesResult& other1249) {
+  tables = other1249.tables;
 }
-GetTablesResult& GetTablesResult::operator=(const GetTablesResult& other1243) {
-  tables = other1243.tables;
+GetTablesResult& GetTablesResult::operator=(const GetTablesResult& other1250) {
+  tables = other1250.tables;
   return *this;
 }
 void GetTablesResult::printTo(std::ostream& out) const {
@@ -33760,14 +33847,14 @@ uint32_t GetTablesExtRequest::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1244;
-            ::apache::thrift::protocol::TType _etype1247;
-            xfer += iprot->readListBegin(_etype1247, _size1244);
-            this->processorCapabilities.resize(_size1244);
-            uint32_t _i1248;
-            for (_i1248 = 0; _i1248 < _size1244; ++_i1248)
+            uint32_t _size1251;
+            ::apache::thrift::protocol::TType _etype1254;
+            xfer += iprot->readListBegin(_etype1254, _size1251);
+            this->processorCapabilities.resize(_size1251);
+            uint32_t _i1255;
+            for (_i1255 = 0; _i1255 < _size1251; ++_i1255)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1248]);
+              xfer += iprot->readString(this->processorCapabilities[_i1255]);
             }
             xfer += iprot->readListEnd();
           }
@@ -33834,10 +33921,10 @@ uint32_t GetTablesExtRequest::write(::apache::thrift::protocol::TProtocol* oprot
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1249;
-      for (_iter1249 = this->processorCapabilities.begin(); _iter1249 != this->processorCapabilities.end(); ++_iter1249)
+      std::vector<std::string> ::const_iterator _iter1256;
+      for (_iter1256 = this->processorCapabilities.begin(); _iter1256 != this->processorCapabilities.end(); ++_iter1256)
       {
-        xfer += oprot->writeString((*_iter1249));
+        xfer += oprot->writeString((*_iter1256));
       }
       xfer += oprot->writeListEnd();
     }
@@ -33865,25 +33952,25 @@ void swap(GetTablesExtRequest &a, GetTablesExtRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTablesExtRequest::GetTablesExtRequest(const GetTablesExtRequest& other1250) {
-  catalog = other1250.catalog;
-  database = other1250.database;
-  tableNamePattern = other1250.tableNamePattern;
-  requestedFields = other1250.requestedFields;
-  limit = other1250.limit;
-  processorCapabilities = other1250.processorCapabilities;
-  processorIdentifier = other1250.processorIdentifier;
-  __isset = other1250.__isset;
+GetTablesExtRequest::GetTablesExtRequest(const GetTablesExtRequest& other1257) {
+  catalog = other1257.catalog;
+  database = other1257.database;
+  tableNamePattern = other1257.tableNamePattern;
+  requestedFields = other1257.requestedFields;
+  limit = other1257.limit;
+  processorCapabilities = other1257.processorCapabilities;
+  processorIdentifier = other1257.processorIdentifier;
+  __isset = other1257.__isset;
 }
-GetTablesExtRequest& GetTablesExtRequest::operator=(const GetTablesExtRequest& other1251) {
-  catalog = other1251.catalog;
-  database = other1251.database;
-  tableNamePattern = other1251.tableNamePattern;
-  requestedFields = other1251.requestedFields;
-  limit = other1251.limit;
-  processorCapabilities = other1251.processorCapabilities;
-  processorIdentifier = other1251.processorIdentifier;
-  __isset = other1251.__isset;
+GetTablesExtRequest& GetTablesExtRequest::operator=(const GetTablesExtRequest& other1258) {
+  catalog = other1258.catalog;
+  database = other1258.database;
+  tableNamePattern = other1258.tableNamePattern;
+  requestedFields = other1258.requestedFields;
+  limit = other1258.limit;
+  processorCapabilities = other1258.processorCapabilities;
+  processorIdentifier = other1258.processorIdentifier;
+  __isset = other1258.__isset;
   return *this;
 }
 void GetTablesExtRequest::printTo(std::ostream& out) const {
@@ -33971,14 +34058,14 @@ uint32_t ExtendedTableInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredReadCapabilities.clear();
-            uint32_t _size1252;
-            ::apache::thrift::protocol::TType _etype1255;
-            xfer += iprot->readListBegin(_etype1255, _size1252);
-            this->requiredReadCapabilities.resize(_size1252);
-            uint32_t _i1256;
-            for (_i1256 = 0; _i1256 < _size1252; ++_i1256)
+            uint32_t _size1259;
+            ::apache::thrift::protocol::TType _etype1262;
+            xfer += iprot->readListBegin(_etype1262, _size1259);
+            this->requiredReadCapabilities.resize(_size1259);
+            uint32_t _i1263;
+            for (_i1263 = 0; _i1263 < _size1259; ++_i1263)
             {
-              xfer += iprot->readString(this->requiredReadCapabilities[_i1256]);
+              xfer += iprot->readString(this->requiredReadCapabilities[_i1263]);
             }
             xfer += iprot->readListEnd();
           }
@@ -33991,14 +34078,14 @@ uint32_t ExtendedTableInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredWriteCapabilities.clear();
-            uint32_t _size1257;
-            ::apache::thrift::protocol::TType _etype1260;
-            xfer += iprot->readListBegin(_etype1260, _size1257);
-            this->requiredWriteCapabilities.resize(_size1257);
-            uint32_t _i1261;
-            for (_i1261 = 0; _i1261 < _size1257; ++_i1261)
+            uint32_t _size1264;
+            ::apache::thrift::protocol::TType _etype1267;
+            xfer += iprot->readListBegin(_etype1267, _size1264);
+            this->requiredWriteCapabilities.resize(_size1264);
+            uint32_t _i1268;
+            for (_i1268 = 0; _i1268 < _size1264; ++_i1268)
             {
-              xfer += iprot->readString(this->requiredWriteCapabilities[_i1261]);
+              xfer += iprot->readString(this->requiredWriteCapabilities[_i1268]);
             }
             xfer += iprot->readListEnd();
           }
@@ -34039,10 +34126,10 @@ uint32_t ExtendedTableInfo::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("requiredReadCapabilities", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredReadCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1262;
-      for (_iter1262 = this->requiredReadCapabilities.begin(); _iter1262 != this->requiredReadCapabilities.end(); ++_iter1262)
+      std::vector<std::string> ::const_iterator _iter1269;
+      for (_iter1269 = this->requiredReadCapabilities.begin(); _iter1269 != this->requiredReadCapabilities.end(); ++_iter1269)
       {
-        xfer += oprot->writeString((*_iter1262));
+        xfer += oprot->writeString((*_iter1269));
       }
       xfer += oprot->writeListEnd();
     }
@@ -34052,10 +34139,10 @@ uint32_t ExtendedTableInfo::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("requiredWriteCapabilities", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredWriteCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1263;
-      for (_iter1263 = this->requiredWriteCapabilities.begin(); _iter1263 != this->requiredWriteCapabilities.end(); ++_iter1263)
+      std::vector<std::string> ::const_iterator _iter1270;
+      for (_iter1270 = this->requiredWriteCapabilities.begin(); _iter1270 != this->requiredWriteCapabilities.end(); ++_iter1270)
       {
-        xfer += oprot->writeString((*_iter1263));
+        xfer += oprot->writeString((*_iter1270));
       }
       xfer += oprot->writeListEnd();
     }
@@ -34075,19 +34162,19 @@ void swap(ExtendedTableInfo &a, ExtendedTableInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ExtendedTableInfo::ExtendedTableInfo(const ExtendedTableInfo& other1264) {
-  tblName = other1264.tblName;
-  accessType = other1264.accessType;
-  requiredReadCapabilities = other1264.requiredReadCapabilities;
-  requiredWriteCapabilities = other1264.requiredWriteCapabilities;
-  __isset = other1264.__isset;
+ExtendedTableInfo::ExtendedTableInfo(const ExtendedTableInfo& other1271) {
+  tblName = other1271.tblName;
+  accessType = other1271.accessType;
+  requiredReadCapabilities = other1271.requiredReadCapabilities;
+  requiredWriteCapabilities = other1271.requiredWriteCapabilities;
+  __isset = other1271.__isset;
 }
-ExtendedTableInfo& ExtendedTableInfo::operator=(const ExtendedTableInfo& other1265) {
-  tblName = other1265.tblName;
-  accessType = other1265.accessType;
-  requiredReadCapabilities = other1265.requiredReadCapabilities;
-  requiredWriteCapabilities = other1265.requiredWriteCapabilities;
-  __isset = other1265.__isset;
+ExtendedTableInfo& ExtendedTableInfo::operator=(const ExtendedTableInfo& other1272) {
+  tblName = other1272.tblName;
+  accessType = other1272.accessType;
+  requiredReadCapabilities = other1272.requiredReadCapabilities;
+  requiredWriteCapabilities = other1272.requiredWriteCapabilities;
+  __isset = other1272.__isset;
   return *this;
 }
 void ExtendedTableInfo::printTo(std::ostream& out) const {
@@ -34172,14 +34259,14 @@ uint32_t GetDatabaseRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1266;
-            ::apache::thrift::protocol::TType _etype1269;
-            xfer += iprot->readListBegin(_etype1269, _size1266);
-            this->processorCapabilities.resize(_size1266);
-            uint32_t _i1270;
-            for (_i1270 = 0; _i1270 < _size1266; ++_i1270)
+            uint32_t _size1273;
+            ::apache::thrift::protocol::TType _etype1276;
+            xfer += iprot->readListBegin(_etype1276, _size1273);
+            this->processorCapabilities.resize(_size1273);
+            uint32_t _i1277;
+            for (_i1277 = 0; _i1277 < _size1273; ++_i1277)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1270]);
+              xfer += iprot->readString(this->processorCapabilities[_i1277]);
             }
             xfer += iprot->readListEnd();
           }
@@ -34227,10 +34314,10 @@ uint32_t GetDatabaseRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1271;
-      for (_iter1271 = this->processorCapabilities.begin(); _iter1271 != this->processorCapabilities.end(); ++_iter1271)
+      std::vector<std::string> ::const_iterator _iter1278;
+      for (_iter1278 = this->processorCapabilities.begin(); _iter1278 != this->processorCapabilities.end(); ++_iter1278)
       {
-        xfer += oprot->writeString((*_iter1271));
+        xfer += oprot->writeString((*_iter1278));
       }
       xfer += oprot->writeListEnd();
     }
@@ -34255,19 +34342,19 @@ void swap(GetDatabaseRequest &a, GetDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other1272) {
-  name = other1272.name;
-  catalogName = other1272.catalogName;
-  processorCapabilities = other1272.processorCapabilities;
-  processorIdentifier = other1272.processorIdentifier;
-  __isset = other1272.__isset;
+GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other1279) {
+  name = other1279.name;
+  catalogName = other1279.catalogName;
+  processorCapabilities = other1279.processorCapabilities;
+  processorIdentifier = other1279.processorIdentifier;
+  __isset = other1279.__isset;
 }
-GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other1273) {
-  name = other1273.name;
-  catalogName = other1273.catalogName;
-  processorCapabilities = other1273.processorCapabilities;
-  processorIdentifier = other1273.processorIdentifier;
-  __isset = other1273.__isset;
+GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other1280) {
+  name = other1280.name;
+  catalogName = other1280.catalogName;
+  processorCapabilities = other1280.processorCapabilities;
+  processorIdentifier = other1280.processorIdentifier;
+  __isset = other1280.__isset;
   return *this;
 }
 void GetDatabaseRequest::printTo(std::ostream& out) const {
@@ -34378,13 +34465,13 @@ void swap(CmRecycleRequest &a, CmRecycleRequest &b) {
   swap(a.purge, b.purge);
 }
 
-CmRecycleRequest::CmRecycleRequest(const CmRecycleRequest& other1274) {
-  dataPath = other1274.dataPath;
-  purge = other1274.purge;
+CmRecycleRequest::CmRecycleRequest(const CmRecycleRequest& other1281) {
+  dataPath = other1281.dataPath;
+  purge = other1281.purge;
 }
-CmRecycleRequest& CmRecycleRequest::operator=(const CmRecycleRequest& other1275) {
-  dataPath = other1275.dataPath;
-  purge = other1275.purge;
+CmRecycleRequest& CmRecycleRequest::operator=(const CmRecycleRequest& other1282) {
+  dataPath = other1282.dataPath;
+  purge = other1282.purge;
   return *this;
 }
 void CmRecycleRequest::printTo(std::ostream& out) const {
@@ -34450,11 +34537,11 @@ void swap(CmRecycleResponse &a, CmRecycleResponse &b) {
   (void) b;
 }
 
-CmRecycleResponse::CmRecycleResponse(const CmRecycleResponse& other1276) {
-  (void) other1276;
+CmRecycleResponse::CmRecycleResponse(const CmRecycleResponse& other1283) {
+  (void) other1283;
 }
-CmRecycleResponse& CmRecycleResponse::operator=(const CmRecycleResponse& other1277) {
-  (void) other1277;
+CmRecycleResponse& CmRecycleResponse::operator=(const CmRecycleResponse& other1284) {
+  (void) other1284;
   return *this;
 }
 void CmRecycleResponse::printTo(std::ostream& out) const {
@@ -34620,21 +34707,21 @@ void swap(TableMeta &a, TableMeta &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableMeta::TableMeta(const TableMeta& other1278) {
-  dbName = other1278.dbName;
-  tableName = other1278.tableName;
-  tableType = other1278.tableType;
-  comments = other1278.comments;
-  catName = other1278.catName;
-  __isset = other1278.__isset;
+TableMeta::TableMeta(const TableMeta& other1285) {
+  dbName = other1285.dbName;
+  tableName = other1285.tableName;
+  tableType = other1285.tableType;
+  comments = other1285.comments;
+  catName = other1285.catName;
+  __isset = other1285.__isset;
 }
-TableMeta& TableMeta::operator=(const TableMeta& other1279) {
-  dbName = other1279.dbName;
-  tableName = other1279.tableName;
-  tableType = other1279.tableType;
-  comments = other1279.comments;
-  catName = other1279.catName;
-  __isset = other1279.__isset;
+TableMeta& TableMeta::operator=(const TableMeta& other1286) {
+  dbName = other1286.dbName;
+  tableName = other1286.tableName;
+  tableType = other1286.tableType;
+  comments = other1286.comments;
+  catName = other1286.catName;
+  __isset = other1286.__isset;
   return *this;
 }
 void TableMeta::printTo(std::ostream& out) const {
@@ -34746,13 +34833,13 @@ void swap(Materialization &a, Materialization &b) {
   swap(a.sourceTablesCompacted, b.sourceTablesCompacted);
 }
 
-Materialization::Materialization(const Materialization& other1280) {
-  sourceTablesUpdateDeleteModified = other1280.sourceTablesUpdateDeleteModified;
-  sourceTablesCompacted = other1280.sourceTablesCompacted;
+Materialization::Materialization(const Materialization& other1287) {
+  sourceTablesUpdateDeleteModified = other1287.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1287.sourceTablesCompacted;
 }
-Materialization& Materialization::operator=(const Materialization& other1281) {
-  sourceTablesUpdateDeleteModified = other1281.sourceTablesUpdateDeleteModified;
-  sourceTablesCompacted = other1281.sourceTablesCompacted;
+Materialization& Materialization::operator=(const Materialization& other1288) {
+  sourceTablesUpdateDeleteModified = other1288.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1288.sourceTablesCompacted;
   return *this;
 }
 void Materialization::printTo(std::ostream& out) const {
@@ -34830,9 +34917,9 @@ uint32_t WMResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1282;
-          xfer += iprot->readI32(ecast1282);
-          this->status = (WMResourcePlanStatus::type)ecast1282;
+          int32_t ecast1289;
+          xfer += iprot->readI32(ecast1289);
+          this->status = (WMResourcePlanStatus::type)ecast1289;
           this->__isset.status = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -34920,21 +35007,21 @@ void swap(WMResourcePlan &a, WMResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMResourcePlan::WMResourcePlan(const WMResourcePlan& other1283) {
-  name = other1283.name;
-  status = other1283.status;
-  queryParallelism = other1283.queryParallelism;
-  defaultPoolPath = other1283.defaultPoolPath;
-  ns = other1283.ns;
-  __isset = other1283.__isset;
+WMResourcePlan::WMResourcePlan(const WMResourcePlan& other1290) {
+  name = other1290.name;
+  status = other1290.status;
+  queryParallelism = other1290.queryParallelism;
+  defaultPoolPath = other1290.defaultPoolPath;
+  ns = other1290.ns;
+  __isset = other1290.__isset;
 }
-WMResourcePlan& WMResourcePlan::operator=(const WMResourcePlan& other1284) {
-  name = other1284.name;
-  status = other1284.status;
-  queryParallelism = other1284.queryParallelism;
-  defaultPoolPath = other1284.defaultPoolPath;
-  ns = other1284.ns;
-  __isset = other1284.__isset;
+WMResourcePlan& WMResourcePlan::operator=(const WMResourcePlan& other1291) {
+  name = other1291.name;
+  status = other1291.status;
+  queryParallelism = other1291.queryParallelism;
+  defaultPoolPath = other1291.defaultPoolPath;
+  ns = other1291.ns;
+  __isset = other1291.__isset;
   return *this;
 }
 void WMResourcePlan::printTo(std::ostream& out) const {
@@ -35025,9 +35112,9 @@ uint32_t WMNullableResourcePlan::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1285;
-          xfer += iprot->readI32(ecast1285);
-          this->status = (WMResourcePlanStatus::type)ecast1285;
+          int32_t ecast1292;
+          xfer += iprot->readI32(ecast1292);
+          this->status = (WMResourcePlanStatus::type)ecast1292;
           this->__isset.status = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -35142,25 +35229,25 @@ void swap(WMNullableResourcePlan &a, WMNullableResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMNullableResourcePlan::WMNullableResourcePlan(const WMNullableResourcePlan& other1286) {
-  name = other1286.name;
-  status = other1286.status;
-  queryParallelism = other1286.queryParallelism;
-  isSetQueryParallelism = other1286.isSetQueryParallelism;
-  defaultPoolPath = other1286.defaultPoolPath;
-  isSetDefaultPoolPath = other1286.isSetDefaultPoolPath;
-  ns = other1286.ns;
-  __isset = other1286.__isset;
+WMNullableResourcePlan::WMNullableResourcePlan(const WMNullableResourcePlan& other1293) {
+  name = other1293.name;
+  status = other1293.status;
+  queryParallelism = other1293.queryParallelism;
+  isSetQueryParallelism = other1293.isSetQueryParallelism;
+  defaultPoolPath = other1293.defaultPoolPath;
+  isSetDefaultPoolPath = other1293.isSetDefaultPoolPath;
+  ns = other1293.ns;
+  __isset = other1293.__isset;
 }
-WMNullableResourcePlan& WMNullableResourcePlan::operator=(const WMNullableResourcePlan& other1287) {
-  name = other1287.name;
-  status = other1287.status;
-  queryParallelism = other1287.queryParallelism;
-  isSetQueryParallelism = other1287.isSetQueryParallelism;
-  defaultPoolPath = other1287.defaultPoolPath;
-  isSetDefaultPoolPath = other1287.isSetDefaultPoolPath;
-  ns = other1287.ns;
-  __isset = other1287.__isset;
+WMNullableResourcePlan& WMNullableResourcePlan::operator=(const WMNullableResourcePlan& other1294) {
+  name = other1294.name;
+  status = other1294.status;
+  queryParallelism = other1294.queryParallelism;
+  isSetQueryParallelism = other1294.isSetQueryParallelism;
+  defaultPoolPath = other1294.defaultPoolPath;
+  isSetDefaultPoolPath = other1294.isSetDefaultPoolPath;
+  ns = other1294.ns;
+  __isset = other1294.__isset;
   return *this;
 }
 void WMNullableResourcePlan::printTo(std::ostream& out) const {
@@ -35351,23 +35438,23 @@ void swap(WMPool &a, WMPool &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMPool::WMPool(const WMPool& other1288) {
-  resourcePlanName = other1288.resourcePlanName;
-  poolPath = other1288.poolPath;
-  allocFraction = other1288.allocFraction;
-  queryParallelism = other1288.queryParallelism;
-  schedulingPolicy = other1288.schedulingPolicy;
-  ns = other1288.ns;
-  __isset = other1288.__isset;
+WMPool::WMPool(const WMPool& other1295) {
+  resourcePlanName = other1295.resourcePlanName;
+  poolPath = other1295.poolPath;
+  allocFraction = other1295.allocFraction;
+  queryParallelism = other1295.queryParallelism;
+  schedulingPolicy = other1295.schedulingPolicy;
+  ns = other1295.ns;
+  __isset = other1295.__isset;
 }
-WMPool& WMPool::operator=(const WMPool& other1289) {
-  resourcePlanName = other1289.resourcePlanName;
-  poolPath = other1289.poolPath;
-  allocFraction = other1289.allocFraction;
-  queryParallelism = other1289.queryParallelism;
-  schedulingPolicy = other1289.schedulingPolicy;
-  ns = other1289.ns;
-  __isset = other1289.__isset;
+WMPool& WMPool::operator=(const WMPool& other1296) {
+  resourcePlanName = other1296.resourcePlanName;
+  poolPath = other1296.poolPath;
+  allocFraction = other1296.allocFraction;
+  queryParallelism = other1296.queryParallelism;
+  schedulingPolicy = other1296.schedulingPolicy;
+  ns = other1296.ns;
+  __isset = other1296.__isset;
   return *this;
 }
 void WMPool::printTo(std::ostream& out) const {
@@ -35576,25 +35663,25 @@ void swap(WMNullablePool &a, WMNullablePool &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMNullablePool::WMNullablePool(const WMNullablePool& other1290) {
-  resourcePlanName = other1290.resourcePlanName;
-  poolPath = other1290.poolPath;
-  allocFraction = other1290.allocFraction;
-  queryParallelism = other1290.queryParallelism;
-  schedulingPolicy = other1290.schedulingPolicy;
-  isSetSchedulingPolicy = other1290.isSetSchedulingPolicy;
-  ns = other1290.ns;
-  __isset = other1290.__isset;
+WMNullablePool::WMNullablePool(const WMNullablePool& other1297) {
+  resourcePlanName = other1297.resourcePlanName;
+  poolPath = other1297.poolPath;
+  allocFraction = other1297.allocFraction;
+  queryParallelism = other1297.queryParallelism;
+  schedulingPolicy = other1297.schedulingPolicy;
+  isSetSchedulingPolicy = other1297.isSetSchedulingPolicy;
+  ns = other1297.ns;
+  __isset = other1297.__isset;
 }
-WMNullablePool& WMNullablePool::operator=(const WMNullablePool& other1291) {
-  resourcePlanName = other1291.resourcePlanName;
-  poolPath = other1291.poolPath;
-  allocFraction = other1291.allocFraction;
-  queryParallelism = other1291.queryParallelism;
-  schedulingPolicy = other1291.schedulingPolicy;
-  isSetSchedulingPolicy = other1291.isSetSchedulingPolicy;
-  ns = other1291.ns;
-  __isset = other1291.__isset;
+WMNullablePool& WMNullablePool::operator=(const WMNullablePool& other1298) {
+  resourcePlanName = other1298.resourcePlanName;
+  poolPath = other1298.poolPath;
+  allocFraction = other1298.allocFraction;
+  queryParallelism = other1298.queryParallelism;
+  schedulingPolicy = other1298.schedulingPolicy;
+  isSetSchedulingPolicy = other1298.isSetSchedulingPolicy;
+  ns = other1298.ns;
+  __isset = other1298.__isset;
   return *this;
 }
 void WMNullablePool::printTo(std::ostream& out) const {
@@ -35785,23 +35872,23 @@ void swap(WMTrigger &a, WMTrigger &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMTrigger::WMTrigger(const WMTrigger& other1292) {
-  resourcePlanName = other1292.resourcePlanName;
-  triggerName = other1292.triggerName;
-  triggerExpression = other1292.triggerExpression;
-  actionExpression = other1292.actionExpression;
-  isInUnmanaged = other1292.isInUnmanaged;
-  ns = other1292.ns;
-  __isset = other1292.__isset;
+WMTrigger::WMTrigger(const WMTrigger& other1299) {
+  resourcePlanName = other1299.resourcePlanName;
+  triggerName = other1299.triggerName;
+  triggerExpression = other1299.triggerExpression;
+  actionExpression = other1299.actionExpression;
+  isInUnmanaged = other1299.isInUnmanaged;
+  ns = other1299.ns;
+  __isset = other1299.__isset;
 }
-WMTrigger& WMTrigger::operator=(const WMTrigger& other1293) {
-  resourcePlanName = other1293.resourcePlanName;
-  triggerName = other1293.triggerName;
-  triggerExpression = other1293.triggerExpression;
-  actionExpression = other1293.actionExpression;
-  isInUnmanaged = other1293.isInUnmanaged;
-  ns = other1293.ns;
-  __isset = other1293.__isset;
+WMTrigger& WMTrigger::operator=(const WMTrigger& other1300) {
+  resourcePlanName = other1300.resourcePlanName;
+  triggerName = other1300.triggerName;
+  triggerExpression = other1300.triggerExpression;
+  actionExpression = other1300.actionExpression;
+  isInUnmanaged = other1300.isInUnmanaged;
+  ns = other1300.ns;
+  __isset = other1300.__isset;
   return *this;
 }
 void WMTrigger::printTo(std::ostream& out) const {
@@ -35992,23 +36079,23 @@ void swap(WMMapping &a, WMMapping &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMMapping::WMMapping(const WMMapping& other1294) {
-  resourcePlanName = other1294.resourcePlanName;
-  entityType = other1294.entityType;
-  entityName = other1294.entityName;
-  poolPath = other1294.poolPath;
-  ordering = other1294.ordering;
-  ns = other1294.ns;
-  __isset = other1294.__isset;
+WMMapping::WMMapping(const WMMapping& other1301) {
+  resourcePlanName = other1301.resourcePlanName;
+  entityType = other1301.entityType;
+  entityName = other1301.entityName;
+  poolPath = other1301.poolPath;
+  ordering = other1301.ordering;
+  ns = other1301.ns;
+  __isset = other1301.__isset;
 }
-WMMapping& WMMapping::operator=(const WMMapping& other1295) {
-  resourcePlanName = other1295.resourcePlanName;
-  entityType = other1295.entityType;
-  entityName = other1295.entityName;
-  poolPath = other1295.poolPath;
-  ordering = other1295.ordering;
-  ns = other1295.ns;
-  __isset = other1295.__isset;
+WMMapping& WMMapping::operator=(const WMMapping& other1302) {
+  resourcePlanName = other1302.resourcePlanName;
+  entityType = other1302.entityType;
+  entityName = other1302.entityName;
+  poolPath = other1302.poolPath;
+  ordering = other1302.ordering;
+  ns = other1302.ns;
+  __isset = other1302.__isset;
   return *this;
 }
 void WMMapping::printTo(std::ostream& out) const {
@@ -36141,17 +36228,17 @@ void swap(WMPoolTrigger &a, WMPoolTrigger &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMPoolTrigger::WMPoolTrigger(const WMPoolTrigger& other1296) {
-  pool = other1296.pool;
-  trigger = other1296.trigger;
-  ns = other1296.ns;
-  __isset = other1296.__isset;
+WMPoolTrigger::WMPoolTrigger(const WMPoolTrigger& other1303) {
+  pool = other1303.pool;
+  trigger = other1303.trigger;
+  ns = other1303.ns;
+  __isset = other1303.__isset;
 }
-WMPoolTrigger& WMPoolTrigger::operator=(const WMPoolTrigger& other1297) {
-  pool = other1297.pool;
-  trigger = other1297.trigger;
-  ns = other1297.ns;
-  __isset = other1297.__isset;
+WMPoolTrigger& WMPoolTrigger::operator=(const WMPoolTrigger& other1304) {
+  pool = other1304.pool;
+  trigger = other1304.trigger;
+  ns = other1304.ns;
+  __isset = other1304.__isset;
   return *this;
 }
 void WMPoolTrigger::printTo(std::ostream& out) const {
@@ -36232,14 +36319,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->pools.clear();
-            uint32_t _size1298;
-            ::apache::thrift::protocol::TType _etype1301;
-            xfer += iprot->readListBegin(_etype1301, _size1298);
-            this->pools.resize(_size1298);
-            uint32_t _i1302;
-            for (_i1302 = 0; _i1302 < _size1298; ++_i1302)
+            uint32_t _size1305;
+            ::apache::thrift::protocol::TType _etype1308;
+            xfer += iprot->readListBegin(_etype1308, _size1305);
+            this->pools.resize(_size1305);
+            uint32_t _i1309;
+            for (_i1309 = 0; _i1309 < _size1305; ++_i1309)
             {
-              xfer += this->pools[_i1302].read(iprot);
+              xfer += this->pools[_i1309].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -36252,14 +36339,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->mappings.clear();
-            uint32_t _size1303;
-            ::apache::thrift::protocol::TType _etype1306;
-            xfer += iprot->readListBegin(_etype1306, _size1303);
-            this->mappings.resize(_size1303);
-            uint32_t _i1307;
-            for (_i1307 = 0; _i1307 < _size1303; ++_i1307)
+            uint32_t _size1310;
+            ::apache::thrift::protocol::TType _etype1313;
+            xfer += iprot->readListBegin(_etype1313, _size1310);
+            this->mappings.resize(_size1310);
+            uint32_t _i1314;
+            for (_i1314 = 0; _i1314 < _size1310; ++_i1314)
             {
-              xfer += this->mappings[_i1307].read(iprot);
+              xfer += this->mappings[_i1314].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -36272,14 +36359,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->triggers.clear();
-            uint32_t _size1308;
-            ::apache::thrift::protocol::TType _etype1311;
-            xfer += iprot->readListBegin(_etype1311, _size1308);
-            this->triggers.resize(_size1308);
-            uint32_t _i1312;
-            for (_i1312 = 0; _i1312 < _size1308; ++_i1312)
+            uint32_t _size1315;
+            ::apache::thrift::protocol::TType _etype1318;
+            xfer += iprot->readListBegin(_etype1318, _size1315);
+            this->triggers.resize(_size1315);
+            uint32_t _i1319;
+            for (_i1319 = 0; _i1319 < _size1315; ++_i1319)
             {
-              xfer += this->triggers[_i1312].read(iprot);
+              xfer += this->triggers[_i1319].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -36292,14 +36379,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->poolTriggers.clear();
-            uint32_t _size1313;
-            ::apache::thrift::protocol::TType _etype1316;
-            xfer += iprot->readListBegin(_etype1316, _size1313);
-            this->poolTriggers.resize(_size1313);
-            uint32_t _i1317;
-            for (_i1317 = 0; _i1317 < _size1313; ++_i1317)
+            uint32_t _size1320;
+            ::apache::thrift::protocol::TType _etype1323;
+            xfer += iprot->readListBegin(_etype1323, _size1320);
+            this->poolTriggers.resize(_size1320);
+            uint32_t _i1324;
+            for (_i1324 = 0; _i1324 < _size1320; ++_i1324)
             {
-              xfer += this->poolTriggers[_i1317].read(iprot);
+              xfer += this->poolTriggers[_i1324].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -36336,10 +36423,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("pools", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->pools.size()));
-    std::vector<WMPool> ::const_iterator _iter1318;
-    for (_iter1318 = this->pools.begin(); _iter1318 != this->pools.end(); ++_iter1318)
+    std::vector<WMPool> ::const_iterator _iter1325;
+    for (_iter1325 = this->pools.begin(); _iter1325 != this->pools.end(); ++_iter1325)
     {
-      xfer += (*_iter1318).write(oprot);
+      xfer += (*_iter1325).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -36349,10 +36436,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("mappings", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->mappings.size()));
-      std::vector<WMMapping> ::const_iterator _iter1319;
-      for (_iter1319 = this->mappings.begin(); _iter1319 != this->mappings.end(); ++_iter1319)
+      std::vector<WMMapping> ::const_iterator _iter1326;
+      for (_iter1326 = this->mappings.begin(); _iter1326 != this->mappings.end(); ++_iter1326)
       {
-        xfer += (*_iter1319).write(oprot);
+        xfer += (*_iter1326).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -36362,10 +36449,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("triggers", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->triggers.size()));
-      std::vector<WMTrigger> ::const_iterator _iter1320;
-      for (_iter1320 = this->triggers.begin(); _iter1320 != this->triggers.end(); ++_iter1320)
+      std::vector<WMTrigger> ::const_iterator _iter1327;
+      for (_iter1327 = this->triggers.begin(); _iter1327 != this->triggers.end(); ++_iter1327)
       {
-        xfer += (*_iter1320).write(oprot);
+        xfer += (*_iter1327).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -36375,10 +36462,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("poolTriggers", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->poolTriggers.size()));
-      std::vector<WMPoolTrigger> ::const_iterator _iter1321;
-      for (_iter1321 = this->poolTriggers.begin(); _iter1321 != this->poolTriggers.end(); ++_iter1321)
+      std::vector<WMPoolTrigger> ::const_iterator _iter1328;
+      for (_iter1328 = this->poolTriggers.begin(); _iter1328 != this->poolTriggers.end(); ++_iter1328)
       {
-        xfer += (*_iter1321).write(oprot);
+        xfer += (*_iter1328).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -36399,21 +36486,21 @@ void swap(WMFullResourcePlan &a, WMFullResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMFullResourcePlan::WMFullResourcePlan(const WMFullResourcePlan& other1322) {
-  plan = other1322.plan;
-  pools = other1322.pools;
-  mappings = other1322.mappings;
-  triggers = other1322.triggers;
-  poolTriggers = other1322.poolTriggers;
-  __isset = other1322.__isset;
+WMFullResourcePlan::WMFullResourcePlan(const WMFullResourcePlan& other1329) {
+  plan = other1329.plan;
+  pools = other1329.pools;
+  mappings = other1329.mappings;
+  triggers = other1329.triggers;
+  poolTriggers = other1329.poolTriggers;
+  __isset = other1329.__isset;
 }
-WMFullResourcePlan& WMFullResourcePlan::operator=(const WMFullResourcePlan& other1323) {
-  plan = other1323.plan;
-  pools = other1323.pools;
-  mappings = other1323.mappings;
-  triggers = other1323.triggers;
-  poolTriggers = other1323.poolTriggers;
-  __isset = other1323.__isset;
+WMFullResourcePlan& WMFullResourcePlan::operator=(const WMFullResourcePlan& other1330) {
+  plan = other1330.plan;
+  pools = other1330.pools;
+  mappings = other1330.mappings;
+  triggers = other1330.triggers;
+  poolTriggers = other1330.poolTriggers;
+  __isset = other1330.__isset;
   return *this;
 }
 void WMFullResourcePlan::printTo(std::ostream& out) const {
@@ -36524,15 +36611,15 @@ void swap(WMCreateResourcePlanRequest &a, WMCreateResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreateResourcePlanRequest::WMCreateResourcePlanRequest(const WMCreateResourcePlanRequest& other1324) {
-  resourcePlan = other1324.resourcePlan;
-  copyFrom = other1324.copyFrom;
-  __isset = other1324.__isset;
+WMCreateResourcePlanRequest::WMCreateResourcePlanRequest(const WMCreateResourcePlanRequest& other1331) {
+  resourcePlan = other1331.resourcePlan;
+  copyFrom = other1331.copyFrom;
+  __isset = other1331.__isset;
 }
-WMCreateResourcePlanRequest& WMCreateResourcePlanRequest::operator=(const WMCreateResourcePlanRequest& other1325) {
-  resourcePlan = other1325.resourcePlan;
-  copyFrom = other1325.copyFrom;
-  __isset = other1325.__isset;
+WMCreateResourcePlanRequest& WMCreateResourcePlanRequest::operator=(const WMCreateResourcePlanRequest& other1332) {
+  resourcePlan = other1332.resourcePlan;
+  copyFrom = other1332.copyFrom;
+  __isset = other1332.__isset;
   return *this;
 }
 void WMCreateResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36598,11 +36685,11 @@ void swap(WMCreateResourcePlanResponse &a, WMCreateResourcePlanResponse &b) {
   (void) b;
 }
 
-WMCreateResourcePlanResponse::WMCreateResourcePlanResponse(const WMCreateResourcePlanResponse& other1326) {
-  (void) other1326;
+WMCreateResourcePlanResponse::WMCreateResourcePlanResponse(const WMCreateResourcePlanResponse& other1333) {
+  (void) other1333;
 }
-WMCreateResourcePlanResponse& WMCreateResourcePlanResponse::operator=(const WMCreateResourcePlanResponse& other1327) {
-  (void) other1327;
+WMCreateResourcePlanResponse& WMCreateResourcePlanResponse::operator=(const WMCreateResourcePlanResponse& other1334) {
+  (void) other1334;
   return *this;
 }
 void WMCreateResourcePlanResponse::printTo(std::ostream& out) const {
@@ -36689,13 +36776,13 @@ void swap(WMGetActiveResourcePlanRequest &a, WMGetActiveResourcePlanRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMGetActiveResourcePlanRequest::WMGetActiveResourcePlanRequest(const WMGetActiveResourcePlanRequest& other1328) {
-  ns = other1328.ns;
-  __isset = other1328.__isset;
+WMGetActiveResourcePlanRequest::WMGetActiveResourcePlanRequest(const WMGetActiveResourcePlanRequest& other1335) {
+  ns = other1335.ns;
+  __isset = other1335.__isset;
 }
-WMGetActiveResourcePlanRequest& WMGetActiveResourcePlanRequest::operator=(const WMGetActiveResourcePlanRequest& other1329) {
-  ns = other1329.ns;
-  __isset = other1329.__isset;
+WMGetActiveResourcePlanRequest& WMGetActiveResourcePlanRequest::operator=(const WMGetActiveResourcePlanRequest& other1336) {
+  ns = other1336.ns;
+  __isset = other1336.__isset;
   return *this;
 }
 void WMGetActiveResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36783,13 +36870,13 @@ void swap(WMGetActiveResourcePlanResponse &a, WMGetActiveResourcePlanResponse &b
   swap(a.__isset, b.__isset);
 }
 
-WMGetActiveResourcePlanResponse::WMGetActiveResourcePlanResponse(const WMGetActiveResourcePlanResponse& other1330) {
-  resourcePlan = other1330.resourcePlan;
-  __isset = other1330.__isset;
+WMGetActiveResourcePlanResponse::WMGetActiveResourcePlanResponse(const WMGetActiveResourcePlanResponse& other1337) {
+  resourcePlan = other1337.resourcePlan;
+  __isset = other1337.__isset;
 }
-WMGetActiveResourcePlanResponse& WMGetActiveResourcePlanResponse::operator=(const WMGetActiveResourcePlanResponse& other1331) {
-  resourcePlan = other1331.resourcePlan;
-  __isset = other1331.__isset;
+WMGetActiveResourcePlanResponse& WMGetActiveResourcePlanResponse::operator=(const WMGetActiveResourcePlanResponse& other1338) {
+  resourcePlan = other1338.resourcePlan;
+  __isset = other1338.__isset;
   return *this;
 }
 void WMGetActiveResourcePlanResponse::printTo(std::ostream& out) const {
@@ -36896,15 +36983,15 @@ void swap(WMGetResourcePlanRequest &a, WMGetResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetResourcePlanRequest::WMGetResourcePlanRequest(const WMGetResourcePlanRequest& other1332) {
-  resourcePlanName = other1332.resourcePlanName;
-  ns = other1332.ns;
-  __isset = other1332.__isset;
+WMGetResourcePlanRequest::WMGetResourcePlanRequest(const WMGetResourcePlanRequest& other1339) {
+  resourcePlanName = other1339.resourcePlanName;
+  ns = other1339.ns;
+  __isset = other1339.__isset;
 }
-WMGetResourcePlanRequest& WMGetResourcePlanRequest::operator=(const WMGetResourcePlanRequest& other1333) {
-  resourcePlanName = other1333.resourcePlanName;
-  ns = other1333.ns;
-  __isset = other1333.__isset;
+WMGetResourcePlanRequest& WMGetResourcePlanRequest::operator=(const WMGetResourcePlanRequest& other1340) {
+  resourcePlanName = other1340.resourcePlanName;
+  ns = other1340.ns;
+  __isset = other1340.__isset;
   return *this;
 }
 void WMGetResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36993,13 +37080,13 @@ void swap(WMGetResourcePlanResponse &a, WMGetResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetResourcePlanResponse::WMGetResourcePlanResponse(const WMGetResourcePlanResponse& other1334) {
-  resourcePlan = other1334.resourcePlan;
-  __isset = other1334.__isset;
+WMGetResourcePlanResponse::WMGetResourcePlanResponse(const WMGetResourcePlanResponse& other1341) {
+  resourcePlan = other1341.resourcePlan;
+  __isset = other1341.__isset;
 }
-WMGetResourcePlanResponse& WMGetResourcePlanResponse::operator=(const WMGetResourcePlanResponse& other1335) {
-  resourcePlan = other1335.resourcePlan;
-  __isset = other1335.__isset;
+WMGetResourcePlanResponse& WMGetResourcePlanResponse::operator=(const WMGetResourcePlanResponse& other1342) {
+  resourcePlan = other1342.resourcePlan;
+  __isset = other1342.__isset;
   return *this;
 }
 void WMGetResourcePlanResponse::printTo(std::ostream& out) const {
@@ -37087,13 +37174,13 @@ void swap(WMGetAllResourcePlanRequest &a, WMGetAllResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetAllResourcePlanRequest::WMGetAllResourcePlanRequest(const WMGetAllResourcePlanRequest& other1336) {
-  ns = other1336.ns;
-  __isset = other1336.__isset;
+WMGetAllResourcePlanRequest::WMGetAllResourcePlanRequest(const WMGetAllResourcePlanRequest& other1343) {
+  ns = other1343.ns;
+  __isset = other1343.__isset;
 }
-WMGetAllResourcePlanRequest& WMGetAllResourcePlanRequest::operator=(const WMGetAllResourcePlanRequest& other1337) {
-  ns = other1337.ns;
-  __isset = other1337.__isset;
+WMGetAllResourcePlanRequest& WMGetAllResourcePlanRequest::operator=(const WMGetAllResourcePlanRequest& other1344) {
+  ns = other1344.ns;
+  __isset = other1344.__isset;
   return *this;
 }
 void WMGetAllResourcePlanRequest::printTo(std::ostream& out) const {
@@ -37144,14 +37231,14 @@ uint32_t WMGetAllResourcePlanResponse::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->resourcePlans.clear();
-            uint32_t _size1338;
-            ::apache::thrift::protocol::TType _etype1341;
-            xfer += iprot->readListBegin(_etype1341, _size1338);
-            this->resourcePlans.resize(_size1338);
-            uint32_t _i1342;
-            for (_i1342 = 0; _i1342 < _size1338; ++_i1342)
+            uint32_t _size1345;
+            ::apache::thrift::protocol::TType _etype1348;
+            xfer += iprot->readListBegin(_etype1348, _size1345);
+            this->resourcePlans.resize(_size1345);
+            uint32_t _i1349;
+            for (_i1349 = 0; _i1349 < _size1345; ++_i1349)
             {
-              xfer += this->resourcePlans[_i1342].read(iprot);
+              xfer += this->resourcePlans[_i1349].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -37181,10 +37268,10 @@ uint32_t WMGetAllResourcePlanResponse::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("resourcePlans", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->resourcePlans.size()));
-      std::vector<WMResourcePlan> ::const_iterator _iter1343;
-      for (_iter1343 = this->resourcePlans.begin(); _iter1343 != this->resourcePlans.end(); ++_iter1343)
+      std::vector<WMResourcePlan> ::const_iterator _iter1350;
+      for (_iter1350 = this->resourcePlans.begin(); _iter1350 != this->resourcePlans.end(); ++_iter1350)
       {
-        xfer += (*_iter1343).write(oprot);
+        xfer += (*_iter1350).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -37201,13 +37288,13 @@ void swap(WMGetAllResourcePlanResponse &a, WMGetAllResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetAllResourcePlanResponse::WMGetAllResourcePlanResponse(const WMGetAllResourcePlanResponse& other1344) {
-  resourcePlans = other1344.resourcePlans;
-  __isset = other1344.__isset;
+WMGetAllResourcePlanResponse::WMGetAllResourcePlanResponse(const WMGetAllResourcePlanResponse& other1351) {
+  resourcePlans = other1351.resourcePlans;
+  __isset = other1351.__isset;
 }
-WMGetAllResourcePlanResponse& WMGetAllResourcePlanResponse::operator=(const WMGetAllResourcePlanResponse& other1345) {
-  resourcePlans = other1345.resourcePlans;
-  __isset = other1345.__isset;
+WMGetAllResourcePlanResponse& WMGetAllResourcePlanResponse::operator=(const WMGetAllResourcePlanResponse& other1352) {
+  resourcePlans = other1352.resourcePlans;
+  __isset = other1352.__isset;
   return *this;
 }
 void WMGetAllResourcePlanResponse::printTo(std::ostream& out) const {
@@ -37390,23 +37477,23 @@ void swap(WMAlterResourcePlanRequest &a, WMAlterResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterResourcePlanRequest::WMAlterResourcePlanRequest(const WMAlterResourcePlanRequest& other1346) {
-  resourcePlanName = other1346.resourcePlanName;
-  resourcePlan = other1346.resourcePlan;
-  isEnableAndActivate = other1346.isEnableAndActivate;
-  isForceDeactivate = other1346.isForceDeactivate;
-  isReplace = other1346.isReplace;
-  ns = other1346.ns;
-  __isset = other1346.__isset;
+WMAlterResourcePlanRequest::WMAlterResourcePlanRequest(const WMAlterResourcePlanRequest& other1353) {
+  resourcePlanName = other1353.resourcePlanName;
+  resourcePlan = other1353.resourcePlan;
+  isEnableAndActivate = other1353.isEnableAndActivate;
+  isForceDeactivate = other1353.isForceDeactivate;
+  isReplace = other1353.isReplace;
+  ns = other1353.ns;
+  __isset = other1353.__isset;
 }
-WMAlterResourcePlanRequest& WMAlterResourcePlanRequest::operator=(const WMAlterResourcePlanRequest& other1347) {
-  resourcePlanName = other1347.resourcePlanName;
-  resourcePlan = other1347.resourcePlan;
-  isEnableAndActivate = other1347.isEnableAndActivate;
-  isForceDeactivate = other1347.isForceDeactivate;
-  isReplace = other1347.isReplace;
-  ns = other1347.ns;
-  __isset = other1347.__isset;
+WMAlterResourcePlanRequest& WMAlterResourcePlanRequest::operator=(const WMAlterResourcePlanRequest& other1354) {
+  resourcePlanName = other1354.resourcePlanName;
+  resourcePlan = other1354.resourcePlan;
+  isEnableAndActivate = other1354.isEnableAndActivate;
+  isForceDeactivate = other1354.isForceDeactivate;
+  isReplace = other1354.isReplace;
+  ns = other1354.ns;
+  __isset = other1354.__isset;
   return *this;
 }
 void WMAlterResourcePlanRequest::printTo(std::ostream& out) const {
@@ -37499,13 +37586,13 @@ void swap(WMAlterResourcePlanResponse &a, WMAlterResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterResourcePlanResponse::WMAlterResourcePlanResponse(const WMAlterResourcePlanResponse& other1348) {
-  fullResourcePlan = other1348.fullResourcePlan;
-  __isset = other1348.__isset;
+WMAlterResourcePlanResponse::WMAlterResourcePlanResponse(const WMAlterResourcePlanResponse& other1355) {
+  fullResourcePlan = other1355.fullResourcePlan;
+  __isset = other1355.__isset;
 }
-WMAlterResourcePlanResponse& WMAlterResourcePlanResponse::operator=(const WMAlterResourcePlanResponse& other1349) {
-  fullResourcePlan = other1349.fullResourcePlan;
-  __isset = other1349.__isset;
+WMAlterResourcePlanResponse& WMAlterResourcePlanResponse::operator=(const WMAlterResourcePlanResponse& other1356) {
+  fullResourcePlan = other1356.fullResourcePlan;
+  __isset = other1356.__isset;
   return *this;
 }
 void WMAlterResourcePlanResponse::printTo(std::ostream& out) const {
@@ -37612,15 +37699,15 @@ void swap(WMValidateResourcePlanRequest &a, WMValidateResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMValidateResourcePlanRequest::WMValidateResourcePlanRequest(const WMValidateResourcePlanRequest& other1350) {
-  resourcePlanName = other1350.resourcePlanName;
-  ns = other1350.ns;
-  __isset = other1350.__isset;
+WMValidateResourcePlanRequest::WMValidateResourcePlanRequest(const WMValidateResourcePlanRequest& other1357) {
+  resourcePlanName = other1357.resourcePlanName;
+  ns = other1357.ns;
+  __isset = other1357.__isset;
 }
-WMValidateResourcePlanRequest& WMValidateResourcePlanRequest::operator=(const WMValidateResourcePlanRequest& other1351) {
-  resourcePlanName = other1351.resourcePlanName;
-  ns = other1351.ns;
-  __isset = other1351.__isset;
+WMValidateResourcePlanRequest& WMValidateResourcePlanRequest::operator=(const WMValidateResourcePlanRequest& other1358) {
+  resourcePlanName = other1358.resourcePlanName;
+  ns = other1358.ns;
+  __isset = other1358.__isset;
   return *this;
 }
 void WMValidateResourcePlanRequest::printTo(std::ostream& out) const {
@@ -37677,14 +37764,14 @@ uint32_t WMValidateResourcePlanResponse::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->errors.clear();
-            uint32_t _size1352;
-            ::apache::thrift::protocol::TType _etype1355;
-            xfer += iprot->readListBegin(_etype1355, _size1352);
-            this->errors.resize(_size1352);
-            uint32_t _i1356;
-            for (_i1356 = 0; _i1356 < _size1352; ++_i1356)
+            uint32_t _size1359;
+            ::apache::thrift::protocol::TType _etype1362;
+            xfer += iprot->readListBegin(_etype1362, _size1359);
+            this->errors.resize(_size1359);
+            uint32_t _i1363;
+            for (_i1363 = 0; _i1363 < _size1359; ++_i1363)
             {
-              xfer += iprot->readString(this->errors[_i1356]);
+              xfer += iprot->readString(this->errors[_i1363]);
             }
             xfer += iprot->readListEnd();
           }
@@ -37697,14 +37784,14 @@ uint32_t WMValidateResourcePlanResponse::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->warnings.clear();
-            uint32_t _size1357;
-            ::apache::thrift::protocol::TType _etype1360;
-            xfer += iprot->readListBegin(_etype1360, _size1357);
-            this->warnings.resize(_size1357);
-            uint32_t _i1361;
-            for (_i1361 = 0; _i1361 < _size1357; ++_i1361)
+            uint32_t _size1364;
+            ::apache::thrift::protocol::TType _etype1367;
+            xfer += iprot->readListBegin(_etype1367, _size1364);
+            this->warnings.resize(_size1364);
+            uint32_t _i1368;
+            for (_i1368 = 0; _i1368 < _size1364; ++_i1368)
             {
-              xfer += iprot->readString(this->warnings[_i1361]);
+              xfer += iprot->readString(this->warnings[_i1368]);
             }
             xfer += iprot->readListEnd();
           }
@@ -37734,10 +37821,10 @@ uint32_t WMValidateResourcePlanResponse::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("errors", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->errors.size()));
-      std::vector<std::string> ::const_iterator _iter1362;
-      for (_iter1362 = this->errors.begin(); _iter1362 != this->errors.end(); ++_iter1362)
+      std::vector<std::string> ::const_iterator _iter1369;
+      for (_iter1369 = this->errors.begin(); _iter1369 != this->errors.end(); ++_iter1369)
       {
-        xfer += oprot->writeString((*_iter1362));
+        xfer += oprot->writeString((*_iter1369));
       }
       xfer += oprot->writeListEnd();
     }
@@ -37747,10 +37834,10 @@ uint32_t WMValidateResourcePlanResponse::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("warnings", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->warnings.size()));
-      std::vector<std::string> ::const_iterator _iter1363;
-      for (_iter1363 = this->warnings.begin(); _iter1363 != this->warnings.end(); ++_iter1363)
+      std::vector<std::string> ::const_iterator _iter1370;
+      for (_iter1370 = this->warnings.begin(); _iter1370 != this->warnings.end(); ++_iter1370)
       {
-        xfer += oprot->writeString((*_iter1363));
+        xfer += oprot->writeString((*_iter1370));
       }
       xfer += oprot->writeListEnd();
     }
@@ -37768,15 +37855,15 @@ void swap(WMValidateResourcePlanResponse &a, WMValidateResourcePlanResponse &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMValidateResourcePlanResponse::WMValidateResourcePlanResponse(const WMValidateResourcePlanResponse& other1364) {
-  errors = other1364.errors;
-  warnings = other1364.warnings;
-  __isset = other1364.__isset;
+WMValidateResourcePlanResponse::WMValidateResourcePlanResponse(const WMValidateResourcePlanResponse& other1371) {
+  errors = other1371.errors;
+  warnings = other1371.warnings;
+  __isset = other1371.__isset;
 }
-WMValidateResourcePlanResponse& WMValidateResourcePlanResponse::operator=(const WMValidateResourcePlanResponse& other1365) {
-  errors = other1365.errors;
-  warnings = other1365.warnings;
-  __isset = other1365.__isset;
+WMValidateResourcePlanResponse& WMValidateResourcePlanResponse::operator=(const WMValidateResourcePlanResponse& other1372) {
+  errors = other1372.errors;
+  warnings = other1372.warnings;
+  __isset = other1372.__isset;
   return *this;
 }
 void WMValidateResourcePlanResponse::printTo(std::ostream& out) const {
@@ -37884,15 +37971,15 @@ void swap(WMDropResourcePlanRequest &a, WMDropResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropResourcePlanRequest::WMDropResourcePlanRequest(const WMDropResourcePlanRequest& other1366) {
-  resourcePlanName = other1366.resourcePlanName;
-  ns = other1366.ns;
-  __isset = other1366.__isset;
+WMDropResourcePlanRequest::WMDropResourcePlanRequest(const WMDropResourcePlanRequest& other1373) {
+  resourcePlanName = other1373.resourcePlanName;
+  ns = other1373.ns;
+  __isset = other1373.__isset;
 }
-WMDropResourcePlanRequest& WMDropResourcePlanRequest::operator=(const WMDropResourcePlanRequest& other1367) {
-  resourcePlanName = other1367.resourcePlanName;
-  ns = other1367.ns;
-  __isset = other1367.__isset;
+WMDropResourcePlanRequest& WMDropResourcePlanRequest::operator=(const WMDropResourcePlanRequest& other1374) {
+  resourcePlanName = other1374.resourcePlanName;
+  ns = other1374.ns;
+  __isset = other1374.__isset;
   return *this;
 }
 void WMDropResourcePlanRequest::printTo(std::ostream& out) const {
@@ -37958,11 +38045,11 @@ void swap(WMDropResourcePlanResponse &a, WMDropResourcePlanResponse &b) {
   (void) b;
 }
 
-WMDropResourcePlanResponse::WMDropResourcePlanResponse(const WMDropResourcePlanResponse& other1368) {
-  (void) other1368;
+WMDropResourcePlanResponse::WMDropResourcePlanResponse(const WMDropResourcePlanResponse& other1375) {
+  (void) other1375;
 }
-WMDropResourcePlanResponse& WMDropResourcePlanResponse::operator=(const WMDropResourcePlanResponse& other1369) {
-  (void) other1369;
+WMDropResourcePlanResponse& WMDropResourcePlanResponse::operator=(const WMDropResourcePlanResponse& other1376) {
+  (void) other1376;
   return *this;
 }
 void WMDropResourcePlanResponse::printTo(std::ostream& out) const {
@@ -38049,13 +38136,13 @@ void swap(WMCreateTriggerRequest &a, WMCreateTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreateTriggerRequest::WMCreateTriggerRequest(const WMCreateTriggerRequest& other1370) {
-  trigger = other1370.trigger;
-  __isset = other1370.__isset;
+WMCreateTriggerRequest::WMCreateTriggerRequest(const WMCreateTriggerRequest& other1377) {
+  trigger = other1377.trigger;
+  __isset = other1377.__isset;
 }
-WMCreateTriggerRequest& WMCreateTriggerRequest::operator=(const WMCreateTriggerRequest& other1371) {
-  trigger = other1371.trigger;
-  __isset = other1371.__isset;
+WMCreateTriggerRequest& WMCreateTriggerRequest::operator=(const WMCreateTriggerRequest& other1378) {
+  trigger = other1378.trigger;
+  __isset = other1378.__isset;
   return *this;
 }
 void WMCreateTriggerRequest::printTo(std::ostream& out) const {
@@ -38120,11 +38207,11 @@ void swap(WMCreateTriggerResponse &a, WMCreateTriggerResponse &b) {
   (void) b;
 }
 
-WMCreateTriggerResponse::WMCreateTriggerResponse(const WMCreateTriggerResponse& other1372) {
-  (void) other1372;
+WMCreateTriggerResponse::WMCreateTriggerResponse(const WMCreateTriggerResponse& other1379) {
+  (void) other1379;
 }
-WMCreateTriggerResponse& WMCreateTriggerResponse::operator=(const WMCreateTriggerResponse& other1373) {
-  (void) other1373;
+WMCreateTriggerResponse& WMCreateTriggerResponse::operator=(const WMCreateTriggerResponse& other1380) {
+  (void) other1380;
   return *this;
 }
 void WMCreateTriggerResponse::printTo(std::ostream& out) const {
@@ -38211,13 +38298,13 @@ void swap(WMAlterTriggerRequest &a, WMAlterTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterTriggerRequest::WMAlterTriggerRequest(const WMAlterTriggerRequest& other1374) {
-  trigger = other1374.trigger;
-  __isset = other1374.__isset;
+WMAlterTriggerRequest::WMAlterTriggerRequest(const WMAlterTriggerRequest& other1381) {
+  trigger = other1381.trigger;
+  __isset = other1381.__isset;
 }
-WMAlterTriggerRequest& WMAlterTriggerRequest::operator=(const WMAlterTriggerRequest& other1375) {
-  trigger = other1375.trigger;
-  __isset = other1375.__isset;
+WMAlterTriggerRequest& WMAlterTriggerRequest::operator=(const WMAlterTriggerRequest& other1382) {
+  trigger = other1382.trigger;
+  __isset = other1382.__isset;
   return *this;
 }
 void WMAlterTriggerRequest::printTo(std::ostream& out) const {
@@ -38282,11 +38369,11 @@ void swap(WMAlterTriggerResponse &a, WMAlterTriggerResponse &b) {
   (void) b;
 }
 
-WMAlterTriggerResponse::WMAlterTriggerResponse(const WMAlterTriggerResponse& other1376) {
-  (void) other1376;
+WMAlterTriggerResponse::WMAlterTriggerResponse(const WMAlterTriggerResponse& other1383) {
+  (void) other1383;
 }
-WMAlterTriggerResponse& WMAlterTriggerResponse::operator=(const WMAlterTriggerResponse& other1377) {
-  (void) other1377;
+WMAlterTriggerResponse& WMAlterTriggerResponse::operator=(const WMAlterTriggerResponse& other1384) {
+  (void) other1384;
   return *this;
 }
 void WMAlterTriggerResponse::printTo(std::ostream& out) const {
@@ -38411,17 +38498,17 @@ void swap(WMDropTriggerRequest &a, WMDropTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropTriggerRequest::WMDropTriggerRequest(const WMDropTriggerRequest& other1378) {
-  resourcePlanName = other1378.resourcePlanName;
-  triggerName = other1378.triggerName;
-  ns = other1378.ns;
-  __isset = other1378.__isset;
+WMDropTriggerRequest::WMDropTriggerRequest(const WMDropTriggerRequest& other1385) {
+  resourcePlanName = other1385.resourcePlanName;
+  triggerName = other1385.triggerName;
+  ns = other1385.ns;
+  __isset = other1385.__isset;
 }
-WMDropTriggerRequest& WMDropTriggerRequest::operator=(const WMDropTriggerRequest& other1379) {
-  resourcePlanName = other1379.resourcePlanName;
-  triggerName = other1379.triggerName;
-  ns = other1379.ns;
-  __isset = other1379.__isset;
+WMDropTriggerRequest& WMDropTriggerRequest::operator=(const WMDropTriggerRequest& other1386) {
+  resourcePlanName = other1386.resourcePlanName;
+  triggerName = other1386.triggerName;
+  ns = other1386.ns;
+  __isset = other1386.__isset;
   return *this;
 }
 void WMDropTriggerRequest::printTo(std::ostream& out) const {
@@ -38488,11 +38575,11 @@ void swap(WMDropTriggerResponse &a, WMDropTriggerResponse &b) {
   (void) b;
 }
 
-WMDropTriggerResponse::WMDropTriggerResponse(const WMDropTriggerResponse& other1380) {
-  (void) other1380;
+WMDropTriggerResponse::WMDropTriggerResponse(const WMDropTriggerResponse& other1387) {
+  (void) other1387;
 }
-WMDropTriggerResponse& WMDropTriggerResponse::operator=(const WMDropTriggerResponse& other1381) {
-  (void) other1381;
+WMDropTriggerResponse& WMDropTriggerResponse::operator=(const WMDropTriggerResponse& other1388) {
+  (void) other1388;
   return *this;
 }
 void WMDropTriggerResponse::printTo(std::ostream& out) const {
@@ -38598,15 +38685,15 @@ void swap(WMGetTriggersForResourePlanRequest &a, WMGetTriggersForResourePlanRequ
   swap(a.__isset, b.__isset);
 }
 
-WMGetTriggersForResourePlanRequest::WMGetTriggersForResourePlanRequest(const WMGetTriggersForResourePlanRequest& other1382) {
-  resourcePlanName = other1382.resourcePlanName;
-  ns = other1382.ns;
-  __isset = other1382.__isset;
+WMGetTriggersForResourePlanRequest::WMGetTriggersForResourePlanRequest(const WMGetTriggersForResourePlanRequest& other1389) {
+  resourcePlanName = other1389.resourcePlanName;
+  ns = other1389.ns;
+  __isset = other1389.__isset;
 }
-WMGetTriggersForResourePlanRequest& WMGetTriggersForResourePlanRequest::operator=(const WMGetTriggersForResourePlanRequest& other1383) {
-  resourcePlanName = other1383.resourcePlanName;
-  ns = other1383.ns;
-  __isset = other1383.__isset;
+WMGetTriggersForResourePlanRequest& WMGetTriggersForResourePlanRequest::operator=(const WMGetTriggersForResourePlanRequest& other1390) {
+  resourcePlanName = other1390.resourcePlanName;
+  ns = other1390.ns;
+  __isset = other1390.__isset;
   return *this;
 }
 void WMGetTriggersForResourePlanRequest::printTo(std::ostream& out) const {
@@ -38658,14 +38745,14 @@ uint32_t WMGetTriggersForResourePlanResponse::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->triggers.clear();
-            uint32_t _size1384;
-            ::apache::thrift::protocol::TType _etype1387;
-            xfer += iprot->readListBegin(_etype1387, _size1384);
-            this->triggers.resize(_size1384);
-            uint32_t _i1388;
-            for (_i1388 = 0; _i1388 < _size1384; ++_i1388)
+            uint32_t _size1391;
+            ::apache::thrift::protocol::TType _etype1394;
+            xfer += iprot->readListBegin(_etype1394, _size1391);
+            this->triggers.resize(_size1391);
+            uint32_t _i1395;
+            for (_i1395 = 0; _i1395 < _size1391; ++_i1395)
             {
-              xfer += this->triggers[_i1388].read(iprot);
+              xfer += this->triggers[_i1395].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -38695,10 +38782,10 @@ uint32_t WMGetTriggersForResourePlanResponse::write(::apache::thrift::protocol::
     xfer += oprot->writeFieldBegin("triggers", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->triggers.size()));
-      std::vector<WMTrigger> ::const_iterator _iter1389;
-      for (_iter1389 = this->triggers.begin(); _iter1389 != this->triggers.end(); ++_iter1389)
+      std::vector<WMTrigger> ::const_iterator _iter1396;
+      for (_iter1396 = this->triggers.begin(); _iter1396 != this->triggers.end(); ++_iter1396)
       {
-        xfer += (*_iter1389).write(oprot);
+        xfer += (*_iter1396).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -38715,13 +38802,13 @@ void swap(WMGetTriggersForResourePlanResponse &a, WMGetTriggersForResourePlanRes
   swap(a.__isset, b.__isset);
 }
 
-WMGetTriggersForResourePlanResponse::WMGetTriggersForResourePlanResponse(const WMGetTriggersForResourePlanResponse& other1390) {
-  triggers = other1390.triggers;
-  __isset = other1390.__isset;
+WMGetTriggersForResourePlanResponse::WMGetTriggersForResourePlanResponse(const WMGetTriggersForResourePlanResponse& other1397) {
+  triggers = other1397.triggers;
+  __isset = other1397.__isset;
 }
-WMGetTriggersForResourePlanResponse& WMGetTriggersForResourePlanResponse::operator=(const WMGetTriggersForResourePlanResponse& other1391) {
-  triggers = other1391.triggers;
-  __isset = other1391.__isset;
+WMGetTriggersForResourePlanResponse& WMGetTriggersForResourePlanResponse::operator=(const WMGetTriggersForResourePlanResponse& other1398) {
+  triggers = other1398.triggers;
+  __isset = other1398.__isset;
   return *this;
 }
 void WMGetTriggersForResourePlanResponse::printTo(std::ostream& out) const {
@@ -38809,13 +38896,13 @@ void swap(WMCreatePoolRequest &a, WMCreatePoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreatePoolRequest::WMCreatePoolRequest(const WMCreatePoolRequest& other1392) {
-  pool = other1392.pool;
-  __isset = other1392.__isset;
+WMCreatePoolRequest::WMCreatePoolRequest(const WMCreatePoolRequest& other1399) {
+  pool = other1399.pool;
+  __isset = other1399.__isset;
 }
-WMCreatePoolRequest& WMCreatePoolRequest::operator=(const WMCreatePoolRequest& other1393) {
-  pool = other1393.pool;
-  __isset = other1393.__isset;
+WMCreatePoolRequest& WMCreatePoolRequest::operator=(const WMCreatePoolRequest& other1400) {
+  pool = other1400.pool;
+  __isset = other1400.__isset;
   return *this;
 }
 void WMCreatePoolRequest::printTo(std::ostream& out) const {
@@ -38880,11 +38967,11 @@ void swap(WMCreatePoolResponse &a, WMCreatePoolResponse &b) {
   (void) b;
 }
 
-WMCreatePoolResponse::WMCreatePoolResponse(const WMCreatePoolResponse& other1394) {
-  (void) other1394;
+WMCreatePoolResponse::WMCreatePoolResponse(const WMCreatePoolResponse& other1401) {
+  (void) other1401;
 }
-WMCreatePoolResponse& WMCreatePoolResponse::operator=(const WMCreatePoolResponse& other1395) {
-  (void) other1395;
+WMCreatePoolResponse& WMCreatePoolResponse::operator=(const WMCreatePoolResponse& other1402) {
+  (void) other1402;
   return *this;
 }
 void WMCreatePoolResponse::printTo(std::ostream& out) const {
@@ -38990,15 +39077,15 @@ void swap(WMAlterPoolRequest &a, WMAlterPoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterPoolRequest::WMAlterPoolRequest(const WMAlterPoolRequest& other1396) {
-  pool = other1396.pool;
-  poolPath = other1396.poolPath;
-  __isset = other1396.__isset;
+WMAlterPoolRequest::WMAlterPoolRequest(const WMAlterPoolRequest& other1403) {
+  pool = other1403.pool;
+  poolPath = other1403.poolPath;
+  __isset = other1403.__isset;
 }
-WMAlterPoolRequest& WMAlterPoolRequest::operator=(const WMAlterPoolRequest& other1397) {
-  pool = other1397.pool;
-  poolPath = other1397.poolPath;
-  __isset = other1397.__isset;
+WMAlterPoolRequest& WMAlterPoolRequest::operator=(const WMAlterPoolRequest& other1404) {
+  pool = other1404.pool;
+  poolPath = other1404.poolPath;
+  __isset = other1404.__isset;
   return *this;
 }
 void WMAlterPoolRequest::printTo(std::ostream& out) const {
@@ -39064,11 +39151,11 @@ void swap(WMAlterPoolResponse &a, WMAlterPoolResponse &b) {
   (void) b;
 }
 
-WMAlterPoolResponse::WMAlterPoolResponse(const WMAlterPoolResponse& other1398) {
-  (void) other1398;
+WMAlterPoolResponse::WMAlterPoolResponse(const WMAlterPoolResponse& other1405) {
+  (void) other1405;
 }
-WMAlterPoolResponse& WMAlterPoolResponse::operator=(const WMAlterPoolResponse& other1399) {
-  (void) other1399;
+WMAlterPoolResponse& WMAlterPoolResponse::operator=(const WMAlterPoolResponse& other1406) {
+  (void) other1406;
   return *this;
 }
 void WMAlterPoolResponse::printTo(std::ostream& out) const {
@@ -39193,17 +39280,17 @@ void swap(WMDropPoolRequest &a, WMDropPoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropPoolRequest::WMDropPoolRequest(const WMDropPoolRequest& other1400) {
-  resourcePlanName = other1400.resourcePlanName;
-  poolPath = other1400.poolPath;
-  ns = other1400.ns;
-  __isset = other1400.__isset;
+WMDropPoolRequest::WMDropPoolRequest(const WMDropPoolRequest& other1407) {
+  resourcePlanName = other1407.resourcePlanName;
+  poolPath = other1407.poolPath;
+  ns = other1407.ns;
+  __isset = other1407.__isset;
 }
-WMDropPoolRequest& WMDropPoolRequest::operator=(const WMDropPoolRequest& other1401) {
-  resourcePlanName = other1401.resourcePlanName;
-  poolPath = other1401.poolPath;
-  ns = other1401.ns;
-  __isset = other1401.__isset;
+WMDropPoolRequest& WMDropPoolRequest::operator=(const WMDropPoolRequest& other1408) {
+  resourcePlanName = other1408.resourcePlanName;
+  poolPath = other1408.poolPath;
+  ns = other1408.ns;
+  __isset = other1408.__isset;
   return *this;
 }
 void WMDropPoolRequest::printTo(std::ostream& out) const {
@@ -39270,11 +39357,11 @@ void swap(WMDropPoolResponse &a, WMDropPoolResponse &b) {
   (void) b;
 }
 
-WMDropPoolResponse::WMDropPoolResponse(const WMDropPoolResponse& other1402) {
-  (void) other1402;
+WMDropPoolResponse::WMDropPoolResponse(const WMDropPoolResponse& other1409) {
+  (void) other1409;
 }
-WMDropPoolResponse& WMDropPoolResponse::operator=(const WMDropPoolResponse& other1403) {
-  (void) other1403;
+WMDropPoolResponse& WMDropPoolResponse::operator=(const WMDropPoolResponse& other1410) {
+  (void) other1410;
   return *this;
 }
 void WMDropPoolResponse::printTo(std::ostream& out) const {
@@ -39380,15 +39467,15 @@ void swap(WMCreateOrUpdateMappingRequest &a, WMCreateOrUpdateMappingRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMCreateOrUpdateMappingRequest::WMCreateOrUpdateMappingRequest(const WMCreateOrUpdateMappingRequest& other1404) {
-  mapping = other1404.mapping;
-  update = other1404.update;
-  __isset = other1404.__isset;
+WMCreateOrUpdateMappingRequest::WMCreateOrUpdateMappingRequest(const WMCreateOrUpdateMappingRequest& other1411) {
+  mapping = other1411.mapping;
+  update = other1411.update;
+  __isset = other1411.__isset;
 }
-WMCreateOrUpdateMappingRequest& WMCreateOrUpdateMappingRequest::operator=(const WMCreateOrUpdateMappingRequest& other1405) {
-  mapping = other1405.mapping;
-  update = other1405.update;
-  __isset = other1405.__isset;
+WMCreateOrUpdateMappingRequest& WMCreateOrUpdateMappingRequest::operator=(const WMCreateOrUpdateMappingRequest& other1412) {
+  mapping = other1412.mapping;
+  update = other1412.update;
+  __isset = other1412.__isset;
   return *this;
 }
 void WMCreateOrUpdateMappingRequest::printTo(std::ostream& out) const {
@@ -39454,11 +39541,11 @@ void swap(WMCreateOrUpdateMappingResponse &a, WMCreateOrUpdateMappingResponse &b
   (void) b;
 }
 
-WMCreateOrUpdateMappingResponse::WMCreateOrUpdateMappingResponse(const WMCreateOrUpdateMappingResponse& other1406) {
-  (void) other1406;
+WMCreateOrUpdateMappingResponse::WMCreateOrUpdateMappingResponse(const WMCreateOrUpdateMappingResponse& other1413) {
+  (void) other1413;
 }
-WMCreateOrUpdateMappingResponse& WMCreateOrUpdateMappingResponse::operator=(const WMCreateOrUpdateMappingResponse& other1407) {
-  (void) other1407;
+WMCreateOrUpdateMappingResponse& WMCreateOrUpdateMappingResponse::operator=(const WMCreateOrUpdateMappingResponse& other1414) {
+  (void) other1414;
   return *this;
 }
 void WMCreateOrUpdateMappingResponse::printTo(std::ostream& out) const {
@@ -39545,13 +39632,13 @@ void swap(WMDropMappingRequest &a, WMDropMappingRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropMappingRequest::WMDropMappingRequest(const WMDropMappingRequest& other1408) {
-  mapping = other1408.mapping;
-  __isset = other1408.__isset;
+WMDropMappingRequest::WMDropMappingRequest(const WMDropMappingRequest& other1415) {
+  mapping = other1415.mapping;
+  __isset = other1415.__isset;
 }
-WMDropMappingRequest& WMDropMappingRequest::operator=(const WMDropMappingRequest& other1409) {
-  mapping = other1409.mapping;
-  __isset = other1409.__isset;
+WMDropMappingRequest& WMDropMappingRequest::operator=(const WMDropMappingRequest& other1416) {
+  mapping = other1416.mapping;
+  __isset = other1416.__isset;
   return *this;
 }
 void WMDropMappingRequest::printTo(std::ostream& out) const {
@@ -39616,11 +39703,11 @@ void swap(WMDropMappingResponse &a, WMDropMappingResponse &b) {
   (void) b;
 }
 
-WMDropMappingResponse::WMDropMappingResponse(const WMDropMappingResponse& other1410) {
-  (void) other1410;
+WMDropMappingResponse::WMDropMappingResponse(const WMDropMappingResponse& other1417) {
+  (void) other1417;
 }
-WMDropMappingResponse& WMDropMappingResponse::operator=(const WMDropMappingResponse& other1411) {
-  (void) other1411;
+WMDropMappingResponse& WMDropMappingResponse::operator=(const WMDropMappingResponse& other1418) {
+  (void) other1418;
   return *this;
 }
 void WMDropMappingResponse::printTo(std::ostream& out) const {
@@ -39783,21 +39870,21 @@ void swap(WMCreateOrDropTriggerToPoolMappingRequest &a, WMCreateOrDropTriggerToP
   swap(a.__isset, b.__isset);
 }
 
-WMCreateOrDropTriggerToPoolMappingRequest::WMCreateOrDropTriggerToPoolMappingRequest(const WMCreateOrDropTriggerToPoolMappingRequest& other1412) {
-  resourcePlanName = other1412.resourcePlanName;
-  triggerName = other1412.triggerName;
-  poolPath = other1412.poolPath;
-  drop = other1412.drop;
-  ns = other1412.ns;
-  __isset = other1412.__isset;
+WMCreateOrDropTriggerToPoolMappingRequest::WMCreateOrDropTriggerToPoolMappingRequest(const WMCreateOrDropTriggerToPoolMappingRequest& other1419) {
+  resourcePlanName = other1419.resourcePlanName;
+  triggerName = other1419.triggerName;
+  poolPath = other1419.poolPath;
+  drop = other1419.drop;
+  ns = other1419.ns;
+  __isset = other1419.__isset;
 }
-WMCreateOrDropTriggerToPoolMappingRequest& WMCreateOrDropTriggerToPoolMappingRequest::operator=(const WMCreateOrDropTriggerToPoolMappingRequest& other1413) {
-  resourcePlanName = other1413.resourcePlanName;
-  triggerName = other1413.triggerName;
-  poolPath = other1413.poolPath;
-  drop = other1413.drop;
-  ns = other1413.ns;
-  __isset = other1413.__isset;
+WMCreateOrDropTriggerToPoolMappingRequest& WMCreateOrDropTriggerToPoolMappingRequest::operator=(const WMCreateOrDropTriggerToPoolMappingRequest& other1420) {
+  resourcePlanName = other1420.resourcePlanName;
+  triggerName = other1420.triggerName;
+  poolPath = other1420.poolPath;
+  drop = other1420.drop;
+  ns = other1420.ns;
+  __isset = other1420.__isset;
   return *this;
 }
 void WMCreateOrDropTriggerToPoolMappingRequest::printTo(std::ostream& out) const {
@@ -39866,11 +39953,11 @@ void swap(WMCreateOrDropTriggerToPoolMappingResponse &a, WMCreateOrDropTriggerTo
   (void) b;
 }
 
-WMCreateOrDropTriggerToPoolMappingResponse::WMCreateOrDropTriggerToPoolMappingResponse(const WMCreateOrDropTriggerToPoolMappingResponse& other1414) {
-  (void) other1414;
+WMCreateOrDropTriggerToPoolMappingResponse::WMCreateOrDropTriggerToPoolMappingResponse(const WMCreateOrDropTriggerToPoolMappingResponse& other1421) {
+  (void) other1421;
 }
-WMCreateOrDropTriggerToPoolMappingResponse& WMCreateOrDropTriggerToPoolMappingResponse::operator=(const WMCreateOrDropTriggerToPoolMappingResponse& other1415) {
-  (void) other1415;
+WMCreateOrDropTriggerToPoolMappingResponse& WMCreateOrDropTriggerToPoolMappingResponse::operator=(const WMCreateOrDropTriggerToPoolMappingResponse& other1422) {
+  (void) other1422;
   return *this;
 }
 void WMCreateOrDropTriggerToPoolMappingResponse::printTo(std::ostream& out) const {
@@ -39951,9 +40038,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1416;
-          xfer += iprot->readI32(ecast1416);
-          this->schemaType = (SchemaType::type)ecast1416;
+          int32_t ecast1423;
+          xfer += iprot->readI32(ecast1423);
+          this->schemaType = (SchemaType::type)ecast1423;
           this->__isset.schemaType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -39985,9 +40072,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1417;
-          xfer += iprot->readI32(ecast1417);
-          this->compatibility = (SchemaCompatibility::type)ecast1417;
+          int32_t ecast1424;
+          xfer += iprot->readI32(ecast1424);
+          this->compatibility = (SchemaCompatibility::type)ecast1424;
           this->__isset.compatibility = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -39995,9 +40082,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1418;
-          xfer += iprot->readI32(ecast1418);
-          this->validationLevel = (SchemaValidation::type)ecast1418;
+          int32_t ecast1425;
+          xfer += iprot->readI32(ecast1425);
+          this->validationLevel = (SchemaValidation::type)ecast1425;
           this->__isset.validationLevel = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -40101,29 +40188,29 @@ void swap(ISchema &a, ISchema &b) {
   swap(a.__isset, b.__isset);
 }
 
-ISchema::ISchema(const ISchema& other1419) {
-  schemaType = other1419.schemaType;
-  name = other1419.name;
-  catName = other1419.catName;
-  dbName = other1419.dbName;
-  compatibility = other1419.compatibility;
-  validationLevel = other1419.validationLevel;
-  canEvolve = other1419.canEvolve;
-  schemaGroup = other1419.schemaGroup;
-  description = other1419.description;
-  __isset = other1419.__isset;
+ISchema::ISchema(const ISchema& other1426) {
+  schemaType = other1426.schemaType;
+  name = other1426.name;
+  catName = other1426.catName;
+  dbName = other1426.dbName;
+  compatibility = other1426.compatibility;
+  validationLevel = other1426.validationLevel;
+  canEvolve = other1426.canEvolve;
+  schemaGroup = other1426.schemaGroup;
+  description = other1426.description;
+  __isset = other1426.__isset;
 }
-ISchema& ISchema::operator=(const ISchema& other1420) {
-  schemaType = other1420.schemaType;
-  name = other1420.name;
-  catName = other1420.catName;
-  dbName = other1420.dbName;
-  compatibility = other1420.compatibility;
-  validationLevel = other1420.validationLevel;
-  canEvolve = other1420.canEvolve;
-  schemaGroup = other1420.schemaGroup;
-  description = other1420.description;
-  __isset = other1420.__isset;
+ISchema& ISchema::operator=(const ISchema& other1427) {
+  schemaType = other1427.schemaType;
+  name = other1427.name;
+  catName = other1427.catName;
+  dbName = other1427.dbName;
+  compatibility = other1427.compatibility;
+  validationLevel = other1427.validationLevel;
+  canEvolve = other1427.canEvolve;
+  schemaGroup = other1427.schemaGroup;
+  description = other1427.description;
+  __isset = other1427.__isset;
   return *this;
 }
 void ISchema::printTo(std::ostream& out) const {
@@ -40251,17 +40338,17 @@ void swap(ISchemaName &a, ISchemaName &b) {
   swap(a.__isset, b.__isset);
 }
 
-ISchemaName::ISchemaName(const ISchemaName& other1421) {
-  catName = other1421.catName;
-  dbName = other1421.dbName;
-  schemaName = other1421.schemaName;
-  __isset = other1421.__isset;
+ISchemaName::ISchemaName(const ISchemaName& other1428) {
+  catName = other1428.catName;
+  dbName = other1428.dbName;
+  schemaName = other1428.schemaName;
+  __isset = other1428.__isset;
 }
-ISchemaName& ISchemaName::operator=(const ISchemaName& other1422) {
-  catName = other1422.catName;
-  dbName = other1422.dbName;
-  schemaName = other1422.schemaName;
-  __isset = other1422.__isset;
+ISchemaName& ISchemaName::operator=(const ISchemaName& other1429) {
+  catName = other1429.catName;
+  dbName = other1429.dbName;
+  schemaName = other1429.schemaName;
+  __isset = other1429.__isset;
   return *this;
 }
 void ISchemaName::printTo(std::ostream& out) const {
@@ -40366,15 +40453,15 @@ void swap(AlterISchemaRequest &a, AlterISchemaRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterISchemaRequest::AlterISchemaRequest(const AlterISchemaRequest& other1423) {
-  name = other1423.name;
-  newSchema = other1423.newSchema;
-  __isset = other1423.__isset;
+AlterISchemaRequest::AlterISchemaRequest(const AlterISchemaRequest& other1430) {
+  name = other1430.name;
+  newSchema = other1430.newSchema;
+  __isset = other1430.__isset;
 }
-AlterISchemaRequest& AlterISchemaRequest::operator=(const AlterISchemaRequest& other1424) {
-  name = other1424.name;
-  newSchema = other1424.newSchema;
-  __isset = other1424.__isset;
+AlterISchemaRequest& AlterISchemaRequest::operator=(const AlterISchemaRequest& other1431) {
+  name = other1431.name;
+  newSchema = other1431.newSchema;
+  __isset = other1431.__isset;
   return *this;
 }
 void AlterISchemaRequest::printTo(std::ostream& out) const {
@@ -40491,14 +40578,14 @@ uint32_t SchemaVersion::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->cols.clear();
-            uint32_t _size1425;
-            ::apache::thrift::protocol::TType _etype1428;
-            xfer += iprot->readListBegin(_etype1428, _size1425);
-            this->cols.resize(_size1425);
-            uint32_t _i1429;
-            for (_i1429 = 0; _i1429 < _size1425; ++_i1429)
+            uint32_t _size1432;
+            ::apache::thrift::protocol::TType _etype1435;
+            xfer += iprot->readListBegin(_etype1435, _size1432);
+            this->cols.resize(_size1432);
+            uint32_t _i1436;
+            for (_i1436 = 0; _i1436 < _size1432; ++_i1436)
             {
-              xfer += this->cols[_i1429].read(iprot);
+              xfer += this->cols[_i1436].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40509,9 +40596,9 @@ uint32_t SchemaVersion::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1430;
-          xfer += iprot->readI32(ecast1430);
-          this->state = (SchemaVersionState::type)ecast1430;
+          int32_t ecast1437;
+          xfer += iprot->readI32(ecast1437);
+          this->state = (SchemaVersionState::type)ecast1437;
           this->__isset.state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -40589,10 +40676,10 @@ uint32_t SchemaVersion::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("cols", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->cols.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1431;
-    for (_iter1431 = this->cols.begin(); _iter1431 != this->cols.end(); ++_iter1431)
+    std::vector<FieldSchema> ::const_iterator _iter1438;
+    for (_iter1438 = this->cols.begin(); _iter1438 != this->cols.end(); ++_iter1438)
     {
-      xfer += (*_iter1431).write(oprot);
+      xfer += (*_iter1438).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -40648,31 +40735,31 @@ void swap(SchemaVersion &a, SchemaVersion &b) {
   swap(a.__isset, b.__isset);
 }
 
-SchemaVersion::SchemaVersion(const SchemaVersion& other1432) {
-  schema = other1432.schema;
-  version = other1432.version;
-  createdAt = other1432.createdAt;
-  cols = other1432.cols;
-  state = other1432.state;
-  description = other1432.description;
-  schemaText = other1432.schemaText;
-  fingerprint = other1432.fingerprint;
-  name = other1432.name;
-  serDe = other1432.serDe;
-  __isset = other1432.__isset;
+SchemaVersion::SchemaVersion(const SchemaVersion& other1439) {
+  schema = other1439.schema;
+  version = other1439.version;
+  createdAt = other1439.createdAt;
+  cols = other1439.cols;
+  state = other1439.state;
+  description = other1439.description;
+  schemaText = other1439.schemaText;
+  fingerprint = other1439.fingerprint;
+  name = other1439.name;
+  serDe = other1439.serDe;
+  __isset = other1439.__isset;
 }
-SchemaVersion& SchemaVersion::operator=(const SchemaVersion& other1433) {
-  schema = other1433.schema;
-  version = other1433.version;
-  createdAt = other1433.createdAt;
-  cols = other1433.cols;
-  state = other1433.state;
-  description = other1433.description;
-  schemaText = other1433.schemaText;
-  fingerprint = other1433.fingerprint;
-  name = other1433.name;
-  serDe = other1433.serDe;
-  __isset = other1433.__isset;
+SchemaVersion& SchemaVersion::operator=(const SchemaVersion& other1440) {
+  schema = other1440.schema;
+  version = other1440.version;
+  createdAt = other1440.createdAt;
+  cols = other1440.cols;
+  state = other1440.state;
+  description = other1440.description;
+  schemaText = other1440.schemaText;
+  fingerprint = other1440.fingerprint;
+  name = other1440.name;
+  serDe = other1440.serDe;
+  __isset = other1440.__isset;
   return *this;
 }
 void SchemaVersion::printTo(std::ostream& out) const {
@@ -40784,15 +40871,15 @@ void swap(SchemaVersionDescriptor &a, SchemaVersionDescriptor &b) {
   swap(a.__isset, b.__isset);
 }
 
-SchemaVersionDescriptor::SchemaVersionDescriptor(const SchemaVersionDescriptor& other1434) {
-  schema = other1434.schema;
-  version = other1434.version;
-  __isset = other1434.__isset;
+SchemaVersionDescriptor::SchemaVersionDescriptor(const SchemaVersionDescriptor& other1441) {
+  schema = other1441.schema;
+  version = other1441.version;
+  __isset = other1441.__isset;
 }
-SchemaVersionDescriptor& SchemaVersionDescriptor::operator=(const SchemaVersionDescriptor& other1435) {
-  schema = other1435.schema;
-  version = other1435.version;
-  __isset = other1435.__isset;
+SchemaVersionDescriptor& SchemaVersionDescriptor::operator=(const SchemaVersionDescriptor& other1442) {
+  schema = other1442.schema;
+  version = other1442.version;
+  __isset = other1442.__isset;
   return *this;
 }
 void SchemaVersionDescriptor::printTo(std::ostream& out) const {
@@ -40919,17 +41006,17 @@ void swap(FindSchemasByColsRqst &a, FindSchemasByColsRqst &b) {
   swap(a.__isset, b.__isset);
 }
 
-FindSchemasByColsRqst::FindSchemasByColsRqst(const FindSchemasByColsRqst& other1436) {
-  colName = other1436.colName;
-  colNamespace = other1436.colNamespace;
-  type = other1436.type;
-  __isset = other1436.__isset;
+FindSchemasByColsRqst::FindSchemasByColsRqst(const FindSchemasByColsRqst& other1443) {
+  colName = other1443.colName;
+  colNamespace = other1443.colNamespace;
+  type = other1443.type;
+  __isset = other1443.__isset;
 }
-FindSchemasByColsRqst& FindSchemasByColsRqst::operator=(const FindSchemasByColsRqst& other1437) {
-  colName = other1437.colName;
-  colNamespace = other1437.colNamespace;
-  type = other1437.type;
-  __isset = other1437.__isset;
+FindSchemasByColsRqst& FindSchemasByColsRqst::operator=(const FindSchemasByColsRqst& other1444) {
+  colName = other1444.colName;
+  colNamespace = other1444.colNamespace;
+  type = other1444.type;
+  __isset = other1444.__isset;
   return *this;
 }
 void FindSchemasByColsRqst::printTo(std::ostream& out) const {
@@ -40981,14 +41068,14 @@ uint32_t FindSchemasByColsResp::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->schemaVersions.clear();
-            uint32_t _size1438;
-            ::apache::thrift::protocol::TType _etype1441;
-            xfer += iprot->readListBegin(_etype1441, _size1438);
-            this->schemaVersions.resize(_size1438);
-            uint32_t _i1442;
-            for (_i1442 = 0; _i1442 < _size1438; ++_i1442)
+            uint32_t _size1445;
+            ::apache::thrift::protocol::TType _etype1448;
+            xfer += iprot->readListBegin(_etype1448, _size1445);
+            this->schemaVersions.resize(_size1445);
+            uint32_t _i1449;
+            for (_i1449 = 0; _i1449 < _size1445; ++_i1449)
             {
-              xfer += this->schemaVersions[_i1442].read(iprot);
+              xfer += this->schemaVersions[_i1449].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41017,10 +41104,10 @@ uint32_t FindSchemasByColsResp::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("schemaVersions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->schemaVersions.size()));
-    std::vector<SchemaVersionDescriptor> ::const_iterator _iter1443;
-    for (_iter1443 = this->schemaVersions.begin(); _iter1443 != this->schemaVersions.end(); ++_iter1443)
+    std::vector<SchemaVersionDescriptor> ::const_iterator _iter1450;
+    for (_iter1450 = this->schemaVersions.begin(); _iter1450 != this->schemaVersions.end(); ++_iter1450)
     {
-      xfer += (*_iter1443).write(oprot);
+      xfer += (*_iter1450).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -41037,13 +41124,13 @@ void swap(FindSchemasByColsResp &a, FindSchemasByColsResp &b) {
   swap(a.__isset, b.__isset);
 }
 
-FindSchemasByColsResp::FindSchemasByColsResp(const FindSchemasByColsResp& other1444) {
-  schemaVersions = other1444.schemaVersions;
-  __isset = other1444.__isset;
+FindSchemasByColsResp::FindSchemasByColsResp(const FindSchemasByColsResp& other1451) {
+  schemaVersions = other1451.schemaVersions;
+  __isset = other1451.__isset;
 }
-FindSchemasByColsResp& FindSchemasByColsResp::operator=(const FindSchemasByColsResp& other1445) {
-  schemaVersions = other1445.schemaVersions;
-  __isset = other1445.__isset;
+FindSchemasByColsResp& FindSchemasByColsResp::operator=(const FindSchemasByColsResp& other1452) {
+  schemaVersions = other1452.schemaVersions;
+  __isset = other1452.__isset;
   return *this;
 }
 void FindSchemasByColsResp::printTo(std::ostream& out) const {
@@ -41146,15 +41233,15 @@ void swap(MapSchemaVersionToSerdeRequest &a, MapSchemaVersionToSerdeRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-MapSchemaVersionToSerdeRequest::MapSchemaVersionToSerdeRequest(const MapSchemaVersionToSerdeRequest& other1446) {
-  schemaVersion = other1446.schemaVersion;
-  serdeName = other1446.serdeName;
-  __isset = other1446.__isset;
+MapSchemaVersionToSerdeRequest::MapSchemaVersionToSerdeRequest(const MapSchemaVersionToSerdeRequest& other1453) {
+  schemaVersion = other1453.schemaVersion;
+  serdeName = other1453.serdeName;
+  __isset = other1453.__isset;
 }
-MapSchemaVersionToSerdeRequest& MapSchemaVersionToSerdeRequest::operator=(const MapSchemaVersionToSerdeRequest& other1447) {
-  schemaVersion = other1447.schemaVersion;
-  serdeName = other1447.serdeName;
-  __isset = other1447.__isset;
+MapSchemaVersionToSerdeRequest& MapSchemaVersionToSerdeRequest::operator=(const MapSchemaVersionToSerdeRequest& other1454) {
+  schemaVersion = other1454.schemaVersion;
+  serdeName = other1454.serdeName;
+  __isset = other1454.__isset;
   return *this;
 }
 void MapSchemaVersionToSerdeRequest::printTo(std::ostream& out) const {
@@ -41215,9 +41302,9 @@ uint32_t SetSchemaVersionStateRequest::read(::apache::thrift::protocol::TProtoco
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1448;
-          xfer += iprot->readI32(ecast1448);
-          this->state = (SchemaVersionState::type)ecast1448;
+          int32_t ecast1455;
+          xfer += iprot->readI32(ecast1455);
+          this->state = (SchemaVersionState::type)ecast1455;
           this->__isset.state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -41260,15 +41347,15 @@ void swap(SetSchemaVersionStateRequest &a, SetSchemaVersionStateRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-SetSchemaVersionStateRequest::SetSchemaVersionStateRequest(const SetSchemaVersionStateRequest& other1449) {
-  schemaVersion = other1449.schemaVersion;
-  state = other1449.state;
-  __isset = other1449.__isset;
+SetSchemaVersionStateRequest::SetSchemaVersionStateRequest(const SetSchemaVersionStateRequest& other1456) {
+  schemaVersion = other1456.schemaVersion;
+  state = other1456.state;
+  __isset = other1456.__isset;
 }
-SetSchemaVersionStateRequest& SetSchemaVersionStateRequest::operator=(const SetSchemaVersionStateRequest& other1450) {
-  schemaVersion = other1450.schemaVersion;
-  state = other1450.state;
-  __isset = other1450.__isset;
+SetSchemaVersionStateRequest& SetSchemaVersionStateRequest::operator=(const SetSchemaVersionStateRequest& other1457) {
+  schemaVersion = other1457.schemaVersion;
+  state = other1457.state;
+  __isset = other1457.__isset;
   return *this;
 }
 void SetSchemaVersionStateRequest::printTo(std::ostream& out) const {
@@ -41355,13 +41442,13 @@ void swap(GetSerdeRequest &a, GetSerdeRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetSerdeRequest::GetSerdeRequest(const GetSerdeRequest& other1451) {
-  serdeName = other1451.serdeName;
-  __isset = other1451.__isset;
+GetSerdeRequest::GetSerdeRequest(const GetSerdeRequest& other1458) {
+  serdeName = other1458.serdeName;
+  __isset = other1458.__isset;
 }
-GetSerdeRequest& GetSerdeRequest::operator=(const GetSerdeRequest& other1452) {
-  serdeName = other1452.serdeName;
-  __isset = other1452.__isset;
+GetSerdeRequest& GetSerdeRequest::operator=(const GetSerdeRequest& other1459) {
+  serdeName = other1459.serdeName;
+  __isset = other1459.__isset;
   return *this;
 }
 void GetSerdeRequest::printTo(std::ostream& out) const {
@@ -41489,17 +41576,17 @@ void swap(RuntimeStat &a, RuntimeStat &b) {
   swap(a.__isset, b.__isset);
 }
 
-RuntimeStat::RuntimeStat(const RuntimeStat& other1453) {
-  createTime = other1453.createTime;
-  weight = other1453.weight;
-  payload = other1453.payload;
-  __isset = other1453.__isset;
+RuntimeStat::RuntimeStat(const RuntimeStat& other1460) {
+  createTime = other1460.createTime;
+  weight = other1460.weight;
+  payload = other1460.payload;
+  __isset = other1460.__isset;
 }
-RuntimeStat& RuntimeStat::operator=(const RuntimeStat& other1454) {
-  createTime = other1454.createTime;
-  weight = other1454.weight;
-  payload = other1454.payload;
-  __isset = other1454.__isset;
+RuntimeStat& RuntimeStat::operator=(const RuntimeStat& other1461) {
+  createTime = other1461.createTime;
+  weight = other1461.weight;
+  payload = other1461.payload;
+  __isset = other1461.__isset;
   return *this;
 }
 void RuntimeStat::printTo(std::ostream& out) const {
@@ -41609,13 +41696,13 @@ void swap(GetRuntimeStatsRequest &a, GetRuntimeStatsRequest &b) {
   swap(a.maxCreateTime, b.maxCreateTime);
 }
 
-GetRuntimeStatsRequest::GetRuntimeStatsRequest(const GetRuntimeStatsRequest& other1455) {
-  maxWeight = other1455.maxWeight;
-  maxCreateTime = other1455.maxCreateTime;
+GetRuntimeStatsRequest::GetRuntimeStatsRequest(const GetRuntimeStatsRequest& other1462) {
+  maxWeight = other1462.maxWeight;
+  maxCreateTime = other1462.maxCreateTime;
 }
-GetRuntimeStatsRequest& GetRuntimeStatsRequest::operator=(const GetRuntimeStatsRequest& other1456) {
-  maxWeight = other1456.maxWeight;
-  maxCreateTime = other1456.maxCreateTime;
+GetRuntimeStatsRequest& GetRuntimeStatsRequest::operator=(const GetRuntimeStatsRequest& other1463) {
+  maxWeight = other1463.maxWeight;
+  maxCreateTime = other1463.maxCreateTime;
   return *this;
 }
 void GetRuntimeStatsRequest::printTo(std::ostream& out) const {
@@ -41728,14 +41815,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size1457;
-            ::apache::thrift::protocol::TType _etype1460;
-            xfer += iprot->readListBegin(_etype1460, _size1457);
-            this->primaryKeys.resize(_size1457);
-            uint32_t _i1461;
-            for (_i1461 = 0; _i1461 < _size1457; ++_i1461)
+            uint32_t _size1464;
+            ::apache::thrift::protocol::TType _etype1467;
+            xfer += iprot->readListBegin(_etype1467, _size1464);
+            this->primaryKeys.resize(_size1464);
+            uint32_t _i1468;
+            for (_i1468 = 0; _i1468 < _size1464; ++_i1468)
             {
-              xfer += this->primaryKeys[_i1461].read(iprot);
+              xfer += this->primaryKeys[_i1468].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41748,14 +41835,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size1462;
-            ::apache::thrift::protocol::TType _etype1465;
-            xfer += iprot->readListBegin(_etype1465, _size1462);
-            this->foreignKeys.resize(_size1462);
-            uint32_t _i1466;
-            for (_i1466 = 0; _i1466 < _size1462; ++_i1466)
+            uint32_t _size1469;
+            ::apache::thrift::protocol::TType _etype1472;
+            xfer += iprot->readListBegin(_etype1472, _size1469);
+            this->foreignKeys.resize(_size1469);
+            uint32_t _i1473;
+            for (_i1473 = 0; _i1473 < _size1469; ++_i1473)
             {
-              xfer += this->foreignKeys[_i1466].read(iprot);
+              xfer += this->foreignKeys[_i1473].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41768,14 +41855,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size1467;
-            ::apache::thrift::protocol::TType _etype1470;
-            xfer += iprot->readListBegin(_etype1470, _size1467);
-            this->uniqueConstraints.resize(_size1467);
-            uint32_t _i1471;
-            for (_i1471 = 0; _i1471 < _size1467; ++_i1471)
+            uint32_t _size1474;
+            ::apache::thrift::protocol::TType _etype1477;
+            xfer += iprot->readListBegin(_etype1477, _size1474);
+            this->uniqueConstraints.resize(_size1474);
+            uint32_t _i1478;
+            for (_i1478 = 0; _i1478 < _size1474; ++_i1478)
             {
-              xfer += this->uniqueConstraints[_i1471].read(iprot);
+              xfer += this->uniqueConstraints[_i1478].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41788,14 +41875,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size1472;
-            ::apache::thrift::protocol::TType _etype1475;
-            xfer += iprot->readListBegin(_etype1475, _size1472);
-            this->notNullConstraints.resize(_size1472);
-            uint32_t _i1476;
-            for (_i1476 = 0; _i1476 < _size1472; ++_i1476)
+            uint32_t _size1479;
+            ::apache::thrift::protocol::TType _etype1482;
+            xfer += iprot->readListBegin(_etype1482, _size1479);
+            this->notNullConstraints.resize(_size1479);
+            uint32_t _i1483;
+            for (_i1483 = 0; _i1483 < _size1479; ++_i1483)
             {
-              xfer += this->notNullConstraints[_i1476].read(iprot);
+              xfer += this->notNullConstraints[_i1483].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41808,14 +41895,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size1477;
-            ::apache::thrift::protocol::TType _etype1480;
-            xfer += iprot->readListBegin(_etype1480, _size1477);
-            this->defaultConstraints.resize(_size1477);
-            uint32_t _i1481;
-            for (_i1481 = 0; _i1481 < _size1477; ++_i1481)
+            uint32_t _size1484;
+            ::apache::thrift::protocol::TType _etype1487;
+            xfer += iprot->readListBegin(_etype1487, _size1484);
+            this->defaultConstraints.resize(_size1484);
+            uint32_t _i1488;
+            for (_i1488 = 0; _i1488 < _size1484; ++_i1488)
             {
-              xfer += this->defaultConstraints[_i1481].read(iprot);
+              xfer += this->defaultConstraints[_i1488].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41828,14 +41915,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size1482;
-            ::apache::thrift::protocol::TType _etype1485;
-            xfer += iprot->readListBegin(_etype1485, _size1482);
-            this->checkConstraints.resize(_size1482);
-            uint32_t _i1486;
-            for (_i1486 = 0; _i1486 < _size1482; ++_i1486)
+            uint32_t _size1489;
+            ::apache::thrift::protocol::TType _etype1492;
+            xfer += iprot->readListBegin(_etype1492, _size1489);
+            this->checkConstraints.resize(_size1489);
+            uint32_t _i1493;
+            for (_i1493 = 0; _i1493 < _size1489; ++_i1493)
             {
-              xfer += this->checkConstraints[_i1486].read(iprot);
+              xfer += this->checkConstraints[_i1493].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -41848,14 +41935,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1487;
-            ::apache::thrift::protocol::TType _etype1490;
-            xfer += iprot->readListBegin(_etype1490, _size1487);
-            this->processorCapabilities.resize(_size1487);
-            uint32_t _i1491;
-            for (_i1491 = 0; _i1491 < _size1487; ++_i1491)
+            uint32_t _size1494;
+            ::apache::thrift::protocol::TType _etype1497;
+            xfer += iprot->readListBegin(_etype1497, _size1494);
+            this->processorCapabilities.resize(_size1494);
+            uint32_t _i1498;
+            for (_i1498 = 0; _i1498 < _size1494; ++_i1498)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1491]);
+              xfer += iprot->readString(this->processorCapabilities[_i1498]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41904,10 +41991,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-      std::vector<SQLPrimaryKey> ::const_iterator _iter1492;
-      for (_iter1492 = this->primaryKeys.begin(); _iter1492 != this->primaryKeys.end(); ++_iter1492)
+      std::vector<SQLPrimaryKey> ::const_iterator _iter1499;
+      for (_iter1499 = this->primaryKeys.begin(); _iter1499 != this->primaryKeys.end(); ++_iter1499)
       {
-        xfer += (*_iter1492).write(oprot);
+        xfer += (*_iter1499).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41917,10 +42004,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-      std::vector<SQLForeignKey> ::const_iterator _iter1493;
-      for (_iter1493 = this->foreignKeys.begin(); _iter1493 != this->foreignKeys.end(); ++_iter1493)
+      std::vector<SQLForeignKey> ::const_iterator _iter1500;
+      for (_iter1500 = this->foreignKeys.begin(); _iter1500 != this->foreignKeys.end(); ++_iter1500)
       {
-        xfer += (*_iter1493).write(oprot);
+        xfer += (*_iter1500).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41930,10 +42017,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-      std::vector<SQLUniqueConstraint> ::const_iterator _iter1494;
-      for (_iter1494 = this->uniqueConstraints.begin(); _iter1494 != this->uniqueConstraints.end(); ++_iter1494)
+      std::vector<SQLUniqueConstraint> ::const_iterator _iter1501;
+      for (_iter1501 = this->uniqueConstraints.begin(); _iter1501 != this->uniqueConstraints.end(); ++_iter1501)
       {
-        xfer += (*_iter1494).write(oprot);
+        xfer += (*_iter1501).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41943,10 +42030,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-      std::vector<SQLNotNullConstraint> ::const_iterator _iter1495;
-      for (_iter1495 = this->notNullConstraints.begin(); _iter1495 != this->notNullConstraints.end(); ++_iter1495)
+      std::vector<SQLNotNullConstraint> ::const_iterator _iter1502;
+      for (_iter1502 = this->notNullConstraints.begin(); _iter1502 != this->notNullConstraints.end(); ++_iter1502)
       {
-        xfer += (*_iter1495).write(oprot);
+        xfer += (*_iter1502).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41956,10 +42043,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-      std::vector<SQLDefaultConstraint> ::const_iterator _iter1496;
-      for (_iter1496 = this->defaultConstraints.begin(); _iter1496 != this->defaultConstraints.end(); ++_iter1496)
+      std::vector<SQLDefaultConstraint> ::const_iterator _iter1503;
+      for (_iter1503 = this->defaultConstraints.begin(); _iter1503 != this->defaultConstraints.end(); ++_iter1503)
       {
-        xfer += (*_iter1496).write(oprot);
+        xfer += (*_iter1503).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41969,10 +42056,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-      std::vector<SQLCheckConstraint> ::const_iterator _iter1497;
-      for (_iter1497 = this->checkConstraints.begin(); _iter1497 != this->checkConstraints.end(); ++_iter1497)
+      std::vector<SQLCheckConstraint> ::const_iterator _iter1504;
+      for (_iter1504 = this->checkConstraints.begin(); _iter1504 != this->checkConstraints.end(); ++_iter1504)
       {
-        xfer += (*_iter1497).write(oprot);
+        xfer += (*_iter1504).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -41982,10 +42069,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 9);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1498;
-      for (_iter1498 = this->processorCapabilities.begin(); _iter1498 != this->processorCapabilities.end(); ++_iter1498)
+      std::vector<std::string> ::const_iterator _iter1505;
+      for (_iter1505 = this->processorCapabilities.begin(); _iter1505 != this->processorCapabilities.end(); ++_iter1505)
       {
-        xfer += oprot->writeString((*_iter1498));
+        xfer += oprot->writeString((*_iter1505));
       }
       xfer += oprot->writeListEnd();
     }
@@ -42016,31 +42103,31 @@ void swap(CreateTableRequest &a, CreateTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateTableRequest::CreateTableRequest(const CreateTableRequest& other1499) {
-  table = other1499.table;
-  envContext = other1499.envContext;
-  primaryKeys = other1499.primaryKeys;
-  foreignKeys = other1499.foreignKeys;
-  uniqueConstraints = other1499.uniqueConstraints;
-  notNullConstraints = other1499.notNullConstraints;
-  defaultConstraints = other1499.defaultConstraints;
-  checkConstraints = other1499.checkConstraints;
-  processorCapabilities = other1499.processorCapabilities;
-  processorIdentifier = other1499.processorIdentifier;
-  __isset = other1499.__isset;
+CreateTableRequest::CreateTableRequest(const CreateTableRequest& other1506) {
+  table = other1506.table;
+  envContext = other1506.envContext;
+  primaryKeys = other1506.primaryKeys;
+  foreignKeys = other1506.foreignKeys;
+  uniqueConstraints = other1506.uniqueConstraints;
+  notNullConstraints = other1506.notNullConstraints;
+  defaultConstraints = other1506.defaultConstraints;
+  checkConstraints = other1506.checkConstraints;
+  processorCapabilities = other1506.processorCapabilities;
+  processorIdentifier = other1506.processorIdentifier;
+  __isset = other1506.__isset;
 }
-CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other1500) {
-  table = other1500.table;
-  envContext = other1500.envContext;
-  primaryKeys = other1500.primaryKeys;
-  foreignKeys = other1500.foreignKeys;
-  uniqueConstraints = other1500.uniqueConstraints;
-  notNullConstraints = other1500.notNullConstraints;
-  defaultConstraints = other1500.defaultConstraints;
-  checkConstraints = other1500.checkConstraints;
-  processorCapabilities = other1500.processorCapabilities;
-  processorIdentifier = other1500.processorIdentifier;
-  __isset = other1500.__isset;
+CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other1507) {
+  table = other1507.table;
+  envContext = other1507.envContext;
+  primaryKeys = other1507.primaryKeys;
+  foreignKeys = other1507.foreignKeys;
+  uniqueConstraints = other1507.uniqueConstraints;
+  notNullConstraints = other1507.notNullConstraints;
+  defaultConstraints = other1507.defaultConstraints;
+  checkConstraints = other1507.checkConstraints;
+  processorCapabilities = other1507.processorCapabilities;
+  processorIdentifier = other1507.processorIdentifier;
+  __isset = other1507.__isset;
   return *this;
 }
 void CreateTableRequest::printTo(std::ostream& out) const {
@@ -42179,17 +42266,17 @@ uint32_t CreateDatabaseRequest::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size1501;
-            ::apache::thrift::protocol::TType _ktype1502;
-            ::apache::thrift::protocol::TType _vtype1503;
-            xfer += iprot->readMapBegin(_ktype1502, _vtype1503, _size1501);
-            uint32_t _i1505;
-            for (_i1505 = 0; _i1505 < _size1501; ++_i1505)
+            uint32_t _size1508;
+            ::apache::thrift::protocol::TType _ktype1509;
+            ::apache::thrift::protocol::TType _vtype1510;
+            xfer += iprot->readMapBegin(_ktype1509, _vtype1510, _size1508);
+            uint32_t _i1512;
+            for (_i1512 = 0; _i1512 < _size1508; ++_i1512)
             {
-              std::string _key1506;
-              xfer += iprot->readString(_key1506);
-              std::string& _val1507 = this->parameters[_key1506];
-              xfer += iprot->readString(_val1507);
+              std::string _key1513;
+              xfer += iprot->readString(_key1513);
+              std::string& _val1514 = this->parameters[_key1513];
+              xfer += iprot->readString(_val1514);
             }
             xfer += iprot->readMapEnd();
           }
@@ -42216,9 +42303,9 @@ uint32_t CreateDatabaseRequest::read(::apache::thrift::protocol::TProtocol* ipro
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1508;
-          xfer += iprot->readI32(ecast1508);
-          this->ownerType = (PrincipalType::type)ecast1508;
+          int32_t ecast1515;
+          xfer += iprot->readI32(ecast1515);
+          this->ownerType = (PrincipalType::type)ecast1515;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -42301,11 +42388,11 @@ uint32_t CreateDatabaseRequest::write(::apache::thrift::protocol::TProtocol* opr
     xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 4);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-      std::map<std::string, std::string> ::const_iterator _iter1509;
-      for (_iter1509 = this->parameters.begin(); _iter1509 != this->parameters.end(); ++_iter1509)
+      std::map<std::string, std::string> ::const_iterator _iter1516;
+      for (_iter1516 = this->parameters.begin(); _iter1516 != this->parameters.end(); ++_iter1516)
       {
-        xfer += oprot->writeString(_iter1509->first);
-        xfer += oprot->writeString(_iter1509->second);
+        xfer += oprot->writeString(_iter1516->first);
+        xfer += oprot->writeString(_iter1516->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -42373,35 +42460,35 @@ void swap(CreateDatabaseRequest &a, CreateDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other1510) {
-  databaseName = other1510.databaseName;
-  description = other1510.description;
-  locationUri = other1510.locationUri;
-  parameters = other1510.parameters;
-  privileges = other1510.privileges;
-  ownerName = other1510.ownerName;
-  ownerType = other1510.ownerType;
-  catalogName = other1510.catalogName;
-  createTime = other1510.createTime;
-  managedLocationUri = other1510.managedLocationUri;
-  type = other1510.type;
-  dataConnectorName = other1510.dataConnectorName;
-  __isset = other1510.__isset;
+CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other1517) {
+  databaseName = other1517.databaseName;
+  description = other1517.description;
+  locationUri = other1517.locationUri;
+  parameters = other1517.parameters;
+  privileges = other1517.privileges;
+  ownerName = other1517.ownerName;
+  ownerType = other1517.ownerType;
+  catalogName = other1517.catalogName;
+  createTime = other1517.createTime;
+  managedLocationUri = other1517.managedLocationUri;
+  type = other1517.type;
+  dataConnectorName = other1517.dataConnectorName;
+  __isset = other1517.__isset;
 }
-CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other1511) {
-  databaseName = other1511.databaseName;
-  description = other1511.description;
-  locationUri = other1511.locationUri;
-  parameters = other1511.parameters;
-  privileges = other1511.privileges;
-  ownerName = other1511.ownerName;
-  ownerType = other1511.ownerType;
-  catalogName = other1511.catalogName;
-  createTime = other1511.createTime;
-  managedLocationUri = other1511.managedLocationUri;
-  type = other1511.type;
-  dataConnectorName = other1511.dataConnectorName;
-  __isset = other1511.__isset;
+CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other1518) {
+  databaseName = other1518.databaseName;
+  description = other1518.description;
+  locationUri = other1518.locationUri;
+  parameters = other1518.parameters;
+  privileges = other1518.privileges;
+  ownerName = other1518.ownerName;
+  ownerType = other1518.ownerType;
+  catalogName = other1518.catalogName;
+  createTime = other1518.createTime;
+  managedLocationUri = other1518.managedLocationUri;
+  type = other1518.type;
+  dataConnectorName = other1518.dataConnectorName;
+  __isset = other1518.__isset;
   return *this;
 }
 void CreateDatabaseRequest::printTo(std::ostream& out) const {
@@ -42498,13 +42585,13 @@ void swap(CreateDataConnectorRequest &a, CreateDataConnectorRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateDataConnectorRequest::CreateDataConnectorRequest(const CreateDataConnectorRequest& other1512) {
-  connector = other1512.connector;
-  __isset = other1512.__isset;
+CreateDataConnectorRequest::CreateDataConnectorRequest(const CreateDataConnectorRequest& other1519) {
+  connector = other1519.connector;
+  __isset = other1519.__isset;
 }
-CreateDataConnectorRequest& CreateDataConnectorRequest::operator=(const CreateDataConnectorRequest& other1513) {
-  connector = other1513.connector;
-  __isset = other1513.__isset;
+CreateDataConnectorRequest& CreateDataConnectorRequest::operator=(const CreateDataConnectorRequest& other1520) {
+  connector = other1520.connector;
+  __isset = other1520.__isset;
   return *this;
 }
 void CreateDataConnectorRequest::printTo(std::ostream& out) const {
@@ -42592,11 +42679,11 @@ void swap(GetDataConnectorRequest &a, GetDataConnectorRequest &b) {
   swap(a.connectorName, b.connectorName);
 }
 
-GetDataConnectorRequest::GetDataConnectorRequest(const GetDataConnectorRequest& other1514) {
-  connectorName = other1514.connectorName;
+GetDataConnectorRequest::GetDataConnectorRequest(const GetDataConnectorRequest& other1521) {
+  connectorName = other1521.connectorName;
 }
-GetDataConnectorRequest& GetDataConnectorRequest::operator=(const GetDataConnectorRequest& other1515) {
-  connectorName = other1515.connectorName;
+GetDataConnectorRequest& GetDataConnectorRequest::operator=(const GetDataConnectorRequest& other1522) {
+  connectorName = other1522.connectorName;
   return *this;
 }
 void GetDataConnectorRequest::printTo(std::ostream& out) const {
@@ -42684,11 +42771,11 @@ void swap(ScheduledQueryPollRequest &a, ScheduledQueryPollRequest &b) {
   swap(a.clusterNamespace, b.clusterNamespace);
 }
 
-ScheduledQueryPollRequest::ScheduledQueryPollRequest(const ScheduledQueryPollRequest& other1516) {
-  clusterNamespace = other1516.clusterNamespace;
+ScheduledQueryPollRequest::ScheduledQueryPollRequest(const ScheduledQueryPollRequest& other1523) {
+  clusterNamespace = other1523.clusterNamespace;
 }
-ScheduledQueryPollRequest& ScheduledQueryPollRequest::operator=(const ScheduledQueryPollRequest& other1517) {
-  clusterNamespace = other1517.clusterNamespace;
+ScheduledQueryPollRequest& ScheduledQueryPollRequest::operator=(const ScheduledQueryPollRequest& other1524) {
+  clusterNamespace = other1524.clusterNamespace;
   return *this;
 }
 void ScheduledQueryPollRequest::printTo(std::ostream& out) const {
@@ -42796,13 +42883,13 @@ void swap(ScheduledQueryKey &a, ScheduledQueryKey &b) {
   swap(a.clusterNamespace, b.clusterNamespace);
 }
 
-ScheduledQueryKey::ScheduledQueryKey(const ScheduledQueryKey& other1518) {
-  scheduleName = other1518.scheduleName;
-  clusterNamespace = other1518.clusterNamespace;
+ScheduledQueryKey::ScheduledQueryKey(const ScheduledQueryKey& other1525) {
+  scheduleName = other1525.scheduleName;
+  clusterNamespace = other1525.clusterNamespace;
 }
-ScheduledQueryKey& ScheduledQueryKey::operator=(const ScheduledQueryKey& other1519) {
-  scheduleName = other1519.scheduleName;
-  clusterNamespace = other1519.clusterNamespace;
+ScheduledQueryKey& ScheduledQueryKey::operator=(const ScheduledQueryKey& other1526) {
+  scheduleName = other1526.scheduleName;
+  clusterNamespace = other1526.clusterNamespace;
   return *this;
 }
 void ScheduledQueryKey::printTo(std::ostream& out) const {
@@ -42948,19 +43035,19 @@ void swap(ScheduledQueryPollResponse &a, ScheduledQueryPollResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQueryPollResponse::ScheduledQueryPollResponse(const ScheduledQueryPollResponse& other1520) {
-  scheduleKey = other1520.scheduleKey;
-  executionId = other1520.executionId;
-  query = other1520.query;
-  user = other1520.user;
-  __isset = other1520.__isset;
+ScheduledQueryPollResponse::ScheduledQueryPollResponse(const ScheduledQueryPollResponse& other1527) {
+  scheduleKey = other1527.scheduleKey;
+  executionId = other1527.executionId;
+  query = other1527.query;
+  user = other1527.user;
+  __isset = other1527.__isset;
 }
-ScheduledQueryPollResponse& ScheduledQueryPollResponse::operator=(const ScheduledQueryPollResponse& other1521) {
-  scheduleKey = other1521.scheduleKey;
-  executionId = other1521.executionId;
-  query = other1521.query;
-  user = other1521.user;
-  __isset = other1521.__isset;
+ScheduledQueryPollResponse& ScheduledQueryPollResponse::operator=(const ScheduledQueryPollResponse& other1528) {
+  scheduleKey = other1528.scheduleKey;
+  executionId = other1528.executionId;
+  query = other1528.query;
+  user = other1528.user;
+  __isset = other1528.__isset;
   return *this;
 }
 void ScheduledQueryPollResponse::printTo(std::ostream& out) const {
@@ -43147,23 +43234,23 @@ void swap(ScheduledQuery &a, ScheduledQuery &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQuery::ScheduledQuery(const ScheduledQuery& other1522) {
-  scheduleKey = other1522.scheduleKey;
-  enabled = other1522.enabled;
-  schedule = other1522.schedule;
-  user = other1522.user;
-  query = other1522.query;
-  nextExecution = other1522.nextExecution;
-  __isset = other1522.__isset;
+ScheduledQuery::ScheduledQuery(const ScheduledQuery& other1529) {
+  scheduleKey = other1529.scheduleKey;
+  enabled = other1529.enabled;
+  schedule = other1529.schedule;
+  user = other1529.user;
+  query = other1529.query;
+  nextExecution = other1529.nextExecution;
+  __isset = other1529.__isset;
 }
-ScheduledQuery& ScheduledQuery::operator=(const ScheduledQuery& other1523) {
-  scheduleKey = other1523.scheduleKey;
-  enabled = other1523.enabled;
-  schedule = other1523.schedule;
-  user = other1523.user;
-  query = other1523.query;
-  nextExecution = other1523.nextExecution;
-  __isset = other1523.__isset;
+ScheduledQuery& ScheduledQuery::operator=(const ScheduledQuery& other1530) {
+  scheduleKey = other1530.scheduleKey;
+  enabled = other1530.enabled;
+  schedule = other1530.schedule;
+  user = other1530.user;
+  query = other1530.query;
+  nextExecution = other1530.nextExecution;
+  __isset = other1530.__isset;
   return *this;
 }
 void ScheduledQuery::printTo(std::ostream& out) const {
@@ -43222,9 +43309,9 @@ uint32_t ScheduledQueryMaintenanceRequest::read(::apache::thrift::protocol::TPro
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1524;
-          xfer += iprot->readI32(ecast1524);
-          this->type = (ScheduledQueryMaintenanceRequestType::type)ecast1524;
+          int32_t ecast1531;
+          xfer += iprot->readI32(ecast1531);
+          this->type = (ScheduledQueryMaintenanceRequestType::type)ecast1531;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -43278,13 +43365,13 @@ void swap(ScheduledQueryMaintenanceRequest &a, ScheduledQueryMaintenanceRequest 
   swap(a.scheduledQuery, b.scheduledQuery);
 }
 
-ScheduledQueryMaintenanceRequest::ScheduledQueryMaintenanceRequest(const ScheduledQueryMaintenanceRequest& other1525) {
-  type = other1525.type;
-  scheduledQuery = other1525.scheduledQuery;
+ScheduledQueryMaintenanceRequest::ScheduledQueryMaintenanceRequest(const ScheduledQueryMaintenanceRequest& other1532) {
+  type = other1532.type;
+  scheduledQuery = other1532.scheduledQuery;
 }
-ScheduledQueryMaintenanceRequest& ScheduledQueryMaintenanceRequest::operator=(const ScheduledQueryMaintenanceRequest& other1526) {
-  type = other1526.type;
-  scheduledQuery = other1526.scheduledQuery;
+ScheduledQueryMaintenanceRequest& ScheduledQueryMaintenanceRequest::operator=(const ScheduledQueryMaintenanceRequest& other1533) {
+  type = other1533.type;
+  scheduledQuery = other1533.scheduledQuery;
   return *this;
 }
 void ScheduledQueryMaintenanceRequest::printTo(std::ostream& out) const {
@@ -43357,9 +43444,9 @@ uint32_t ScheduledQueryProgressInfo::read(::apache::thrift::protocol::TProtocol*
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1527;
-          xfer += iprot->readI32(ecast1527);
-          this->state = (QueryState::type)ecast1527;
+          int32_t ecast1534;
+          xfer += iprot->readI32(ecast1534);
+          this->state = (QueryState::type)ecast1534;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -43435,19 +43522,19 @@ void swap(ScheduledQueryProgressInfo &a, ScheduledQueryProgressInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQueryProgressInfo::ScheduledQueryProgressInfo(const ScheduledQueryProgressInfo& other1528) {
-  scheduledExecutionId = other1528.scheduledExecutionId;
-  state = other1528.state;
-  executorQueryId = other1528.executorQueryId;
-  errorMessage = other1528.errorMessage;
-  __isset = other1528.__isset;
+ScheduledQueryProgressInfo::ScheduledQueryProgressInfo(const ScheduledQueryProgressInfo& other1535) {
+  scheduledExecutionId = other1535.scheduledExecutionId;
+  state = other1535.state;
+  executorQueryId = other1535.executorQueryId;
+  errorMessage = other1535.errorMessage;
+  __isset = other1535.__isset;
 }
-ScheduledQueryProgressInfo& ScheduledQueryProgressInfo::operator=(const ScheduledQueryProgressInfo& other1529) {
-  scheduledExecutionId = other1529.scheduledExecutionId;
-  state = other1529.state;
-  executorQueryId = other1529.executorQueryId;
-  errorMessage = other1529.errorMessage;
-  __isset = other1529.__isset;
+ScheduledQueryProgressInfo& ScheduledQueryProgressInfo::operator=(const ScheduledQueryProgressInfo& other1536) {
+  scheduledExecutionId = other1536.scheduledExecutionId;
+  state = other1536.state;
+  executorQueryId = other1536.executorQueryId;
+  errorMessage = other1536.errorMessage;
+  __isset = other1536.__isset;
   return *this;
 }
 void ScheduledQueryProgressInfo::printTo(std::ostream& out) const {
@@ -43555,14 +43642,14 @@ uint32_t AlterPartitionsRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1530;
-            ::apache::thrift::protocol::TType _etype1533;
-            xfer += iprot->readListBegin(_etype1533, _size1530);
-            this->partitions.resize(_size1530);
-            uint32_t _i1534;
-            for (_i1534 = 0; _i1534 < _size1530; ++_i1534)
+            uint32_t _size1537;
+            ::apache::thrift::protocol::TType _etype1540;
+            xfer += iprot->readListBegin(_etype1540, _size1537);
+            this->partitions.resize(_size1537);
+            uint32_t _i1541;
+            for (_i1541 = 0; _i1541 < _size1537; ++_i1541)
             {
-              xfer += this->partitions[_i1534].read(iprot);
+              xfer += this->partitions[_i1541].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -43634,10 +43721,10 @@ uint32_t AlterPartitionsRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1535;
-    for (_iter1535 = this->partitions.begin(); _iter1535 != this->partitions.end(); ++_iter1535)
+    std::vector<Partition> ::const_iterator _iter1542;
+    for (_iter1542 = this->partitions.begin(); _iter1542 != this->partitions.end(); ++_iter1542)
     {
-      xfer += (*_iter1535).write(oprot);
+      xfer += (*_iter1542).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -43675,25 +43762,25 @@ void swap(AlterPartitionsRequest &a, AlterPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterPartitionsRequest::AlterPartitionsRequest(const AlterPartitionsRequest& other1536) {
-  catName = other1536.catName;
-  dbName = other1536.dbName;
-  tableName = other1536.tableName;
-  partitions = other1536.partitions;
-  environmentContext = other1536.environmentContext;
-  writeId = other1536.writeId;
-  validWriteIdList = other1536.validWriteIdList;
-  __isset = other1536.__isset;
+AlterPartitionsRequest::AlterPartitionsRequest(const AlterPartitionsRequest& other1543) {
+  catName = other1543.catName;
+  dbName = other1543.dbName;
+  tableName = other1543.tableName;
+  partitions = other1543.partitions;
+  environmentContext = other1543.environmentContext;
+  writeId = other1543.writeId;
+  validWriteIdList = other1543.validWriteIdList;
+  __isset = other1543.__isset;
 }
-AlterPartitionsRequest& AlterPartitionsRequest::operator=(const AlterPartitionsRequest& other1537) {
-  catName = other1537.catName;
-  dbName = other1537.dbName;
-  tableName = other1537.tableName;
-  partitions = other1537.partitions;
-  environmentContext = other1537.environmentContext;
-  writeId = other1537.writeId;
-  validWriteIdList = other1537.validWriteIdList;
-  __isset = other1537.__isset;
+AlterPartitionsRequest& AlterPartitionsRequest::operator=(const AlterPartitionsRequest& other1544) {
+  catName = other1544.catName;
+  dbName = other1544.dbName;
+  tableName = other1544.tableName;
+  partitions = other1544.partitions;
+  environmentContext = other1544.environmentContext;
+  writeId = other1544.writeId;
+  validWriteIdList = other1544.validWriteIdList;
+  __isset = other1544.__isset;
   return *this;
 }
 void AlterPartitionsRequest::printTo(std::ostream& out) const {
@@ -43764,11 +43851,11 @@ void swap(AlterPartitionsResponse &a, AlterPartitionsResponse &b) {
   (void) b;
 }
 
-AlterPartitionsResponse::AlterPartitionsResponse(const AlterPartitionsResponse& other1538) {
-  (void) other1538;
+AlterPartitionsResponse::AlterPartitionsResponse(const AlterPartitionsResponse& other1545) {
+  (void) other1545;
 }
-AlterPartitionsResponse& AlterPartitionsResponse::operator=(const AlterPartitionsResponse& other1539) {
-  (void) other1539;
+AlterPartitionsResponse& AlterPartitionsResponse::operator=(const AlterPartitionsResponse& other1546) {
+  (void) other1546;
   return *this;
 }
 void AlterPartitionsResponse::printTo(std::ostream& out) const {
@@ -43867,14 +43954,14 @@ uint32_t RenamePartitionRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1540;
-            ::apache::thrift::protocol::TType _etype1543;
-            xfer += iprot->readListBegin(_etype1543, _size1540);
-            this->partVals.resize(_size1540);
-            uint32_t _i1544;
-            for (_i1544 = 0; _i1544 < _size1540; ++_i1544)
+            uint32_t _size1547;
+            ::apache::thrift::protocol::TType _etype1550;
+            xfer += iprot->readListBegin(_etype1550, _size1547);
+            this->partVals.resize(_size1547);
+            uint32_t _i1551;
+            for (_i1551 = 0; _i1551 < _size1547; ++_i1551)
             {
-              xfer += iprot->readString(this->partVals[_i1544]);
+              xfer += iprot->readString(this->partVals[_i1551]);
             }
             xfer += iprot->readListEnd();
           }
@@ -43940,10 +44027,10 @@ uint32_t RenamePartitionRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-    std::vector<std::string> ::const_iterator _iter1545;
-    for (_iter1545 = this->partVals.begin(); _iter1545 != this->partVals.end(); ++_iter1545)
+    std::vector<std::string> ::const_iterator _iter1552;
+    for (_iter1552 = this->partVals.begin(); _iter1552 != this->partVals.end(); ++_iter1552)
     {
-      xfer += oprot->writeString((*_iter1545));
+      xfer += oprot->writeString((*_iter1552));
     }
     xfer += oprot->writeListEnd();
   }
@@ -43974,23 +44061,23 @@ void swap(RenamePartitionRequest &a, RenamePartitionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-RenamePartitionRequest::RenamePartitionRequest(const RenamePartitionRequest& other1546) {
-  catName = other1546.catName;
-  dbName = other1546.dbName;
-  tableName = other1546.tableName;
-  partVals = other1546.partVals;
-  newPart = other1546.newPart;
-  validWriteIdList = other1546.validWriteIdList;
-  __isset = other1546.__isset;
+RenamePartitionRequest::RenamePartitionRequest(const RenamePartitionRequest& other1553) {
+  catName = other1553.catName;
+  dbName = other1553.dbName;
+  tableName = other1553.tableName;
+  partVals = other1553.partVals;
+  newPart = other1553.newPart;
+  validWriteIdList = other1553.validWriteIdList;
+  __isset = other1553.__isset;
 }
-RenamePartitionRequest& RenamePartitionRequest::operator=(const RenamePartitionRequest& other1547) {
-  catName = other1547.catName;
-  dbName = other1547.dbName;
-  tableName = other1547.tableName;
-  partVals = other1547.partVals;
-  newPart = other1547.newPart;
-  validWriteIdList = other1547.validWriteIdList;
-  __isset = other1547.__isset;
+RenamePartitionRequest& RenamePartitionRequest::operator=(const RenamePartitionRequest& other1554) {
+  catName = other1554.catName;
+  dbName = other1554.dbName;
+  tableName = other1554.tableName;
+  partVals = other1554.partVals;
+  newPart = other1554.newPart;
+  validWriteIdList = other1554.validWriteIdList;
+  __isset = other1554.__isset;
   return *this;
 }
 void RenamePartitionRequest::printTo(std::ostream& out) const {
@@ -44060,11 +44147,11 @@ void swap(RenamePartitionResponse &a, RenamePartitionResponse &b) {
   (void) b;
 }
 
-RenamePartitionResponse::RenamePartitionResponse(const RenamePartitionResponse& other1548) {
-  (void) other1548;
+RenamePartitionResponse::RenamePartitionResponse(const RenamePartitionResponse& other1555) {
+  (void) other1555;
 }
-RenamePartitionResponse& RenamePartitionResponse::operator=(const RenamePartitionResponse& other1549) {
-  (void) other1549;
+RenamePartitionResponse& RenamePartitionResponse::operator=(const RenamePartitionResponse& other1556) {
+  (void) other1556;
   return *this;
 }
 void RenamePartitionResponse::printTo(std::ostream& out) const {
@@ -44210,14 +44297,14 @@ uint32_t AlterTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1550;
-            ::apache::thrift::protocol::TType _etype1553;
-            xfer += iprot->readListBegin(_etype1553, _size1550);
-            this->processorCapabilities.resize(_size1550);
-            uint32_t _i1554;
-            for (_i1554 = 0; _i1554 < _size1550; ++_i1554)
+            uint32_t _size1557;
+            ::apache::thrift::protocol::TType _etype1560;
+            xfer += iprot->readListBegin(_etype1560, _size1557);
+            this->processorCapabilities.resize(_size1557);
+            uint32_t _i1561;
+            for (_i1561 = 0; _i1561 < _size1557; ++_i1561)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1554]);
+              xfer += iprot->readString(this->processorCapabilities[_i1561]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44293,10 +44380,10 @@ uint32_t AlterTableRequest::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1555;
-      for (_iter1555 = this->processorCapabilities.begin(); _iter1555 != this->processorCapabilities.end(); ++_iter1555)
+      std::vector<std::string> ::const_iterator _iter1562;
+      for (_iter1562 = this->processorCapabilities.begin(); _iter1562 != this->processorCapabilities.end(); ++_iter1562)
       {
-        xfer += oprot->writeString((*_iter1555));
+        xfer += oprot->writeString((*_iter1562));
       }
       xfer += oprot->writeListEnd();
     }
@@ -44326,29 +44413,29 @@ void swap(AlterTableRequest &a, AlterTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterTableRequest::AlterTableRequest(const AlterTableRequest& other1556) {
-  catName = other1556.catName;
-  dbName = other1556.dbName;
-  tableName = other1556.tableName;
-  table = other1556.table;
-  environmentContext = other1556.environmentContext;
-  writeId = other1556.writeId;
-  validWriteIdList = other1556.validWriteIdList;
-  processorCapabilities = other1556.processorCapabilities;
-  processorIdentifier = other1556.processorIdentifier;
-  __isset = other1556.__isset;
+AlterTableRequest::AlterTableRequest(const AlterTableRequest& other1563) {
+  catName = other1563.catName;
+  dbName = other1563.dbName;
+  tableName = other1563.tableName;
+  table = other1563.table;
+  environmentContext = other1563.environmentContext;
+  writeId = other1563.writeId;
+  validWriteIdList = other1563.validWriteIdList;
+  processorCapabilities = other1563.processorCapabilities;
+  processorIdentifier = other1563.processorIdentifier;
+  __isset = other1563.__isset;
 }
-AlterTableRequest& AlterTableRequest::operator=(const AlterTableRequest& other1557) {
-  catName = other1557.catName;
-  dbName = other1557.dbName;
-  tableName = other1557.tableName;
-  table = other1557.table;
-  environmentContext = other1557.environmentContext;
-  writeId = other1557.writeId;
-  validWriteIdList = other1557.validWriteIdList;
-  processorCapabilities = other1557.processorCapabilities;
-  processorIdentifier = other1557.processorIdentifier;
-  __isset = other1557.__isset;
+AlterTableRequest& AlterTableRequest::operator=(const AlterTableRequest& other1564) {
+  catName = other1564.catName;
+  dbName = other1564.dbName;
+  tableName = other1564.tableName;
+  table = other1564.table;
+  environmentContext = other1564.environmentContext;
+  writeId = other1564.writeId;
+  validWriteIdList = other1564.validWriteIdList;
+  processorCapabilities = other1564.processorCapabilities;
+  processorIdentifier = other1564.processorIdentifier;
+  __isset = other1564.__isset;
   return *this;
 }
 void AlterTableRequest::printTo(std::ostream& out) const {
@@ -44421,11 +44508,11 @@ void swap(AlterTableResponse &a, AlterTableResponse &b) {
   (void) b;
 }
 
-AlterTableResponse::AlterTableResponse(const AlterTableResponse& other1558) {
-  (void) other1558;
+AlterTableResponse::AlterTableResponse(const AlterTableResponse& other1565) {
+  (void) other1565;
 }
-AlterTableResponse& AlterTableResponse::operator=(const AlterTableResponse& other1559) {
-  (void) other1559;
+AlterTableResponse& AlterTableResponse::operator=(const AlterTableResponse& other1566) {
+  (void) other1566;
   return *this;
 }
 void AlterTableResponse::printTo(std::ostream& out) const {
@@ -44478,9 +44565,9 @@ uint32_t GetPartitionsFilterSpec::read(::apache::thrift::protocol::TProtocol* ip
     {
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1560;
-          xfer += iprot->readI32(ecast1560);
-          this->filterMode = (PartitionFilterMode::type)ecast1560;
+          int32_t ecast1567;
+          xfer += iprot->readI32(ecast1567);
+          this->filterMode = (PartitionFilterMode::type)ecast1567;
           this->__isset.filterMode = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -44490,14 +44577,14 @@ uint32_t GetPartitionsFilterSpec::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filters.clear();
-            uint32_t _size1561;
-            ::apache::thrift::protocol::TType _etype1564;
-            xfer += iprot->readListBegin(_etype1564, _size1561);
-            this->filters.resize(_size1561);
-            uint32_t _i1565;
-            for (_i1565 = 0; _i1565 < _size1561; ++_i1565)
+            uint32_t _size1568;
+            ::apache::thrift::protocol::TType _etype1571;
+            xfer += iprot->readListBegin(_etype1571, _size1568);
+            this->filters.resize(_size1568);
+            uint32_t _i1572;
+            for (_i1572 = 0; _i1572 < _size1568; ++_i1572)
             {
-              xfer += iprot->readString(this->filters[_i1565]);
+              xfer += iprot->readString(this->filters[_i1572]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44532,10 +44619,10 @@ uint32_t GetPartitionsFilterSpec::write(::apache::thrift::protocol::TProtocol* o
     xfer += oprot->writeFieldBegin("filters", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filters.size()));
-      std::vector<std::string> ::const_iterator _iter1566;
-      for (_iter1566 = this->filters.begin(); _iter1566 != this->filters.end(); ++_iter1566)
+      std::vector<std::string> ::const_iterator _iter1573;
+      for (_iter1573 = this->filters.begin(); _iter1573 != this->filters.end(); ++_iter1573)
       {
-        xfer += oprot->writeString((*_iter1566));
+        xfer += oprot->writeString((*_iter1573));
       }
       xfer += oprot->writeListEnd();
     }
@@ -44553,15 +44640,15 @@ void swap(GetPartitionsFilterSpec &a, GetPartitionsFilterSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsFilterSpec::GetPartitionsFilterSpec(const GetPartitionsFilterSpec& other1567) {
-  filterMode = other1567.filterMode;
-  filters = other1567.filters;
-  __isset = other1567.__isset;
+GetPartitionsFilterSpec::GetPartitionsFilterSpec(const GetPartitionsFilterSpec& other1574) {
+  filterMode = other1574.filterMode;
+  filters = other1574.filters;
+  __isset = other1574.__isset;
 }
-GetPartitionsFilterSpec& GetPartitionsFilterSpec::operator=(const GetPartitionsFilterSpec& other1568) {
-  filterMode = other1568.filterMode;
-  filters = other1568.filters;
-  __isset = other1568.__isset;
+GetPartitionsFilterSpec& GetPartitionsFilterSpec::operator=(const GetPartitionsFilterSpec& other1575) {
+  filterMode = other1575.filterMode;
+  filters = other1575.filters;
+  __isset = other1575.__isset;
   return *this;
 }
 void GetPartitionsFilterSpec::printTo(std::ostream& out) const {
@@ -44612,14 +44699,14 @@ uint32_t GetPartitionsResponse::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionSpec.clear();
-            uint32_t _size1569;
-            ::apache::thrift::protocol::TType _etype1572;
-            xfer += iprot->readListBegin(_etype1572, _size1569);
-            this->partitionSpec.resize(_size1569);
-            uint32_t _i1573;
-            for (_i1573 = 0; _i1573 < _size1569; ++_i1573)
+            uint32_t _size1576;
+            ::apache::thrift::protocol::TType _etype1579;
+            xfer += iprot->readListBegin(_etype1579, _size1576);
+            this->partitionSpec.resize(_size1576);
+            uint32_t _i1580;
+            for (_i1580 = 0; _i1580 < _size1576; ++_i1580)
             {
-              xfer += this->partitionSpec[_i1573].read(iprot);
+              xfer += this->partitionSpec[_i1580].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -44648,10 +44735,10 @@ uint32_t GetPartitionsResponse::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("partitionSpec", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionSpec.size()));
-    std::vector<PartitionSpec> ::const_iterator _iter1574;
-    for (_iter1574 = this->partitionSpec.begin(); _iter1574 != this->partitionSpec.end(); ++_iter1574)
+    std::vector<PartitionSpec> ::const_iterator _iter1581;
+    for (_iter1581 = this->partitionSpec.begin(); _iter1581 != this->partitionSpec.end(); ++_iter1581)
     {
-      xfer += (*_iter1574).write(oprot);
+      xfer += (*_iter1581).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -44668,13 +44755,13 @@ void swap(GetPartitionsResponse &a, GetPartitionsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsResponse::GetPartitionsResponse(const GetPartitionsResponse& other1575) {
-  partitionSpec = other1575.partitionSpec;
-  __isset = other1575.__isset;
+GetPartitionsResponse::GetPartitionsResponse(const GetPartitionsResponse& other1582) {
+  partitionSpec = other1582.partitionSpec;
+  __isset = other1582.__isset;
 }
-GetPartitionsResponse& GetPartitionsResponse::operator=(const GetPartitionsResponse& other1576) {
-  partitionSpec = other1576.partitionSpec;
-  __isset = other1576.__isset;
+GetPartitionsResponse& GetPartitionsResponse::operator=(const GetPartitionsResponse& other1583) {
+  partitionSpec = other1583.partitionSpec;
+  __isset = other1583.__isset;
   return *this;
 }
 void GetPartitionsResponse::printTo(std::ostream& out) const {
@@ -44811,14 +44898,14 @@ uint32_t GetPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->groupNames.clear();
-            uint32_t _size1577;
-            ::apache::thrift::protocol::TType _etype1580;
-            xfer += iprot->readListBegin(_etype1580, _size1577);
-            this->groupNames.resize(_size1577);
-            uint32_t _i1581;
-            for (_i1581 = 0; _i1581 < _size1577; ++_i1581)
+            uint32_t _size1584;
+            ::apache::thrift::protocol::TType _etype1587;
+            xfer += iprot->readListBegin(_etype1587, _size1584);
+            this->groupNames.resize(_size1584);
+            uint32_t _i1588;
+            for (_i1588 = 0; _i1588 < _size1584; ++_i1588)
             {
-              xfer += iprot->readString(this->groupNames[_i1581]);
+              xfer += iprot->readString(this->groupNames[_i1588]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44847,14 +44934,14 @@ uint32_t GetPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1582;
-            ::apache::thrift::protocol::TType _etype1585;
-            xfer += iprot->readListBegin(_etype1585, _size1582);
-            this->processorCapabilities.resize(_size1582);
-            uint32_t _i1586;
-            for (_i1586 = 0; _i1586 < _size1582; ++_i1586)
+            uint32_t _size1589;
+            ::apache::thrift::protocol::TType _etype1592;
+            xfer += iprot->readListBegin(_etype1592, _size1589);
+            this->processorCapabilities.resize(_size1589);
+            uint32_t _i1593;
+            for (_i1593 = 0; _i1593 < _size1589; ++_i1593)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1586]);
+              xfer += iprot->readString(this->processorCapabilities[_i1593]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44923,10 +45010,10 @@ uint32_t GetPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("groupNames", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->groupNames.size()));
-      std::vector<std::string> ::const_iterator _iter1587;
-      for (_iter1587 = this->groupNames.begin(); _iter1587 != this->groupNames.end(); ++_iter1587)
+      std::vector<std::string> ::const_iterator _iter1594;
+      for (_iter1594 = this->groupNames.begin(); _iter1594 != this->groupNames.end(); ++_iter1594)
       {
-        xfer += oprot->writeString((*_iter1587));
+        xfer += oprot->writeString((*_iter1594));
       }
       xfer += oprot->writeListEnd();
     }
@@ -44944,10 +45031,10 @@ uint32_t GetPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 9);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1588;
-      for (_iter1588 = this->processorCapabilities.begin(); _iter1588 != this->processorCapabilities.end(); ++_iter1588)
+      std::vector<std::string> ::const_iterator _iter1595;
+      for (_iter1595 = this->processorCapabilities.begin(); _iter1595 != this->processorCapabilities.end(); ++_iter1595)
       {
-        xfer += oprot->writeString((*_iter1588));
+        xfer += oprot->writeString((*_iter1595));
       }
       xfer += oprot->writeListEnd();
     }
@@ -44984,33 +45071,33 @@ void swap(GetPartitionsRequest &a, GetPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsRequest::GetPartitionsRequest(const GetPartitionsRequest& other1589) {
-  catName = other1589.catName;
-  dbName = other1589.dbName;
-  tblName = other1589.tblName;
-  withAuth = other1589.withAuth;
-  user = other1589.user;
-  groupNames = other1589.groupNames;
-  projectionSpec = other1589.projectionSpec;
-  filterSpec = other1589.filterSpec;
-  processorCapabilities = other1589.processorCapabilities;
-  processorIdentifier = other1589.processorIdentifier;
-  validWriteIdList = other1589.validWriteIdList;
-  __isset = other1589.__isset;
+GetPartitionsRequest::GetPartitionsRequest(const GetPartitionsRequest& other1596) {
+  catName = other1596.catName;
+  dbName = other1596.dbName;
+  tblName = other1596.tblName;
+  withAuth = other1596.withAuth;
+  user = other1596.user;
+  groupNames = other1596.groupNames;
+  projectionSpec = other1596.projectionSpec;
+  filterSpec = other1596.filterSpec;
+  processorCapabilities = other1596.processorCapabilities;
+  processorIdentifier = other1596.processorIdentifier;
+  validWriteIdList = other1596.validWriteIdList;
+  __isset = other1596.__isset;
 }
-GetPartitionsRequest& GetPartitionsRequest::operator=(const GetPartitionsRequest& other1590) {
-  catName = other1590.catName;
-  dbName = other1590.dbName;
-  tblName = other1590.tblName;
-  withAuth = other1590.withAuth;
-  user = other1590.user;
-  groupNames = other1590.groupNames;
-  projectionSpec = other1590.projectionSpec;
-  filterSpec = other1590.filterSpec;
-  processorCapabilities = other1590.processorCapabilities;
-  processorIdentifier = other1590.processorIdentifier;
-  validWriteIdList = other1590.validWriteIdList;
-  __isset = other1590.__isset;
+GetPartitionsRequest& GetPartitionsRequest::operator=(const GetPartitionsRequest& other1597) {
+  catName = other1597.catName;
+  dbName = other1597.dbName;
+  tblName = other1597.tblName;
+  withAuth = other1597.withAuth;
+  user = other1597.user;
+  groupNames = other1597.groupNames;
+  projectionSpec = other1597.projectionSpec;
+  filterSpec = other1597.filterSpec;
+  processorCapabilities = other1597.processorCapabilities;
+  processorIdentifier = other1597.processorIdentifier;
+  validWriteIdList = other1597.validWriteIdList;
+  __isset = other1597.__isset;
   return *this;
 }
 void GetPartitionsRequest::printTo(std::ostream& out) const {
@@ -45205,23 +45292,23 @@ void swap(GetFieldsRequest &a, GetFieldsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetFieldsRequest::GetFieldsRequest(const GetFieldsRequest& other1591) {
-  catName = other1591.catName;
-  dbName = other1591.dbName;
-  tblName = other1591.tblName;
-  envContext = other1591.envContext;
-  validWriteIdList = other1591.validWriteIdList;
-  id = other1591.id;
-  __isset = other1591.__isset;
+GetFieldsRequest::GetFieldsRequest(const GetFieldsRequest& other1598) {
+  catName = other1598.catName;
+  dbName = other1598.dbName;
+  tblName = other1598.tblName;
+  envContext = other1598.envContext;
+  validWriteIdList = other1598.validWriteIdList;
+  id = other1598.id;
+  __isset = other1598.__isset;
 }
-GetFieldsRequest& GetFieldsRequest::operator=(const GetFieldsRequest& other1592) {
-  catName = other1592.catName;
-  dbName = other1592.dbName;
-  tblName = other1592.tblName;
-  envContext = other1592.envContext;
-  validWriteIdList = other1592.validWriteIdList;
-  id = other1592.id;
-  __isset = other1592.__isset;
+GetFieldsRequest& GetFieldsRequest::operator=(const GetFieldsRequest& other1599) {
+  catName = other1599.catName;
+  dbName = other1599.dbName;
+  tblName = other1599.tblName;
+  envContext = other1599.envContext;
+  validWriteIdList = other1599.validWriteIdList;
+  id = other1599.id;
+  __isset = other1599.__isset;
   return *this;
 }
 void GetFieldsRequest::printTo(std::ostream& out) const {
@@ -45277,14 +45364,14 @@ uint32_t GetFieldsResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size1593;
-            ::apache::thrift::protocol::TType _etype1596;
-            xfer += iprot->readListBegin(_etype1596, _size1593);
-            this->fields.resize(_size1593);
-            uint32_t _i1597;
-            for (_i1597 = 0; _i1597 < _size1593; ++_i1597)
+            uint32_t _size1600;
+            ::apache::thrift::protocol::TType _etype1603;
+            xfer += iprot->readListBegin(_etype1603, _size1600);
+            this->fields.resize(_size1600);
+            uint32_t _i1604;
+            for (_i1604 = 0; _i1604 < _size1600; ++_i1604)
             {
-              xfer += this->fields[_i1597].read(iprot);
+              xfer += this->fields[_i1604].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -45315,10 +45402,10 @@ uint32_t GetFieldsResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1598;
-    for (_iter1598 = this->fields.begin(); _iter1598 != this->fields.end(); ++_iter1598)
+    std::vector<FieldSchema> ::const_iterator _iter1605;
+    for (_iter1605 = this->fields.begin(); _iter1605 != this->fields.end(); ++_iter1605)
     {
-      xfer += (*_iter1598).write(oprot);
+      xfer += (*_iter1605).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -45334,11 +45421,11 @@ void swap(GetFieldsResponse &a, GetFieldsResponse &b) {
   swap(a.fields, b.fields);
 }
 
-GetFieldsResponse::GetFieldsResponse(const GetFieldsResponse& other1599) {
-  fields = other1599.fields;
+GetFieldsResponse::GetFieldsResponse(const GetFieldsResponse& other1606) {
+  fields = other1606.fields;
 }
-GetFieldsResponse& GetFieldsResponse::operator=(const GetFieldsResponse& other1600) {
-  fields = other1600.fields;
+GetFieldsResponse& GetFieldsResponse::operator=(const GetFieldsResponse& other1607) {
+  fields = other1607.fields;
   return *this;
 }
 void GetFieldsResponse::printTo(std::ostream& out) const {
@@ -45523,23 +45610,23 @@ void swap(GetSchemaRequest &a, GetSchemaRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetSchemaRequest::GetSchemaRequest(const GetSchemaRequest& other1601) {
-  catName = other1601.catName;
-  dbName = other1601.dbName;
-  tblName = other1601.tblName;
-  envContext = other1601.envContext;
-  validWriteIdList = other1601.validWriteIdList;
-  id = other1601.id;
-  __isset = other1601.__isset;
+GetSchemaRequest::GetSchemaRequest(const GetSchemaRequest& other1608) {
+  catName = other1608.catName;
+  dbName = other1608.dbName;
+  tblName = other1608.tblName;
+  envContext = other1608.envContext;
+  validWriteIdList = other1608.validWriteIdList;
+  id = other1608.id;
+  __isset = other1608.__isset;
 }
-GetSchemaRequest& GetSchemaRequest::operator=(const GetSchemaRequest& other1602) {
-  catName = other1602.catName;
-  dbName = other1602.dbName;
-  tblName = other1602.tblName;
-  envContext = other1602.envContext;
-  validWriteIdList = other1602.validWriteIdList;
-  id = other1602.id;
-  __isset = other1602.__isset;
+GetSchemaRequest& GetSchemaRequest::operator=(const GetSchemaRequest& other1609) {
+  catName = other1609.catName;
+  dbName = other1609.dbName;
+  tblName = other1609.tblName;
+  envContext = other1609.envContext;
+  validWriteIdList = other1609.validWriteIdList;
+  id = other1609.id;
+  __isset = other1609.__isset;
   return *this;
 }
 void GetSchemaRequest::printTo(std::ostream& out) const {
@@ -45595,14 +45682,14 @@ uint32_t GetSchemaResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size1603;
-            ::apache::thrift::protocol::TType _etype1606;
-            xfer += iprot->readListBegin(_etype1606, _size1603);
-            this->fields.resize(_size1603);
-            uint32_t _i1607;
-            for (_i1607 = 0; _i1607 < _size1603; ++_i1607)
+            uint32_t _size1610;
+            ::apache::thrift::protocol::TType _etype1613;
+            xfer += iprot->readListBegin(_etype1613, _size1610);
+            this->fields.resize(_size1610);
+            uint32_t _i1614;
+            for (_i1614 = 0; _i1614 < _size1610; ++_i1614)
             {
-              xfer += this->fields[_i1607].read(iprot);
+              xfer += this->fields[_i1614].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -45633,10 +45720,10 @@ uint32_t GetSchemaResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1608;
-    for (_iter1608 = this->fields.begin(); _iter1608 != this->fields.end(); ++_iter1608)
+    std::vector<FieldSchema> ::const_iterator _iter1615;
+    for (_iter1615 = this->fields.begin(); _iter1615 != this->fields.end(); ++_iter1615)
     {
-      xfer += (*_iter1608).write(oprot);
+      xfer += (*_iter1615).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -45652,11 +45739,11 @@ void swap(GetSchemaResponse &a, GetSchemaResponse &b) {
   swap(a.fields, b.fields);
 }
 
-GetSchemaResponse::GetSchemaResponse(const GetSchemaResponse& other1609) {
-  fields = other1609.fields;
+GetSchemaResponse::GetSchemaResponse(const GetSchemaResponse& other1616) {
+  fields = other1616.fields;
 }
-GetSchemaResponse& GetSchemaResponse::operator=(const GetSchemaResponse& other1610) {
-  fields = other1610.fields;
+GetSchemaResponse& GetSchemaResponse::operator=(const GetSchemaResponse& other1617) {
+  fields = other1617.fields;
   return *this;
 }
 void GetSchemaResponse::printTo(std::ostream& out) const {
@@ -45756,14 +45843,14 @@ uint32_t GetPartitionRequest::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1611;
-            ::apache::thrift::protocol::TType _etype1614;
-            xfer += iprot->readListBegin(_etype1614, _size1611);
-            this->partVals.resize(_size1611);
-            uint32_t _i1615;
-            for (_i1615 = 0; _i1615 < _size1611; ++_i1615)
+            uint32_t _size1618;
+            ::apache::thrift::protocol::TType _etype1621;
+            xfer += iprot->readListBegin(_etype1621, _size1618);
+            this->partVals.resize(_size1618);
+            uint32_t _i1622;
+            for (_i1622 = 0; _i1622 < _size1618; ++_i1622)
             {
-              xfer += iprot->readString(this->partVals[_i1615]);
+              xfer += iprot->readString(this->partVals[_i1622]);
             }
             xfer += iprot->readListEnd();
           }
@@ -45827,10 +45914,10 @@ uint32_t GetPartitionRequest::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-    std::vector<std::string> ::const_iterator _iter1616;
-    for (_iter1616 = this->partVals.begin(); _iter1616 != this->partVals.end(); ++_iter1616)
+    std::vector<std::string> ::const_iterator _iter1623;
+    for (_iter1623 = this->partVals.begin(); _iter1623 != this->partVals.end(); ++_iter1623)
     {
-      xfer += oprot->writeString((*_iter1616));
+      xfer += oprot->writeString((*_iter1623));
     }
     xfer += oprot->writeListEnd();
   }
@@ -45862,23 +45949,23 @@ void swap(GetPartitionRequest &a, GetPartitionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionRequest::GetPartitionRequest(const GetPartitionRequest& other1617) {
-  catName = other1617.catName;
-  dbName = other1617.dbName;
-  tblName = other1617.tblName;
-  partVals = other1617.partVals;
-  validWriteIdList = other1617.validWriteIdList;
-  id = other1617.id;
-  __isset = other1617.__isset;
+GetPartitionRequest::GetPartitionRequest(const GetPartitionRequest& other1624) {
+  catName = other1624.catName;
+  dbName = other1624.dbName;
+  tblName = other1624.tblName;
+  partVals = other1624.partVals;
+  validWriteIdList = other1624.validWriteIdList;
+  id = other1624.id;
+  __isset = other1624.__isset;
 }
-GetPartitionRequest& GetPartitionRequest::operator=(const GetPartitionRequest& other1618) {
-  catName = other1618.catName;
-  dbName = other1618.dbName;
-  tblName = other1618.tblName;
-  partVals = other1618.partVals;
-  validWriteIdList = other1618.validWriteIdList;
-  id = other1618.id;
-  __isset = other1618.__isset;
+GetPartitionRequest& GetPartitionRequest::operator=(const GetPartitionRequest& other1625) {
+  catName = other1625.catName;
+  dbName = other1625.dbName;
+  tblName = other1625.tblName;
+  partVals = other1625.partVals;
+  validWriteIdList = other1625.validWriteIdList;
+  id = other1625.id;
+  __isset = other1625.__isset;
   return *this;
 }
 void GetPartitionRequest::printTo(std::ostream& out) const {
@@ -45971,11 +46058,11 @@ void swap(GetPartitionResponse &a, GetPartitionResponse &b) {
   swap(a.partition, b.partition);
 }
 
-GetPartitionResponse::GetPartitionResponse(const GetPartitionResponse& other1619) {
-  partition = other1619.partition;
+GetPartitionResponse::GetPartitionResponse(const GetPartitionResponse& other1626) {
+  partition = other1626.partition;
 }
-GetPartitionResponse& GetPartitionResponse::operator=(const GetPartitionResponse& other1620) {
-  partition = other1620.partition;
+GetPartitionResponse& GetPartitionResponse::operator=(const GetPartitionResponse& other1627) {
+  partition = other1627.partition;
   return *this;
 }
 void GetPartitionResponse::printTo(std::ostream& out) const {
@@ -46160,23 +46247,23 @@ void swap(PartitionsRequest &a, PartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionsRequest::PartitionsRequest(const PartitionsRequest& other1621) {
-  catName = other1621.catName;
-  dbName = other1621.dbName;
-  tblName = other1621.tblName;
-  maxParts = other1621.maxParts;
-  validWriteIdList = other1621.validWriteIdList;
-  id = other1621.id;
-  __isset = other1621.__isset;
+PartitionsRequest::PartitionsRequest(const PartitionsRequest& other1628) {
+  catName = other1628.catName;
+  dbName = other1628.dbName;
+  tblName = other1628.tblName;
+  maxParts = other1628.maxParts;
+  validWriteIdList = other1628.validWriteIdList;
+  id = other1628.id;
+  __isset = other1628.__isset;
 }
-PartitionsRequest& PartitionsRequest::operator=(const PartitionsRequest& other1622) {
-  catName = other1622.catName;
-  dbName = other1622.dbName;
-  tblName = other1622.tblName;
-  maxParts = other1622.maxParts;
-  validWriteIdList = other1622.validWriteIdList;
-  id = other1622.id;
-  __isset = other1622.__isset;
+PartitionsRequest& PartitionsRequest::operator=(const PartitionsRequest& other1629) {
+  catName = other1629.catName;
+  dbName = other1629.dbName;
+  tblName = other1629.tblName;
+  maxParts = other1629.maxParts;
+  validWriteIdList = other1629.validWriteIdList;
+  id = other1629.id;
+  __isset = other1629.__isset;
   return *this;
 }
 void PartitionsRequest::printTo(std::ostream& out) const {
@@ -46232,14 +46319,14 @@ uint32_t PartitionsResponse::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1623;
-            ::apache::thrift::protocol::TType _etype1626;
-            xfer += iprot->readListBegin(_etype1626, _size1623);
-            this->partitions.resize(_size1623);
-            uint32_t _i1627;
-            for (_i1627 = 0; _i1627 < _size1623; ++_i1627)
+            uint32_t _size1630;
+            ::apache::thrift::protocol::TType _etype1633;
+            xfer += iprot->readListBegin(_etype1633, _size1630);
+            this->partitions.resize(_size1630);
+            uint32_t _i1634;
+            for (_i1634 = 0; _i1634 < _size1630; ++_i1634)
             {
-              xfer += this->partitions[_i1627].read(iprot);
+              xfer += this->partitions[_i1634].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -46270,10 +46357,10 @@ uint32_t PartitionsResponse::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1628;
-    for (_iter1628 = this->partitions.begin(); _iter1628 != this->partitions.end(); ++_iter1628)
+    std::vector<Partition> ::const_iterator _iter1635;
+    for (_iter1635 = this->partitions.begin(); _iter1635 != this->partitions.end(); ++_iter1635)
     {
-      xfer += (*_iter1628).write(oprot);
+      xfer += (*_iter1635).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -46289,11 +46376,11 @@ void swap(PartitionsResponse &a, PartitionsResponse &b) {
   swap(a.partitions, b.partitions);
 }
 
-PartitionsResponse::PartitionsResponse(const PartitionsResponse& other1629) {
-  partitions = other1629.partitions;
+PartitionsResponse::PartitionsResponse(const PartitionsResponse& other1636) {
+  partitions = other1636.partitions;
 }
-PartitionsResponse& PartitionsResponse::operator=(const PartitionsResponse& other1630) {
-  partitions = other1630.partitions;
+PartitionsResponse& PartitionsResponse::operator=(const PartitionsResponse& other1637) {
+  partitions = other1637.partitions;
   return *this;
 }
 void PartitionsResponse::printTo(std::ostream& out) const {
@@ -46398,14 +46485,14 @@ uint32_t GetPartitionNamesPsRequest::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partValues.clear();
-            uint32_t _size1631;
-            ::apache::thrift::protocol::TType _etype1634;
-            xfer += iprot->readListBegin(_etype1634, _size1631);
-            this->partValues.resize(_size1631);
-            uint32_t _i1635;
-            for (_i1635 = 0; _i1635 < _size1631; ++_i1635)
+            uint32_t _size1638;
+            ::apache::thrift::protocol::TType _etype1641;
+            xfer += iprot->readListBegin(_etype1641, _size1638);
+            this->partValues.resize(_size1638);
+            uint32_t _i1642;
+            for (_i1642 = 0; _i1642 < _size1638; ++_i1642)
             {
-              xfer += iprot->readString(this->partValues[_i1635]);
+              xfer += iprot->readString(this->partValues[_i1642]);
             }
             xfer += iprot->readListEnd();
           }
@@ -46476,10 +46563,10 @@ uint32_t GetPartitionNamesPsRequest::write(::apache::thrift::protocol::TProtocol
     xfer += oprot->writeFieldBegin("partValues", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partValues.size()));
-      std::vector<std::string> ::const_iterator _iter1636;
-      for (_iter1636 = this->partValues.begin(); _iter1636 != this->partValues.end(); ++_iter1636)
+      std::vector<std::string> ::const_iterator _iter1643;
+      for (_iter1643 = this->partValues.begin(); _iter1643 != this->partValues.end(); ++_iter1643)
       {
-        xfer += oprot->writeString((*_iter1636));
+        xfer += oprot->writeString((*_iter1643));
       }
       xfer += oprot->writeListEnd();
     }
@@ -46517,25 +46604,25 @@ void swap(GetPartitionNamesPsRequest &a, GetPartitionNamesPsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionNamesPsRequest::GetPartitionNamesPsRequest(const GetPartitionNamesPsRequest& other1637) {
-  catName = other1637.catName;
-  dbName = other1637.dbName;
-  tblName = other1637.tblName;
-  partValues = other1637.partValues;
-  maxParts = other1637.maxParts;
-  validWriteIdList = other1637.validWriteIdList;
-  id = other1637.id;
-  __isset = other1637.__isset;
+GetPartitionNamesPsRequest::GetPartitionNamesPsRequest(const GetPartitionNamesPsRequest& other1644) {
+  catName = other1644.catName;
+  dbName = other1644.dbName;
+  tblName = other1644.tblName;
+  partValues = other1644.partValues;
+  maxParts = other1644.maxParts;
+  validWriteIdList = other1644.validWriteIdList;
+  id = other1644.id;
+  __isset = other1644.__isset;
 }
-GetPartitionNamesPsRequest& GetPartitionNamesPsRequest::operator=(const GetPartitionNamesPsRequest& other1638) {
-  catName = other1638.catName;
-  dbName = other1638.dbName;
-  tblName = other1638.tblName;
-  partValues = other1638.partValues;
-  maxParts = other1638.maxParts;
-  validWriteIdList = other1638.validWriteIdList;
-  id = other1638.id;
-  __isset = other1638.__isset;
+GetPartitionNamesPsRequest& GetPartitionNamesPsRequest::operator=(const GetPartitionNamesPsRequest& other1645) {
+  catName = other1645.catName;
+  dbName = other1645.dbName;
+  tblName = other1645.tblName;
+  partValues = other1645.partValues;
+  maxParts = other1645.maxParts;
+  validWriteIdList = other1645.validWriteIdList;
+  id = other1645.id;
+  __isset = other1645.__isset;
   return *this;
 }
 void GetPartitionNamesPsRequest::printTo(std::ostream& out) const {
@@ -46592,14 +46679,14 @@ uint32_t GetPartitionNamesPsResponse::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size1639;
-            ::apache::thrift::protocol::TType _etype1642;
-            xfer += iprot->readListBegin(_etype1642, _size1639);
-            this->names.resize(_size1639);
-            uint32_t _i1643;
-            for (_i1643 = 0; _i1643 < _size1639; ++_i1643)
+            uint32_t _size1646;
+            ::apache::thrift::protocol::TType _etype1649;
+            xfer += iprot->readListBegin(_etype1649, _size1646);
+            this->names.resize(_size1646);
+            uint32_t _i1650;
+            for (_i1650 = 0; _i1650 < _size1646; ++_i1650)
             {
-              xfer += iprot->readString(this->names[_i1643]);
+              xfer += iprot->readString(this->names[_i1650]);
             }
             xfer += iprot->readListEnd();
           }
@@ -46630,10 +46717,10 @@ uint32_t GetPartitionNamesPsResponse::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-    std::vector<std::string> ::const_iterator _iter1644;
-    for (_iter1644 = this->names.begin(); _iter1644 != this->names.end(); ++_iter1644)
+    std::vector<std::string> ::const_iterator _iter1651;
+    for (_iter1651 = this->names.begin(); _iter1651 != this->names.end(); ++_iter1651)
     {
-      xfer += oprot->writeString((*_iter1644));
+      xfer += oprot->writeString((*_iter1651));
     }
     xfer += oprot->writeListEnd();
   }
@@ -46649,11 +46736,11 @@ void swap(GetPartitionNamesPsResponse &a, GetPartitionNamesPsResponse &b) {
   swap(a.names, b.names);
 }
 
-GetPartitionNamesPsResponse::GetPartitionNamesPsResponse(const GetPartitionNamesPsResponse& other1645) {
-  names = other1645.names;
+GetPartitionNamesPsResponse::GetPartitionNamesPsResponse(const GetPartitionNamesPsResponse& other1652) {
+  names = other1652.names;
 }
-GetPartitionNamesPsResponse& GetPartitionNamesPsResponse::operator=(const GetPartitionNamesPsResponse& other1646) {
-  names = other1646.names;
+GetPartitionNamesPsResponse& GetPartitionNamesPsResponse::operator=(const GetPartitionNamesPsResponse& other1653) {
+  names = other1653.names;
   return *this;
 }
 void GetPartitionNamesPsResponse::printTo(std::ostream& out) const {
@@ -46768,14 +46855,14 @@ uint32_t GetPartitionsPsWithAuthRequest::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1647;
-            ::apache::thrift::protocol::TType _etype1650;
-            xfer += iprot->readListBegin(_etype1650, _size1647);
-            this->partVals.resize(_size1647);
-            uint32_t _i1651;
-            for (_i1651 = 0; _i1651 < _size1647; ++_i1651)
+            uint32_t _size1654;
+            ::apache::thrift::protocol::TType _etype1657;
+            xfer += iprot->readListBegin(_etype1657, _size1654);
+            this->partVals.resize(_size1654);
+            uint32_t _i1658;
+            for (_i1658 = 0; _i1658 < _size1654; ++_i1658)
             {
-              xfer += iprot->readString(this->partVals[_i1651]);
+              xfer += iprot->readString(this->partVals[_i1658]);
             }
             xfer += iprot->readListEnd();
           }
@@ -46804,14 +46891,14 @@ uint32_t GetPartitionsPsWithAuthRequest::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->groupNames.clear();
-            uint32_t _size1652;
-            ::apache::thrift::protocol::TType _etype1655;
-            xfer += iprot->readListBegin(_etype1655, _size1652);
-            this->groupNames.resize(_size1652);
-            uint32_t _i1656;
-            for (_i1656 = 0; _i1656 < _size1652; ++_i1656)
+            uint32_t _size1659;
+            ::apache::thrift::protocol::TType _etype1662;
+            xfer += iprot->readListBegin(_etype1662, _size1659);
+            this->groupNames.resize(_size1659);
+            uint32_t _i1663;
+            for (_i1663 = 0; _i1663 < _size1659; ++_i1663)
             {
-              xfer += iprot->readString(this->groupNames[_i1656]);
+              xfer += iprot->readString(this->groupNames[_i1663]);
             }
             xfer += iprot->readListEnd();
           }
@@ -46874,10 +46961,10 @@ uint32_t GetPartitionsPsWithAuthRequest::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-      std::vector<std::string> ::const_iterator _iter1657;
-      for (_iter1657 = this->partVals.begin(); _iter1657 != this->partVals.end(); ++_iter1657)
+      std::vector<std::string> ::const_iterator _iter1664;
+      for (_iter1664 = this->partVals.begin(); _iter1664 != this->partVals.end(); ++_iter1664)
       {
-        xfer += oprot->writeString((*_iter1657));
+        xfer += oprot->writeString((*_iter1664));
       }
       xfer += oprot->writeListEnd();
     }
@@ -46897,10 +46984,10 @@ uint32_t GetPartitionsPsWithAuthRequest::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("groupNames", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->groupNames.size()));
-      std::vector<std::string> ::const_iterator _iter1658;
-      for (_iter1658 = this->groupNames.begin(); _iter1658 != this->groupNames.end(); ++_iter1658)
+      std::vector<std::string> ::const_iterator _iter1665;
+      for (_iter1665 = this->groupNames.begin(); _iter1665 != this->groupNames.end(); ++_iter1665)
       {
-        xfer += oprot->writeString((*_iter1658));
+        xfer += oprot->writeString((*_iter1665));
       }
       xfer += oprot->writeListEnd();
     }
@@ -46935,29 +47022,29 @@ void swap(GetPartitionsPsWithAuthRequest &a, GetPartitionsPsWithAuthRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsPsWithAuthRequest::GetPartitionsPsWithAuthRequest(const GetPartitionsPsWithAuthRequest& other1659) {
-  catName = other1659.catName;
-  dbName = other1659.dbName;
-  tblName = other1659.tblName;
-  partVals = other1659.partVals;
-  maxParts = other1659.maxParts;
-  userName = other1659.userName;
-  groupNames = other1659.groupNames;
-  validWriteIdList = other1659.validWriteIdList;
-  id = other1659.id;
-  __isset = other1659.__isset;
+GetPartitionsPsWithAuthRequest::GetPartitionsPsWithAuthRequest(const GetPartitionsPsWithAuthRequest& other1666) {
+  catName = other1666.catName;
+  dbName = other1666.dbName;
+  tblName = other1666.tblName;
+  partVals = other1666.partVals;
+  maxParts = other1666.maxParts;
+  userName = other1666.userName;
+  groupNames = other1666.groupNames;
+  validWriteIdList = other1666.validWriteIdList;
+  id = other1666.id;
+  __isset = other1666.__isset;
 }
-GetPartitionsPsWithAuthRequest& GetPartitionsPsWithAuthRequest::operator=(const GetPartitionsPsWithAuthRequest& other1660) {
-  catName = other1660.catName;
-  dbName = other1660.dbName;
-  tblName = other1660.tblName;
-  partVals = other1660.partVals;
-  maxParts = other1660.maxParts;
-  userName = other1660.userName;
-  groupNames = other1660.groupNames;
-  validWriteIdList = other1660.validWriteIdList;
-  id = other1660.id;
-  __isset = other1660.__isset;
+GetPartitionsPsWithAuthRequest& GetPartitionsPsWithAuthRequest::operator=(const GetPartitionsPsWithAuthRequest& other1667) {
+  catName = other1667.catName;
+  dbName = other1667.dbName;
+  tblName = other1667.tblName;
+  partVals = other1667.partVals;
+  maxParts = other1667.maxParts;
+  userName = other1667.userName;
+  groupNames = other1667.groupNames;
+  validWriteIdList = other1667.validWriteIdList;
+  id = other1667.id;
+  __isset = other1667.__isset;
   return *this;
 }
 void GetPartitionsPsWithAuthRequest::printTo(std::ostream& out) const {
@@ -47016,14 +47103,14 @@ uint32_t GetPartitionsPsWithAuthResponse::read(::apache::thrift::protocol::TProt
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1661;
-            ::apache::thrift::protocol::TType _etype1664;
-            xfer += iprot->readListBegin(_etype1664, _size1661);
-            this->partitions.resize(_size1661);
-            uint32_t _i1665;
-            for (_i1665 = 0; _i1665 < _size1661; ++_i1665)
+            uint32_t _size1668;
+            ::apache::thrift::protocol::TType _etype1671;
+            xfer += iprot->readListBegin(_etype1671, _size1668);
+            this->partitions.resize(_size1668);
+            uint32_t _i1672;
+            for (_i1672 = 0; _i1672 < _size1668; ++_i1672)
             {
-              xfer += this->partitions[_i1665].read(iprot);
+              xfer += this->partitions[_i1672].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -47054,10 +47141,10 @@ uint32_t GetPartitionsPsWithAuthResponse::write(::apache::thrift::protocol::TPro
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1666;
-    for (_iter1666 = this->partitions.begin(); _iter1666 != this->partitions.end(); ++_iter1666)
+    std::vector<Partition> ::const_iterator _iter1673;
+    for (_iter1673 = this->partitions.begin(); _iter1673 != this->partitions.end(); ++_iter1673)
     {
-      xfer += (*_iter1666).write(oprot);
+      xfer += (*_iter1673).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -47073,11 +47160,11 @@ void swap(GetPartitionsPsWithAuthResponse &a, GetPartitionsPsWithAuthResponse &b
   swap(a.partitions, b.partitions);
 }
 
-GetPartitionsPsWithAuthResponse::GetPartitionsPsWithAuthResponse(const GetPartitionsPsWithAuthResponse& other1667) {
-  partitions = other1667.partitions;
+GetPartitionsPsWithAuthResponse::GetPartitionsPsWithAuthResponse(const GetPartitionsPsWithAuthResponse& other1674) {
+  partitions = other1674.partitions;
 }
-GetPartitionsPsWithAuthResponse& GetPartitionsPsWithAuthResponse::operator=(const GetPartitionsPsWithAuthResponse& other1668) {
-  partitions = other1668.partitions;
+GetPartitionsPsWithAuthResponse& GetPartitionsPsWithAuthResponse::operator=(const GetPartitionsPsWithAuthResponse& other1675) {
+  partitions = other1675.partitions;
   return *this;
 }
 void GetPartitionsPsWithAuthResponse::printTo(std::ostream& out) const {
@@ -47263,23 +47350,23 @@ void swap(ReplicationMetrics &a, ReplicationMetrics &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplicationMetrics::ReplicationMetrics(const ReplicationMetrics& other1669) {
-  scheduledExecutionId = other1669.scheduledExecutionId;
-  policy = other1669.policy;
-  dumpExecutionId = other1669.dumpExecutionId;
-  metadata = other1669.metadata;
-  progress = other1669.progress;
-  messageFormat = other1669.messageFormat;
-  __isset = other1669.__isset;
+ReplicationMetrics::ReplicationMetrics(const ReplicationMetrics& other1676) {
+  scheduledExecutionId = other1676.scheduledExecutionId;
+  policy = other1676.policy;
+  dumpExecutionId = other1676.dumpExecutionId;
+  metadata = other1676.metadata;
+  progress = other1676.progress;
+  messageFormat = other1676.messageFormat;
+  __isset = other1676.__isset;
 }
-ReplicationMetrics& ReplicationMetrics::operator=(const ReplicationMetrics& other1670) {
-  scheduledExecutionId = other1670.scheduledExecutionId;
-  policy = other1670.policy;
-  dumpExecutionId = other1670.dumpExecutionId;
-  metadata = other1670.metadata;
-  progress = other1670.progress;
-  messageFormat = other1670.messageFormat;
-  __isset = other1670.__isset;
+ReplicationMetrics& ReplicationMetrics::operator=(const ReplicationMetrics& other1677) {
+  scheduledExecutionId = other1677.scheduledExecutionId;
+  policy = other1677.policy;
+  dumpExecutionId = other1677.dumpExecutionId;
+  metadata = other1677.metadata;
+  progress = other1677.progress;
+  messageFormat = other1677.messageFormat;
+  __isset = other1677.__isset;
   return *this;
 }
 void ReplicationMetrics::printTo(std::ostream& out) const {
@@ -47335,14 +47422,14 @@ uint32_t ReplicationMetricList::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->replicationMetricList.clear();
-            uint32_t _size1671;
-            ::apache::thrift::protocol::TType _etype1674;
-            xfer += iprot->readListBegin(_etype1674, _size1671);
-            this->replicationMetricList.resize(_size1671);
-            uint32_t _i1675;
-            for (_i1675 = 0; _i1675 < _size1671; ++_i1675)
+            uint32_t _size1678;
+            ::apache::thrift::protocol::TType _etype1681;
+            xfer += iprot->readListBegin(_etype1681, _size1678);
+            this->replicationMetricList.resize(_size1678);
+            uint32_t _i1682;
+            for (_i1682 = 0; _i1682 < _size1678; ++_i1682)
             {
-              xfer += this->replicationMetricList[_i1675].read(iprot);
+              xfer += this->replicationMetricList[_i1682].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -47373,10 +47460,10 @@ uint32_t ReplicationMetricList::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("replicationMetricList", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->replicationMetricList.size()));
-    std::vector<ReplicationMetrics> ::const_iterator _iter1676;
-    for (_iter1676 = this->replicationMetricList.begin(); _iter1676 != this->replicationMetricList.end(); ++_iter1676)
+    std::vector<ReplicationMetrics> ::const_iterator _iter1683;
+    for (_iter1683 = this->replicationMetricList.begin(); _iter1683 != this->replicationMetricList.end(); ++_iter1683)
     {
-      xfer += (*_iter1676).write(oprot);
+      xfer += (*_iter1683).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -47392,11 +47479,11 @@ void swap(ReplicationMetricList &a, ReplicationMetricList &b) {
   swap(a.replicationMetricList, b.replicationMetricList);
 }
 
-ReplicationMetricList::ReplicationMetricList(const ReplicationMetricList& other1677) {
-  replicationMetricList = other1677.replicationMetricList;
+ReplicationMetricList::ReplicationMetricList(const ReplicationMetricList& other1684) {
+  replicationMetricList = other1684.replicationMetricList;
 }
-ReplicationMetricList& ReplicationMetricList::operator=(const ReplicationMetricList& other1678) {
-  replicationMetricList = other1678.replicationMetricList;
+ReplicationMetricList& ReplicationMetricList::operator=(const ReplicationMetricList& other1685) {
+  replicationMetricList = other1685.replicationMetricList;
   return *this;
 }
 void ReplicationMetricList::printTo(std::ostream& out) const {
@@ -47522,17 +47609,17 @@ void swap(GetReplicationMetricsRequest &a, GetReplicationMetricsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetReplicationMetricsRequest::GetReplicationMetricsRequest(const GetReplicationMetricsRequest& other1679) {
-  scheduledExecutionId = other1679.scheduledExecutionId;
-  policy = other1679.policy;
-  dumpExecutionId = other1679.dumpExecutionId;
-  __isset = other1679.__isset;
+GetReplicationMetricsRequest::GetReplicationMetricsRequest(const GetReplicationMetricsRequest& other1686) {
+  scheduledExecutionId = other1686.scheduledExecutionId;
+  policy = other1686.policy;
+  dumpExecutionId = other1686.dumpExecutionId;
+  __isset = other1686.__isset;
 }
-GetReplicationMetricsRequest& GetReplicationMetricsRequest::operator=(const GetReplicationMetricsRequest& other1680) {
-  scheduledExecutionId = other1680.scheduledExecutionId;
-  policy = other1680.policy;
-  dumpExecutionId = other1680.dumpExecutionId;
-  __isset = other1680.__isset;
+GetReplicationMetricsRequest& GetReplicationMetricsRequest::operator=(const GetReplicationMetricsRequest& other1687) {
+  scheduledExecutionId = other1687.scheduledExecutionId;
+  policy = other1687.policy;
+  dumpExecutionId = other1687.dumpExecutionId;
+  __isset = other1687.__isset;
   return *this;
 }
 void GetReplicationMetricsRequest::printTo(std::ostream& out) const {
@@ -47585,16 +47672,16 @@ uint32_t GetOpenTxnsRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->excludeTxnTypes.clear();
-            uint32_t _size1681;
-            ::apache::thrift::protocol::TType _etype1684;
-            xfer += iprot->readListBegin(_etype1684, _size1681);
-            this->excludeTxnTypes.resize(_size1681);
-            uint32_t _i1685;
-            for (_i1685 = 0; _i1685 < _size1681; ++_i1685)
+            uint32_t _size1688;
+            ::apache::thrift::protocol::TType _etype1691;
+            xfer += iprot->readListBegin(_etype1691, _size1688);
+            this->excludeTxnTypes.resize(_size1688);
+            uint32_t _i1692;
+            for (_i1692 = 0; _i1692 < _size1688; ++_i1692)
             {
-              int32_t ecast1686;
-              xfer += iprot->readI32(ecast1686);
-              this->excludeTxnTypes[_i1685] = (TxnType::type)ecast1686;
+              int32_t ecast1693;
+              xfer += iprot->readI32(ecast1693);
+              this->excludeTxnTypes[_i1692] = (TxnType::type)ecast1693;
             }
             xfer += iprot->readListEnd();
           }
@@ -47624,10 +47711,10 @@ uint32_t GetOpenTxnsRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("excludeTxnTypes", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->excludeTxnTypes.size()));
-      std::vector<TxnType::type> ::const_iterator _iter1687;
-      for (_iter1687 = this->excludeTxnTypes.begin(); _iter1687 != this->excludeTxnTypes.end(); ++_iter1687)
+      std::vector<TxnType::type> ::const_iterator _iter1694;
+      for (_iter1694 = this->excludeTxnTypes.begin(); _iter1694 != this->excludeTxnTypes.end(); ++_iter1694)
       {
-        xfer += oprot->writeI32((int32_t)(*_iter1687));
+        xfer += oprot->writeI32((int32_t)(*_iter1694));
       }
       xfer += oprot->writeListEnd();
     }
@@ -47644,13 +47731,13 @@ void swap(GetOpenTxnsRequest &a, GetOpenTxnsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetOpenTxnsRequest::GetOpenTxnsRequest(const GetOpenTxnsRequest& other1688) {
-  excludeTxnTypes = other1688.excludeTxnTypes;
-  __isset = other1688.__isset;
+GetOpenTxnsRequest::GetOpenTxnsRequest(const GetOpenTxnsRequest& other1695) {
+  excludeTxnTypes = other1695.excludeTxnTypes;
+  __isset = other1695.__isset;
 }
-GetOpenTxnsRequest& GetOpenTxnsRequest::operator=(const GetOpenTxnsRequest& other1689) {
-  excludeTxnTypes = other1689.excludeTxnTypes;
-  __isset = other1689.__isset;
+GetOpenTxnsRequest& GetOpenTxnsRequest::operator=(const GetOpenTxnsRequest& other1696) {
+  excludeTxnTypes = other1696.excludeTxnTypes;
+  __isset = other1696.__isset;
   return *this;
 }
 void GetOpenTxnsRequest::printTo(std::ostream& out) const {
@@ -47778,15 +47865,15 @@ void swap(StoredProcedureRequest &a, StoredProcedureRequest &b) {
   swap(a.procName, b.procName);
 }
 
-StoredProcedureRequest::StoredProcedureRequest(const StoredProcedureRequest& other1690) {
-  catName = other1690.catName;
-  dbName = other1690.dbName;
-  procName = other1690.procName;
+StoredProcedureRequest::StoredProcedureRequest(const StoredProcedureRequest& other1697) {
+  catName = other1697.catName;
+  dbName = other1697.dbName;
+  procName = other1697.procName;
 }
-StoredProcedureRequest& StoredProcedureRequest::operator=(const StoredProcedureRequest& other1691) {
-  catName = other1691.catName;
-  dbName = other1691.dbName;
-  procName = other1691.procName;
+StoredProcedureRequest& StoredProcedureRequest::operator=(const StoredProcedureRequest& other1698) {
+  catName = other1698.catName;
+  dbName = other1698.dbName;
+  procName = other1698.procName;
   return *this;
 }
 void StoredProcedureRequest::printTo(std::ostream& out) const {
@@ -47896,15 +47983,15 @@ void swap(ListStoredProcedureRequest &a, ListStoredProcedureRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ListStoredProcedureRequest::ListStoredProcedureRequest(const ListStoredProcedureRequest& other1692) {
-  catName = other1692.catName;
-  dbName = other1692.dbName;
-  __isset = other1692.__isset;
+ListStoredProcedureRequest::ListStoredProcedureRequest(const ListStoredProcedureRequest& other1699) {
+  catName = other1699.catName;
+  dbName = other1699.dbName;
+  __isset = other1699.__isset;
 }
-ListStoredProcedureRequest& ListStoredProcedureRequest::operator=(const ListStoredProcedureRequest& other1693) {
-  catName = other1693.catName;
-  dbName = other1693.dbName;
-  __isset = other1693.__isset;
+ListStoredProcedureRequest& ListStoredProcedureRequest::operator=(const ListStoredProcedureRequest& other1700) {
+  catName = other1700.catName;
+  dbName = other1700.dbName;
+  __isset = other1700.__isset;
   return *this;
 }
 void ListStoredProcedureRequest::printTo(std::ostream& out) const {
@@ -48059,21 +48146,21 @@ void swap(StoredProcedure &a, StoredProcedure &b) {
   swap(a.__isset, b.__isset);
 }
 
-StoredProcedure::StoredProcedure(const StoredProcedure& other1694) {
-  name = other1694.name;
-  dbName = other1694.dbName;
-  catName = other1694.catName;
-  ownerName = other1694.ownerName;
-  source = other1694.source;
-  __isset = other1694.__isset;
+StoredProcedure::StoredProcedure(const StoredProcedure& other1701) {
+  name = other1701.name;
+  dbName = other1701.dbName;
+  catName = other1701.catName;
+  ownerName = other1701.ownerName;
+  source = other1701.source;
+  __isset = other1701.__isset;
 }
-StoredProcedure& StoredProcedure::operator=(const StoredProcedure& other1695) {
-  name = other1695.name;
-  dbName = other1695.dbName;
-  catName = other1695.catName;
-  ownerName = other1695.ownerName;
-  source = other1695.source;
-  __isset = other1695.__isset;
+StoredProcedure& StoredProcedure::operator=(const StoredProcedure& other1702) {
+  name = other1702.name;
+  dbName = other1702.dbName;
+  catName = other1702.catName;
+  ownerName = other1702.ownerName;
+  source = other1702.source;
+  __isset = other1702.__isset;
   return *this;
 }
 void StoredProcedure::printTo(std::ostream& out) const {
@@ -48248,23 +48335,23 @@ void swap(AddPackageRequest &a, AddPackageRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddPackageRequest::AddPackageRequest(const AddPackageRequest& other1696) {
-  catName = other1696.catName;
-  dbName = other1696.dbName;
-  packageName = other1696.packageName;
-  ownerName = other1696.ownerName;
-  header = other1696.header;
-  body = other1696.body;
-  __isset = other1696.__isset;
+AddPackageRequest::AddPackageRequest(const AddPackageRequest& other1703) {
+  catName = other1703.catName;
+  dbName = other1703.dbName;
+  packageName = other1703.packageName;
+  ownerName = other1703.ownerName;
+  header = other1703.header;
+  body = other1703.body;
+  __isset = other1703.__isset;
 }
-AddPackageRequest& AddPackageRequest::operator=(const AddPackageRequest& other1697) {
-  catName = other1697.catName;
-  dbName = other1697.dbName;
-  packageName = other1697.packageName;
-  ownerName = other1697.ownerName;
-  header = other1697.header;
-  body = other1697.body;
-  __isset = other1697.__isset;
+AddPackageRequest& AddPackageRequest::operator=(const AddPackageRequest& other1704) {
+  catName = other1704.catName;
+  dbName = other1704.dbName;
+  packageName = other1704.packageName;
+  ownerName = other1704.ownerName;
+  header = other1704.header;
+  body = other1704.body;
+  __isset = other1704.__isset;
   return *this;
 }
 void AddPackageRequest::printTo(std::ostream& out) const {
@@ -48397,15 +48484,15 @@ void swap(GetPackageRequest &a, GetPackageRequest &b) {
   swap(a.packageName, b.packageName);
 }
 
-GetPackageRequest::GetPackageRequest(const GetPackageRequest& other1698) {
-  catName = other1698.catName;
-  dbName = other1698.dbName;
-  packageName = other1698.packageName;
+GetPackageRequest::GetPackageRequest(const GetPackageRequest& other1705) {
+  catName = other1705.catName;
+  dbName = other1705.dbName;
+  packageName = other1705.packageName;
 }
-GetPackageRequest& GetPackageRequest::operator=(const GetPackageRequest& other1699) {
-  catName = other1699.catName;
-  dbName = other1699.dbName;
-  packageName = other1699.packageName;
+GetPackageRequest& GetPackageRequest::operator=(const GetPackageRequest& other1706) {
+  catName = other1706.catName;
+  dbName = other1706.dbName;
+  packageName = other1706.packageName;
   return *this;
 }
 void GetPackageRequest::printTo(std::ostream& out) const {
@@ -48535,15 +48622,15 @@ void swap(DropPackageRequest &a, DropPackageRequest &b) {
   swap(a.packageName, b.packageName);
 }
 
-DropPackageRequest::DropPackageRequest(const DropPackageRequest& other1700) {
-  catName = other1700.catName;
-  dbName = other1700.dbName;
-  packageName = other1700.packageName;
+DropPackageRequest::DropPackageRequest(const DropPackageRequest& other1707) {
+  catName = other1707.catName;
+  dbName = other1707.dbName;
+  packageName = other1707.packageName;
 }
-DropPackageRequest& DropPackageRequest::operator=(const DropPackageRequest& other1701) {
-  catName = other1701.catName;
-  dbName = other1701.dbName;
-  packageName = other1701.packageName;
+DropPackageRequest& DropPackageRequest::operator=(const DropPackageRequest& other1708) {
+  catName = other1708.catName;
+  dbName = other1708.dbName;
+  packageName = other1708.packageName;
   return *this;
 }
 void DropPackageRequest::printTo(std::ostream& out) const {
@@ -48653,15 +48740,15 @@ void swap(ListPackageRequest &a, ListPackageRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ListPackageRequest::ListPackageRequest(const ListPackageRequest& other1702) {
-  catName = other1702.catName;
-  dbName = other1702.dbName;
-  __isset = other1702.__isset;
+ListPackageRequest::ListPackageRequest(const ListPackageRequest& other1709) {
+  catName = other1709.catName;
+  dbName = other1709.dbName;
+  __isset = other1709.__isset;
 }
-ListPackageRequest& ListPackageRequest::operator=(const ListPackageRequest& other1703) {
-  catName = other1703.catName;
-  dbName = other1703.dbName;
-  __isset = other1703.__isset;
+ListPackageRequest& ListPackageRequest::operator=(const ListPackageRequest& other1710) {
+  catName = other1710.catName;
+  dbName = other1710.dbName;
+  __isset = other1710.__isset;
   return *this;
 }
 void ListPackageRequest::printTo(std::ostream& out) const {
@@ -48833,23 +48920,23 @@ void swap(Package &a, Package &b) {
   swap(a.__isset, b.__isset);
 }
 
-Package::Package(const Package& other1704) {
-  catName = other1704.catName;
-  dbName = other1704.dbName;
-  packageName = other1704.packageName;
-  ownerName = other1704.ownerName;
-  header = other1704.header;
-  body = other1704.body;
-  __isset = other1704.__isset;
+Package::Package(const Package& other1711) {
+  catName = other1711.catName;
+  dbName = other1711.dbName;
+  packageName = other1711.packageName;
+  ownerName = other1711.ownerName;
+  header = other1711.header;
+  body = other1711.body;
+  __isset = other1711.__isset;
 }
-Package& Package::operator=(const Package& other1705) {
-  catName = other1705.catName;
-  dbName = other1705.dbName;
-  packageName = other1705.packageName;
-  ownerName = other1705.ownerName;
-  header = other1705.header;
-  body = other1705.body;
-  __isset = other1705.__isset;
+Package& Package::operator=(const Package& other1712) {
+  catName = other1712.catName;
+  dbName = other1712.dbName;
+  packageName = other1712.packageName;
+  ownerName = other1712.ownerName;
+  header = other1712.header;
+  body = other1712.body;
+  __isset = other1712.__isset;
   return *this;
 }
 void Package::printTo(std::ostream& out) const {
@@ -48981,17 +49068,17 @@ void swap(GetAllWriteEventInfoRequest &a, GetAllWriteEventInfoRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetAllWriteEventInfoRequest::GetAllWriteEventInfoRequest(const GetAllWriteEventInfoRequest& other1706) {
-  txnId = other1706.txnId;
-  dbName = other1706.dbName;
-  tableName = other1706.tableName;
-  __isset = other1706.__isset;
+GetAllWriteEventInfoRequest::GetAllWriteEventInfoRequest(const GetAllWriteEventInfoRequest& other1713) {
+  txnId = other1713.txnId;
+  dbName = other1713.dbName;
+  tableName = other1713.tableName;
+  __isset = other1713.__isset;
 }
-GetAllWriteEventInfoRequest& GetAllWriteEventInfoRequest::operator=(const GetAllWriteEventInfoRequest& other1707) {
-  txnId = other1707.txnId;
-  dbName = other1707.dbName;
-  tableName = other1707.tableName;
-  __isset = other1707.__isset;
+GetAllWriteEventInfoRequest& GetAllWriteEventInfoRequest::operator=(const GetAllWriteEventInfoRequest& other1714) {
+  txnId = other1714.txnId;
+  dbName = other1714.dbName;
+  tableName = other1714.tableName;
+  __isset = other1714.__isset;
   return *this;
 }
 void GetAllWriteEventInfoRequest::printTo(std::ostream& out) const {
@@ -49079,13 +49166,13 @@ void swap(MetaException &a, MetaException &b) {
   swap(a.__isset, b.__isset);
 }
 
-MetaException::MetaException(const MetaException& other1708) : TException() {
-  message = other1708.message;
-  __isset = other1708.__isset;
+MetaException::MetaException(const MetaException& other1715) : TException() {
+  message = other1715.message;
+  __isset = other1715.__isset;
 }
-MetaException& MetaException::operator=(const MetaException& other1709) {
-  message = other1709.message;
-  __isset = other1709.__isset;
+MetaException& MetaException::operator=(const MetaException& other1716) {
+  message = other1716.message;
+  __isset = other1716.__isset;
   return *this;
 }
 void MetaException::printTo(std::ostream& out) const {
@@ -49182,13 +49269,13 @@ void swap(UnknownTableException &a, UnknownTableException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownTableException::UnknownTableException(const UnknownTableException& other1710) : TException() {
-  message = other1710.message;
-  __isset = other1710.__isset;
+UnknownTableException::UnknownTableException(const UnknownTableException& other1717) : TException() {
+  message = other1717.message;
+  __isset = other1717.__isset;
 }
-UnknownTableException& UnknownTableException::operator=(const UnknownTableException& other1711) {
-  message = other1711.message;
-  __isset = other1711.__isset;
+UnknownTableException& UnknownTableException::operator=(const UnknownTableException& other1718) {
+  message = other1718.message;
+  __isset = other1718.__isset;
   return *this;
 }
 void UnknownTableException::printTo(std::ostream& out) const {
@@ -49285,13 +49372,13 @@ void swap(UnknownDBException &a, UnknownDBException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownDBException::UnknownDBException(const UnknownDBException& other1712) : TException() {
-  message = other1712.message;
-  __isset = other1712.__isset;
+UnknownDBException::UnknownDBException(const UnknownDBException& other1719) : TException() {
+  message = other1719.message;
+  __isset = other1719.__isset;
 }
-UnknownDBException& UnknownDBException::operator=(const UnknownDBException& other1713) {
-  message = other1713.message;
-  __isset = other1713.__isset;
+UnknownDBException& UnknownDBException::operator=(const UnknownDBException& other1720) {
+  message = other1720.message;
+  __isset = other1720.__isset;
   return *this;
 }
 void UnknownDBException::printTo(std::ostream& out) const {
@@ -49388,13 +49475,13 @@ void swap(AlreadyExistsException &a, AlreadyExistsException &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlreadyExistsException::AlreadyExistsException(const AlreadyExistsException& other1714) : TException() {
-  message = other1714.message;
-  __isset = other1714.__isset;
+AlreadyExistsException::AlreadyExistsException(const AlreadyExistsException& other1721) : TException() {
+  message = other1721.message;
+  __isset = other1721.__isset;
 }
-AlreadyExistsException& AlreadyExistsException::operator=(const AlreadyExistsException& other1715) {
-  message = other1715.message;
-  __isset = other1715.__isset;
+AlreadyExistsException& AlreadyExistsException::operator=(const AlreadyExistsException& other1722) {
+  message = other1722.message;
+  __isset = other1722.__isset;
   return *this;
 }
 void AlreadyExistsException::printTo(std::ostream& out) const {
@@ -49491,13 +49578,13 @@ void swap(InvalidPartitionException &a, InvalidPartitionException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidPartitionException::InvalidPartitionException(const InvalidPartitionException& other1716) : TException() {
-  message = other1716.message;
-  __isset = other1716.__isset;
+InvalidPartitionException::InvalidPartitionException(const InvalidPartitionException& other1723) : TException() {
+  message = other1723.message;
+  __isset = other1723.__isset;
 }
-InvalidPartitionException& InvalidPartitionException::operator=(const InvalidPartitionException& other1717) {
-  message = other1717.message;
-  __isset = other1717.__isset;
+InvalidPartitionException& InvalidPartitionException::operator=(const InvalidPartitionException& other1724) {
+  message = other1724.message;
+  __isset = other1724.__isset;
   return *this;
 }
 void InvalidPartitionException::printTo(std::ostream& out) const {
@@ -49594,13 +49681,13 @@ void swap(UnknownPartitionException &a, UnknownPartitionException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownPartitionException::UnknownPartitionException(const UnknownPartitionException& other1718) : TException() {
-  message = other1718.message;
-  __isset = other1718.__isset;
+UnknownPartitionException::UnknownPartitionException(const UnknownPartitionException& other1725) : TException() {
+  message = other1725.message;
+  __isset = other1725.__isset;
 }
-UnknownPartitionException& UnknownPartitionException::operator=(const UnknownPartitionException& other1719) {
-  message = other1719.message;
-  __isset = other1719.__isset;
+UnknownPartitionException& UnknownPartitionException::operator=(const UnknownPartitionException& other1726) {
+  message = other1726.message;
+  __isset = other1726.__isset;
   return *this;
 }
 void UnknownPartitionException::printTo(std::ostream& out) const {
@@ -49697,13 +49784,13 @@ void swap(InvalidObjectException &a, InvalidObjectException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidObjectException::InvalidObjectException(const InvalidObjectException& other1720) : TException() {
-  message = other1720.message;
-  __isset = other1720.__isset;
+InvalidObjectException::InvalidObjectException(const InvalidObjectException& other1727) : TException() {
+  message = other1727.message;
+  __isset = other1727.__isset;
 }
-InvalidObjectException& InvalidObjectException::operator=(const InvalidObjectException& other1721) {
-  message = other1721.message;
-  __isset = other1721.__isset;
+InvalidObjectException& InvalidObjectException::operator=(const InvalidObjectException& other1728) {
+  message = other1728.message;
+  __isset = other1728.__isset;
   return *this;
 }
 void InvalidObjectException::printTo(std::ostream& out) const {
@@ -49800,13 +49887,13 @@ void swap(NoSuchObjectException &a, NoSuchObjectException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchObjectException::NoSuchObjectException(const NoSuchObjectException& other1722) : TException() {
-  message = other1722.message;
-  __isset = other1722.__isset;
+NoSuchObjectException::NoSuchObjectException(const NoSuchObjectException& other1729) : TException() {
+  message = other1729.message;
+  __isset = other1729.__isset;
 }
-NoSuchObjectException& NoSuchObjectException::operator=(const NoSuchObjectException& other1723) {
-  message = other1723.message;
-  __isset = other1723.__isset;
+NoSuchObjectException& NoSuchObjectException::operator=(const NoSuchObjectException& other1730) {
+  message = other1730.message;
+  __isset = other1730.__isset;
   return *this;
 }
 void NoSuchObjectException::printTo(std::ostream& out) const {
@@ -49903,13 +49990,13 @@ void swap(InvalidOperationException &a, InvalidOperationException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidOperationException::InvalidOperationException(const InvalidOperationException& other1724) : TException() {
-  message = other1724.message;
-  __isset = other1724.__isset;
+InvalidOperationException::InvalidOperationException(const InvalidOperationException& other1731) : TException() {
+  message = other1731.message;
+  __isset = other1731.__isset;
 }
-InvalidOperationException& InvalidOperationException::operator=(const InvalidOperationException& other1725) {
-  message = other1725.message;
-  __isset = other1725.__isset;
+InvalidOperationException& InvalidOperationException::operator=(const InvalidOperationException& other1732) {
+  message = other1732.message;
+  __isset = other1732.__isset;
   return *this;
 }
 void InvalidOperationException::printTo(std::ostream& out) const {
@@ -50006,13 +50093,13 @@ void swap(ConfigValSecurityException &a, ConfigValSecurityException &b) {
   swap(a.__isset, b.__isset);
 }
 
-ConfigValSecurityException::ConfigValSecurityException(const ConfigValSecurityException& other1726) : TException() {
-  message = other1726.message;
-  __isset = other1726.__isset;
+ConfigValSecurityException::ConfigValSecurityException(const ConfigValSecurityException& other1733) : TException() {
+  message = other1733.message;
+  __isset = other1733.__isset;
 }
-ConfigValSecurityException& ConfigValSecurityException::operator=(const ConfigValSecurityException& other1727) {
-  message = other1727.message;
-  __isset = other1727.__isset;
+ConfigValSecurityException& ConfigValSecurityException::operator=(const ConfigValSecurityException& other1734) {
+  message = other1734.message;
+  __isset = other1734.__isset;
   return *this;
 }
 void ConfigValSecurityException::printTo(std::ostream& out) const {
@@ -50109,13 +50196,13 @@ void swap(InvalidInputException &a, InvalidInputException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidInputException::InvalidInputException(const InvalidInputException& other1728) : TException() {
-  message = other1728.message;
-  __isset = other1728.__isset;
+InvalidInputException::InvalidInputException(const InvalidInputException& other1735) : TException() {
+  message = other1735.message;
+  __isset = other1735.__isset;
 }
-InvalidInputException& InvalidInputException::operator=(const InvalidInputException& other1729) {
-  message = other1729.message;
-  __isset = other1729.__isset;
+InvalidInputException& InvalidInputException::operator=(const InvalidInputException& other1736) {
+  message = other1736.message;
+  __isset = other1736.__isset;
   return *this;
 }
 void InvalidInputException::printTo(std::ostream& out) const {
@@ -50212,13 +50299,13 @@ void swap(NoSuchTxnException &a, NoSuchTxnException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchTxnException::NoSuchTxnException(const NoSuchTxnException& other1730) : TException() {
-  message = other1730.message;
-  __isset = other1730.__isset;
+NoSuchTxnException::NoSuchTxnException(const NoSuchTxnException& other1737) : TException() {
+  message = other1737.message;
+  __isset = other1737.__isset;
 }
-NoSuchTxnException& NoSuchTxnException::operator=(const NoSuchTxnException& other1731) {
-  message = other1731.message;
-  __isset = other1731.__isset;
+NoSuchTxnException& NoSuchTxnException::operator=(const NoSuchTxnException& other1738) {
+  message = other1738.message;
+  __isset = other1738.__isset;
   return *this;
 }
 void NoSuchTxnException::printTo(std::ostream& out) const {
@@ -50315,13 +50402,13 @@ void swap(TxnAbortedException &a, TxnAbortedException &b) {
   swap(a.__isset, b.__isset);
 }
 
-TxnAbortedException::TxnAbortedException(const TxnAbortedException& other1732) : TException() {
-  message = other1732.message;
-  __isset = other1732.__isset;
+TxnAbortedException::TxnAbortedException(const TxnAbortedException& other1739) : TException() {
+  message = other1739.message;
+  __isset = other1739.__isset;
 }
-TxnAbortedException& TxnAbortedException::operator=(const TxnAbortedException& other1733) {
-  message = other1733.message;
-  __isset = other1733.__isset;
+TxnAbortedException& TxnAbortedException::operator=(const TxnAbortedException& other1740) {
+  message = other1740.message;
+  __isset = other1740.__isset;
   return *this;
 }
 void TxnAbortedException::printTo(std::ostream& out) const {
@@ -50418,13 +50505,13 @@ void swap(TxnOpenException &a, TxnOpenException &b) {
   swap(a.__isset, b.__isset);
 }
 
-TxnOpenException::TxnOpenException(const TxnOpenException& other1734) : TException() {
-  message = other1734.message;
-  __isset = other1734.__isset;
+TxnOpenException::TxnOpenException(const TxnOpenException& other1741) : TException() {
+  message = other1741.message;
+  __isset = other1741.__isset;
 }
-TxnOpenException& TxnOpenException::operator=(const TxnOpenException& other1735) {
-  message = other1735.message;
-  __isset = other1735.__isset;
+TxnOpenException& TxnOpenException::operator=(const TxnOpenException& other1742) {
+  message = other1742.message;
+  __isset = other1742.__isset;
   return *this;
 }
 void TxnOpenException::printTo(std::ostream& out) const {
@@ -50521,13 +50608,13 @@ void swap(NoSuchLockException &a, NoSuchLockException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchLockException::NoSuchLockException(const NoSuchLockException& other1736) : TException() {
-  message = other1736.message;
-  __isset = other1736.__isset;
+NoSuchLockException::NoSuchLockException(const NoSuchLockException& other1743) : TException() {
+  message = other1743.message;
+  __isset = other1743.__isset;
 }
-NoSuchLockException& NoSuchLockException::operator=(const NoSuchLockException& other1737) {
-  message = other1737.message;
-  __isset = other1737.__isset;
+NoSuchLockException& NoSuchLockException::operator=(const NoSuchLockException& other1744) {
+  message = other1744.message;
+  __isset = other1744.__isset;
   return *this;
 }
 void NoSuchLockException::printTo(std::ostream& out) const {

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -27926,51 +27926,6 @@ void swap(ShowCompactResponseElement &a, ShowCompactResponseElement &b) {
   swap(a.__isset, b.__isset);
 }
 
-<<<<<<< HEAD
-ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other984) {
-  dbname = other984.dbname;
-  tablename = other984.tablename;
-  partitionname = other984.partitionname;
-  type = other984.type;
-  state = other984.state;
-  workerid = other984.workerid;
-  start = other984.start;
-  runAs = other984.runAs;
-  hightestTxnId = other984.hightestTxnId;
-  metaInfo = other984.metaInfo;
-  endTime = other984.endTime;
-  hadoopJobId = other984.hadoopJobId;
-  id = other984.id;
-  errorMessage = other984.errorMessage;
-  enqueueTime = other984.enqueueTime;
-  workerVersion = other984.workerVersion;
-  initiatorId = other984.initiatorId;
-  initiatorVersion = other984.initiatorVersion;
-  cleanerStart = other984.cleanerStart;
-  __isset = other984.__isset;
-}
-ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowCompactResponseElement& other985) {
-  dbname = other985.dbname;
-  tablename = other985.tablename;
-  partitionname = other985.partitionname;
-  type = other985.type;
-  state = other985.state;
-  workerid = other985.workerid;
-  start = other985.start;
-  runAs = other985.runAs;
-  hightestTxnId = other985.hightestTxnId;
-  metaInfo = other985.metaInfo;
-  endTime = other985.endTime;
-  hadoopJobId = other985.hadoopJobId;
-  id = other985.id;
-  errorMessage = other985.errorMessage;
-  enqueueTime = other985.enqueueTime;
-  workerVersion = other985.workerVersion;
-  initiatorId = other985.initiatorId;
-  initiatorVersion = other985.initiatorVersion;
-  cleanerStart = other985.cleanerStart;
-  __isset = other985.__isset;
-=======
 ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other991) {
   dbname = other991.dbname;
   tablename = other991.tablename;
@@ -27990,6 +27945,7 @@ ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponse
   workerVersion = other991.workerVersion;
   initiatorId = other991.initiatorId;
   initiatorVersion = other991.initiatorVersion;
+  cleanerStart = other991.cleanerStart;
   __isset = other991.__isset;
 }
 ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowCompactResponseElement& other992) {
@@ -28011,8 +27967,8 @@ ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowComp
   workerVersion = other992.workerVersion;
   initiatorId = other992.initiatorId;
   initiatorVersion = other992.initiatorVersion;
+  cleanerStart = other992.cleanerStart;
   __isset = other992.__isset;
->>>>>>> HIVE-25744: Support backward compatibility of thrift struct CreationMetadata
   return *this;
 }
 void ShowCompactResponseElement::printTo(std::ostream& out) const {

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -3683,9 +3683,10 @@ void swap(SourceTable &a, SourceTable &b);
 std::ostream& operator<<(std::ostream& out, const SourceTable& obj);
 
 typedef struct _CreationMetadata__isset {
-  _CreationMetadata__isset() : validTxnList(false), materializationTime(false) {}
+  _CreationMetadata__isset() : validTxnList(false), materializationTime(false), sourceTables(false) {}
   bool validTxnList :1;
   bool materializationTime :1;
+  bool sourceTables :1;
 } _CreationMetadata__isset;
 
 class CreationMetadata : public virtual ::apache::thrift::TBase {
@@ -3700,9 +3701,10 @@ class CreationMetadata : public virtual ::apache::thrift::TBase {
   std::string catName;
   std::string dbName;
   std::string tblName;
-  std::set<SourceTable>  tablesUsed;
+  std::set<std::string>  tablesUsed;
   std::string validTxnList;
   int64_t materializationTime;
+  std::set<SourceTable>  sourceTables;
 
   _CreationMetadata__isset __isset;
 
@@ -3712,11 +3714,13 @@ class CreationMetadata : public virtual ::apache::thrift::TBase {
 
   void __set_tblName(const std::string& val);
 
-  void __set_tablesUsed(const std::set<SourceTable> & val);
+  void __set_tablesUsed(const std::set<std::string> & val);
 
   void __set_validTxnList(const std::string& val);
 
   void __set_materializationTime(const int64_t val);
+
+  void __set_sourceTables(const std::set<SourceTable> & val);
 
   bool operator == (const CreationMetadata & rhs) const
   {
@@ -3735,6 +3739,10 @@ class CreationMetadata : public virtual ::apache::thrift::TBase {
     if (__isset.materializationTime != rhs.__isset.materializationTime)
       return false;
     else if (__isset.materializationTime && !(materializationTime == rhs.materializationTime))
+      return false;
+    if (__isset.sourceTables != rhs.__isset.sourceTables)
+      return false;
+    else if (__isset.sourceTables && !(sourceTables == rhs.sourceTables))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnsRequest.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TXN_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list734 = iprot.readListBegin();
-                struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list734.size);
-                long _elem735;
-                for (int _i736 = 0; _i736 < _list734.size; ++_i736)
+                org.apache.thrift.protocol.TList _list742 = iprot.readListBegin();
+                struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list742.size);
+                long _elem743;
+                for (int _i744 = 0; _i744 < _list742.size; ++_i744)
                 {
-                  _elem735 = iprot.readI64();
-                  struct.txn_ids.add(_elem735);
+                  _elem743 = iprot.readI64();
+                  struct.txn_ids.add(_elem743);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TXN_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.txn_ids.size()));
-          for (long _iter737 : struct.txn_ids)
+          for (long _iter745 : struct.txn_ids)
           {
-            oprot.writeI64(_iter737);
+            oprot.writeI64(_iter745);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.txn_ids.size());
-        for (long _iter738 : struct.txn_ids)
+        for (long _iter746 : struct.txn_ids)
         {
-          oprot.writeI64(_iter738);
+          oprot.writeI64(_iter746);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AbortTxnsRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list739 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list739.size);
-        long _elem740;
-        for (int _i741 = 0; _i741 < _list739.size; ++_i741)
+        org.apache.thrift.protocol.TList _list747 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list747.size);
+        long _elem748;
+        for (int _i749 = 0; _i749 < _list747.size; ++_i749)
         {
-          _elem740 = iprot.readI64();
-          struct.txn_ids.add(_elem740);
+          _elem748 = iprot.readI64();
+          struct.txn_ids.add(_elem748);
         }
       }
       struct.setTxn_idsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddCheckConstraintRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddCheckConstraintRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // CHECK_CONSTRAINT_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list514 = iprot.readListBegin();
-                struct.checkConstraintCols = new java.util.ArrayList<SQLCheckConstraint>(_list514.size);
-                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem515;
-                for (int _i516 = 0; _i516 < _list514.size; ++_i516)
+                org.apache.thrift.protocol.TList _list522 = iprot.readListBegin();
+                struct.checkConstraintCols = new java.util.ArrayList<SQLCheckConstraint>(_list522.size);
+                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem523;
+                for (int _i524 = 0; _i524 < _list522.size; ++_i524)
                 {
-                  _elem515 = new SQLCheckConstraint();
-                  _elem515.read(iprot);
-                  struct.checkConstraintCols.add(_elem515);
+                  _elem523 = new SQLCheckConstraint();
+                  _elem523.read(iprot);
+                  struct.checkConstraintCols.add(_elem523);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(CHECK_CONSTRAINT_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.checkConstraintCols.size()));
-          for (SQLCheckConstraint _iter517 : struct.checkConstraintCols)
+          for (SQLCheckConstraint _iter525 : struct.checkConstraintCols)
           {
-            _iter517.write(oprot);
+            _iter525.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.checkConstraintCols.size());
-        for (SQLCheckConstraint _iter518 : struct.checkConstraintCols)
+        for (SQLCheckConstraint _iter526 : struct.checkConstraintCols)
         {
-          _iter518.write(oprot);
+          _iter526.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddCheckConstraintRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list519 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.checkConstraintCols = new java.util.ArrayList<SQLCheckConstraint>(_list519.size);
-        @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem520;
-        for (int _i521 = 0; _i521 < _list519.size; ++_i521)
+        org.apache.thrift.protocol.TList _list527 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.checkConstraintCols = new java.util.ArrayList<SQLCheckConstraint>(_list527.size);
+        @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem528;
+        for (int _i529 = 0; _i529 < _list527.size; ++_i529)
         {
-          _elem520 = new SQLCheckConstraint();
-          _elem520.read(iprot);
-          struct.checkConstraintCols.add(_elem520);
+          _elem528 = new SQLCheckConstraint();
+          _elem528.read(iprot);
+          struct.checkConstraintCols.add(_elem528);
         }
       }
       struct.setCheckConstraintColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddDefaultConstraintRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddDefaultConstraintRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // DEFAULT_CONSTRAINT_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list506 = iprot.readListBegin();
-                struct.defaultConstraintCols = new java.util.ArrayList<SQLDefaultConstraint>(_list506.size);
-                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem507;
-                for (int _i508 = 0; _i508 < _list506.size; ++_i508)
+                org.apache.thrift.protocol.TList _list514 = iprot.readListBegin();
+                struct.defaultConstraintCols = new java.util.ArrayList<SQLDefaultConstraint>(_list514.size);
+                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem515;
+                for (int _i516 = 0; _i516 < _list514.size; ++_i516)
                 {
-                  _elem507 = new SQLDefaultConstraint();
-                  _elem507.read(iprot);
-                  struct.defaultConstraintCols.add(_elem507);
+                  _elem515 = new SQLDefaultConstraint();
+                  _elem515.read(iprot);
+                  struct.defaultConstraintCols.add(_elem515);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(DEFAULT_CONSTRAINT_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.defaultConstraintCols.size()));
-          for (SQLDefaultConstraint _iter509 : struct.defaultConstraintCols)
+          for (SQLDefaultConstraint _iter517 : struct.defaultConstraintCols)
           {
-            _iter509.write(oprot);
+            _iter517.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.defaultConstraintCols.size());
-        for (SQLDefaultConstraint _iter510 : struct.defaultConstraintCols)
+        for (SQLDefaultConstraint _iter518 : struct.defaultConstraintCols)
         {
-          _iter510.write(oprot);
+          _iter518.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddDefaultConstraintRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list511 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.defaultConstraintCols = new java.util.ArrayList<SQLDefaultConstraint>(_list511.size);
-        @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem512;
-        for (int _i513 = 0; _i513 < _list511.size; ++_i513)
+        org.apache.thrift.protocol.TList _list519 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.defaultConstraintCols = new java.util.ArrayList<SQLDefaultConstraint>(_list519.size);
+        @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem520;
+        for (int _i521 = 0; _i521 < _list519.size; ++_i521)
         {
-          _elem512 = new SQLDefaultConstraint();
-          _elem512.read(iprot);
-          struct.defaultConstraintCols.add(_elem512);
+          _elem520 = new SQLDefaultConstraint();
+          _elem520.read(iprot);
+          struct.defaultConstraintCols.add(_elem520);
         }
       }
       struct.setDefaultConstraintColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddDynamicPartitions.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddDynamicPartitions.java
@@ -785,13 +785,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARTITIONNAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list880 = iprot.readListBegin();
-                struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list880.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem881;
-                for (int _i882 = 0; _i882 < _list880.size; ++_i882)
+                org.apache.thrift.protocol.TList _list888 = iprot.readListBegin();
+                struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list888.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem889;
+                for (int _i890 = 0; _i890 < _list888.size; ++_i890)
                 {
-                  _elem881 = iprot.readString();
-                  struct.partitionnames.add(_elem881);
+                  _elem889 = iprot.readString();
+                  struct.partitionnames.add(_elem889);
                 }
                 iprot.readListEnd();
               }
@@ -841,9 +841,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONNAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionnames.size()));
-          for (java.lang.String _iter883 : struct.partitionnames)
+          for (java.lang.String _iter891 : struct.partitionnames)
           {
-            oprot.writeString(_iter883);
+            oprot.writeString(_iter891);
           }
           oprot.writeListEnd();
         }
@@ -879,9 +879,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tablename);
       {
         oprot.writeI32(struct.partitionnames.size());
-        for (java.lang.String _iter884 : struct.partitionnames)
+        for (java.lang.String _iter892 : struct.partitionnames)
         {
-          oprot.writeString(_iter884);
+          oprot.writeString(_iter892);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -906,13 +906,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tablename = iprot.readString();
       struct.setTablenameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list885 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list885.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem886;
-        for (int _i887 = 0; _i887 < _list885.size; ++_i887)
+        org.apache.thrift.protocol.TList _list893 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list893.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem894;
+        for (int _i895 = 0; _i895 < _list893.size; ++_i895)
         {
-          _elem886 = iprot.readString();
-          struct.partitionnames.add(_elem886);
+          _elem894 = iprot.readString();
+          struct.partitionnames.add(_elem894);
         }
       }
       struct.setPartitionnamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddForeignKeyRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddForeignKeyRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FOREIGN_KEY_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list482 = iprot.readListBegin();
-                struct.foreignKeyCols = new java.util.ArrayList<SQLForeignKey>(_list482.size);
-                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem483;
-                for (int _i484 = 0; _i484 < _list482.size; ++_i484)
+                org.apache.thrift.protocol.TList _list490 = iprot.readListBegin();
+                struct.foreignKeyCols = new java.util.ArrayList<SQLForeignKey>(_list490.size);
+                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem491;
+                for (int _i492 = 0; _i492 < _list490.size; ++_i492)
                 {
-                  _elem483 = new SQLForeignKey();
-                  _elem483.read(iprot);
-                  struct.foreignKeyCols.add(_elem483);
+                  _elem491 = new SQLForeignKey();
+                  _elem491.read(iprot);
+                  struct.foreignKeyCols.add(_elem491);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FOREIGN_KEY_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.foreignKeyCols.size()));
-          for (SQLForeignKey _iter485 : struct.foreignKeyCols)
+          for (SQLForeignKey _iter493 : struct.foreignKeyCols)
           {
-            _iter485.write(oprot);
+            _iter493.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.foreignKeyCols.size());
-        for (SQLForeignKey _iter486 : struct.foreignKeyCols)
+        for (SQLForeignKey _iter494 : struct.foreignKeyCols)
         {
-          _iter486.write(oprot);
+          _iter494.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddForeignKeyRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list487 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.foreignKeyCols = new java.util.ArrayList<SQLForeignKey>(_list487.size);
-        @org.apache.thrift.annotation.Nullable SQLForeignKey _elem488;
-        for (int _i489 = 0; _i489 < _list487.size; ++_i489)
+        org.apache.thrift.protocol.TList _list495 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.foreignKeyCols = new java.util.ArrayList<SQLForeignKey>(_list495.size);
+        @org.apache.thrift.annotation.Nullable SQLForeignKey _elem496;
+        for (int _i497 = 0; _i497 < _list495.size; ++_i497)
         {
-          _elem488 = new SQLForeignKey();
-          _elem488.read(iprot);
-          struct.foreignKeyCols.add(_elem488);
+          _elem496 = new SQLForeignKey();
+          _elem496.read(iprot);
+          struct.foreignKeyCols.add(_elem496);
         }
       }
       struct.setForeignKeyColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddNotNullConstraintRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddNotNullConstraintRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // NOT_NULL_CONSTRAINT_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list498 = iprot.readListBegin();
-                struct.notNullConstraintCols = new java.util.ArrayList<SQLNotNullConstraint>(_list498.size);
-                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem499;
-                for (int _i500 = 0; _i500 < _list498.size; ++_i500)
+                org.apache.thrift.protocol.TList _list506 = iprot.readListBegin();
+                struct.notNullConstraintCols = new java.util.ArrayList<SQLNotNullConstraint>(_list506.size);
+                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem507;
+                for (int _i508 = 0; _i508 < _list506.size; ++_i508)
                 {
-                  _elem499 = new SQLNotNullConstraint();
-                  _elem499.read(iprot);
-                  struct.notNullConstraintCols.add(_elem499);
+                  _elem507 = new SQLNotNullConstraint();
+                  _elem507.read(iprot);
+                  struct.notNullConstraintCols.add(_elem507);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(NOT_NULL_CONSTRAINT_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.notNullConstraintCols.size()));
-          for (SQLNotNullConstraint _iter501 : struct.notNullConstraintCols)
+          for (SQLNotNullConstraint _iter509 : struct.notNullConstraintCols)
           {
-            _iter501.write(oprot);
+            _iter509.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.notNullConstraintCols.size());
-        for (SQLNotNullConstraint _iter502 : struct.notNullConstraintCols)
+        for (SQLNotNullConstraint _iter510 : struct.notNullConstraintCols)
         {
-          _iter502.write(oprot);
+          _iter510.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddNotNullConstraintRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list503 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.notNullConstraintCols = new java.util.ArrayList<SQLNotNullConstraint>(_list503.size);
-        @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem504;
-        for (int _i505 = 0; _i505 < _list503.size; ++_i505)
+        org.apache.thrift.protocol.TList _list511 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.notNullConstraintCols = new java.util.ArrayList<SQLNotNullConstraint>(_list511.size);
+        @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem512;
+        for (int _i513 = 0; _i513 < _list511.size; ++_i513)
         {
-          _elem504 = new SQLNotNullConstraint();
-          _elem504.read(iprot);
-          struct.notNullConstraintCols.add(_elem504);
+          _elem512 = new SQLNotNullConstraint();
+          _elem512.read(iprot);
+          struct.notNullConstraintCols.add(_elem512);
         }
       }
       struct.setNotNullConstraintColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsRequest.java
@@ -837,14 +837,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PARTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list596 = iprot.readListBegin();
-                struct.parts = new java.util.ArrayList<Partition>(_list596.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem597;
-                for (int _i598 = 0; _i598 < _list596.size; ++_i598)
+                org.apache.thrift.protocol.TList _list604 = iprot.readListBegin();
+                struct.parts = new java.util.ArrayList<Partition>(_list604.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem605;
+                for (int _i606 = 0; _i606 < _list604.size; ++_i606)
                 {
-                  _elem597 = new Partition();
-                  _elem597.read(iprot);
-                  struct.parts.add(_elem597);
+                  _elem605 = new Partition();
+                  _elem605.read(iprot);
+                  struct.parts.add(_elem605);
                 }
                 iprot.readListEnd();
               }
@@ -912,9 +912,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.parts.size()));
-          for (Partition _iter599 : struct.parts)
+          for (Partition _iter607 : struct.parts)
           {
-            _iter599.write(oprot);
+            _iter607.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -963,9 +963,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.parts.size());
-        for (Partition _iter600 : struct.parts)
+        for (Partition _iter608 : struct.parts)
         {
-          _iter600.write(oprot);
+          _iter608.write(oprot);
         }
       }
       oprot.writeBool(struct.ifNotExists);
@@ -999,14 +999,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list601 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.parts = new java.util.ArrayList<Partition>(_list601.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem602;
-        for (int _i603 = 0; _i603 < _list601.size; ++_i603)
+        org.apache.thrift.protocol.TList _list609 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.parts = new java.util.ArrayList<Partition>(_list609.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem610;
+        for (int _i611 = 0; _i611 < _list609.size; ++_i611)
         {
-          _elem602 = new Partition();
-          _elem602.read(iprot);
-          struct.parts.add(_elem602);
+          _elem610 = new Partition();
+          _elem610.read(iprot);
+          struct.parts.add(_elem610);
         }
       }
       struct.setPartsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsResult.java
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list588 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list588.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem589;
-                for (int _i590 = 0; _i590 < _list588.size; ++_i590)
+                org.apache.thrift.protocol.TList _list596 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list596.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem597;
+                for (int _i598 = 0; _i598 < _list596.size; ++_i598)
                 {
-                  _elem589 = new Partition();
-                  _elem589.read(iprot);
-                  struct.partitions.add(_elem589);
+                  _elem597 = new Partition();
+                  _elem597.read(iprot);
+                  struct.partitions.add(_elem597);
                 }
                 iprot.readListEnd();
               }
@@ -442,9 +442,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-            for (Partition _iter591 : struct.partitions)
+            for (Partition _iter599 : struct.partitions)
             {
-              _iter591.write(oprot);
+              _iter599.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -484,9 +484,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (Partition _iter592 : struct.partitions)
+          for (Partition _iter600 : struct.partitions)
           {
-            _iter592.write(oprot);
+            _iter600.write(oprot);
           }
         }
       }
@@ -501,14 +501,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list593 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<Partition>(_list593.size);
-          @org.apache.thrift.annotation.Nullable Partition _elem594;
-          for (int _i595 = 0; _i595 < _list593.size; ++_i595)
+          org.apache.thrift.protocol.TList _list601 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<Partition>(_list601.size);
+          @org.apache.thrift.annotation.Nullable Partition _elem602;
+          for (int _i603 = 0; _i603 < _list601.size; ++_i603)
           {
-            _elem594 = new Partition();
-            _elem594.read(iprot);
-            struct.partitions.add(_elem594);
+            _elem602 = new Partition();
+            _elem602.read(iprot);
+            struct.partitions.add(_elem602);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPrimaryKeyRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPrimaryKeyRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRIMARY_KEY_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list474 = iprot.readListBegin();
-                struct.primaryKeyCols = new java.util.ArrayList<SQLPrimaryKey>(_list474.size);
-                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem475;
-                for (int _i476 = 0; _i476 < _list474.size; ++_i476)
+                org.apache.thrift.protocol.TList _list482 = iprot.readListBegin();
+                struct.primaryKeyCols = new java.util.ArrayList<SQLPrimaryKey>(_list482.size);
+                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem483;
+                for (int _i484 = 0; _i484 < _list482.size; ++_i484)
                 {
-                  _elem475 = new SQLPrimaryKey();
-                  _elem475.read(iprot);
-                  struct.primaryKeyCols.add(_elem475);
+                  _elem483 = new SQLPrimaryKey();
+                  _elem483.read(iprot);
+                  struct.primaryKeyCols.add(_elem483);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PRIMARY_KEY_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.primaryKeyCols.size()));
-          for (SQLPrimaryKey _iter477 : struct.primaryKeyCols)
+          for (SQLPrimaryKey _iter485 : struct.primaryKeyCols)
           {
-            _iter477.write(oprot);
+            _iter485.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.primaryKeyCols.size());
-        for (SQLPrimaryKey _iter478 : struct.primaryKeyCols)
+        for (SQLPrimaryKey _iter486 : struct.primaryKeyCols)
         {
-          _iter478.write(oprot);
+          _iter486.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddPrimaryKeyRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list479 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.primaryKeyCols = new java.util.ArrayList<SQLPrimaryKey>(_list479.size);
-        @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem480;
-        for (int _i481 = 0; _i481 < _list479.size; ++_i481)
+        org.apache.thrift.protocol.TList _list487 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.primaryKeyCols = new java.util.ArrayList<SQLPrimaryKey>(_list487.size);
+        @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem488;
+        for (int _i489 = 0; _i489 < _list487.size; ++_i489)
         {
-          _elem480 = new SQLPrimaryKey();
-          _elem480.read(iprot);
-          struct.primaryKeyCols.add(_elem480);
+          _elem488 = new SQLPrimaryKey();
+          _elem488.read(iprot);
+          struct.primaryKeyCols.add(_elem488);
         }
       }
       struct.setPrimaryKeyColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddUniqueConstraintRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddUniqueConstraintRequest.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // UNIQUE_CONSTRAINT_COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list490 = iprot.readListBegin();
-                struct.uniqueConstraintCols = new java.util.ArrayList<SQLUniqueConstraint>(_list490.size);
-                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem491;
-                for (int _i492 = 0; _i492 < _list490.size; ++_i492)
+                org.apache.thrift.protocol.TList _list498 = iprot.readListBegin();
+                struct.uniqueConstraintCols = new java.util.ArrayList<SQLUniqueConstraint>(_list498.size);
+                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem499;
+                for (int _i500 = 0; _i500 < _list498.size; ++_i500)
                 {
-                  _elem491 = new SQLUniqueConstraint();
-                  _elem491.read(iprot);
-                  struct.uniqueConstraintCols.add(_elem491);
+                  _elem499 = new SQLUniqueConstraint();
+                  _elem499.read(iprot);
+                  struct.uniqueConstraintCols.add(_elem499);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(UNIQUE_CONSTRAINT_COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.uniqueConstraintCols.size()));
-          for (SQLUniqueConstraint _iter493 : struct.uniqueConstraintCols)
+          for (SQLUniqueConstraint _iter501 : struct.uniqueConstraintCols)
           {
-            _iter493.write(oprot);
+            _iter501.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.uniqueConstraintCols.size());
-        for (SQLUniqueConstraint _iter494 : struct.uniqueConstraintCols)
+        for (SQLUniqueConstraint _iter502 : struct.uniqueConstraintCols)
         {
-          _iter494.write(oprot);
+          _iter502.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AddUniqueConstraintRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list495 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.uniqueConstraintCols = new java.util.ArrayList<SQLUniqueConstraint>(_list495.size);
-        @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem496;
-        for (int _i497 = 0; _i497 < _list495.size; ++_i497)
+        org.apache.thrift.protocol.TList _list503 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.uniqueConstraintCols = new java.util.ArrayList<SQLUniqueConstraint>(_list503.size);
+        @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem504;
+        for (int _i505 = 0; _i505 < _list503.size; ++_i505)
         {
-          _elem496 = new SQLUniqueConstraint();
-          _elem496.read(iprot);
-          struct.uniqueConstraintCols.add(_elem496);
+          _elem504 = new SQLUniqueConstraint();
+          _elem504.read(iprot);
+          struct.uniqueConstraintCols.add(_elem504);
         }
       }
       struct.setUniqueConstraintColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AggrStats.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AggrStats.java
@@ -487,14 +487,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COL_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list392 = iprot.readListBegin();
-                struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list392.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem393;
-                for (int _i394 = 0; _i394 < _list392.size; ++_i394)
+                org.apache.thrift.protocol.TList _list400 = iprot.readListBegin();
+                struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list400.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem401;
+                for (int _i402 = 0; _i402 < _list400.size; ++_i402)
                 {
-                  _elem393 = new ColumnStatisticsObj();
-                  _elem393.read(iprot);
-                  struct.colStats.add(_elem393);
+                  _elem401 = new ColumnStatisticsObj();
+                  _elem401.read(iprot);
+                  struct.colStats.add(_elem401);
                 }
                 iprot.readListEnd();
               }
@@ -536,9 +536,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_STATS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.colStats.size()));
-          for (ColumnStatisticsObj _iter395 : struct.colStats)
+          for (ColumnStatisticsObj _iter403 : struct.colStats)
           {
-            _iter395.write(oprot);
+            _iter403.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -571,9 +571,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.colStats.size());
-        for (ColumnStatisticsObj _iter396 : struct.colStats)
+        for (ColumnStatisticsObj _iter404 : struct.colStats)
         {
-          _iter396.write(oprot);
+          _iter404.write(oprot);
         }
       }
       oprot.writeI64(struct.partsFound);
@@ -591,14 +591,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AggrStats struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list397 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list397.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem398;
-        for (int _i399 = 0; _i399 < _list397.size; ++_i399)
+        org.apache.thrift.protocol.TList _list405 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.colStats = new java.util.ArrayList<ColumnStatisticsObj>(_list405.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem406;
+        for (int _i407 = 0; _i407 < _list405.size; ++_i407)
         {
-          _elem398 = new ColumnStatisticsObj();
-          _elem398.read(iprot);
-          struct.colStats.add(_elem398);
+          _elem406 = new ColumnStatisticsObj();
+          _elem406.read(iprot);
+          struct.colStats.add(_elem406);
         }
       }
       struct.setColStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AllocateTableWriteIdsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AllocateTableWriteIdsRequest.java
@@ -692,13 +692,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // TXN_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list790 = iprot.readListBegin();
-                struct.txnIds = new java.util.ArrayList<java.lang.Long>(_list790.size);
-                long _elem791;
-                for (int _i792 = 0; _i792 < _list790.size; ++_i792)
+                org.apache.thrift.protocol.TList _list798 = iprot.readListBegin();
+                struct.txnIds = new java.util.ArrayList<java.lang.Long>(_list798.size);
+                long _elem799;
+                for (int _i800 = 0; _i800 < _list798.size; ++_i800)
                 {
-                  _elem791 = iprot.readI64();
-                  struct.txnIds.add(_elem791);
+                  _elem799 = iprot.readI64();
+                  struct.txnIds.add(_elem799);
                 }
                 iprot.readListEnd();
               }
@@ -718,14 +718,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // SRC_TXN_TO_WRITE_ID_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list793 = iprot.readListBegin();
-                struct.srcTxnToWriteIdList = new java.util.ArrayList<TxnToWriteId>(_list793.size);
-                @org.apache.thrift.annotation.Nullable TxnToWriteId _elem794;
-                for (int _i795 = 0; _i795 < _list793.size; ++_i795)
+                org.apache.thrift.protocol.TList _list801 = iprot.readListBegin();
+                struct.srcTxnToWriteIdList = new java.util.ArrayList<TxnToWriteId>(_list801.size);
+                @org.apache.thrift.annotation.Nullable TxnToWriteId _elem802;
+                for (int _i803 = 0; _i803 < _list801.size; ++_i803)
                 {
-                  _elem794 = new TxnToWriteId();
-                  _elem794.read(iprot);
-                  struct.srcTxnToWriteIdList.add(_elem794);
+                  _elem802 = new TxnToWriteId();
+                  _elem802.read(iprot);
+                  struct.srcTxnToWriteIdList.add(_elem802);
                 }
                 iprot.readListEnd();
               }
@@ -762,9 +762,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(TXN_IDS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.txnIds.size()));
-            for (long _iter796 : struct.txnIds)
+            for (long _iter804 : struct.txnIds)
             {
-              oprot.writeI64(_iter796);
+              oprot.writeI64(_iter804);
             }
             oprot.writeListEnd();
           }
@@ -783,9 +783,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(SRC_TXN_TO_WRITE_ID_LIST_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.srcTxnToWriteIdList.size()));
-            for (TxnToWriteId _iter797 : struct.srcTxnToWriteIdList)
+            for (TxnToWriteId _iter805 : struct.srcTxnToWriteIdList)
             {
-              _iter797.write(oprot);
+              _iter805.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -825,9 +825,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetTxnIds()) {
         {
           oprot.writeI32(struct.txnIds.size());
-          for (long _iter798 : struct.txnIds)
+          for (long _iter806 : struct.txnIds)
           {
-            oprot.writeI64(_iter798);
+            oprot.writeI64(_iter806);
           }
         }
       }
@@ -837,9 +837,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetSrcTxnToWriteIdList()) {
         {
           oprot.writeI32(struct.srcTxnToWriteIdList.size());
-          for (TxnToWriteId _iter799 : struct.srcTxnToWriteIdList)
+          for (TxnToWriteId _iter807 : struct.srcTxnToWriteIdList)
           {
-            _iter799.write(oprot);
+            _iter807.write(oprot);
           }
         }
       }
@@ -855,13 +855,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list800 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-          struct.txnIds = new java.util.ArrayList<java.lang.Long>(_list800.size);
-          long _elem801;
-          for (int _i802 = 0; _i802 < _list800.size; ++_i802)
+          org.apache.thrift.protocol.TList _list808 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+          struct.txnIds = new java.util.ArrayList<java.lang.Long>(_list808.size);
+          long _elem809;
+          for (int _i810 = 0; _i810 < _list808.size; ++_i810)
           {
-            _elem801 = iprot.readI64();
-            struct.txnIds.add(_elem801);
+            _elem809 = iprot.readI64();
+            struct.txnIds.add(_elem809);
           }
         }
         struct.setTxnIdsIsSet(true);
@@ -872,14 +872,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list803 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.srcTxnToWriteIdList = new java.util.ArrayList<TxnToWriteId>(_list803.size);
-          @org.apache.thrift.annotation.Nullable TxnToWriteId _elem804;
-          for (int _i805 = 0; _i805 < _list803.size; ++_i805)
+          org.apache.thrift.protocol.TList _list811 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.srcTxnToWriteIdList = new java.util.ArrayList<TxnToWriteId>(_list811.size);
+          @org.apache.thrift.annotation.Nullable TxnToWriteId _elem812;
+          for (int _i813 = 0; _i813 < _list811.size; ++_i813)
           {
-            _elem804 = new TxnToWriteId();
-            _elem804.read(iprot);
-            struct.srcTxnToWriteIdList.add(_elem804);
+            _elem812 = new TxnToWriteId();
+            _elem812.read(iprot);
+            struct.srcTxnToWriteIdList.add(_elem812);
           }
         }
         struct.setSrcTxnToWriteIdListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AllocateTableWriteIdsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AllocateTableWriteIdsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TXN_TO_WRITE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list806 = iprot.readListBegin();
-                struct.txnToWriteIds = new java.util.ArrayList<TxnToWriteId>(_list806.size);
-                @org.apache.thrift.annotation.Nullable TxnToWriteId _elem807;
-                for (int _i808 = 0; _i808 < _list806.size; ++_i808)
+                org.apache.thrift.protocol.TList _list814 = iprot.readListBegin();
+                struct.txnToWriteIds = new java.util.ArrayList<TxnToWriteId>(_list814.size);
+                @org.apache.thrift.annotation.Nullable TxnToWriteId _elem815;
+                for (int _i816 = 0; _i816 < _list814.size; ++_i816)
                 {
-                  _elem807 = new TxnToWriteId();
-                  _elem807.read(iprot);
-                  struct.txnToWriteIds.add(_elem807);
+                  _elem815 = new TxnToWriteId();
+                  _elem815.read(iprot);
+                  struct.txnToWriteIds.add(_elem815);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TXN_TO_WRITE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.txnToWriteIds.size()));
-          for (TxnToWriteId _iter809 : struct.txnToWriteIds)
+          for (TxnToWriteId _iter817 : struct.txnToWriteIds)
           {
-            _iter809.write(oprot);
+            _iter817.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.txnToWriteIds.size());
-        for (TxnToWriteId _iter810 : struct.txnToWriteIds)
+        for (TxnToWriteId _iter818 : struct.txnToWriteIds)
         {
-          _iter810.write(oprot);
+          _iter818.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, AllocateTableWriteIdsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list811 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.txnToWriteIds = new java.util.ArrayList<TxnToWriteId>(_list811.size);
-        @org.apache.thrift.annotation.Nullable TxnToWriteId _elem812;
-        for (int _i813 = 0; _i813 < _list811.size; ++_i813)
+        org.apache.thrift.protocol.TList _list819 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.txnToWriteIds = new java.util.ArrayList<TxnToWriteId>(_list819.size);
+        @org.apache.thrift.annotation.Nullable TxnToWriteId _elem820;
+        for (int _i821 = 0; _i821 < _list819.size; ++_i821)
         {
-          _elem812 = new TxnToWriteId();
-          _elem812.read(iprot);
-          struct.txnToWriteIds.add(_elem812);
+          _elem820 = new TxnToWriteId();
+          _elem820.read(iprot);
+          struct.txnToWriteIds.add(_elem820);
         }
       }
       struct.setTxnToWriteIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AlterPartitionsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AlterPartitionsRequest.java
@@ -851,14 +851,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1270 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list1270.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem1271;
-                for (int _i1272 = 0; _i1272 < _list1270.size; ++_i1272)
+                org.apache.thrift.protocol.TList _list1278 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list1278.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem1279;
+                for (int _i1280 = 0; _i1280 < _list1278.size; ++_i1280)
                 {
-                  _elem1271 = new Partition();
-                  _elem1271.read(iprot);
-                  struct.partitions.add(_elem1271);
+                  _elem1279 = new Partition();
+                  _elem1279.read(iprot);
+                  struct.partitions.add(_elem1279);
                 }
                 iprot.readListEnd();
               }
@@ -926,9 +926,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter1273 : struct.partitions)
+          for (Partition _iter1281 : struct.partitions)
           {
-            _iter1273.write(oprot);
+            _iter1281.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -974,9 +974,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tableName);
       {
         oprot.writeI32(struct.partitions.size());
-        for (Partition _iter1274 : struct.partitions)
+        for (Partition _iter1282 : struct.partitions)
         {
-          _iter1274.write(oprot);
+          _iter1282.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -1015,14 +1015,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tableName = iprot.readString();
       struct.setTableNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list1275 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitions = new java.util.ArrayList<Partition>(_list1275.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem1276;
-        for (int _i1277 = 0; _i1277 < _list1275.size; ++_i1277)
+        org.apache.thrift.protocol.TList _list1283 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitions = new java.util.ArrayList<Partition>(_list1283.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem1284;
+        for (int _i1285 = 0; _i1285 < _list1283.size; ++_i1285)
         {
-          _elem1276 = new Partition();
-          _elem1276.read(iprot);
-          struct.partitions.add(_elem1276);
+          _elem1284 = new Partition();
+          _elem1284.read(iprot);
+          struct.partitions.add(_elem1284);
         }
       }
       struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AlterTableRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AlterTableRequest.java
@@ -1047,13 +1047,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1286 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1286.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1287;
-                for (int _i1288 = 0; _i1288 < _list1286.size; ++_i1288)
+                org.apache.thrift.protocol.TList _list1294 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1294.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1295;
+                for (int _i1296 = 0; _i1296 < _list1294.size; ++_i1296)
                 {
-                  _elem1287 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1287);
+                  _elem1295 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1295);
                 }
                 iprot.readListEnd();
               }
@@ -1129,9 +1129,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1289 : struct.processorCapabilities)
+            for (java.lang.String _iter1297 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1289);
+              oprot.writeString(_iter1297);
             }
             oprot.writeListEnd();
           }
@@ -1200,9 +1200,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1290 : struct.processorCapabilities)
+          for (java.lang.String _iter1298 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1290);
+            oprot.writeString(_iter1298);
           }
         }
       }
@@ -1241,13 +1241,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TList _list1291 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1291.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1292;
-          for (int _i1293 = 0; _i1293 < _list1291.size; ++_i1293)
+          org.apache.thrift.protocol.TList _list1299 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1299.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1300;
+          for (int _i1301 = 0; _i1301 < _list1299.size; ++_i1301)
           {
-            _elem1292 = iprot.readString();
-            struct.processorCapabilities.add(_elem1292);
+            _elem1300 = iprot.readString();
+            struct.processorCapabilities.add(_elem1300);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CheckConstraintsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CheckConstraintsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // CHECK_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list466 = iprot.readListBegin();
-                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list466.size);
-                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem467;
-                for (int _i468 = 0; _i468 < _list466.size; ++_i468)
+                org.apache.thrift.protocol.TList _list474 = iprot.readListBegin();
+                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list474.size);
+                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem475;
+                for (int _i476 = 0; _i476 < _list474.size; ++_i476)
                 {
-                  _elem467 = new SQLCheckConstraint();
-                  _elem467.read(iprot);
-                  struct.checkConstraints.add(_elem467);
+                  _elem475 = new SQLCheckConstraint();
+                  _elem475.read(iprot);
+                  struct.checkConstraints.add(_elem475);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(CHECK_CONSTRAINTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.checkConstraints.size()));
-          for (SQLCheckConstraint _iter469 : struct.checkConstraints)
+          for (SQLCheckConstraint _iter477 : struct.checkConstraints)
           {
-            _iter469.write(oprot);
+            _iter477.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.checkConstraints.size());
-        for (SQLCheckConstraint _iter470 : struct.checkConstraints)
+        for (SQLCheckConstraint _iter478 : struct.checkConstraints)
         {
-          _iter470.write(oprot);
+          _iter478.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, CheckConstraintsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list471 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list471.size);
-        @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem472;
-        for (int _i473 = 0; _i473 < _list471.size; ++_i473)
+        org.apache.thrift.protocol.TList _list479 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list479.size);
+        @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem480;
+        for (int _i481 = 0; _i481 < _list479.size; ++_i481)
         {
-          _elem472 = new SQLCheckConstraint();
-          _elem472.read(iprot);
-          struct.checkConstraints.add(_elem472);
+          _elem480 = new SQLCheckConstraint();
+          _elem480.read(iprot);
+          struct.checkConstraints.add(_elem480);
         }
       }
       struct.setCheckConstraintsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ClearFileMetadataRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ClearFileMetadataRequest.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FILE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1028 = iprot.readListBegin();
-                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1028.size);
-                long _elem1029;
-                for (int _i1030 = 0; _i1030 < _list1028.size; ++_i1030)
+                org.apache.thrift.protocol.TList _list1036 = iprot.readListBegin();
+                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1036.size);
+                long _elem1037;
+                for (int _i1038 = 0; _i1038 < _list1036.size; ++_i1038)
                 {
-                  _elem1029 = iprot.readI64();
-                  struct.fileIds.add(_elem1029);
+                  _elem1037 = iprot.readI64();
+                  struct.fileIds.add(_elem1037);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FILE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.fileIds.size()));
-          for (long _iter1031 : struct.fileIds)
+          for (long _iter1039 : struct.fileIds)
           {
-            oprot.writeI64(_iter1031);
+            oprot.writeI64(_iter1039);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fileIds.size());
-        for (long _iter1032 : struct.fileIds)
+        for (long _iter1040 : struct.fileIds)
         {
-          oprot.writeI64(_iter1032);
+          oprot.writeI64(_iter1040);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ClearFileMetadataRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1033 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1033.size);
-        long _elem1034;
-        for (int _i1035 = 0; _i1035 < _list1033.size; ++_i1035)
+        org.apache.thrift.protocol.TList _list1041 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1041.size);
+        long _elem1042;
+        for (int _i1043 = 0; _i1043 < _list1041.size; ++_i1043)
         {
-          _elem1034 = iprot.readI64();
-          struct.fileIds.add(_elem1034);
+          _elem1042 = iprot.readI64();
+          struct.fileIds.add(_elem1042);
         }
       }
       struct.setFileIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ClientCapabilities.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ClientCapabilities.java
@@ -329,15 +329,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1044 = iprot.readListBegin();
-                struct.values = new java.util.ArrayList<ClientCapability>(_list1044.size);
-                @org.apache.thrift.annotation.Nullable ClientCapability _elem1045;
-                for (int _i1046 = 0; _i1046 < _list1044.size; ++_i1046)
+                org.apache.thrift.protocol.TList _list1052 = iprot.readListBegin();
+                struct.values = new java.util.ArrayList<ClientCapability>(_list1052.size);
+                @org.apache.thrift.annotation.Nullable ClientCapability _elem1053;
+                for (int _i1054 = 0; _i1054 < _list1052.size; ++_i1054)
                 {
-                  _elem1045 = org.apache.hadoop.hive.metastore.api.ClientCapability.findByValue(iprot.readI32());
-                  if (_elem1045 != null)
+                  _elem1053 = org.apache.hadoop.hive.metastore.api.ClientCapability.findByValue(iprot.readI32());
+                  if (_elem1053 != null)
                   {
-                    struct.values.add(_elem1045);
+                    struct.values.add(_elem1053);
                   }
                 }
                 iprot.readListEnd();
@@ -364,9 +364,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.values.size()));
-          for (ClientCapability _iter1047 : struct.values)
+          for (ClientCapability _iter1055 : struct.values)
           {
-            oprot.writeI32(_iter1047.getValue());
+            oprot.writeI32(_iter1055.getValue());
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.values.size());
-        for (ClientCapability _iter1048 : struct.values)
+        for (ClientCapability _iter1056 : struct.values)
         {
-          oprot.writeI32(_iter1048.getValue());
+          oprot.writeI32(_iter1056.getValue());
         }
       }
     }
@@ -402,15 +402,15 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ClientCapabilities struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1049 = iprot.readListBegin(org.apache.thrift.protocol.TType.I32);
-        struct.values = new java.util.ArrayList<ClientCapability>(_list1049.size);
-        @org.apache.thrift.annotation.Nullable ClientCapability _elem1050;
-        for (int _i1051 = 0; _i1051 < _list1049.size; ++_i1051)
+        org.apache.thrift.protocol.TList _list1057 = iprot.readListBegin(org.apache.thrift.protocol.TType.I32);
+        struct.values = new java.util.ArrayList<ClientCapability>(_list1057.size);
+        @org.apache.thrift.annotation.Nullable ClientCapability _elem1058;
+        for (int _i1059 = 0; _i1059 < _list1057.size; ++_i1059)
         {
-          _elem1050 = org.apache.hadoop.hive.metastore.api.ClientCapability.findByValue(iprot.readI32());
-          if (_elem1050 != null)
+          _elem1058 = org.apache.hadoop.hive.metastore.api.ClientCapability.findByValue(iprot.readI32());
+          if (_elem1058 != null)
           {
-            struct.values.add(_elem1050);
+            struct.values.add(_elem1058);
           }
         }
       }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatistics.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatistics.java
@@ -587,14 +587,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // STATS_OBJ
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list272 = iprot.readListBegin();
-                struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list272.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem273;
-                for (int _i274 = 0; _i274 < _list272.size; ++_i274)
+                org.apache.thrift.protocol.TList _list280 = iprot.readListBegin();
+                struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list280.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem281;
+                for (int _i282 = 0; _i282 < _list280.size; ++_i282)
                 {
-                  _elem273 = new ColumnStatisticsObj();
-                  _elem273.read(iprot);
-                  struct.statsObj.add(_elem273);
+                  _elem281 = new ColumnStatisticsObj();
+                  _elem281.read(iprot);
+                  struct.statsObj.add(_elem281);
                 }
                 iprot.readListEnd();
               }
@@ -641,9 +641,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(STATS_OBJ_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.statsObj.size()));
-          for (ColumnStatisticsObj _iter275 : struct.statsObj)
+          for (ColumnStatisticsObj _iter283 : struct.statsObj)
           {
-            _iter275.write(oprot);
+            _iter283.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -681,9 +681,9 @@ package org.apache.hadoop.hive.metastore.api;
       struct.statsDesc.write(oprot);
       {
         oprot.writeI32(struct.statsObj.size());
-        for (ColumnStatisticsObj _iter276 : struct.statsObj)
+        for (ColumnStatisticsObj _iter284 : struct.statsObj)
         {
-          _iter276.write(oprot);
+          _iter284.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -709,14 +709,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.statsDesc.read(iprot);
       struct.setStatsDescIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list277 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list277.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem278;
-        for (int _i279 = 0; _i279 < _list277.size; ++_i279)
+        org.apache.thrift.protocol.TList _list285 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.statsObj = new java.util.ArrayList<ColumnStatisticsObj>(_list285.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem286;
+        for (int _i287 = 0; _i287 < _list285.size; ++_i287)
         {
-          _elem278 = new ColumnStatisticsObj();
-          _elem278.read(iprot);
-          struct.statsObj.add(_elem278);
+          _elem286 = new ColumnStatisticsObj();
+          _elem286.read(iprot);
+          struct.statsObj.add(_elem286);
         }
       }
       struct.setStatsObjIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
@@ -843,14 +843,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // WRITE_EVENT_INFOS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list750 = iprot.readListBegin();
-                struct.writeEventInfos = new java.util.ArrayList<WriteEventInfo>(_list750.size);
-                @org.apache.thrift.annotation.Nullable WriteEventInfo _elem751;
-                for (int _i752 = 0; _i752 < _list750.size; ++_i752)
+                org.apache.thrift.protocol.TList _list758 = iprot.readListBegin();
+                struct.writeEventInfos = new java.util.ArrayList<WriteEventInfo>(_list758.size);
+                @org.apache.thrift.annotation.Nullable WriteEventInfo _elem759;
+                for (int _i760 = 0; _i760 < _list758.size; ++_i760)
                 {
-                  _elem751 = new WriteEventInfo();
-                  _elem751.read(iprot);
-                  struct.writeEventInfos.add(_elem751);
+                  _elem759 = new WriteEventInfo();
+                  _elem759.read(iprot);
+                  struct.writeEventInfos.add(_elem759);
                 }
                 iprot.readListEnd();
               }
@@ -921,9 +921,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(WRITE_EVENT_INFOS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.writeEventInfos.size()));
-            for (WriteEventInfo _iter753 : struct.writeEventInfos)
+            for (WriteEventInfo _iter761 : struct.writeEventInfos)
             {
-              _iter753.write(oprot);
+              _iter761.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1000,9 +1000,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetWriteEventInfos()) {
         {
           oprot.writeI32(struct.writeEventInfos.size());
-          for (WriteEventInfo _iter754 : struct.writeEventInfos)
+          for (WriteEventInfo _iter762 : struct.writeEventInfos)
           {
-            _iter754.write(oprot);
+            _iter762.write(oprot);
           }
         }
       }
@@ -1032,14 +1032,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list755 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.writeEventInfos = new java.util.ArrayList<WriteEventInfo>(_list755.size);
-          @org.apache.thrift.annotation.Nullable WriteEventInfo _elem756;
-          for (int _i757 = 0; _i757 < _list755.size; ++_i757)
+          org.apache.thrift.protocol.TList _list763 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.writeEventInfos = new java.util.ArrayList<WriteEventInfo>(_list763.size);
+          @org.apache.thrift.annotation.Nullable WriteEventInfo _elem764;
+          for (int _i765 = 0; _i765 < _list763.size; ++_i765)
           {
-            _elem756 = new WriteEventInfo();
-            _elem756.read(iprot);
-            struct.writeEventInfos.add(_elem756);
+            _elem764 = new WriteEventInfo();
+            _elem764.read(iprot);
+            struct.writeEventInfos.add(_elem764);
           }
         }
         struct.setWriteEventInfosIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CompactionRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CompactionRequest.java
@@ -950,15 +950,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // PROPERTIES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map846 = iprot.readMapBegin();
-                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map846.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key847;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val848;
-                for (int _i849 = 0; _i849 < _map846.size; ++_i849)
+                org.apache.thrift.protocol.TMap _map854 = iprot.readMapBegin();
+                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map854.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key855;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val856;
+                for (int _i857 = 0; _i857 < _map854.size; ++_i857)
                 {
-                  _key847 = iprot.readString();
-                  _val848 = iprot.readString();
-                  struct.properties.put(_key847, _val848);
+                  _key855 = iprot.readString();
+                  _val856 = iprot.readString();
+                  struct.properties.put(_key855, _val856);
                 }
                 iprot.readMapEnd();
               }
@@ -1030,10 +1030,10 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROPERTIES_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.properties.size()));
-            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter850 : struct.properties.entrySet())
+            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter858 : struct.properties.entrySet())
             {
-              oprot.writeString(_iter850.getKey());
-              oprot.writeString(_iter850.getValue());
+              oprot.writeString(_iter858.getKey());
+              oprot.writeString(_iter858.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1100,10 +1100,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProperties()) {
         {
           oprot.writeI32(struct.properties.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter851 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter859 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter851.getKey());
-            oprot.writeString(_iter851.getValue());
+            oprot.writeString(_iter859.getKey());
+            oprot.writeString(_iter859.getValue());
           }
         }
       }
@@ -1135,15 +1135,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map852 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map852.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key853;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val854;
-          for (int _i855 = 0; _i855 < _map852.size; ++_i855)
+          org.apache.thrift.protocol.TMap _map860 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map860.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key861;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val862;
+          for (int _i863 = 0; _i863 < _map860.size; ++_i863)
           {
-            _key853 = iprot.readString();
-            _val854 = iprot.readString();
-            struct.properties.put(_key853, _val854);
+            _key861 = iprot.readString();
+            _val862 = iprot.readString();
+            struct.properties.put(_key861, _val862);
           }
         }
         struct.setPropertiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreateDatabaseRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreateDatabaseRequest.java
@@ -1251,15 +1251,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map1260 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map1260.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key1261;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val1262;
-                for (int _i1263 = 0; _i1263 < _map1260.size; ++_i1263)
+                org.apache.thrift.protocol.TMap _map1268 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map1268.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key1269;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val1270;
+                for (int _i1271 = 0; _i1271 < _map1268.size; ++_i1271)
                 {
-                  _key1261 = iprot.readString();
-                  _val1262 = iprot.readString();
-                  struct.parameters.put(_key1261, _val1262);
+                  _key1269 = iprot.readString();
+                  _val1270 = iprot.readString();
+                  struct.parameters.put(_key1269, _val1270);
                 }
                 iprot.readMapEnd();
               }
@@ -1370,10 +1370,10 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter1264 : struct.parameters.entrySet())
+            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter1272 : struct.parameters.entrySet())
             {
-              oprot.writeString(_iter1264.getKey());
-              oprot.writeString(_iter1264.getValue());
+              oprot.writeString(_iter1272.getKey());
+              oprot.writeString(_iter1272.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1496,10 +1496,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter1265 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter1273 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter1265.getKey());
-            oprot.writeString(_iter1265.getValue());
+            oprot.writeString(_iter1273.getKey());
+            oprot.writeString(_iter1273.getValue());
           }
         }
       }
@@ -1545,15 +1545,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map1266 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map1266.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key1267;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val1268;
-          for (int _i1269 = 0; _i1269 < _map1266.size; ++_i1269)
+          org.apache.thrift.protocol.TMap _map1274 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map1274.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key1275;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val1276;
+          for (int _i1277 = 0; _i1277 < _map1274.size; ++_i1277)
           {
-            _key1267 = iprot.readString();
-            _val1268 = iprot.readString();
-            struct.parameters.put(_key1267, _val1268);
+            _key1275 = iprot.readString();
+            _val1276 = iprot.readString();
+            struct.parameters.put(_key1275, _val1276);
           }
         }
         struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreateTableRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreateTableRequest.java
@@ -1206,14 +1206,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PRIMARY_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1204 = iprot.readListBegin();
-                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list1204.size);
-                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem1205;
-                for (int _i1206 = 0; _i1206 < _list1204.size; ++_i1206)
+                org.apache.thrift.protocol.TList _list1212 = iprot.readListBegin();
+                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list1212.size);
+                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem1213;
+                for (int _i1214 = 0; _i1214 < _list1212.size; ++_i1214)
                 {
-                  _elem1205 = new SQLPrimaryKey();
-                  _elem1205.read(iprot);
-                  struct.primaryKeys.add(_elem1205);
+                  _elem1213 = new SQLPrimaryKey();
+                  _elem1213.read(iprot);
+                  struct.primaryKeys.add(_elem1213);
                 }
                 iprot.readListEnd();
               }
@@ -1225,14 +1225,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // FOREIGN_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1207 = iprot.readListBegin();
-                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list1207.size);
-                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem1208;
-                for (int _i1209 = 0; _i1209 < _list1207.size; ++_i1209)
+                org.apache.thrift.protocol.TList _list1215 = iprot.readListBegin();
+                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list1215.size);
+                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem1216;
+                for (int _i1217 = 0; _i1217 < _list1215.size; ++_i1217)
                 {
-                  _elem1208 = new SQLForeignKey();
-                  _elem1208.read(iprot);
-                  struct.foreignKeys.add(_elem1208);
+                  _elem1216 = new SQLForeignKey();
+                  _elem1216.read(iprot);
+                  struct.foreignKeys.add(_elem1216);
                 }
                 iprot.readListEnd();
               }
@@ -1244,14 +1244,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // UNIQUE_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1210 = iprot.readListBegin();
-                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list1210.size);
-                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem1211;
-                for (int _i1212 = 0; _i1212 < _list1210.size; ++_i1212)
+                org.apache.thrift.protocol.TList _list1218 = iprot.readListBegin();
+                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list1218.size);
+                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem1219;
+                for (int _i1220 = 0; _i1220 < _list1218.size; ++_i1220)
                 {
-                  _elem1211 = new SQLUniqueConstraint();
-                  _elem1211.read(iprot);
-                  struct.uniqueConstraints.add(_elem1211);
+                  _elem1219 = new SQLUniqueConstraint();
+                  _elem1219.read(iprot);
+                  struct.uniqueConstraints.add(_elem1219);
                 }
                 iprot.readListEnd();
               }
@@ -1263,14 +1263,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // NOT_NULL_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1213 = iprot.readListBegin();
-                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list1213.size);
-                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem1214;
-                for (int _i1215 = 0; _i1215 < _list1213.size; ++_i1215)
+                org.apache.thrift.protocol.TList _list1221 = iprot.readListBegin();
+                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list1221.size);
+                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem1222;
+                for (int _i1223 = 0; _i1223 < _list1221.size; ++_i1223)
                 {
-                  _elem1214 = new SQLNotNullConstraint();
-                  _elem1214.read(iprot);
-                  struct.notNullConstraints.add(_elem1214);
+                  _elem1222 = new SQLNotNullConstraint();
+                  _elem1222.read(iprot);
+                  struct.notNullConstraints.add(_elem1222);
                 }
                 iprot.readListEnd();
               }
@@ -1282,14 +1282,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 7: // DEFAULT_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1216 = iprot.readListBegin();
-                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list1216.size);
-                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem1217;
-                for (int _i1218 = 0; _i1218 < _list1216.size; ++_i1218)
+                org.apache.thrift.protocol.TList _list1224 = iprot.readListBegin();
+                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list1224.size);
+                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem1225;
+                for (int _i1226 = 0; _i1226 < _list1224.size; ++_i1226)
                 {
-                  _elem1217 = new SQLDefaultConstraint();
-                  _elem1217.read(iprot);
-                  struct.defaultConstraints.add(_elem1217);
+                  _elem1225 = new SQLDefaultConstraint();
+                  _elem1225.read(iprot);
+                  struct.defaultConstraints.add(_elem1225);
                 }
                 iprot.readListEnd();
               }
@@ -1301,14 +1301,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // CHECK_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1219 = iprot.readListBegin();
-                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list1219.size);
-                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem1220;
-                for (int _i1221 = 0; _i1221 < _list1219.size; ++_i1221)
+                org.apache.thrift.protocol.TList _list1227 = iprot.readListBegin();
+                struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list1227.size);
+                @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem1228;
+                for (int _i1229 = 0; _i1229 < _list1227.size; ++_i1229)
                 {
-                  _elem1220 = new SQLCheckConstraint();
-                  _elem1220.read(iprot);
-                  struct.checkConstraints.add(_elem1220);
+                  _elem1228 = new SQLCheckConstraint();
+                  _elem1228.read(iprot);
+                  struct.checkConstraints.add(_elem1228);
                 }
                 iprot.readListEnd();
               }
@@ -1320,13 +1320,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 9: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1222 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1222.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1223;
-                for (int _i1224 = 0; _i1224 < _list1222.size; ++_i1224)
+                org.apache.thrift.protocol.TList _list1230 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1230.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1231;
+                for (int _i1232 = 0; _i1232 < _list1230.size; ++_i1232)
                 {
-                  _elem1223 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1223);
+                  _elem1231 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1231);
                 }
                 iprot.readListEnd();
               }
@@ -1373,9 +1373,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PRIMARY_KEYS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.primaryKeys.size()));
-            for (SQLPrimaryKey _iter1225 : struct.primaryKeys)
+            for (SQLPrimaryKey _iter1233 : struct.primaryKeys)
             {
-              _iter1225.write(oprot);
+              _iter1233.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1387,9 +1387,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FOREIGN_KEYS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.foreignKeys.size()));
-            for (SQLForeignKey _iter1226 : struct.foreignKeys)
+            for (SQLForeignKey _iter1234 : struct.foreignKeys)
             {
-              _iter1226.write(oprot);
+              _iter1234.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1401,9 +1401,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(UNIQUE_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.uniqueConstraints.size()));
-            for (SQLUniqueConstraint _iter1227 : struct.uniqueConstraints)
+            for (SQLUniqueConstraint _iter1235 : struct.uniqueConstraints)
             {
-              _iter1227.write(oprot);
+              _iter1235.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1415,9 +1415,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(NOT_NULL_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.notNullConstraints.size()));
-            for (SQLNotNullConstraint _iter1228 : struct.notNullConstraints)
+            for (SQLNotNullConstraint _iter1236 : struct.notNullConstraints)
             {
-              _iter1228.write(oprot);
+              _iter1236.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1429,9 +1429,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(DEFAULT_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.defaultConstraints.size()));
-            for (SQLDefaultConstraint _iter1229 : struct.defaultConstraints)
+            for (SQLDefaultConstraint _iter1237 : struct.defaultConstraints)
             {
-              _iter1229.write(oprot);
+              _iter1237.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1443,9 +1443,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(CHECK_CONSTRAINTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.checkConstraints.size()));
-            for (SQLCheckConstraint _iter1230 : struct.checkConstraints)
+            for (SQLCheckConstraint _iter1238 : struct.checkConstraints)
             {
-              _iter1230.write(oprot);
+              _iter1238.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1457,9 +1457,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1231 : struct.processorCapabilities)
+            for (java.lang.String _iter1239 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1231);
+              oprot.writeString(_iter1239);
             }
             oprot.writeListEnd();
           }
@@ -1526,63 +1526,63 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPrimaryKeys()) {
         {
           oprot.writeI32(struct.primaryKeys.size());
-          for (SQLPrimaryKey _iter1232 : struct.primaryKeys)
+          for (SQLPrimaryKey _iter1240 : struct.primaryKeys)
           {
-            _iter1232.write(oprot);
+            _iter1240.write(oprot);
           }
         }
       }
       if (struct.isSetForeignKeys()) {
         {
           oprot.writeI32(struct.foreignKeys.size());
-          for (SQLForeignKey _iter1233 : struct.foreignKeys)
+          for (SQLForeignKey _iter1241 : struct.foreignKeys)
           {
-            _iter1233.write(oprot);
+            _iter1241.write(oprot);
           }
         }
       }
       if (struct.isSetUniqueConstraints()) {
         {
           oprot.writeI32(struct.uniqueConstraints.size());
-          for (SQLUniqueConstraint _iter1234 : struct.uniqueConstraints)
+          for (SQLUniqueConstraint _iter1242 : struct.uniqueConstraints)
           {
-            _iter1234.write(oprot);
+            _iter1242.write(oprot);
           }
         }
       }
       if (struct.isSetNotNullConstraints()) {
         {
           oprot.writeI32(struct.notNullConstraints.size());
-          for (SQLNotNullConstraint _iter1235 : struct.notNullConstraints)
+          for (SQLNotNullConstraint _iter1243 : struct.notNullConstraints)
           {
-            _iter1235.write(oprot);
+            _iter1243.write(oprot);
           }
         }
       }
       if (struct.isSetDefaultConstraints()) {
         {
           oprot.writeI32(struct.defaultConstraints.size());
-          for (SQLDefaultConstraint _iter1236 : struct.defaultConstraints)
+          for (SQLDefaultConstraint _iter1244 : struct.defaultConstraints)
           {
-            _iter1236.write(oprot);
+            _iter1244.write(oprot);
           }
         }
       }
       if (struct.isSetCheckConstraints()) {
         {
           oprot.writeI32(struct.checkConstraints.size());
-          for (SQLCheckConstraint _iter1237 : struct.checkConstraints)
+          for (SQLCheckConstraint _iter1245 : struct.checkConstraints)
           {
-            _iter1237.write(oprot);
+            _iter1245.write(oprot);
           }
         }
       }
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1238 : struct.processorCapabilities)
+          for (java.lang.String _iter1246 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1238);
+            oprot.writeString(_iter1246);
           }
         }
       }
@@ -1605,97 +1605,97 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1239 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list1239.size);
-          @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem1240;
-          for (int _i1241 = 0; _i1241 < _list1239.size; ++_i1241)
+          org.apache.thrift.protocol.TList _list1247 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list1247.size);
+          @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem1248;
+          for (int _i1249 = 0; _i1249 < _list1247.size; ++_i1249)
           {
-            _elem1240 = new SQLPrimaryKey();
-            _elem1240.read(iprot);
-            struct.primaryKeys.add(_elem1240);
+            _elem1248 = new SQLPrimaryKey();
+            _elem1248.read(iprot);
+            struct.primaryKeys.add(_elem1248);
           }
         }
         struct.setPrimaryKeysIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list1242 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list1242.size);
-          @org.apache.thrift.annotation.Nullable SQLForeignKey _elem1243;
-          for (int _i1244 = 0; _i1244 < _list1242.size; ++_i1244)
+          org.apache.thrift.protocol.TList _list1250 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list1250.size);
+          @org.apache.thrift.annotation.Nullable SQLForeignKey _elem1251;
+          for (int _i1252 = 0; _i1252 < _list1250.size; ++_i1252)
           {
-            _elem1243 = new SQLForeignKey();
-            _elem1243.read(iprot);
-            struct.foreignKeys.add(_elem1243);
+            _elem1251 = new SQLForeignKey();
+            _elem1251.read(iprot);
+            struct.foreignKeys.add(_elem1251);
           }
         }
         struct.setForeignKeysIsSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list1245 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list1245.size);
-          @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem1246;
-          for (int _i1247 = 0; _i1247 < _list1245.size; ++_i1247)
+          org.apache.thrift.protocol.TList _list1253 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list1253.size);
+          @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem1254;
+          for (int _i1255 = 0; _i1255 < _list1253.size; ++_i1255)
           {
-            _elem1246 = new SQLUniqueConstraint();
-            _elem1246.read(iprot);
-            struct.uniqueConstraints.add(_elem1246);
+            _elem1254 = new SQLUniqueConstraint();
+            _elem1254.read(iprot);
+            struct.uniqueConstraints.add(_elem1254);
           }
         }
         struct.setUniqueConstraintsIsSet(true);
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TList _list1248 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list1248.size);
-          @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem1249;
-          for (int _i1250 = 0; _i1250 < _list1248.size; ++_i1250)
+          org.apache.thrift.protocol.TList _list1256 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list1256.size);
+          @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem1257;
+          for (int _i1258 = 0; _i1258 < _list1256.size; ++_i1258)
           {
-            _elem1249 = new SQLNotNullConstraint();
-            _elem1249.read(iprot);
-            struct.notNullConstraints.add(_elem1249);
+            _elem1257 = new SQLNotNullConstraint();
+            _elem1257.read(iprot);
+            struct.notNullConstraints.add(_elem1257);
           }
         }
         struct.setNotNullConstraintsIsSet(true);
       }
       if (incoming.get(5)) {
         {
-          org.apache.thrift.protocol.TList _list1251 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list1251.size);
-          @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem1252;
-          for (int _i1253 = 0; _i1253 < _list1251.size; ++_i1253)
+          org.apache.thrift.protocol.TList _list1259 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list1259.size);
+          @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem1260;
+          for (int _i1261 = 0; _i1261 < _list1259.size; ++_i1261)
           {
-            _elem1252 = new SQLDefaultConstraint();
-            _elem1252.read(iprot);
-            struct.defaultConstraints.add(_elem1252);
+            _elem1260 = new SQLDefaultConstraint();
+            _elem1260.read(iprot);
+            struct.defaultConstraints.add(_elem1260);
           }
         }
         struct.setDefaultConstraintsIsSet(true);
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TList _list1254 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list1254.size);
-          @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem1255;
-          for (int _i1256 = 0; _i1256 < _list1254.size; ++_i1256)
+          org.apache.thrift.protocol.TList _list1262 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.checkConstraints = new java.util.ArrayList<SQLCheckConstraint>(_list1262.size);
+          @org.apache.thrift.annotation.Nullable SQLCheckConstraint _elem1263;
+          for (int _i1264 = 0; _i1264 < _list1262.size; ++_i1264)
           {
-            _elem1255 = new SQLCheckConstraint();
-            _elem1255.read(iprot);
-            struct.checkConstraints.add(_elem1255);
+            _elem1263 = new SQLCheckConstraint();
+            _elem1263.read(iprot);
+            struct.checkConstraints.add(_elem1263);
           }
         }
         struct.setCheckConstraintsIsSet(true);
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list1257 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1257.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1258;
-          for (int _i1259 = 0; _i1259 < _list1257.size; ++_i1259)
+          org.apache.thrift.protocol.TList _list1265 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1265.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1266;
+          for (int _i1267 = 0; _i1267 < _list1265.size; ++_i1267)
           {
-            _elem1258 = iprot.readString();
-            struct.processorCapabilities.add(_elem1258);
+            _elem1266 = iprot.readString();
+            struct.processorCapabilities.add(_elem1266);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreationMetadata.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CreationMetadata.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField TABLES_USED_FIELD_DESC = new org.apache.thrift.protocol.TField("tablesUsed", org.apache.thrift.protocol.TType.SET, (short)4);
   private static final org.apache.thrift.protocol.TField VALID_TXN_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("validTxnList", org.apache.thrift.protocol.TType.STRING, (short)5);
   private static final org.apache.thrift.protocol.TField MATERIALIZATION_TIME_FIELD_DESC = new org.apache.thrift.protocol.TField("materializationTime", org.apache.thrift.protocol.TType.I64, (short)6);
+  private static final org.apache.thrift.protocol.TField SOURCE_TABLES_FIELD_DESC = new org.apache.thrift.protocol.TField("sourceTables", org.apache.thrift.protocol.TType.SET, (short)7);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new CreationMetadataStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new CreationMetadataTupleSchemeFactory();
@@ -24,9 +25,10 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String catName; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String dbName; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String tblName; // required
-  private @org.apache.thrift.annotation.Nullable java.util.Set<SourceTable> tablesUsed; // required
+  private @org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> tablesUsed; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String validTxnList; // optional
   private long materializationTime; // optional
+  private @org.apache.thrift.annotation.Nullable java.util.Set<SourceTable> sourceTables; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35,7 +37,8 @@ package org.apache.hadoop.hive.metastore.api;
     TBL_NAME((short)3, "tblName"),
     TABLES_USED((short)4, "tablesUsed"),
     VALID_TXN_LIST((short)5, "validTxnList"),
-    MATERIALIZATION_TIME((short)6, "materializationTime");
+    MATERIALIZATION_TIME((short)6, "materializationTime"),
+    SOURCE_TABLES((short)7, "sourceTables");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -63,6 +66,8 @@ package org.apache.hadoop.hive.metastore.api;
           return VALID_TXN_LIST;
         case 6: // MATERIALIZATION_TIME
           return MATERIALIZATION_TIME;
+        case 7: // SOURCE_TABLES
+          return SOURCE_TABLES;
         default:
           return null;
       }
@@ -106,7 +111,7 @@ package org.apache.hadoop.hive.metastore.api;
   // isset id assignments
   private static final int __MATERIALIZATIONTIME_ISSET_ID = 0;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.VALID_TXN_LIST,_Fields.MATERIALIZATION_TIME};
+  private static final _Fields optionals[] = {_Fields.VALID_TXN_LIST,_Fields.MATERIALIZATION_TIME,_Fields.SOURCE_TABLES};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -118,11 +123,14 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.TABLES_USED, new org.apache.thrift.meta_data.FieldMetaData("tablesUsed", org.apache.thrift.TFieldRequirementType.REQUIRED, 
         new org.apache.thrift.meta_data.SetMetaData(org.apache.thrift.protocol.TType.SET, 
-            new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, SourceTable.class))));
+            new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
     tmpMap.put(_Fields.VALID_TXN_LIST, new org.apache.thrift.meta_data.FieldMetaData("validTxnList", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.MATERIALIZATION_TIME, new org.apache.thrift.meta_data.FieldMetaData("materializationTime", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+    tmpMap.put(_Fields.SOURCE_TABLES, new org.apache.thrift.meta_data.FieldMetaData("sourceTables", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.SetMetaData(org.apache.thrift.protocol.TType.SET, 
+            new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, SourceTable.class))));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(CreationMetadata.class, metaDataMap);
   }
@@ -134,7 +142,7 @@ package org.apache.hadoop.hive.metastore.api;
     java.lang.String catName,
     java.lang.String dbName,
     java.lang.String tblName,
-    java.util.Set<SourceTable> tablesUsed)
+    java.util.Set<java.lang.String> tablesUsed)
   {
     this();
     this.catName = catName;
@@ -158,16 +166,20 @@ package org.apache.hadoop.hive.metastore.api;
       this.tblName = other.tblName;
     }
     if (other.isSetTablesUsed()) {
-      java.util.Set<SourceTable> __this__tablesUsed = new java.util.HashSet<SourceTable>(other.tablesUsed.size());
-      for (SourceTable other_element : other.tablesUsed) {
-        __this__tablesUsed.add(new SourceTable(other_element));
-      }
+      java.util.Set<java.lang.String> __this__tablesUsed = new java.util.HashSet<java.lang.String>(other.tablesUsed);
       this.tablesUsed = __this__tablesUsed;
     }
     if (other.isSetValidTxnList()) {
       this.validTxnList = other.validTxnList;
     }
     this.materializationTime = other.materializationTime;
+    if (other.isSetSourceTables()) {
+      java.util.Set<SourceTable> __this__sourceTables = new java.util.HashSet<SourceTable>(other.sourceTables.size());
+      for (SourceTable other_element : other.sourceTables) {
+        __this__sourceTables.add(new SourceTable(other_element));
+      }
+      this.sourceTables = __this__sourceTables;
+    }
   }
 
   public CreationMetadata deepCopy() {
@@ -183,6 +195,7 @@ package org.apache.hadoop.hive.metastore.api;
     this.validTxnList = null;
     setMaterializationTimeIsSet(false);
     this.materializationTime = 0;
+    this.sourceTables = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -262,23 +275,23 @@ package org.apache.hadoop.hive.metastore.api;
   }
 
   @org.apache.thrift.annotation.Nullable
-  public java.util.Iterator<SourceTable> getTablesUsedIterator() {
+  public java.util.Iterator<java.lang.String> getTablesUsedIterator() {
     return (this.tablesUsed == null) ? null : this.tablesUsed.iterator();
   }
 
-  public void addToTablesUsed(SourceTable elem) {
+  public void addToTablesUsed(java.lang.String elem) {
     if (this.tablesUsed == null) {
-      this.tablesUsed = new java.util.HashSet<SourceTable>();
+      this.tablesUsed = new java.util.HashSet<java.lang.String>();
     }
     this.tablesUsed.add(elem);
   }
 
   @org.apache.thrift.annotation.Nullable
-  public java.util.Set<SourceTable> getTablesUsed() {
+  public java.util.Set<java.lang.String> getTablesUsed() {
     return this.tablesUsed;
   }
 
-  public void setTablesUsed(@org.apache.thrift.annotation.Nullable java.util.Set<SourceTable> tablesUsed) {
+  public void setTablesUsed(@org.apache.thrift.annotation.Nullable java.util.Set<java.lang.String> tablesUsed) {
     this.tablesUsed = tablesUsed;
   }
 
@@ -343,6 +356,46 @@ package org.apache.hadoop.hive.metastore.api;
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __MATERIALIZATIONTIME_ISSET_ID, value);
   }
 
+  public int getSourceTablesSize() {
+    return (this.sourceTables == null) ? 0 : this.sourceTables.size();
+  }
+
+  @org.apache.thrift.annotation.Nullable
+  public java.util.Iterator<SourceTable> getSourceTablesIterator() {
+    return (this.sourceTables == null) ? null : this.sourceTables.iterator();
+  }
+
+  public void addToSourceTables(SourceTable elem) {
+    if (this.sourceTables == null) {
+      this.sourceTables = new java.util.HashSet<SourceTable>();
+    }
+    this.sourceTables.add(elem);
+  }
+
+  @org.apache.thrift.annotation.Nullable
+  public java.util.Set<SourceTable> getSourceTables() {
+    return this.sourceTables;
+  }
+
+  public void setSourceTables(@org.apache.thrift.annotation.Nullable java.util.Set<SourceTable> sourceTables) {
+    this.sourceTables = sourceTables;
+  }
+
+  public void unsetSourceTables() {
+    this.sourceTables = null;
+  }
+
+  /** Returns true if field sourceTables is set (has been assigned a value) and false otherwise */
+  public boolean isSetSourceTables() {
+    return this.sourceTables != null;
+  }
+
+  public void setSourceTablesIsSet(boolean value) {
+    if (!value) {
+      this.sourceTables = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case CAT_NAME:
@@ -373,7 +426,7 @@ package org.apache.hadoop.hive.metastore.api;
       if (value == null) {
         unsetTablesUsed();
       } else {
-        setTablesUsed((java.util.Set<SourceTable>)value);
+        setTablesUsed((java.util.Set<java.lang.String>)value);
       }
       break;
 
@@ -390,6 +443,14 @@ package org.apache.hadoop.hive.metastore.api;
         unsetMaterializationTime();
       } else {
         setMaterializationTime((java.lang.Long)value);
+      }
+      break;
+
+    case SOURCE_TABLES:
+      if (value == null) {
+        unsetSourceTables();
+      } else {
+        setSourceTables((java.util.Set<SourceTable>)value);
       }
       break;
 
@@ -417,6 +478,9 @@ package org.apache.hadoop.hive.metastore.api;
     case MATERIALIZATION_TIME:
       return getMaterializationTime();
 
+    case SOURCE_TABLES:
+      return getSourceTables();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -440,6 +504,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetValidTxnList();
     case MATERIALIZATION_TIME:
       return isSetMaterializationTime();
+    case SOURCE_TABLES:
+      return isSetSourceTables();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -511,6 +577,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_sourceTables = true && this.isSetSourceTables();
+    boolean that_present_sourceTables = true && that.isSetSourceTables();
+    if (this_present_sourceTables || that_present_sourceTables) {
+      if (!(this_present_sourceTables && that_present_sourceTables))
+        return false;
+      if (!this.sourceTables.equals(that.sourceTables))
+        return false;
+    }
+
     return true;
   }
 
@@ -541,6 +616,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetMaterializationTime()) ? 131071 : 524287);
     if (isSetMaterializationTime())
       hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(materializationTime);
+
+    hashCode = hashCode * 8191 + ((isSetSourceTables()) ? 131071 : 524287);
+    if (isSetSourceTables())
+      hashCode = hashCode * 8191 + sourceTables.hashCode();
 
     return hashCode;
   }
@@ -613,6 +692,16 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetSourceTables(), other.isSetSourceTables());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetSourceTables()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sourceTables, other.sourceTables);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -679,6 +768,16 @@ package org.apache.hadoop.hive.metastore.api;
       if (!first) sb.append(", ");
       sb.append("materializationTime:");
       sb.append(this.materializationTime);
+      first = false;
+    }
+    if (isSetSourceTables()) {
+      if (!first) sb.append(", ");
+      sb.append("sourceTables:");
+      if (this.sourceTables == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.sourceTables);
+      }
       first = false;
     }
     sb.append(")");
@@ -770,12 +869,11 @@ package org.apache.hadoop.hive.metastore.api;
             if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
               {
                 org.apache.thrift.protocol.TSet _set264 = iprot.readSetBegin();
-                struct.tablesUsed = new java.util.HashSet<SourceTable>(2*_set264.size);
-                @org.apache.thrift.annotation.Nullable SourceTable _elem265;
+                struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set264.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem265;
                 for (int _i266 = 0; _i266 < _set264.size; ++_i266)
                 {
-                  _elem265 = new SourceTable();
-                  _elem265.read(iprot);
+                  _elem265 = iprot.readString();
                   struct.tablesUsed.add(_elem265);
                 }
                 iprot.readSetEnd();
@@ -797,6 +895,25 @@ package org.apache.hadoop.hive.metastore.api;
             if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
               struct.materializationTime = iprot.readI64();
               struct.setMaterializationTimeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
+          case 7: // SOURCE_TABLES
+            if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
+              {
+                org.apache.thrift.protocol.TSet _set267 = iprot.readSetBegin();
+                struct.sourceTables = new java.util.HashSet<SourceTable>(2*_set267.size);
+                @org.apache.thrift.annotation.Nullable SourceTable _elem268;
+                for (int _i269 = 0; _i269 < _set267.size; ++_i269)
+                {
+                  _elem268 = new SourceTable();
+                  _elem268.read(iprot);
+                  struct.sourceTables.add(_elem268);
+                }
+                iprot.readSetEnd();
+              }
+              struct.setSourceTablesIsSet(true);
             } else { 
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
@@ -832,10 +949,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.tablesUsed != null) {
         oprot.writeFieldBegin(TABLES_USED_FIELD_DESC);
         {
-          oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, struct.tablesUsed.size()));
-          for (SourceTable _iter267 : struct.tablesUsed)
+          oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRING, struct.tablesUsed.size()));
+          for (java.lang.String _iter270 : struct.tablesUsed)
           {
-            _iter267.write(oprot);
+            oprot.writeString(_iter270);
           }
           oprot.writeSetEnd();
         }
@@ -852,6 +969,20 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(MATERIALIZATION_TIME_FIELD_DESC);
         oprot.writeI64(struct.materializationTime);
         oprot.writeFieldEnd();
+      }
+      if (struct.sourceTables != null) {
+        if (struct.isSetSourceTables()) {
+          oprot.writeFieldBegin(SOURCE_TABLES_FIELD_DESC);
+          {
+            oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, struct.sourceTables.size()));
+            for (SourceTable _iter271 : struct.sourceTables)
+            {
+              _iter271.write(oprot);
+            }
+            oprot.writeSetEnd();
+          }
+          oprot.writeFieldEnd();
+        }
       }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
@@ -875,9 +1006,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.tablesUsed.size());
-        for (SourceTable _iter268 : struct.tablesUsed)
+        for (java.lang.String _iter272 : struct.tablesUsed)
         {
-          _iter268.write(oprot);
+          oprot.writeString(_iter272);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -887,12 +1018,24 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetMaterializationTime()) {
         optionals.set(1);
       }
-      oprot.writeBitSet(optionals, 2);
+      if (struct.isSetSourceTables()) {
+        optionals.set(2);
+      }
+      oprot.writeBitSet(optionals, 3);
       if (struct.isSetValidTxnList()) {
         oprot.writeString(struct.validTxnList);
       }
       if (struct.isSetMaterializationTime()) {
         oprot.writeI64(struct.materializationTime);
+      }
+      if (struct.isSetSourceTables()) {
+        {
+          oprot.writeI32(struct.sourceTables.size());
+          for (SourceTable _iter273 : struct.sourceTables)
+          {
+            _iter273.write(oprot);
+          }
+        }
       }
     }
 
@@ -906,18 +1049,17 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TSet _set269 = iprot.readSetBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.tablesUsed = new java.util.HashSet<SourceTable>(2*_set269.size);
-        @org.apache.thrift.annotation.Nullable SourceTable _elem270;
-        for (int _i271 = 0; _i271 < _set269.size; ++_i271)
+        org.apache.thrift.protocol.TSet _set274 = iprot.readSetBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.tablesUsed = new java.util.HashSet<java.lang.String>(2*_set274.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem275;
+        for (int _i276 = 0; _i276 < _set274.size; ++_i276)
         {
-          _elem270 = new SourceTable();
-          _elem270.read(iprot);
-          struct.tablesUsed.add(_elem270);
+          _elem275 = iprot.readString();
+          struct.tablesUsed.add(_elem275);
         }
       }
       struct.setTablesUsedIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(2);
+      java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         struct.validTxnList = iprot.readString();
         struct.setValidTxnListIsSet(true);
@@ -925,6 +1067,20 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(1)) {
         struct.materializationTime = iprot.readI64();
         struct.setMaterializationTimeIsSet(true);
+      }
+      if (incoming.get(2)) {
+        {
+          org.apache.thrift.protocol.TSet _set277 = iprot.readSetBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.sourceTables = new java.util.HashSet<SourceTable>(2*_set277.size);
+          @org.apache.thrift.annotation.Nullable SourceTable _elem278;
+          for (int _i279 = 0; _i279 < _set277.size; ++_i279)
+          {
+            _elem278 = new SourceTable();
+            _elem278.read(iprot);
+            struct.sourceTables.add(_elem278);
+          }
+        }
+        struct.setSourceTablesIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DataConnector.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DataConnector.java
@@ -928,15 +928,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map684 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map684.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key685;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val686;
-                for (int _i687 = 0; _i687 < _map684.size; ++_i687)
+                org.apache.thrift.protocol.TMap _map692 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map692.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key693;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val694;
+                for (int _i695 = 0; _i695 < _map692.size; ++_i695)
                 {
-                  _key685 = iprot.readString();
-                  _val686 = iprot.readString();
-                  struct.parameters.put(_key685, _val686);
+                  _key693 = iprot.readString();
+                  _val694 = iprot.readString();
+                  struct.parameters.put(_key693, _val694);
                 }
                 iprot.readMapEnd();
               }
@@ -1009,10 +1009,10 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter688 : struct.parameters.entrySet())
+            for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter696 : struct.parameters.entrySet())
             {
-              oprot.writeString(_iter688.getKey());
-              oprot.writeString(_iter688.getValue());
+              oprot.writeString(_iter696.getKey());
+              oprot.writeString(_iter696.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1096,10 +1096,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter689 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter697 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter689.getKey());
-            oprot.writeString(_iter689.getValue());
+            oprot.writeString(_iter697.getKey());
+            oprot.writeString(_iter697.getValue());
           }
         }
       }
@@ -1136,15 +1136,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TMap _map690 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map690.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key691;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val692;
-          for (int _i693 = 0; _i693 < _map690.size; ++_i693)
+          org.apache.thrift.protocol.TMap _map698 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map698.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key699;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val700;
+          for (int _i701 = 0; _i701 < _map698.size; ++_i701)
           {
-            _key691 = iprot.readString();
-            _val692 = iprot.readString();
-            struct.parameters.put(_key691, _val692);
+            _key699 = iprot.readString();
+            _val700 = iprot.readString();
+            struct.parameters.put(_key699, _val700);
           }
         }
         struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DefaultConstraintsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DefaultConstraintsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // DEFAULT_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list458 = iprot.readListBegin();
-                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list458.size);
-                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem459;
-                for (int _i460 = 0; _i460 < _list458.size; ++_i460)
+                org.apache.thrift.protocol.TList _list466 = iprot.readListBegin();
+                struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list466.size);
+                @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem467;
+                for (int _i468 = 0; _i468 < _list466.size; ++_i468)
                 {
-                  _elem459 = new SQLDefaultConstraint();
-                  _elem459.read(iprot);
-                  struct.defaultConstraints.add(_elem459);
+                  _elem467 = new SQLDefaultConstraint();
+                  _elem467.read(iprot);
+                  struct.defaultConstraints.add(_elem467);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(DEFAULT_CONSTRAINTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.defaultConstraints.size()));
-          for (SQLDefaultConstraint _iter461 : struct.defaultConstraints)
+          for (SQLDefaultConstraint _iter469 : struct.defaultConstraints)
           {
-            _iter461.write(oprot);
+            _iter469.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.defaultConstraints.size());
-        for (SQLDefaultConstraint _iter462 : struct.defaultConstraints)
+        for (SQLDefaultConstraint _iter470 : struct.defaultConstraints)
         {
-          _iter462.write(oprot);
+          _iter470.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, DefaultConstraintsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list463 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list463.size);
-        @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem464;
-        for (int _i465 = 0; _i465 < _list463.size; ++_i465)
+        org.apache.thrift.protocol.TList _list471 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.defaultConstraints = new java.util.ArrayList<SQLDefaultConstraint>(_list471.size);
+        @org.apache.thrift.annotation.Nullable SQLDefaultConstraint _elem472;
+        for (int _i473 = 0; _i473 < _list471.size; ++_i473)
         {
-          _elem464 = new SQLDefaultConstraint();
-          _elem464.read(iprot);
-          struct.defaultConstraints.add(_elem464);
+          _elem472 = new SQLDefaultConstraint();
+          _elem472.read(iprot);
+          struct.defaultConstraints.add(_elem472);
         }
       }
       struct.setDefaultConstraintsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DropPartitionsResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DropPartitionsResult.java
@@ -321,14 +321,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list604 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list604.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem605;
-                for (int _i606 = 0; _i606 < _list604.size; ++_i606)
+                org.apache.thrift.protocol.TList _list612 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list612.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem613;
+                for (int _i614 = 0; _i614 < _list612.size; ++_i614)
                 {
-                  _elem605 = new Partition();
-                  _elem605.read(iprot);
-                  struct.partitions.add(_elem605);
+                  _elem613 = new Partition();
+                  _elem613.read(iprot);
+                  struct.partitions.add(_elem613);
                 }
                 iprot.readListEnd();
               }
@@ -355,9 +355,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-            for (Partition _iter607 : struct.partitions)
+            for (Partition _iter615 : struct.partitions)
             {
-              _iter607.write(oprot);
+              _iter615.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (Partition _iter608 : struct.partitions)
+          for (Partition _iter616 : struct.partitions)
           {
-            _iter608.write(oprot);
+            _iter616.write(oprot);
           }
         }
       }
@@ -403,14 +403,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list609 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<Partition>(_list609.size);
-          @org.apache.thrift.annotation.Nullable Partition _elem610;
-          for (int _i611 = 0; _i611 < _list609.size; ++_i611)
+          org.apache.thrift.protocol.TList _list617 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<Partition>(_list617.size);
+          @org.apache.thrift.annotation.Nullable Partition _elem618;
+          for (int _i619 = 0; _i619 < _list617.size; ++_i619)
           {
-            _elem610 = new Partition();
-            _elem610.read(iprot);
-            struct.partitions.add(_elem610);
+            _elem618 = new Partition();
+            _elem618.read(iprot);
+            struct.partitions.add(_elem618);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ExtendedTableInfo.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ExtendedTableInfo.java
@@ -602,13 +602,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // REQUIRED_READ_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1100 = iprot.readListBegin();
-                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list1100.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1101;
-                for (int _i1102 = 0; _i1102 < _list1100.size; ++_i1102)
+                org.apache.thrift.protocol.TList _list1108 = iprot.readListBegin();
+                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list1108.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1109;
+                for (int _i1110 = 0; _i1110 < _list1108.size; ++_i1110)
                 {
-                  _elem1101 = iprot.readString();
-                  struct.requiredReadCapabilities.add(_elem1101);
+                  _elem1109 = iprot.readString();
+                  struct.requiredReadCapabilities.add(_elem1109);
                 }
                 iprot.readListEnd();
               }
@@ -620,13 +620,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // REQUIRED_WRITE_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1103 = iprot.readListBegin();
-                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list1103.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1104;
-                for (int _i1105 = 0; _i1105 < _list1103.size; ++_i1105)
+                org.apache.thrift.protocol.TList _list1111 = iprot.readListBegin();
+                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list1111.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1112;
+                for (int _i1113 = 0; _i1113 < _list1111.size; ++_i1113)
                 {
-                  _elem1104 = iprot.readString();
-                  struct.requiredWriteCapabilities.add(_elem1104);
+                  _elem1112 = iprot.readString();
+                  struct.requiredWriteCapabilities.add(_elem1112);
                 }
                 iprot.readListEnd();
               }
@@ -663,9 +663,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_READ_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredReadCapabilities.size()));
-            for (java.lang.String _iter1106 : struct.requiredReadCapabilities)
+            for (java.lang.String _iter1114 : struct.requiredReadCapabilities)
             {
-              oprot.writeString(_iter1106);
+              oprot.writeString(_iter1114);
             }
             oprot.writeListEnd();
           }
@@ -677,9 +677,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_WRITE_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredWriteCapabilities.size()));
-            for (java.lang.String _iter1107 : struct.requiredWriteCapabilities)
+            for (java.lang.String _iter1115 : struct.requiredWriteCapabilities)
             {
-              oprot.writeString(_iter1107);
+              oprot.writeString(_iter1115);
             }
             oprot.writeListEnd();
           }
@@ -721,18 +721,18 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetRequiredReadCapabilities()) {
         {
           oprot.writeI32(struct.requiredReadCapabilities.size());
-          for (java.lang.String _iter1108 : struct.requiredReadCapabilities)
+          for (java.lang.String _iter1116 : struct.requiredReadCapabilities)
           {
-            oprot.writeString(_iter1108);
+            oprot.writeString(_iter1116);
           }
         }
       }
       if (struct.isSetRequiredWriteCapabilities()) {
         {
           oprot.writeI32(struct.requiredWriteCapabilities.size());
-          for (java.lang.String _iter1109 : struct.requiredWriteCapabilities)
+          for (java.lang.String _iter1117 : struct.requiredWriteCapabilities)
           {
-            oprot.writeString(_iter1109);
+            oprot.writeString(_iter1117);
           }
         }
       }
@@ -750,26 +750,26 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1110 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list1110.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1111;
-          for (int _i1112 = 0; _i1112 < _list1110.size; ++_i1112)
+          org.apache.thrift.protocol.TList _list1118 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list1118.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1119;
+          for (int _i1120 = 0; _i1120 < _list1118.size; ++_i1120)
           {
-            _elem1111 = iprot.readString();
-            struct.requiredReadCapabilities.add(_elem1111);
+            _elem1119 = iprot.readString();
+            struct.requiredReadCapabilities.add(_elem1119);
           }
         }
         struct.setRequiredReadCapabilitiesIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list1113 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list1113.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1114;
-          for (int _i1115 = 0; _i1115 < _list1113.size; ++_i1115)
+          org.apache.thrift.protocol.TList _list1121 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list1121.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1122;
+          for (int _i1123 = 0; _i1123 < _list1121.size; ++_i1123)
           {
-            _elem1114 = iprot.readString();
-            struct.requiredWriteCapabilities.add(_elem1114);
+            _elem1122 = iprot.readString();
+            struct.requiredWriteCapabilities.add(_elem1122);
           }
         }
         struct.setRequiredWriteCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FileMetadata.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FileMetadata.java
@@ -494,13 +494,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // DATA
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list280 = iprot.readListBegin();
-                struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list280.size);
-                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem281;
-                for (int _i282 = 0; _i282 < _list280.size; ++_i282)
+                org.apache.thrift.protocol.TList _list288 = iprot.readListBegin();
+                struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list288.size);
+                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem289;
+                for (int _i290 = 0; _i290 < _list288.size; ++_i290)
                 {
-                  _elem281 = iprot.readBinary();
-                  struct.data.add(_elem281);
+                  _elem289 = iprot.readBinary();
+                  struct.data.add(_elem289);
                 }
                 iprot.readListEnd();
               }
@@ -532,9 +532,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(DATA_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.data.size()));
-          for (java.nio.ByteBuffer _iter283 : struct.data)
+          for (java.nio.ByteBuffer _iter291 : struct.data)
           {
-            oprot.writeBinary(_iter283);
+            oprot.writeBinary(_iter291);
           }
           oprot.writeListEnd();
         }
@@ -577,9 +577,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetData()) {
         {
           oprot.writeI32(struct.data.size());
-          for (java.nio.ByteBuffer _iter284 : struct.data)
+          for (java.nio.ByteBuffer _iter292 : struct.data)
           {
-            oprot.writeBinary(_iter284);
+            oprot.writeBinary(_iter292);
           }
         }
       }
@@ -599,13 +599,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list285 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list285.size);
-          @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem286;
-          for (int _i287 = 0; _i287 < _list285.size; ++_i287)
+          org.apache.thrift.protocol.TList _list293 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.data = new java.util.ArrayList<java.nio.ByteBuffer>(_list293.size);
+          @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem294;
+          for (int _i295 = 0; _i295 < _list293.size; ++_i295)
           {
-            _elem286 = iprot.readBinary();
-            struct.data.add(_elem286);
+            _elem294 = iprot.readBinary();
+            struct.data.add(_elem294);
           }
         }
         struct.setDataIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FindSchemasByColsResp.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FindSchemasByColsResp.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // SCHEMA_VERSIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1196 = iprot.readListBegin();
-                struct.schemaVersions = new java.util.ArrayList<SchemaVersionDescriptor>(_list1196.size);
-                @org.apache.thrift.annotation.Nullable SchemaVersionDescriptor _elem1197;
-                for (int _i1198 = 0; _i1198 < _list1196.size; ++_i1198)
+                org.apache.thrift.protocol.TList _list1204 = iprot.readListBegin();
+                struct.schemaVersions = new java.util.ArrayList<SchemaVersionDescriptor>(_list1204.size);
+                @org.apache.thrift.annotation.Nullable SchemaVersionDescriptor _elem1205;
+                for (int _i1206 = 0; _i1206 < _list1204.size; ++_i1206)
                 {
-                  _elem1197 = new SchemaVersionDescriptor();
-                  _elem1197.read(iprot);
-                  struct.schemaVersions.add(_elem1197);
+                  _elem1205 = new SchemaVersionDescriptor();
+                  _elem1205.read(iprot);
+                  struct.schemaVersions.add(_elem1205);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(SCHEMA_VERSIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.schemaVersions.size()));
-          for (SchemaVersionDescriptor _iter1199 : struct.schemaVersions)
+          for (SchemaVersionDescriptor _iter1207 : struct.schemaVersions)
           {
-            _iter1199.write(oprot);
+            _iter1207.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetSchemaVersions()) {
         {
           oprot.writeI32(struct.schemaVersions.size());
-          for (SchemaVersionDescriptor _iter1200 : struct.schemaVersions)
+          for (SchemaVersionDescriptor _iter1208 : struct.schemaVersions)
           {
-            _iter1200.write(oprot);
+            _iter1208.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1201 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.schemaVersions = new java.util.ArrayList<SchemaVersionDescriptor>(_list1201.size);
-          @org.apache.thrift.annotation.Nullable SchemaVersionDescriptor _elem1202;
-          for (int _i1203 = 0; _i1203 < _list1201.size; ++_i1203)
+          org.apache.thrift.protocol.TList _list1209 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.schemaVersions = new java.util.ArrayList<SchemaVersionDescriptor>(_list1209.size);
+          @org.apache.thrift.annotation.Nullable SchemaVersionDescriptor _elem1210;
+          for (int _i1211 = 0; _i1211 < _list1209.size; ++_i1211)
           {
-            _elem1202 = new SchemaVersionDescriptor();
-            _elem1202.read(iprot);
-            struct.schemaVersions.add(_elem1202);
+            _elem1210 = new SchemaVersionDescriptor();
+            _elem1210.read(iprot);
+            struct.schemaVersions.add(_elem1210);
           }
         }
         struct.setSchemaVersionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventRequest.java
@@ -766,13 +766,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARTITION_VALS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list944 = iprot.readListBegin();
-                struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list944.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem945;
-                for (int _i946 = 0; _i946 < _list944.size; ++_i946)
+                org.apache.thrift.protocol.TList _list952 = iprot.readListBegin();
+                struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list952.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem953;
+                for (int _i954 = 0; _i954 < _list952.size; ++_i954)
                 {
-                  _elem945 = iprot.readString();
-                  struct.partitionVals.add(_elem945);
+                  _elem953 = iprot.readString();
+                  struct.partitionVals.add(_elem953);
                 }
                 iprot.readListEnd();
               }
@@ -829,9 +829,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITION_VALS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionVals.size()));
-            for (java.lang.String _iter947 : struct.partitionVals)
+            for (java.lang.String _iter955 : struct.partitionVals)
             {
-              oprot.writeString(_iter947);
+              oprot.writeString(_iter955);
             }
             oprot.writeListEnd();
           }
@@ -887,9 +887,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionVals()) {
         {
           oprot.writeI32(struct.partitionVals.size());
-          for (java.lang.String _iter948 : struct.partitionVals)
+          for (java.lang.String _iter956 : struct.partitionVals)
           {
-            oprot.writeString(_iter948);
+            oprot.writeString(_iter956);
           }
         }
       }
@@ -917,13 +917,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list949 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list949.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem950;
-          for (int _i951 = 0; _i951 < _list949.size; ++_i951)
+          org.apache.thrift.protocol.TList _list957 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list957.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem958;
+          for (int _i959 = 0; _i959 < _list957.size; ++_i959)
           {
-            _elem950 = iprot.readString();
-            struct.partitionVals.add(_elem950);
+            _elem958 = iprot.readString();
+            struct.partitionVals.add(_elem958);
           }
         }
         struct.setPartitionValsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventRequestData.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventRequestData.java
@@ -153,14 +153,14 @@ package org.apache.hadoop.hive.metastore.api;
           if (field.type == INSERT_DATAS_FIELD_DESC.type) {
             java.util.List<InsertEventRequestData> insertDatas;
             {
-              org.apache.thrift.protocol.TList _list936 = iprot.readListBegin();
-              insertDatas = new java.util.ArrayList<InsertEventRequestData>(_list936.size);
-              @org.apache.thrift.annotation.Nullable InsertEventRequestData _elem937;
-              for (int _i938 = 0; _i938 < _list936.size; ++_i938)
+              org.apache.thrift.protocol.TList _list944 = iprot.readListBegin();
+              insertDatas = new java.util.ArrayList<InsertEventRequestData>(_list944.size);
+              @org.apache.thrift.annotation.Nullable InsertEventRequestData _elem945;
+              for (int _i946 = 0; _i946 < _list944.size; ++_i946)
               {
-                _elem937 = new InsertEventRequestData();
-                _elem937.read(iprot);
-                insertDatas.add(_elem937);
+                _elem945 = new InsertEventRequestData();
+                _elem945.read(iprot);
+                insertDatas.add(_elem945);
               }
               iprot.readListEnd();
             }
@@ -189,9 +189,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<InsertEventRequestData> insertDatas = (java.util.List<InsertEventRequestData>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, insertDatas.size()));
-          for (InsertEventRequestData _iter939 : insertDatas)
+          for (InsertEventRequestData _iter947 : insertDatas)
           {
-            _iter939.write(oprot);
+            _iter947.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -214,14 +214,14 @@ package org.apache.hadoop.hive.metastore.api;
         case INSERT_DATAS:
           java.util.List<InsertEventRequestData> insertDatas;
           {
-            org.apache.thrift.protocol.TList _list940 = iprot.readListBegin();
-            insertDatas = new java.util.ArrayList<InsertEventRequestData>(_list940.size);
-            @org.apache.thrift.annotation.Nullable InsertEventRequestData _elem941;
-            for (int _i942 = 0; _i942 < _list940.size; ++_i942)
+            org.apache.thrift.protocol.TList _list948 = iprot.readListBegin();
+            insertDatas = new java.util.ArrayList<InsertEventRequestData>(_list948.size);
+            @org.apache.thrift.annotation.Nullable InsertEventRequestData _elem949;
+            for (int _i950 = 0; _i950 < _list948.size; ++_i950)
             {
-              _elem941 = new InsertEventRequestData();
-              _elem941.read(iprot);
-              insertDatas.add(_elem941);
+              _elem949 = new InsertEventRequestData();
+              _elem949.read(iprot);
+              insertDatas.add(_elem949);
             }
             iprot.readListEnd();
           }
@@ -245,9 +245,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<InsertEventRequestData> insertDatas = (java.util.List<InsertEventRequestData>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, insertDatas.size()));
-          for (InsertEventRequestData _iter943 : insertDatas)
+          for (InsertEventRequestData _iter951 : insertDatas)
           {
-            _iter943.write(oprot);
+            _iter951.write(oprot);
           }
           oprot.writeListEnd();
         }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/FireEventResponse.java
@@ -322,13 +322,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // EVENT_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list952 = iprot.readListBegin();
-                struct.eventIds = new java.util.ArrayList<java.lang.Long>(_list952.size);
-                long _elem953;
-                for (int _i954 = 0; _i954 < _list952.size; ++_i954)
+                org.apache.thrift.protocol.TList _list960 = iprot.readListBegin();
+                struct.eventIds = new java.util.ArrayList<java.lang.Long>(_list960.size);
+                long _elem961;
+                for (int _i962 = 0; _i962 < _list960.size; ++_i962)
                 {
-                  _elem953 = iprot.readI64();
-                  struct.eventIds.add(_elem953);
+                  _elem961 = iprot.readI64();
+                  struct.eventIds.add(_elem961);
                 }
                 iprot.readListEnd();
               }
@@ -354,9 +354,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(EVENT_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.eventIds.size()));
-          for (long _iter955 : struct.eventIds)
+          for (long _iter963 : struct.eventIds)
           {
-            oprot.writeI64(_iter955);
+            oprot.writeI64(_iter963);
           }
           oprot.writeListEnd();
         }
@@ -387,9 +387,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetEventIds()) {
         {
           oprot.writeI32(struct.eventIds.size());
-          for (long _iter956 : struct.eventIds)
+          for (long _iter964 : struct.eventIds)
           {
-            oprot.writeI64(_iter956);
+            oprot.writeI64(_iter964);
           }
         }
       }
@@ -401,13 +401,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list957 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-          struct.eventIds = new java.util.ArrayList<java.lang.Long>(_list957.size);
-          long _elem958;
-          for (int _i959 = 0; _i959 < _list957.size; ++_i959)
+          org.apache.thrift.protocol.TList _list965 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+          struct.eventIds = new java.util.ArrayList<java.lang.Long>(_list965.size);
+          long _elem966;
+          for (int _i967 = 0; _i967 < _list965.size; ++_i967)
           {
-            _elem958 = iprot.readI64();
-            struct.eventIds.add(_elem958);
+            _elem966 = iprot.readI64();
+            struct.eventIds.add(_elem966);
           }
         }
         struct.setEventIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ForeignKeysResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ForeignKeysResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FOREIGN_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list434 = iprot.readListBegin();
-                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list434.size);
-                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem435;
-                for (int _i436 = 0; _i436 < _list434.size; ++_i436)
+                org.apache.thrift.protocol.TList _list442 = iprot.readListBegin();
+                struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list442.size);
+                @org.apache.thrift.annotation.Nullable SQLForeignKey _elem443;
+                for (int _i444 = 0; _i444 < _list442.size; ++_i444)
                 {
-                  _elem435 = new SQLForeignKey();
-                  _elem435.read(iprot);
-                  struct.foreignKeys.add(_elem435);
+                  _elem443 = new SQLForeignKey();
+                  _elem443.read(iprot);
+                  struct.foreignKeys.add(_elem443);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FOREIGN_KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.foreignKeys.size()));
-          for (SQLForeignKey _iter437 : struct.foreignKeys)
+          for (SQLForeignKey _iter445 : struct.foreignKeys)
           {
-            _iter437.write(oprot);
+            _iter445.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.foreignKeys.size());
-        for (SQLForeignKey _iter438 : struct.foreignKeys)
+        for (SQLForeignKey _iter446 : struct.foreignKeys)
         {
-          _iter438.write(oprot);
+          _iter446.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ForeignKeysResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list439 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list439.size);
-        @org.apache.thrift.annotation.Nullable SQLForeignKey _elem440;
-        for (int _i441 = 0; _i441 < _list439.size; ++_i441)
+        org.apache.thrift.protocol.TList _list447 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.foreignKeys = new java.util.ArrayList<SQLForeignKey>(_list447.size);
+        @org.apache.thrift.annotation.Nullable SQLForeignKey _elem448;
+        for (int _i449 = 0; _i449 < _list447.size; ++_i449)
         {
-          _elem440 = new SQLForeignKey();
-          _elem440.read(iprot);
-          struct.foreignKeys.add(_elem440);
+          _elem448 = new SQLForeignKey();
+          _elem448.read(iprot);
+          struct.foreignKeys.add(_elem448);
         }
       }
       struct.setForeignKeysIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Function.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Function.java
@@ -1051,14 +1051,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // RESOURCE_URIS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list694 = iprot.readListBegin();
-                struct.resourceUris = new java.util.ArrayList<ResourceUri>(_list694.size);
-                @org.apache.thrift.annotation.Nullable ResourceUri _elem695;
-                for (int _i696 = 0; _i696 < _list694.size; ++_i696)
+                org.apache.thrift.protocol.TList _list702 = iprot.readListBegin();
+                struct.resourceUris = new java.util.ArrayList<ResourceUri>(_list702.size);
+                @org.apache.thrift.annotation.Nullable ResourceUri _elem703;
+                for (int _i704 = 0; _i704 < _list702.size; ++_i704)
                 {
-                  _elem695 = new ResourceUri();
-                  _elem695.read(iprot);
-                  struct.resourceUris.add(_elem695);
+                  _elem703 = new ResourceUri();
+                  _elem703.read(iprot);
+                  struct.resourceUris.add(_elem703);
                 }
                 iprot.readListEnd();
               }
@@ -1125,9 +1125,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(RESOURCE_URIS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.resourceUris.size()));
-          for (ResourceUri _iter697 : struct.resourceUris)
+          for (ResourceUri _iter705 : struct.resourceUris)
           {
-            _iter697.write(oprot);
+            _iter705.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -1210,9 +1210,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetResourceUris()) {
         {
           oprot.writeI32(struct.resourceUris.size());
-          for (ResourceUri _iter698 : struct.resourceUris)
+          for (ResourceUri _iter706 : struct.resourceUris)
           {
-            _iter698.write(oprot);
+            _iter706.write(oprot);
           }
         }
       }
@@ -1255,14 +1255,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list699 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.resourceUris = new java.util.ArrayList<ResourceUri>(_list699.size);
-          @org.apache.thrift.annotation.Nullable ResourceUri _elem700;
-          for (int _i701 = 0; _i701 < _list699.size; ++_i701)
+          org.apache.thrift.protocol.TList _list707 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.resourceUris = new java.util.ArrayList<ResourceUri>(_list707.size);
+          @org.apache.thrift.annotation.Nullable ResourceUri _elem708;
+          for (int _i709 = 0; _i709 < _list707.size; ++_i709)
           {
-            _elem700 = new ResourceUri();
-            _elem700.read(iprot);
-            struct.resourceUris.add(_elem700);
+            _elem708 = new ResourceUri();
+            _elem708.read(iprot);
+            struct.resourceUris.add(_elem708);
           }
         }
         struct.setResourceUrisIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetAllFunctionsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetAllFunctionsResponse.java
@@ -321,14 +321,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FUNCTIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1036 = iprot.readListBegin();
-                struct.functions = new java.util.ArrayList<Function>(_list1036.size);
-                @org.apache.thrift.annotation.Nullable Function _elem1037;
-                for (int _i1038 = 0; _i1038 < _list1036.size; ++_i1038)
+                org.apache.thrift.protocol.TList _list1044 = iprot.readListBegin();
+                struct.functions = new java.util.ArrayList<Function>(_list1044.size);
+                @org.apache.thrift.annotation.Nullable Function _elem1045;
+                for (int _i1046 = 0; _i1046 < _list1044.size; ++_i1046)
                 {
-                  _elem1037 = new Function();
-                  _elem1037.read(iprot);
-                  struct.functions.add(_elem1037);
+                  _elem1045 = new Function();
+                  _elem1045.read(iprot);
+                  struct.functions.add(_elem1045);
                 }
                 iprot.readListEnd();
               }
@@ -355,9 +355,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FUNCTIONS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.functions.size()));
-            for (Function _iter1039 : struct.functions)
+            for (Function _iter1047 : struct.functions)
             {
-              _iter1039.write(oprot);
+              _iter1047.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFunctions()) {
         {
           oprot.writeI32(struct.functions.size());
-          for (Function _iter1040 : struct.functions)
+          for (Function _iter1048 : struct.functions)
           {
-            _iter1040.write(oprot);
+            _iter1048.write(oprot);
           }
         }
       }
@@ -403,14 +403,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1041 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.functions = new java.util.ArrayList<Function>(_list1041.size);
-          @org.apache.thrift.annotation.Nullable Function _elem1042;
-          for (int _i1043 = 0; _i1043 < _list1041.size; ++_i1043)
+          org.apache.thrift.protocol.TList _list1049 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.functions = new java.util.ArrayList<Function>(_list1049.size);
+          @org.apache.thrift.annotation.Nullable Function _elem1050;
+          for (int _i1051 = 0; _i1051 < _list1049.size; ++_i1051)
           {
-            _elem1042 = new Function();
-            _elem1042.read(iprot);
-            struct.functions.add(_elem1042);
+            _elem1050 = new Function();
+            _elem1050.read(iprot);
+            struct.functions.add(_elem1050);
           }
         }
         struct.setFunctionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetDatabaseRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetDatabaseRequest.java
@@ -577,13 +577,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1116 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1116.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1117;
-                for (int _i1118 = 0; _i1118 < _list1116.size; ++_i1118)
+                org.apache.thrift.protocol.TList _list1124 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1124.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1125;
+                for (int _i1126 = 0; _i1126 < _list1124.size; ++_i1126)
                 {
-                  _elem1117 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1117);
+                  _elem1125 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1125);
                 }
                 iprot.readListEnd();
               }
@@ -632,9 +632,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1119 : struct.processorCapabilities)
+            for (java.lang.String _iter1127 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1119);
+              oprot.writeString(_iter1127);
             }
             oprot.writeListEnd();
           }
@@ -688,9 +688,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1120 : struct.processorCapabilities)
+          for (java.lang.String _iter1128 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1120);
+            oprot.writeString(_iter1128);
           }
         }
       }
@@ -713,13 +713,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list1121 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1121.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1122;
-          for (int _i1123 = 0; _i1123 < _list1121.size; ++_i1123)
+          org.apache.thrift.protocol.TList _list1129 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1129.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1130;
+          for (int _i1131 = 0; _i1131 < _list1129.size; ++_i1131)
           {
-            _elem1122 = iprot.readString();
-            struct.processorCapabilities.add(_elem1122);
+            _elem1130 = iprot.readString();
+            struct.processorCapabilities.add(_elem1130);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFieldsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFieldsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FIELDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1326 = iprot.readListBegin();
-                struct.fields = new java.util.ArrayList<FieldSchema>(_list1326.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem1327;
-                for (int _i1328 = 0; _i1328 < _list1326.size; ++_i1328)
+                org.apache.thrift.protocol.TList _list1334 = iprot.readListBegin();
+                struct.fields = new java.util.ArrayList<FieldSchema>(_list1334.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem1335;
+                for (int _i1336 = 0; _i1336 < _list1334.size; ++_i1336)
                 {
-                  _elem1327 = new FieldSchema();
-                  _elem1327.read(iprot);
-                  struct.fields.add(_elem1327);
+                  _elem1335 = new FieldSchema();
+                  _elem1335.read(iprot);
+                  struct.fields.add(_elem1335);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FIELDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.fields.size()));
-          for (FieldSchema _iter1329 : struct.fields)
+          for (FieldSchema _iter1337 : struct.fields)
           {
-            _iter1329.write(oprot);
+            _iter1337.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fields.size());
-        for (FieldSchema _iter1330 : struct.fields)
+        for (FieldSchema _iter1338 : struct.fields)
         {
-          _iter1330.write(oprot);
+          _iter1338.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetFieldsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1331 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.fields = new java.util.ArrayList<FieldSchema>(_list1331.size);
-        @org.apache.thrift.annotation.Nullable FieldSchema _elem1332;
-        for (int _i1333 = 0; _i1333 < _list1331.size; ++_i1333)
+        org.apache.thrift.protocol.TList _list1339 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.fields = new java.util.ArrayList<FieldSchema>(_list1339.size);
+        @org.apache.thrift.annotation.Nullable FieldSchema _elem1340;
+        for (int _i1341 = 0; _i1341 < _list1339.size; ++_i1341)
         {
-          _elem1332 = new FieldSchema();
-          _elem1332.read(iprot);
-          struct.fields.add(_elem1332);
+          _elem1340 = new FieldSchema();
+          _elem1340.read(iprot);
+          struct.fields.add(_elem1340);
         }
       }
       struct.setFieldsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataByExprRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataByExprRequest.java
@@ -596,13 +596,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FILE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list986 = iprot.readListBegin();
-                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list986.size);
-                long _elem987;
-                for (int _i988 = 0; _i988 < _list986.size; ++_i988)
+                org.apache.thrift.protocol.TList _list994 = iprot.readListBegin();
+                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list994.size);
+                long _elem995;
+                for (int _i996 = 0; _i996 < _list994.size; ++_i996)
                 {
-                  _elem987 = iprot.readI64();
-                  struct.fileIds.add(_elem987);
+                  _elem995 = iprot.readI64();
+                  struct.fileIds.add(_elem995);
                 }
                 iprot.readListEnd();
               }
@@ -652,9 +652,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FILE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.fileIds.size()));
-          for (long _iter989 : struct.fileIds)
+          for (long _iter997 : struct.fileIds)
           {
-            oprot.writeI64(_iter989);
+            oprot.writeI64(_iter997);
           }
           oprot.writeListEnd();
         }
@@ -696,9 +696,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fileIds.size());
-        for (long _iter990 : struct.fileIds)
+        for (long _iter998 : struct.fileIds)
         {
-          oprot.writeI64(_iter990);
+          oprot.writeI64(_iter998);
         }
       }
       oprot.writeBinary(struct.expr);
@@ -722,13 +722,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetFileMetadataByExprRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list991 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list991.size);
-        long _elem992;
-        for (int _i993 = 0; _i993 < _list991.size; ++_i993)
+        org.apache.thrift.protocol.TList _list999 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list999.size);
+        long _elem1000;
+        for (int _i1001 = 0; _i1001 < _list999.size; ++_i1001)
         {
-          _elem992 = iprot.readI64();
-          struct.fileIds.add(_elem992);
+          _elem1000 = iprot.readI64();
+          struct.fileIds.add(_elem1000);
         }
       }
       struct.setFileIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataByExprResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataByExprResult.java
@@ -415,16 +415,16 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // METADATA
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map976 = iprot.readMapBegin();
-                struct.metadata = new java.util.HashMap<java.lang.Long,MetadataPpdResult>(2*_map976.size);
-                long _key977;
-                @org.apache.thrift.annotation.Nullable MetadataPpdResult _val978;
-                for (int _i979 = 0; _i979 < _map976.size; ++_i979)
+                org.apache.thrift.protocol.TMap _map984 = iprot.readMapBegin();
+                struct.metadata = new java.util.HashMap<java.lang.Long,MetadataPpdResult>(2*_map984.size);
+                long _key985;
+                @org.apache.thrift.annotation.Nullable MetadataPpdResult _val986;
+                for (int _i987 = 0; _i987 < _map984.size; ++_i987)
                 {
-                  _key977 = iprot.readI64();
-                  _val978 = new MetadataPpdResult();
-                  _val978.read(iprot);
-                  struct.metadata.put(_key977, _val978);
+                  _key985 = iprot.readI64();
+                  _val986 = new MetadataPpdResult();
+                  _val986.read(iprot);
+                  struct.metadata.put(_key985, _val986);
                 }
                 iprot.readMapEnd();
               }
@@ -458,10 +458,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(METADATA_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, struct.metadata.size()));
-          for (java.util.Map.Entry<java.lang.Long, MetadataPpdResult> _iter980 : struct.metadata.entrySet())
+          for (java.util.Map.Entry<java.lang.Long, MetadataPpdResult> _iter988 : struct.metadata.entrySet())
           {
-            oprot.writeI64(_iter980.getKey());
-            _iter980.getValue().write(oprot);
+            oprot.writeI64(_iter988.getKey());
+            _iter988.getValue().write(oprot);
           }
           oprot.writeMapEnd();
         }
@@ -489,10 +489,10 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.metadata.size());
-        for (java.util.Map.Entry<java.lang.Long, MetadataPpdResult> _iter981 : struct.metadata.entrySet())
+        for (java.util.Map.Entry<java.lang.Long, MetadataPpdResult> _iter989 : struct.metadata.entrySet())
         {
-          oprot.writeI64(_iter981.getKey());
-          _iter981.getValue().write(oprot);
+          oprot.writeI64(_iter989.getKey());
+          _iter989.getValue().write(oprot);
         }
       }
       oprot.writeBool(struct.isSupported);
@@ -502,16 +502,16 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetFileMetadataByExprResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map982 = iprot.readMapBegin(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT); 
-        struct.metadata = new java.util.HashMap<java.lang.Long,MetadataPpdResult>(2*_map982.size);
-        long _key983;
-        @org.apache.thrift.annotation.Nullable MetadataPpdResult _val984;
-        for (int _i985 = 0; _i985 < _map982.size; ++_i985)
+        org.apache.thrift.protocol.TMap _map990 = iprot.readMapBegin(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT); 
+        struct.metadata = new java.util.HashMap<java.lang.Long,MetadataPpdResult>(2*_map990.size);
+        long _key991;
+        @org.apache.thrift.annotation.Nullable MetadataPpdResult _val992;
+        for (int _i993 = 0; _i993 < _map990.size; ++_i993)
         {
-          _key983 = iprot.readI64();
-          _val984 = new MetadataPpdResult();
-          _val984.read(iprot);
-          struct.metadata.put(_key983, _val984);
+          _key991 = iprot.readI64();
+          _val992 = new MetadataPpdResult();
+          _val992.read(iprot);
+          struct.metadata.put(_key991, _val992);
         }
       }
       struct.setMetadataIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataRequest.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FILE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1004 = iprot.readListBegin();
-                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1004.size);
-                long _elem1005;
-                for (int _i1006 = 0; _i1006 < _list1004.size; ++_i1006)
+                org.apache.thrift.protocol.TList _list1012 = iprot.readListBegin();
+                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1012.size);
+                long _elem1013;
+                for (int _i1014 = 0; _i1014 < _list1012.size; ++_i1014)
                 {
-                  _elem1005 = iprot.readI64();
-                  struct.fileIds.add(_elem1005);
+                  _elem1013 = iprot.readI64();
+                  struct.fileIds.add(_elem1013);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FILE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.fileIds.size()));
-          for (long _iter1007 : struct.fileIds)
+          for (long _iter1015 : struct.fileIds)
           {
-            oprot.writeI64(_iter1007);
+            oprot.writeI64(_iter1015);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fileIds.size());
-        for (long _iter1008 : struct.fileIds)
+        for (long _iter1016 : struct.fileIds)
         {
-          oprot.writeI64(_iter1008);
+          oprot.writeI64(_iter1016);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetFileMetadataRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1009 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1009.size);
-        long _elem1010;
-        for (int _i1011 = 0; _i1011 < _list1009.size; ++_i1011)
+        org.apache.thrift.protocol.TList _list1017 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1017.size);
+        long _elem1018;
+        for (int _i1019 = 0; _i1019 < _list1017.size; ++_i1019)
         {
-          _elem1010 = iprot.readI64();
-          struct.fileIds.add(_elem1010);
+          _elem1018 = iprot.readI64();
+          struct.fileIds.add(_elem1018);
         }
       }
       struct.setFileIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetFileMetadataResult.java
@@ -404,15 +404,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // METADATA
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map994 = iprot.readMapBegin();
-                struct.metadata = new java.util.HashMap<java.lang.Long,java.nio.ByteBuffer>(2*_map994.size);
-                long _key995;
-                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _val996;
-                for (int _i997 = 0; _i997 < _map994.size; ++_i997)
+                org.apache.thrift.protocol.TMap _map1002 = iprot.readMapBegin();
+                struct.metadata = new java.util.HashMap<java.lang.Long,java.nio.ByteBuffer>(2*_map1002.size);
+                long _key1003;
+                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _val1004;
+                for (int _i1005 = 0; _i1005 < _map1002.size; ++_i1005)
                 {
-                  _key995 = iprot.readI64();
-                  _val996 = iprot.readBinary();
-                  struct.metadata.put(_key995, _val996);
+                  _key1003 = iprot.readI64();
+                  _val1004 = iprot.readBinary();
+                  struct.metadata.put(_key1003, _val1004);
                 }
                 iprot.readMapEnd();
               }
@@ -446,10 +446,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(METADATA_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRING, struct.metadata.size()));
-          for (java.util.Map.Entry<java.lang.Long, java.nio.ByteBuffer> _iter998 : struct.metadata.entrySet())
+          for (java.util.Map.Entry<java.lang.Long, java.nio.ByteBuffer> _iter1006 : struct.metadata.entrySet())
           {
-            oprot.writeI64(_iter998.getKey());
-            oprot.writeBinary(_iter998.getValue());
+            oprot.writeI64(_iter1006.getKey());
+            oprot.writeBinary(_iter1006.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -477,10 +477,10 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.metadata.size());
-        for (java.util.Map.Entry<java.lang.Long, java.nio.ByteBuffer> _iter999 : struct.metadata.entrySet())
+        for (java.util.Map.Entry<java.lang.Long, java.nio.ByteBuffer> _iter1007 : struct.metadata.entrySet())
         {
-          oprot.writeI64(_iter999.getKey());
-          oprot.writeBinary(_iter999.getValue());
+          oprot.writeI64(_iter1007.getKey());
+          oprot.writeBinary(_iter1007.getValue());
         }
       }
       oprot.writeBool(struct.isSupported);
@@ -490,15 +490,15 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetFileMetadataResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map1000 = iprot.readMapBegin(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRING); 
-        struct.metadata = new java.util.HashMap<java.lang.Long,java.nio.ByteBuffer>(2*_map1000.size);
-        long _key1001;
-        @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _val1002;
-        for (int _i1003 = 0; _i1003 < _map1000.size; ++_i1003)
+        org.apache.thrift.protocol.TMap _map1008 = iprot.readMapBegin(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRING); 
+        struct.metadata = new java.util.HashMap<java.lang.Long,java.nio.ByteBuffer>(2*_map1008.size);
+        long _key1009;
+        @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _val1010;
+        for (int _i1011 = 0; _i1011 < _map1008.size; ++_i1011)
         {
-          _key1001 = iprot.readI64();
-          _val1002 = iprot.readBinary();
-          struct.metadata.put(_key1001, _val1002);
+          _key1009 = iprot.readI64();
+          _val1010 = iprot.readBinary();
+          struct.metadata.put(_key1009, _val1010);
         }
       }
       struct.setMetadataIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetLatestCommittedCompactionInfoRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetLatestCommittedCompactionInfoRequest.java
@@ -509,13 +509,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PARTITIONNAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list864 = iprot.readListBegin();
-                struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list864.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem865;
-                for (int _i866 = 0; _i866 < _list864.size; ++_i866)
+                org.apache.thrift.protocol.TList _list872 = iprot.readListBegin();
+                struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list872.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem873;
+                for (int _i874 = 0; _i874 < _list872.size; ++_i874)
                 {
-                  _elem865 = iprot.readString();
-                  struct.partitionnames.add(_elem865);
+                  _elem873 = iprot.readString();
+                  struct.partitionnames.add(_elem873);
                 }
                 iprot.readListEnd();
               }
@@ -552,9 +552,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITIONNAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionnames.size()));
-            for (java.lang.String _iter867 : struct.partitionnames)
+            for (java.lang.String _iter875 : struct.partitionnames)
             {
-              oprot.writeString(_iter867);
+              oprot.writeString(_iter875);
             }
             oprot.writeListEnd();
           }
@@ -588,9 +588,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionnames()) {
         {
           oprot.writeI32(struct.partitionnames.size());
-          for (java.lang.String _iter868 : struct.partitionnames)
+          for (java.lang.String _iter876 : struct.partitionnames)
           {
-            oprot.writeString(_iter868);
+            oprot.writeString(_iter876);
           }
         }
       }
@@ -606,13 +606,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list869 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list869.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem870;
-          for (int _i871 = 0; _i871 < _list869.size; ++_i871)
+          org.apache.thrift.protocol.TList _list877 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partitionnames = new java.util.ArrayList<java.lang.String>(_list877.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem878;
+          for (int _i879 = 0; _i879 < _list877.size; ++_i879)
           {
-            _elem870 = iprot.readString();
-            struct.partitionnames.add(_elem870);
+            _elem878 = iprot.readString();
+            struct.partitionnames.add(_elem878);
           }
         }
         struct.setPartitionnamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetLatestCommittedCompactionInfoResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetLatestCommittedCompactionInfoResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COMPACTIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list872 = iprot.readListBegin();
-                struct.compactions = new java.util.ArrayList<CompactionInfoStruct>(_list872.size);
-                @org.apache.thrift.annotation.Nullable CompactionInfoStruct _elem873;
-                for (int _i874 = 0; _i874 < _list872.size; ++_i874)
+                org.apache.thrift.protocol.TList _list880 = iprot.readListBegin();
+                struct.compactions = new java.util.ArrayList<CompactionInfoStruct>(_list880.size);
+                @org.apache.thrift.annotation.Nullable CompactionInfoStruct _elem881;
+                for (int _i882 = 0; _i882 < _list880.size; ++_i882)
                 {
-                  _elem873 = new CompactionInfoStruct();
-                  _elem873.read(iprot);
-                  struct.compactions.add(_elem873);
+                  _elem881 = new CompactionInfoStruct();
+                  _elem881.read(iprot);
+                  struct.compactions.add(_elem881);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COMPACTIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.compactions.size()));
-          for (CompactionInfoStruct _iter875 : struct.compactions)
+          for (CompactionInfoStruct _iter883 : struct.compactions)
           {
-            _iter875.write(oprot);
+            _iter883.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.compactions.size());
-        for (CompactionInfoStruct _iter876 : struct.compactions)
+        for (CompactionInfoStruct _iter884 : struct.compactions)
         {
-          _iter876.write(oprot);
+          _iter884.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetLatestCommittedCompactionInfoResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list877 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.compactions = new java.util.ArrayList<CompactionInfoStruct>(_list877.size);
-        @org.apache.thrift.annotation.Nullable CompactionInfoStruct _elem878;
-        for (int _i879 = 0; _i879 < _list877.size; ++_i879)
+        org.apache.thrift.protocol.TList _list885 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.compactions = new java.util.ArrayList<CompactionInfoStruct>(_list885.size);
+        @org.apache.thrift.annotation.Nullable CompactionInfoStruct _elem886;
+        for (int _i887 = 0; _i887 < _list885.size; ++_i887)
         {
-          _elem878 = new CompactionInfoStruct();
-          _elem878.read(iprot);
-          struct.compactions.add(_elem878);
+          _elem886 = new CompactionInfoStruct();
+          _elem886.read(iprot);
+          struct.compactions.add(_elem886);
         }
       }
       struct.setCompactionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsInfoResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsInfoResponse.java
@@ -419,14 +419,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // OPEN_TXNS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list702 = iprot.readListBegin();
-                struct.open_txns = new java.util.ArrayList<TxnInfo>(_list702.size);
-                @org.apache.thrift.annotation.Nullable TxnInfo _elem703;
-                for (int _i704 = 0; _i704 < _list702.size; ++_i704)
+                org.apache.thrift.protocol.TList _list710 = iprot.readListBegin();
+                struct.open_txns = new java.util.ArrayList<TxnInfo>(_list710.size);
+                @org.apache.thrift.annotation.Nullable TxnInfo _elem711;
+                for (int _i712 = 0; _i712 < _list710.size; ++_i712)
                 {
-                  _elem703 = new TxnInfo();
-                  _elem703.read(iprot);
-                  struct.open_txns.add(_elem703);
+                  _elem711 = new TxnInfo();
+                  _elem711.read(iprot);
+                  struct.open_txns.add(_elem711);
                 }
                 iprot.readListEnd();
               }
@@ -455,9 +455,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(OPEN_TXNS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.open_txns.size()));
-          for (TxnInfo _iter705 : struct.open_txns)
+          for (TxnInfo _iter713 : struct.open_txns)
           {
-            _iter705.write(oprot);
+            _iter713.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -483,9 +483,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeI64(struct.txn_high_water_mark);
       {
         oprot.writeI32(struct.open_txns.size());
-        for (TxnInfo _iter706 : struct.open_txns)
+        for (TxnInfo _iter714 : struct.open_txns)
         {
-          _iter706.write(oprot);
+          _iter714.write(oprot);
         }
       }
     }
@@ -496,14 +496,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.txn_high_water_mark = iprot.readI64();
       struct.setTxn_high_water_markIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list707 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.open_txns = new java.util.ArrayList<TxnInfo>(_list707.size);
-        @org.apache.thrift.annotation.Nullable TxnInfo _elem708;
-        for (int _i709 = 0; _i709 < _list707.size; ++_i709)
+        org.apache.thrift.protocol.TList _list715 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.open_txns = new java.util.ArrayList<TxnInfo>(_list715.size);
+        @org.apache.thrift.annotation.Nullable TxnInfo _elem716;
+        for (int _i717 = 0; _i717 < _list715.size; ++_i717)
         {
-          _elem708 = new TxnInfo();
-          _elem708.read(iprot);
-          struct.open_txns.add(_elem708);
+          _elem716 = new TxnInfo();
+          _elem716.read(iprot);
+          struct.open_txns.add(_elem716);
         }
       }
       struct.setOpen_txnsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsRequest.java
@@ -321,15 +321,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // EXCLUDE_TXN_TYPES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1406 = iprot.readListBegin();
-                struct.excludeTxnTypes = new java.util.ArrayList<TxnType>(_list1406.size);
-                @org.apache.thrift.annotation.Nullable TxnType _elem1407;
-                for (int _i1408 = 0; _i1408 < _list1406.size; ++_i1408)
+                org.apache.thrift.protocol.TList _list1414 = iprot.readListBegin();
+                struct.excludeTxnTypes = new java.util.ArrayList<TxnType>(_list1414.size);
+                @org.apache.thrift.annotation.Nullable TxnType _elem1415;
+                for (int _i1416 = 0; _i1416 < _list1414.size; ++_i1416)
                 {
-                  _elem1407 = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
-                  if (_elem1407 != null)
+                  _elem1415 = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+                  if (_elem1415 != null)
                   {
-                    struct.excludeTxnTypes.add(_elem1407);
+                    struct.excludeTxnTypes.add(_elem1415);
                   }
                 }
                 iprot.readListEnd();
@@ -357,9 +357,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(EXCLUDE_TXN_TYPES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.excludeTxnTypes.size()));
-            for (TxnType _iter1409 : struct.excludeTxnTypes)
+            for (TxnType _iter1417 : struct.excludeTxnTypes)
             {
-              oprot.writeI32(_iter1409.getValue());
+              oprot.writeI32(_iter1417.getValue());
             }
             oprot.writeListEnd();
           }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetExcludeTxnTypes()) {
         {
           oprot.writeI32(struct.excludeTxnTypes.size());
-          for (TxnType _iter1410 : struct.excludeTxnTypes)
+          for (TxnType _iter1418 : struct.excludeTxnTypes)
           {
-            oprot.writeI32(_iter1410.getValue());
+            oprot.writeI32(_iter1418.getValue());
           }
         }
       }
@@ -405,15 +405,15 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1411 = iprot.readListBegin(org.apache.thrift.protocol.TType.I32);
-          struct.excludeTxnTypes = new java.util.ArrayList<TxnType>(_list1411.size);
-          @org.apache.thrift.annotation.Nullable TxnType _elem1412;
-          for (int _i1413 = 0; _i1413 < _list1411.size; ++_i1413)
+          org.apache.thrift.protocol.TList _list1419 = iprot.readListBegin(org.apache.thrift.protocol.TType.I32);
+          struct.excludeTxnTypes = new java.util.ArrayList<TxnType>(_list1419.size);
+          @org.apache.thrift.annotation.Nullable TxnType _elem1420;
+          for (int _i1421 = 0; _i1421 < _list1419.size; ++_i1421)
           {
-            _elem1412 = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
-            if (_elem1412 != null)
+            _elem1420 = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+            if (_elem1420 != null)
             {
-              struct.excludeTxnTypes.add(_elem1412);
+              struct.excludeTxnTypes.add(_elem1420);
             }
           }
         }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetOpenTxnsResponse.java
@@ -589,13 +589,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // OPEN_TXNS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list710 = iprot.readListBegin();
-                struct.open_txns = new java.util.ArrayList<java.lang.Long>(_list710.size);
-                long _elem711;
-                for (int _i712 = 0; _i712 < _list710.size; ++_i712)
+                org.apache.thrift.protocol.TList _list718 = iprot.readListBegin();
+                struct.open_txns = new java.util.ArrayList<java.lang.Long>(_list718.size);
+                long _elem719;
+                for (int _i720 = 0; _i720 < _list718.size; ++_i720)
                 {
-                  _elem711 = iprot.readI64();
-                  struct.open_txns.add(_elem711);
+                  _elem719 = iprot.readI64();
+                  struct.open_txns.add(_elem719);
                 }
                 iprot.readListEnd();
               }
@@ -640,9 +640,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(OPEN_TXNS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.open_txns.size()));
-          for (long _iter713 : struct.open_txns)
+          for (long _iter721 : struct.open_txns)
           {
-            oprot.writeI64(_iter713);
+            oprot.writeI64(_iter721);
           }
           oprot.writeListEnd();
         }
@@ -678,9 +678,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeI64(struct.txn_high_water_mark);
       {
         oprot.writeI32(struct.open_txns.size());
-        for (long _iter714 : struct.open_txns)
+        for (long _iter722 : struct.open_txns)
         {
-          oprot.writeI64(_iter714);
+          oprot.writeI64(_iter722);
         }
       }
       oprot.writeBinary(struct.abortedBits);
@@ -700,13 +700,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.txn_high_water_mark = iprot.readI64();
       struct.setTxn_high_water_markIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list715 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.open_txns = new java.util.ArrayList<java.lang.Long>(_list715.size);
-        long _elem716;
-        for (int _i717 = 0; _i717 < _list715.size; ++_i717)
+        org.apache.thrift.protocol.TList _list723 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.open_txns = new java.util.ArrayList<java.lang.Long>(_list723.size);
+        long _elem724;
+        for (int _i725 = 0; _i725 < _list723.size; ++_i725)
         {
-          _elem716 = iprot.readI64();
-          struct.open_txns.add(_elem716);
+          _elem724 = iprot.readI64();
+          struct.open_txns.add(_elem724);
         }
       }
       struct.setOpen_txnsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionNamesPsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionNamesPsRequest.java
@@ -837,13 +837,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1358 = iprot.readListBegin();
-                struct.partValues = new java.util.ArrayList<java.lang.String>(_list1358.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1359;
-                for (int _i1360 = 0; _i1360 < _list1358.size; ++_i1360)
+                org.apache.thrift.protocol.TList _list1366 = iprot.readListBegin();
+                struct.partValues = new java.util.ArrayList<java.lang.String>(_list1366.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1367;
+                for (int _i1368 = 0; _i1368 < _list1366.size; ++_i1368)
                 {
-                  _elem1359 = iprot.readString();
-                  struct.partValues.add(_elem1359);
+                  _elem1367 = iprot.readString();
+                  struct.partValues.add(_elem1367);
                 }
                 iprot.readListEnd();
               }
@@ -911,9 +911,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PART_VALUES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partValues.size()));
-            for (java.lang.String _iter1361 : struct.partValues)
+            for (java.lang.String _iter1369 : struct.partValues)
             {
-              oprot.writeString(_iter1361);
+              oprot.writeString(_iter1369);
             }
             oprot.writeListEnd();
           }
@@ -979,9 +979,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartValues()) {
         {
           oprot.writeI32(struct.partValues.size());
-          for (java.lang.String _iter1362 : struct.partValues)
+          for (java.lang.String _iter1370 : struct.partValues)
           {
-            oprot.writeString(_iter1362);
+            oprot.writeString(_iter1370);
           }
         }
       }
@@ -1010,13 +1010,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1363 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partValues = new java.util.ArrayList<java.lang.String>(_list1363.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1364;
-          for (int _i1365 = 0; _i1365 < _list1363.size; ++_i1365)
+          org.apache.thrift.protocol.TList _list1371 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partValues = new java.util.ArrayList<java.lang.String>(_list1371.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1372;
+          for (int _i1373 = 0; _i1373 < _list1371.size; ++_i1373)
           {
-            _elem1364 = iprot.readString();
-            struct.partValues.add(_elem1364);
+            _elem1372 = iprot.readString();
+            struct.partValues.add(_elem1372);
           }
         }
         struct.setPartValuesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionNamesPsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionNamesPsResponse.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1366 = iprot.readListBegin();
-                struct.names = new java.util.ArrayList<java.lang.String>(_list1366.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1367;
-                for (int _i1368 = 0; _i1368 < _list1366.size; ++_i1368)
+                org.apache.thrift.protocol.TList _list1374 = iprot.readListBegin();
+                struct.names = new java.util.ArrayList<java.lang.String>(_list1374.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1375;
+                for (int _i1376 = 0; _i1376 < _list1374.size; ++_i1376)
                 {
-                  _elem1367 = iprot.readString();
-                  struct.names.add(_elem1367);
+                  _elem1375 = iprot.readString();
+                  struct.names.add(_elem1375);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.names.size()));
-          for (java.lang.String _iter1369 : struct.names)
+          for (java.lang.String _iter1377 : struct.names)
           {
-            oprot.writeString(_iter1369);
+            oprot.writeString(_iter1377);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.names.size());
-        for (java.lang.String _iter1370 : struct.names)
+        for (java.lang.String _iter1378 : struct.names)
         {
-          oprot.writeString(_iter1370);
+          oprot.writeString(_iter1378);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetPartitionNamesPsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1371 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.names = new java.util.ArrayList<java.lang.String>(_list1371.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem1372;
-        for (int _i1373 = 0; _i1373 < _list1371.size; ++_i1373)
+        org.apache.thrift.protocol.TList _list1379 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.names = new java.util.ArrayList<java.lang.String>(_list1379.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem1380;
+        for (int _i1381 = 0; _i1381 < _list1379.size; ++_i1381)
         {
-          _elem1372 = iprot.readString();
-          struct.names.add(_elem1372);
+          _elem1380 = iprot.readString();
+          struct.names.add(_elem1380);
         }
       }
       struct.setNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionRequest.java
@@ -764,13 +764,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_VALS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1342 = iprot.readListBegin();
-                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1342.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1343;
-                for (int _i1344 = 0; _i1344 < _list1342.size; ++_i1344)
+                org.apache.thrift.protocol.TList _list1350 = iprot.readListBegin();
+                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1350.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1351;
+                for (int _i1352 = 0; _i1352 < _list1350.size; ++_i1352)
                 {
-                  _elem1343 = iprot.readString();
-                  struct.partVals.add(_elem1343);
+                  _elem1351 = iprot.readString();
+                  struct.partVals.add(_elem1351);
                 }
                 iprot.readListEnd();
               }
@@ -829,9 +829,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PART_VALS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partVals.size()));
-          for (java.lang.String _iter1345 : struct.partVals)
+          for (java.lang.String _iter1353 : struct.partVals)
           {
-            oprot.writeString(_iter1345);
+            oprot.writeString(_iter1353);
           }
           oprot.writeListEnd();
         }
@@ -870,9 +870,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.partVals.size());
-        for (java.lang.String _iter1346 : struct.partVals)
+        for (java.lang.String _iter1354 : struct.partVals)
         {
-          oprot.writeString(_iter1346);
+          oprot.writeString(_iter1354);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -905,13 +905,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list1347 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.partVals = new java.util.ArrayList<java.lang.String>(_list1347.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem1348;
-        for (int _i1349 = 0; _i1349 < _list1347.size; ++_i1349)
+        org.apache.thrift.protocol.TList _list1355 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.partVals = new java.util.ArrayList<java.lang.String>(_list1355.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem1356;
+        for (int _i1357 = 0; _i1357 < _list1355.size; ++_i1357)
         {
-          _elem1348 = iprot.readString();
-          struct.partVals.add(_elem1348);
+          _elem1356 = iprot.readString();
+          struct.partVals.add(_elem1356);
         }
       }
       struct.setPartValsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesRequest.java
@@ -1082,13 +1082,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list660 = iprot.readListBegin();
-                struct.names = new java.util.ArrayList<java.lang.String>(_list660.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem661;
-                for (int _i662 = 0; _i662 < _list660.size; ++_i662)
+                org.apache.thrift.protocol.TList _list668 = iprot.readListBegin();
+                struct.names = new java.util.ArrayList<java.lang.String>(_list668.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem669;
+                for (int _i670 = 0; _i670 < _list668.size; ++_i670)
                 {
-                  _elem661 = iprot.readString();
-                  struct.names.add(_elem661);
+                  _elem669 = iprot.readString();
+                  struct.names.add(_elem669);
                 }
                 iprot.readListEnd();
               }
@@ -1108,13 +1108,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list663 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list663.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem664;
-                for (int _i665 = 0; _i665 < _list663.size; ++_i665)
+                org.apache.thrift.protocol.TList _list671 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list671.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem672;
+                for (int _i673 = 0; _i673 < _list671.size; ++_i673)
                 {
-                  _elem664 = iprot.readString();
-                  struct.processorCapabilities.add(_elem664);
+                  _elem672 = iprot.readString();
+                  struct.processorCapabilities.add(_elem672);
                 }
                 iprot.readListEnd();
               }
@@ -1191,9 +1191,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.names.size()));
-            for (java.lang.String _iter666 : struct.names)
+            for (java.lang.String _iter674 : struct.names)
             {
-              oprot.writeString(_iter666);
+              oprot.writeString(_iter674);
             }
             oprot.writeListEnd();
           }
@@ -1210,9 +1210,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter667 : struct.processorCapabilities)
+            for (java.lang.String _iter675 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter667);
+              oprot.writeString(_iter675);
             }
             oprot.writeListEnd();
           }
@@ -1298,9 +1298,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetNames()) {
         {
           oprot.writeI32(struct.names.size());
-          for (java.lang.String _iter668 : struct.names)
+          for (java.lang.String _iter676 : struct.names)
           {
-            oprot.writeString(_iter668);
+            oprot.writeString(_iter676);
           }
         }
       }
@@ -1310,9 +1310,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter669 : struct.processorCapabilities)
+          for (java.lang.String _iter677 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter669);
+            oprot.writeString(_iter677);
           }
         }
       }
@@ -1343,13 +1343,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(8);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list670 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.names = new java.util.ArrayList<java.lang.String>(_list670.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem671;
-          for (int _i672 = 0; _i672 < _list670.size; ++_i672)
+          org.apache.thrift.protocol.TList _list678 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.names = new java.util.ArrayList<java.lang.String>(_list678.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem679;
+          for (int _i680 = 0; _i680 < _list678.size; ++_i680)
           {
-            _elem671 = iprot.readString();
-            struct.names.add(_elem671);
+            _elem679 = iprot.readString();
+            struct.names.add(_elem679);
           }
         }
         struct.setNamesIsSet(true);
@@ -1360,13 +1360,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list673 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list673.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem674;
-          for (int _i675 = 0; _i675 < _list673.size; ++_i675)
+          org.apache.thrift.protocol.TList _list681 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list681.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem682;
+          for (int _i683 = 0; _i683 < _list681.size; ++_i683)
           {
-            _elem674 = iprot.readString();
-            struct.processorCapabilities.add(_elem674);
+            _elem682 = iprot.readString();
+            struct.processorCapabilities.add(_elem682);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesResult.java
@@ -414,14 +414,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list676 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list676.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem677;
-                for (int _i678 = 0; _i678 < _list676.size; ++_i678)
+                org.apache.thrift.protocol.TList _list684 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list684.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem685;
+                for (int _i686 = 0; _i686 < _list684.size; ++_i686)
                 {
-                  _elem677 = new Partition();
-                  _elem677.read(iprot);
-                  struct.partitions.add(_elem677);
+                  _elem685 = new Partition();
+                  _elem685.read(iprot);
+                  struct.partitions.add(_elem685);
                 }
                 iprot.readListEnd();
               }
@@ -456,9 +456,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter679 : struct.partitions)
+          for (Partition _iter687 : struct.partitions)
           {
-            _iter679.write(oprot);
+            _iter687.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -490,9 +490,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitions.size());
-        for (Partition _iter680 : struct.partitions)
+        for (Partition _iter688 : struct.partitions)
         {
-          _iter680.write(oprot);
+          _iter688.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -509,14 +509,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetPartitionsByNamesResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list681 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitions = new java.util.ArrayList<Partition>(_list681.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem682;
-        for (int _i683 = 0; _i683 < _list681.size; ++_i683)
+        org.apache.thrift.protocol.TList _list689 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitions = new java.util.ArrayList<Partition>(_list689.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem690;
+        for (int _i691 = 0; _i691 < _list689.size; ++_i691)
         {
-          _elem682 = new Partition();
-          _elem682.read(iprot);
-          struct.partitions.add(_elem682);
+          _elem690 = new Partition();
+          _elem690.read(iprot);
+          struct.partitions.add(_elem690);
         }
       }
       struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsFilterSpec.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsFilterSpec.java
@@ -419,13 +419,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // FILTERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1294 = iprot.readListBegin();
-                struct.filters = new java.util.ArrayList<java.lang.String>(_list1294.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1295;
-                for (int _i1296 = 0; _i1296 < _list1294.size; ++_i1296)
+                org.apache.thrift.protocol.TList _list1302 = iprot.readListBegin();
+                struct.filters = new java.util.ArrayList<java.lang.String>(_list1302.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1303;
+                for (int _i1304 = 0; _i1304 < _list1302.size; ++_i1304)
                 {
-                  _elem1295 = iprot.readString();
-                  struct.filters.add(_elem1295);
+                  _elem1303 = iprot.readString();
+                  struct.filters.add(_elem1303);
                 }
                 iprot.readListEnd();
               }
@@ -459,9 +459,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FILTERS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.filters.size()));
-            for (java.lang.String _iter1297 : struct.filters)
+            for (java.lang.String _iter1305 : struct.filters)
             {
-              oprot.writeString(_iter1297);
+              oprot.writeString(_iter1305);
             }
             oprot.writeListEnd();
           }
@@ -499,9 +499,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFilters()) {
         {
           oprot.writeI32(struct.filters.size());
-          for (java.lang.String _iter1298 : struct.filters)
+          for (java.lang.String _iter1306 : struct.filters)
           {
-            oprot.writeString(_iter1298);
+            oprot.writeString(_iter1306);
           }
         }
       }
@@ -517,13 +517,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1299 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.filters = new java.util.ArrayList<java.lang.String>(_list1299.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1300;
-          for (int _i1301 = 0; _i1301 < _list1299.size; ++_i1301)
+          org.apache.thrift.protocol.TList _list1307 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.filters = new java.util.ArrayList<java.lang.String>(_list1307.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1308;
+          for (int _i1309 = 0; _i1309 < _list1307.size; ++_i1309)
           {
-            _elem1300 = iprot.readString();
-            struct.filters.add(_elem1300);
+            _elem1308 = iprot.readString();
+            struct.filters.add(_elem1308);
           }
         }
         struct.setFiltersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsPsWithAuthRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsPsWithAuthRequest.java
@@ -1017,13 +1017,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_VALS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1374 = iprot.readListBegin();
-                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1374.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1375;
-                for (int _i1376 = 0; _i1376 < _list1374.size; ++_i1376)
+                org.apache.thrift.protocol.TList _list1382 = iprot.readListBegin();
+                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1382.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1383;
+                for (int _i1384 = 0; _i1384 < _list1382.size; ++_i1384)
                 {
-                  _elem1375 = iprot.readString();
-                  struct.partVals.add(_elem1375);
+                  _elem1383 = iprot.readString();
+                  struct.partVals.add(_elem1383);
                 }
                 iprot.readListEnd();
               }
@@ -1051,13 +1051,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 7: // GROUP_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1377 = iprot.readListBegin();
-                struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1377.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1378;
-                for (int _i1379 = 0; _i1379 < _list1377.size; ++_i1379)
+                org.apache.thrift.protocol.TList _list1385 = iprot.readListBegin();
+                struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1385.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1386;
+                for (int _i1387 = 0; _i1387 < _list1385.size; ++_i1387)
                 {
-                  _elem1378 = iprot.readString();
-                  struct.groupNames.add(_elem1378);
+                  _elem1386 = iprot.readString();
+                  struct.groupNames.add(_elem1386);
                 }
                 iprot.readListEnd();
               }
@@ -1117,9 +1117,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PART_VALS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partVals.size()));
-            for (java.lang.String _iter1380 : struct.partVals)
+            for (java.lang.String _iter1388 : struct.partVals)
             {
-              oprot.writeString(_iter1380);
+              oprot.writeString(_iter1388);
             }
             oprot.writeListEnd();
           }
@@ -1143,9 +1143,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(GROUP_NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.groupNames.size()));
-            for (java.lang.String _iter1381 : struct.groupNames)
+            for (java.lang.String _iter1389 : struct.groupNames)
             {
-              oprot.writeString(_iter1381);
+              oprot.writeString(_iter1389);
             }
             oprot.writeListEnd();
           }
@@ -1212,9 +1212,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartVals()) {
         {
           oprot.writeI32(struct.partVals.size());
-          for (java.lang.String _iter1382 : struct.partVals)
+          for (java.lang.String _iter1390 : struct.partVals)
           {
-            oprot.writeString(_iter1382);
+            oprot.writeString(_iter1390);
           }
         }
       }
@@ -1227,9 +1227,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetGroupNames()) {
         {
           oprot.writeI32(struct.groupNames.size());
-          for (java.lang.String _iter1383 : struct.groupNames)
+          for (java.lang.String _iter1391 : struct.groupNames)
           {
-            oprot.writeString(_iter1383);
+            oprot.writeString(_iter1391);
           }
         }
       }
@@ -1255,13 +1255,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1384 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partVals = new java.util.ArrayList<java.lang.String>(_list1384.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1385;
-          for (int _i1386 = 0; _i1386 < _list1384.size; ++_i1386)
+          org.apache.thrift.protocol.TList _list1392 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partVals = new java.util.ArrayList<java.lang.String>(_list1392.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1393;
+          for (int _i1394 = 0; _i1394 < _list1392.size; ++_i1394)
           {
-            _elem1385 = iprot.readString();
-            struct.partVals.add(_elem1385);
+            _elem1393 = iprot.readString();
+            struct.partVals.add(_elem1393);
           }
         }
         struct.setPartValsIsSet(true);
@@ -1276,13 +1276,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TList _list1387 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1387.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1388;
-          for (int _i1389 = 0; _i1389 < _list1387.size; ++_i1389)
+          org.apache.thrift.protocol.TList _list1395 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1395.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1396;
+          for (int _i1397 = 0; _i1397 < _list1395.size; ++_i1397)
           {
-            _elem1388 = iprot.readString();
-            struct.groupNames.add(_elem1388);
+            _elem1396 = iprot.readString();
+            struct.groupNames.add(_elem1396);
           }
         }
         struct.setGroupNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsPsWithAuthResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsPsWithAuthResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1390 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list1390.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem1391;
-                for (int _i1392 = 0; _i1392 < _list1390.size; ++_i1392)
+                org.apache.thrift.protocol.TList _list1398 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list1398.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem1399;
+                for (int _i1400 = 0; _i1400 < _list1398.size; ++_i1400)
                 {
-                  _elem1391 = new Partition();
-                  _elem1391.read(iprot);
-                  struct.partitions.add(_elem1391);
+                  _elem1399 = new Partition();
+                  _elem1399.read(iprot);
+                  struct.partitions.add(_elem1399);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter1393 : struct.partitions)
+          for (Partition _iter1401 : struct.partitions)
           {
-            _iter1393.write(oprot);
+            _iter1401.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitions.size());
-        for (Partition _iter1394 : struct.partitions)
+        for (Partition _iter1402 : struct.partitions)
         {
-          _iter1394.write(oprot);
+          _iter1402.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetPartitionsPsWithAuthResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1395 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitions = new java.util.ArrayList<Partition>(_list1395.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem1396;
-        for (int _i1397 = 0; _i1397 < _list1395.size; ++_i1397)
+        org.apache.thrift.protocol.TList _list1403 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitions = new java.util.ArrayList<Partition>(_list1403.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem1404;
+        for (int _i1405 = 0; _i1405 < _list1403.size; ++_i1405)
         {
-          _elem1396 = new Partition();
-          _elem1396.read(iprot);
-          struct.partitions.add(_elem1396);
+          _elem1404 = new Partition();
+          _elem1404.read(iprot);
+          struct.partitions.add(_elem1404);
         }
       }
       struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsRequest.java
@@ -1195,13 +1195,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // GROUP_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1310 = iprot.readListBegin();
-                struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1310.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1311;
-                for (int _i1312 = 0; _i1312 < _list1310.size; ++_i1312)
+                org.apache.thrift.protocol.TList _list1318 = iprot.readListBegin();
+                struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1318.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1319;
+                for (int _i1320 = 0; _i1320 < _list1318.size; ++_i1320)
                 {
-                  _elem1311 = iprot.readString();
-                  struct.groupNames.add(_elem1311);
+                  _elem1319 = iprot.readString();
+                  struct.groupNames.add(_elem1319);
                 }
                 iprot.readListEnd();
               }
@@ -1231,13 +1231,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 9: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1313 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1313.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1314;
-                for (int _i1315 = 0; _i1315 < _list1313.size; ++_i1315)
+                org.apache.thrift.protocol.TList _list1321 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1321.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1322;
+                for (int _i1323 = 0; _i1323 < _list1321.size; ++_i1323)
                 {
-                  _elem1314 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1314);
+                  _elem1322 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1322);
                 }
                 iprot.readListEnd();
               }
@@ -1309,9 +1309,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(GROUP_NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.groupNames.size()));
-            for (java.lang.String _iter1316 : struct.groupNames)
+            for (java.lang.String _iter1324 : struct.groupNames)
             {
-              oprot.writeString(_iter1316);
+              oprot.writeString(_iter1324);
             }
             oprot.writeListEnd();
           }
@@ -1333,9 +1333,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1317 : struct.processorCapabilities)
+            for (java.lang.String _iter1325 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1317);
+              oprot.writeString(_iter1325);
             }
             oprot.writeListEnd();
           }
@@ -1426,9 +1426,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetGroupNames()) {
         {
           oprot.writeI32(struct.groupNames.size());
-          for (java.lang.String _iter1318 : struct.groupNames)
+          for (java.lang.String _iter1326 : struct.groupNames)
           {
-            oprot.writeString(_iter1318);
+            oprot.writeString(_iter1326);
           }
         }
       }
@@ -1441,9 +1441,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1319 : struct.processorCapabilities)
+          for (java.lang.String _iter1327 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1319);
+            oprot.writeString(_iter1327);
           }
         }
       }
@@ -1481,13 +1481,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(5)) {
         {
-          org.apache.thrift.protocol.TList _list1320 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1320.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1321;
-          for (int _i1322 = 0; _i1322 < _list1320.size; ++_i1322)
+          org.apache.thrift.protocol.TList _list1328 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.groupNames = new java.util.ArrayList<java.lang.String>(_list1328.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1329;
+          for (int _i1330 = 0; _i1330 < _list1328.size; ++_i1330)
           {
-            _elem1321 = iprot.readString();
-            struct.groupNames.add(_elem1321);
+            _elem1329 = iprot.readString();
+            struct.groupNames.add(_elem1329);
           }
         }
         struct.setGroupNamesIsSet(true);
@@ -1504,13 +1504,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TList _list1323 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1323.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1324;
-          for (int _i1325 = 0; _i1325 < _list1323.size; ++_i1325)
+          org.apache.thrift.protocol.TList _list1331 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1331.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1332;
+          for (int _i1333 = 0; _i1333 < _list1331.size; ++_i1333)
           {
-            _elem1324 = iprot.readString();
-            struct.processorCapabilities.add(_elem1324);
+            _elem1332 = iprot.readString();
+            struct.processorCapabilities.add(_elem1332);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsResponse.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITION_SPEC
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1302 = iprot.readListBegin();
-                struct.partitionSpec = new java.util.ArrayList<PartitionSpec>(_list1302.size);
-                @org.apache.thrift.annotation.Nullable PartitionSpec _elem1303;
-                for (int _i1304 = 0; _i1304 < _list1302.size; ++_i1304)
+                org.apache.thrift.protocol.TList _list1310 = iprot.readListBegin();
+                struct.partitionSpec = new java.util.ArrayList<PartitionSpec>(_list1310.size);
+                @org.apache.thrift.annotation.Nullable PartitionSpec _elem1311;
+                for (int _i1312 = 0; _i1312 < _list1310.size; ++_i1312)
                 {
-                  _elem1303 = new PartitionSpec();
-                  _elem1303.read(iprot);
-                  struct.partitionSpec.add(_elem1303);
+                  _elem1311 = new PartitionSpec();
+                  _elem1311.read(iprot);
+                  struct.partitionSpec.add(_elem1311);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITION_SPEC_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionSpec.size()));
-          for (PartitionSpec _iter1305 : struct.partitionSpec)
+          for (PartitionSpec _iter1313 : struct.partitionSpec)
           {
-            _iter1305.write(oprot);
+            _iter1313.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionSpec()) {
         {
           oprot.writeI32(struct.partitionSpec.size());
-          for (PartitionSpec _iter1306 : struct.partitionSpec)
+          for (PartitionSpec _iter1314 : struct.partitionSpec)
           {
-            _iter1306.write(oprot);
+            _iter1314.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1307 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitionSpec = new java.util.ArrayList<PartitionSpec>(_list1307.size);
-          @org.apache.thrift.annotation.Nullable PartitionSpec _elem1308;
-          for (int _i1309 = 0; _i1309 < _list1307.size; ++_i1309)
+          org.apache.thrift.protocol.TList _list1315 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitionSpec = new java.util.ArrayList<PartitionSpec>(_list1315.size);
+          @org.apache.thrift.annotation.Nullable PartitionSpec _elem1316;
+          for (int _i1317 = 0; _i1317 < _list1315.size; ++_i1317)
           {
-            _elem1308 = new PartitionSpec();
-            _elem1308.read(iprot);
-            struct.partitionSpec.add(_elem1308);
+            _elem1316 = new PartitionSpec();
+            _elem1316.read(iprot);
+            struct.partitionSpec.add(_elem1316);
           }
         }
         struct.setPartitionSpecIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetProjectionsSpec.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetProjectionsSpec.java
@@ -484,13 +484,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FIELD_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1052 = iprot.readListBegin();
-                struct.fieldList = new java.util.ArrayList<java.lang.String>(_list1052.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1053;
-                for (int _i1054 = 0; _i1054 < _list1052.size; ++_i1054)
+                org.apache.thrift.protocol.TList _list1060 = iprot.readListBegin();
+                struct.fieldList = new java.util.ArrayList<java.lang.String>(_list1060.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1061;
+                for (int _i1062 = 0; _i1062 < _list1060.size; ++_i1062)
                 {
-                  _elem1053 = iprot.readString();
-                  struct.fieldList.add(_elem1053);
+                  _elem1061 = iprot.readString();
+                  struct.fieldList.add(_elem1061);
                 }
                 iprot.readListEnd();
               }
@@ -532,9 +532,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FIELD_LIST_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.fieldList.size()));
-          for (java.lang.String _iter1055 : struct.fieldList)
+          for (java.lang.String _iter1063 : struct.fieldList)
           {
-            oprot.writeString(_iter1055);
+            oprot.writeString(_iter1063);
           }
           oprot.writeListEnd();
         }
@@ -581,9 +581,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFieldList()) {
         {
           oprot.writeI32(struct.fieldList.size());
-          for (java.lang.String _iter1056 : struct.fieldList)
+          for (java.lang.String _iter1064 : struct.fieldList)
           {
-            oprot.writeString(_iter1056);
+            oprot.writeString(_iter1064);
           }
         }
       }
@@ -601,13 +601,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1057 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.fieldList = new java.util.ArrayList<java.lang.String>(_list1057.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1058;
-          for (int _i1059 = 0; _i1059 < _list1057.size; ++_i1059)
+          org.apache.thrift.protocol.TList _list1065 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.fieldList = new java.util.ArrayList<java.lang.String>(_list1065.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1066;
+          for (int _i1067 = 0; _i1067 < _list1065.size; ++_i1067)
           {
-            _elem1058 = iprot.readString();
-            struct.fieldList.add(_elem1058);
+            _elem1066 = iprot.readString();
+            struct.fieldList.add(_elem1066);
           }
         }
         struct.setFieldListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetSchemaResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetSchemaResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FIELDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1334 = iprot.readListBegin();
-                struct.fields = new java.util.ArrayList<FieldSchema>(_list1334.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem1335;
-                for (int _i1336 = 0; _i1336 < _list1334.size; ++_i1336)
+                org.apache.thrift.protocol.TList _list1342 = iprot.readListBegin();
+                struct.fields = new java.util.ArrayList<FieldSchema>(_list1342.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem1343;
+                for (int _i1344 = 0; _i1344 < _list1342.size; ++_i1344)
                 {
-                  _elem1335 = new FieldSchema();
-                  _elem1335.read(iprot);
-                  struct.fields.add(_elem1335);
+                  _elem1343 = new FieldSchema();
+                  _elem1343.read(iprot);
+                  struct.fields.add(_elem1343);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FIELDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.fields.size()));
-          for (FieldSchema _iter1337 : struct.fields)
+          for (FieldSchema _iter1345 : struct.fields)
           {
-            _iter1337.write(oprot);
+            _iter1345.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fields.size());
-        for (FieldSchema _iter1338 : struct.fields)
+        for (FieldSchema _iter1346 : struct.fields)
         {
-          _iter1338.write(oprot);
+          _iter1346.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetSchemaResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1339 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.fields = new java.util.ArrayList<FieldSchema>(_list1339.size);
-        @org.apache.thrift.annotation.Nullable FieldSchema _elem1340;
-        for (int _i1341 = 0; _i1341 < _list1339.size; ++_i1341)
+        org.apache.thrift.protocol.TList _list1347 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.fields = new java.util.ArrayList<FieldSchema>(_list1347.size);
+        @org.apache.thrift.annotation.Nullable FieldSchema _elem1348;
+        for (int _i1349 = 0; _i1349 < _list1347.size; ++_i1349)
         {
-          _elem1340 = new FieldSchema();
-          _elem1340.read(iprot);
-          struct.fields.add(_elem1340);
+          _elem1348 = new FieldSchema();
+          _elem1348.read(iprot);
+          struct.fields.add(_elem1348);
         }
       }
       struct.setFieldsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTableRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTableRequest.java
@@ -1106,13 +1106,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1060 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1060.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1061;
-                for (int _i1062 = 0; _i1062 < _list1060.size; ++_i1062)
+                org.apache.thrift.protocol.TList _list1068 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1068.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1069;
+                for (int _i1070 = 0; _i1070 < _list1068.size; ++_i1070)
                 {
-                  _elem1061 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1061);
+                  _elem1069 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1069);
                 }
                 iprot.readListEnd();
               }
@@ -1199,9 +1199,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1063 : struct.processorCapabilities)
+            for (java.lang.String _iter1071 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1063);
+              oprot.writeString(_iter1071);
             }
             oprot.writeListEnd();
           }
@@ -1287,9 +1287,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1064 : struct.processorCapabilities)
+          for (java.lang.String _iter1072 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1064);
+            oprot.writeString(_iter1072);
           }
         }
       }
@@ -1331,13 +1331,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TList _list1065 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1065.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1066;
-          for (int _i1067 = 0; _i1067 < _list1065.size; ++_i1067)
+          org.apache.thrift.protocol.TList _list1073 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1073.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1074;
+          for (int _i1075 = 0; _i1075 < _list1073.size; ++_i1075)
           {
-            _elem1066 = iprot.readString();
-            struct.processorCapabilities.add(_elem1066);
+            _elem1074 = iprot.readString();
+            struct.processorCapabilities.add(_elem1074);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesExtRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesExtRequest.java
@@ -856,13 +856,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1092 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1092.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1093;
-                for (int _i1094 = 0; _i1094 < _list1092.size; ++_i1094)
+                org.apache.thrift.protocol.TList _list1100 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1100.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1101;
+                for (int _i1102 = 0; _i1102 < _list1100.size; ++_i1102)
                 {
-                  _elem1093 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1093);
+                  _elem1101 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1101);
                 }
                 iprot.readListEnd();
               }
@@ -920,9 +920,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1095 : struct.processorCapabilities)
+            for (java.lang.String _iter1103 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1095);
+              oprot.writeString(_iter1103);
             }
             oprot.writeListEnd();
           }
@@ -974,9 +974,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1096 : struct.processorCapabilities)
+          for (java.lang.String _iter1104 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1096);
+            oprot.writeString(_iter1104);
           }
         }
       }
@@ -1003,13 +1003,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1097 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1097.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1098;
-          for (int _i1099 = 0; _i1099 < _list1097.size; ++_i1099)
+          org.apache.thrift.protocol.TList _list1105 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1105.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1106;
+          for (int _i1107 = 0; _i1107 < _list1105.size; ++_i1107)
           {
-            _elem1098 = iprot.readString();
-            struct.processorCapabilities.add(_elem1098);
+            _elem1106 = iprot.readString();
+            struct.processorCapabilities.add(_elem1106);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesRequest.java
@@ -926,13 +926,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // TBL_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1068 = iprot.readListBegin();
-                struct.tblNames = new java.util.ArrayList<java.lang.String>(_list1068.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1069;
-                for (int _i1070 = 0; _i1070 < _list1068.size; ++_i1070)
+                org.apache.thrift.protocol.TList _list1076 = iprot.readListBegin();
+                struct.tblNames = new java.util.ArrayList<java.lang.String>(_list1076.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1077;
+                for (int _i1078 = 0; _i1078 < _list1076.size; ++_i1078)
                 {
-                  _elem1069 = iprot.readString();
-                  struct.tblNames.add(_elem1069);
+                  _elem1077 = iprot.readString();
+                  struct.tblNames.add(_elem1077);
                 }
                 iprot.readListEnd();
               }
@@ -961,13 +961,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PROCESSOR_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1071 = iprot.readListBegin();
-                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1071.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1072;
-                for (int _i1073 = 0; _i1073 < _list1071.size; ++_i1073)
+                org.apache.thrift.protocol.TList _list1079 = iprot.readListBegin();
+                struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1079.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1080;
+                for (int _i1081 = 0; _i1081 < _list1079.size; ++_i1081)
                 {
-                  _elem1072 = iprot.readString();
-                  struct.processorCapabilities.add(_elem1072);
+                  _elem1080 = iprot.readString();
+                  struct.processorCapabilities.add(_elem1080);
                 }
                 iprot.readListEnd();
               }
@@ -1024,9 +1024,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(TBL_NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.tblNames.size()));
-            for (java.lang.String _iter1074 : struct.tblNames)
+            for (java.lang.String _iter1082 : struct.tblNames)
             {
-              oprot.writeString(_iter1074);
+              oprot.writeString(_iter1082);
             }
             oprot.writeListEnd();
           }
@@ -1052,9 +1052,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PROCESSOR_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.processorCapabilities.size()));
-            for (java.lang.String _iter1075 : struct.processorCapabilities)
+            for (java.lang.String _iter1083 : struct.processorCapabilities)
             {
-              oprot.writeString(_iter1075);
+              oprot.writeString(_iter1083);
             }
             oprot.writeListEnd();
           }
@@ -1126,9 +1126,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetTblNames()) {
         {
           oprot.writeI32(struct.tblNames.size());
-          for (java.lang.String _iter1076 : struct.tblNames)
+          for (java.lang.String _iter1084 : struct.tblNames)
           {
-            oprot.writeString(_iter1076);
+            oprot.writeString(_iter1084);
           }
         }
       }
@@ -1141,9 +1141,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorCapabilities()) {
         {
           oprot.writeI32(struct.processorCapabilities.size());
-          for (java.lang.String _iter1077 : struct.processorCapabilities)
+          for (java.lang.String _iter1085 : struct.processorCapabilities)
           {
-            oprot.writeString(_iter1077);
+            oprot.writeString(_iter1085);
           }
         }
       }
@@ -1166,13 +1166,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(7);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1078 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.tblNames = new java.util.ArrayList<java.lang.String>(_list1078.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1079;
-          for (int _i1080 = 0; _i1080 < _list1078.size; ++_i1080)
+          org.apache.thrift.protocol.TList _list1086 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.tblNames = new java.util.ArrayList<java.lang.String>(_list1086.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1087;
+          for (int _i1088 = 0; _i1088 < _list1086.size; ++_i1088)
           {
-            _elem1079 = iprot.readString();
-            struct.tblNames.add(_elem1079);
+            _elem1087 = iprot.readString();
+            struct.tblNames.add(_elem1087);
           }
         }
         struct.setTblNamesIsSet(true);
@@ -1188,13 +1188,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list1081 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1081.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1082;
-          for (int _i1083 = 0; _i1083 < _list1081.size; ++_i1083)
+          org.apache.thrift.protocol.TList _list1089 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.processorCapabilities = new java.util.ArrayList<java.lang.String>(_list1089.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1090;
+          for (int _i1091 = 0; _i1091 < _list1089.size; ++_i1091)
           {
-            _elem1082 = iprot.readString();
-            struct.processorCapabilities.add(_elem1082);
+            _elem1090 = iprot.readString();
+            struct.processorCapabilities.add(_elem1090);
           }
         }
         struct.setProcessorCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesResult.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TABLES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1084 = iprot.readListBegin();
-                struct.tables = new java.util.ArrayList<Table>(_list1084.size);
-                @org.apache.thrift.annotation.Nullable Table _elem1085;
-                for (int _i1086 = 0; _i1086 < _list1084.size; ++_i1086)
+                org.apache.thrift.protocol.TList _list1092 = iprot.readListBegin();
+                struct.tables = new java.util.ArrayList<Table>(_list1092.size);
+                @org.apache.thrift.annotation.Nullable Table _elem1093;
+                for (int _i1094 = 0; _i1094 < _list1092.size; ++_i1094)
                 {
-                  _elem1085 = new Table();
-                  _elem1085.read(iprot);
-                  struct.tables.add(_elem1085);
+                  _elem1093 = new Table();
+                  _elem1093.read(iprot);
+                  struct.tables.add(_elem1093);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TABLES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.tables.size()));
-          for (Table _iter1087 : struct.tables)
+          for (Table _iter1095 : struct.tables)
           {
-            _iter1087.write(oprot);
+            _iter1095.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.tables.size());
-        for (Table _iter1088 : struct.tables)
+        for (Table _iter1096 : struct.tables)
         {
-          _iter1088.write(oprot);
+          _iter1096.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetTablesResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1089 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.tables = new java.util.ArrayList<Table>(_list1089.size);
-        @org.apache.thrift.annotation.Nullable Table _elem1090;
-        for (int _i1091 = 0; _i1091 < _list1089.size; ++_i1091)
+        org.apache.thrift.protocol.TList _list1097 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.tables = new java.util.ArrayList<Table>(_list1097.size);
+        @org.apache.thrift.annotation.Nullable Table _elem1098;
+        for (int _i1099 = 0; _i1099 < _list1097.size; ++_i1099)
         {
-          _elem1090 = new Table();
-          _elem1090.read(iprot);
-          struct.tables.add(_elem1090);
+          _elem1098 = new Table();
+          _elem1098.read(iprot);
+          struct.tables.add(_elem1098);
         }
       }
       struct.setTablesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetValidWriteIdsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetValidWriteIdsRequest.java
@@ -487,13 +487,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FULL_TABLE_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list766 = iprot.readListBegin();
-                struct.fullTableNames = new java.util.ArrayList<java.lang.String>(_list766.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem767;
-                for (int _i768 = 0; _i768 < _list766.size; ++_i768)
+                org.apache.thrift.protocol.TList _list774 = iprot.readListBegin();
+                struct.fullTableNames = new java.util.ArrayList<java.lang.String>(_list774.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem775;
+                for (int _i776 = 0; _i776 < _list774.size; ++_i776)
                 {
-                  _elem767 = iprot.readString();
-                  struct.fullTableNames.add(_elem767);
+                  _elem775 = iprot.readString();
+                  struct.fullTableNames.add(_elem775);
                 }
                 iprot.readListEnd();
               }
@@ -535,9 +535,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FULL_TABLE_NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.fullTableNames.size()));
-          for (java.lang.String _iter769 : struct.fullTableNames)
+          for (java.lang.String _iter777 : struct.fullTableNames)
           {
-            oprot.writeString(_iter769);
+            oprot.writeString(_iter777);
           }
           oprot.writeListEnd();
         }
@@ -574,9 +574,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fullTableNames.size());
-        for (java.lang.String _iter770 : struct.fullTableNames)
+        for (java.lang.String _iter778 : struct.fullTableNames)
         {
-          oprot.writeString(_iter770);
+          oprot.writeString(_iter778);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -599,13 +599,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetValidWriteIdsRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list771 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.fullTableNames = new java.util.ArrayList<java.lang.String>(_list771.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem772;
-        for (int _i773 = 0; _i773 < _list771.size; ++_i773)
+        org.apache.thrift.protocol.TList _list779 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.fullTableNames = new java.util.ArrayList<java.lang.String>(_list779.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem780;
+        for (int _i781 = 0; _i781 < _list779.size; ++_i781)
         {
-          _elem772 = iprot.readString();
-          struct.fullTableNames.add(_elem772);
+          _elem780 = iprot.readString();
+          struct.fullTableNames.add(_elem780);
         }
       }
       struct.setFullTableNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetValidWriteIdsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetValidWriteIdsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TBL_VALID_WRITE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list782 = iprot.readListBegin();
-                struct.tblValidWriteIds = new java.util.ArrayList<TableValidWriteIds>(_list782.size);
-                @org.apache.thrift.annotation.Nullable TableValidWriteIds _elem783;
-                for (int _i784 = 0; _i784 < _list782.size; ++_i784)
+                org.apache.thrift.protocol.TList _list790 = iprot.readListBegin();
+                struct.tblValidWriteIds = new java.util.ArrayList<TableValidWriteIds>(_list790.size);
+                @org.apache.thrift.annotation.Nullable TableValidWriteIds _elem791;
+                for (int _i792 = 0; _i792 < _list790.size; ++_i792)
                 {
-                  _elem783 = new TableValidWriteIds();
-                  _elem783.read(iprot);
-                  struct.tblValidWriteIds.add(_elem783);
+                  _elem791 = new TableValidWriteIds();
+                  _elem791.read(iprot);
+                  struct.tblValidWriteIds.add(_elem791);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TBL_VALID_WRITE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.tblValidWriteIds.size()));
-          for (TableValidWriteIds _iter785 : struct.tblValidWriteIds)
+          for (TableValidWriteIds _iter793 : struct.tblValidWriteIds)
           {
-            _iter785.write(oprot);
+            _iter793.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.tblValidWriteIds.size());
-        for (TableValidWriteIds _iter786 : struct.tblValidWriteIds)
+        for (TableValidWriteIds _iter794 : struct.tblValidWriteIds)
         {
-          _iter786.write(oprot);
+          _iter794.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, GetValidWriteIdsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list787 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.tblValidWriteIds = new java.util.ArrayList<TableValidWriteIds>(_list787.size);
-        @org.apache.thrift.annotation.Nullable TableValidWriteIds _elem788;
-        for (int _i789 = 0; _i789 < _list787.size; ++_i789)
+        org.apache.thrift.protocol.TList _list795 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.tblValidWriteIds = new java.util.ArrayList<TableValidWriteIds>(_list795.size);
+        @org.apache.thrift.annotation.Nullable TableValidWriteIds _elem796;
+        for (int _i797 = 0; _i797 < _list795.size; ++_i797)
         {
-          _elem788 = new TableValidWriteIds();
-          _elem788.read(iprot);
-          struct.tblValidWriteIds.add(_elem788);
+          _elem796 = new TableValidWriteIds();
+          _elem796.read(iprot);
+          struct.tblValidWriteIds.add(_elem796);
         }
       }
       struct.setTblValidWriteIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HeartbeatTxnRangeResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HeartbeatTxnRangeResponse.java
@@ -429,13 +429,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // ABORTED
             if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
               {
-                org.apache.thrift.protocol.TSet _set830 = iprot.readSetBegin();
-                struct.aborted = new java.util.HashSet<java.lang.Long>(2*_set830.size);
-                long _elem831;
-                for (int _i832 = 0; _i832 < _set830.size; ++_i832)
+                org.apache.thrift.protocol.TSet _set838 = iprot.readSetBegin();
+                struct.aborted = new java.util.HashSet<java.lang.Long>(2*_set838.size);
+                long _elem839;
+                for (int _i840 = 0; _i840 < _set838.size; ++_i840)
                 {
-                  _elem831 = iprot.readI64();
-                  struct.aborted.add(_elem831);
+                  _elem839 = iprot.readI64();
+                  struct.aborted.add(_elem839);
                 }
                 iprot.readSetEnd();
               }
@@ -447,13 +447,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // NOSUCH
             if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
               {
-                org.apache.thrift.protocol.TSet _set833 = iprot.readSetBegin();
-                struct.nosuch = new java.util.HashSet<java.lang.Long>(2*_set833.size);
-                long _elem834;
-                for (int _i835 = 0; _i835 < _set833.size; ++_i835)
+                org.apache.thrift.protocol.TSet _set841 = iprot.readSetBegin();
+                struct.nosuch = new java.util.HashSet<java.lang.Long>(2*_set841.size);
+                long _elem842;
+                for (int _i843 = 0; _i843 < _set841.size; ++_i843)
                 {
-                  _elem834 = iprot.readI64();
-                  struct.nosuch.add(_elem834);
+                  _elem842 = iprot.readI64();
+                  struct.nosuch.add(_elem842);
                 }
                 iprot.readSetEnd();
               }
@@ -479,9 +479,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(ABORTED_FIELD_DESC);
         {
           oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.aborted.size()));
-          for (long _iter836 : struct.aborted)
+          for (long _iter844 : struct.aborted)
           {
-            oprot.writeI64(_iter836);
+            oprot.writeI64(_iter844);
           }
           oprot.writeSetEnd();
         }
@@ -491,9 +491,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(NOSUCH_FIELD_DESC);
         {
           oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.nosuch.size()));
-          for (long _iter837 : struct.nosuch)
+          for (long _iter845 : struct.nosuch)
           {
-            oprot.writeI64(_iter837);
+            oprot.writeI64(_iter845);
           }
           oprot.writeSetEnd();
         }
@@ -518,16 +518,16 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.aborted.size());
-        for (long _iter838 : struct.aborted)
+        for (long _iter846 : struct.aborted)
         {
-          oprot.writeI64(_iter838);
+          oprot.writeI64(_iter846);
         }
       }
       {
         oprot.writeI32(struct.nosuch.size());
-        for (long _iter839 : struct.nosuch)
+        for (long _iter847 : struct.nosuch)
         {
-          oprot.writeI64(_iter839);
+          oprot.writeI64(_iter847);
         }
       }
     }
@@ -536,24 +536,24 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, HeartbeatTxnRangeResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TSet _set840 = iprot.readSetBegin(org.apache.thrift.protocol.TType.I64);
-        struct.aborted = new java.util.HashSet<java.lang.Long>(2*_set840.size);
-        long _elem841;
-        for (int _i842 = 0; _i842 < _set840.size; ++_i842)
+        org.apache.thrift.protocol.TSet _set848 = iprot.readSetBegin(org.apache.thrift.protocol.TType.I64);
+        struct.aborted = new java.util.HashSet<java.lang.Long>(2*_set848.size);
+        long _elem849;
+        for (int _i850 = 0; _i850 < _set848.size; ++_i850)
         {
-          _elem841 = iprot.readI64();
-          struct.aborted.add(_elem841);
+          _elem849 = iprot.readI64();
+          struct.aborted.add(_elem849);
         }
       }
       struct.setAbortedIsSet(true);
       {
-        org.apache.thrift.protocol.TSet _set843 = iprot.readSetBegin(org.apache.thrift.protocol.TType.I64);
-        struct.nosuch = new java.util.HashSet<java.lang.Long>(2*_set843.size);
-        long _elem844;
-        for (int _i845 = 0; _i845 < _set843.size; ++_i845)
+        org.apache.thrift.protocol.TSet _set851 = iprot.readSetBegin(org.apache.thrift.protocol.TType.I64);
+        struct.nosuch = new java.util.HashSet<java.lang.Long>(2*_set851.size);
+        long _elem852;
+        for (int _i853 = 0; _i853 < _set851.size; ++_i853)
         {
-          _elem844 = iprot.readI64();
-          struct.nosuch.add(_elem844);
+          _elem852 = iprot.readI64();
+          struct.nosuch.add(_elem852);
         }
       }
       struct.setNosuchIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/InsertEventRequestData.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/InsertEventRequestData.java
@@ -711,13 +711,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // FILES_ADDED
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list904 = iprot.readListBegin();
-                struct.filesAdded = new java.util.ArrayList<java.lang.String>(_list904.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem905;
-                for (int _i906 = 0; _i906 < _list904.size; ++_i906)
+                org.apache.thrift.protocol.TList _list912 = iprot.readListBegin();
+                struct.filesAdded = new java.util.ArrayList<java.lang.String>(_list912.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem913;
+                for (int _i914 = 0; _i914 < _list912.size; ++_i914)
                 {
-                  _elem905 = iprot.readString();
-                  struct.filesAdded.add(_elem905);
+                  _elem913 = iprot.readString();
+                  struct.filesAdded.add(_elem913);
                 }
                 iprot.readListEnd();
               }
@@ -729,13 +729,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // FILES_ADDED_CHECKSUM
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list907 = iprot.readListBegin();
-                struct.filesAddedChecksum = new java.util.ArrayList<java.lang.String>(_list907.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem908;
-                for (int _i909 = 0; _i909 < _list907.size; ++_i909)
+                org.apache.thrift.protocol.TList _list915 = iprot.readListBegin();
+                struct.filesAddedChecksum = new java.util.ArrayList<java.lang.String>(_list915.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem916;
+                for (int _i917 = 0; _i917 < _list915.size; ++_i917)
                 {
-                  _elem908 = iprot.readString();
-                  struct.filesAddedChecksum.add(_elem908);
+                  _elem916 = iprot.readString();
+                  struct.filesAddedChecksum.add(_elem916);
                 }
                 iprot.readListEnd();
               }
@@ -747,13 +747,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // SUB_DIRECTORY_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list910 = iprot.readListBegin();
-                struct.subDirectoryList = new java.util.ArrayList<java.lang.String>(_list910.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem911;
-                for (int _i912 = 0; _i912 < _list910.size; ++_i912)
+                org.apache.thrift.protocol.TList _list918 = iprot.readListBegin();
+                struct.subDirectoryList = new java.util.ArrayList<java.lang.String>(_list918.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem919;
+                for (int _i920 = 0; _i920 < _list918.size; ++_i920)
                 {
-                  _elem911 = iprot.readString();
-                  struct.subDirectoryList.add(_elem911);
+                  _elem919 = iprot.readString();
+                  struct.subDirectoryList.add(_elem919);
                 }
                 iprot.readListEnd();
               }
@@ -765,13 +765,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARTITION_VAL
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list913 = iprot.readListBegin();
-                struct.partitionVal = new java.util.ArrayList<java.lang.String>(_list913.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem914;
-                for (int _i915 = 0; _i915 < _list913.size; ++_i915)
+                org.apache.thrift.protocol.TList _list921 = iprot.readListBegin();
+                struct.partitionVal = new java.util.ArrayList<java.lang.String>(_list921.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem922;
+                for (int _i923 = 0; _i923 < _list921.size; ++_i923)
                 {
-                  _elem914 = iprot.readString();
-                  struct.partitionVal.add(_elem914);
+                  _elem922 = iprot.readString();
+                  struct.partitionVal.add(_elem922);
                 }
                 iprot.readListEnd();
               }
@@ -802,9 +802,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FILES_ADDED_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.filesAdded.size()));
-          for (java.lang.String _iter916 : struct.filesAdded)
+          for (java.lang.String _iter924 : struct.filesAdded)
           {
-            oprot.writeString(_iter916);
+            oprot.writeString(_iter924);
           }
           oprot.writeListEnd();
         }
@@ -815,9 +815,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(FILES_ADDED_CHECKSUM_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.filesAddedChecksum.size()));
-            for (java.lang.String _iter917 : struct.filesAddedChecksum)
+            for (java.lang.String _iter925 : struct.filesAddedChecksum)
             {
-              oprot.writeString(_iter917);
+              oprot.writeString(_iter925);
             }
             oprot.writeListEnd();
           }
@@ -829,9 +829,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(SUB_DIRECTORY_LIST_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.subDirectoryList.size()));
-            for (java.lang.String _iter918 : struct.subDirectoryList)
+            for (java.lang.String _iter926 : struct.subDirectoryList)
             {
-              oprot.writeString(_iter918);
+              oprot.writeString(_iter926);
             }
             oprot.writeListEnd();
           }
@@ -843,9 +843,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITION_VAL_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionVal.size()));
-            for (java.lang.String _iter919 : struct.partitionVal)
+            for (java.lang.String _iter927 : struct.partitionVal)
             {
-              oprot.writeString(_iter919);
+              oprot.writeString(_iter927);
             }
             oprot.writeListEnd();
           }
@@ -871,9 +871,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.filesAdded.size());
-        for (java.lang.String _iter920 : struct.filesAdded)
+        for (java.lang.String _iter928 : struct.filesAdded)
         {
-          oprot.writeString(_iter920);
+          oprot.writeString(_iter928);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -896,27 +896,27 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFilesAddedChecksum()) {
         {
           oprot.writeI32(struct.filesAddedChecksum.size());
-          for (java.lang.String _iter921 : struct.filesAddedChecksum)
+          for (java.lang.String _iter929 : struct.filesAddedChecksum)
           {
-            oprot.writeString(_iter921);
+            oprot.writeString(_iter929);
           }
         }
       }
       if (struct.isSetSubDirectoryList()) {
         {
           oprot.writeI32(struct.subDirectoryList.size());
-          for (java.lang.String _iter922 : struct.subDirectoryList)
+          for (java.lang.String _iter930 : struct.subDirectoryList)
           {
-            oprot.writeString(_iter922);
+            oprot.writeString(_iter930);
           }
         }
       }
       if (struct.isSetPartitionVal()) {
         {
           oprot.writeI32(struct.partitionVal.size());
-          for (java.lang.String _iter923 : struct.partitionVal)
+          for (java.lang.String _iter931 : struct.partitionVal)
           {
-            oprot.writeString(_iter923);
+            oprot.writeString(_iter931);
           }
         }
       }
@@ -926,13 +926,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, InsertEventRequestData struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list924 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.filesAdded = new java.util.ArrayList<java.lang.String>(_list924.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem925;
-        for (int _i926 = 0; _i926 < _list924.size; ++_i926)
+        org.apache.thrift.protocol.TList _list932 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.filesAdded = new java.util.ArrayList<java.lang.String>(_list932.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem933;
+        for (int _i934 = 0; _i934 < _list932.size; ++_i934)
         {
-          _elem925 = iprot.readString();
-          struct.filesAdded.add(_elem925);
+          _elem933 = iprot.readString();
+          struct.filesAdded.add(_elem933);
         }
       }
       struct.setFilesAddedIsSet(true);
@@ -943,39 +943,39 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list927 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.filesAddedChecksum = new java.util.ArrayList<java.lang.String>(_list927.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem928;
-          for (int _i929 = 0; _i929 < _list927.size; ++_i929)
+          org.apache.thrift.protocol.TList _list935 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.filesAddedChecksum = new java.util.ArrayList<java.lang.String>(_list935.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem936;
+          for (int _i937 = 0; _i937 < _list935.size; ++_i937)
           {
-            _elem928 = iprot.readString();
-            struct.filesAddedChecksum.add(_elem928);
+            _elem936 = iprot.readString();
+            struct.filesAddedChecksum.add(_elem936);
           }
         }
         struct.setFilesAddedChecksumIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list930 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.subDirectoryList = new java.util.ArrayList<java.lang.String>(_list930.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem931;
-          for (int _i932 = 0; _i932 < _list930.size; ++_i932)
+          org.apache.thrift.protocol.TList _list938 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.subDirectoryList = new java.util.ArrayList<java.lang.String>(_list938.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem939;
+          for (int _i940 = 0; _i940 < _list938.size; ++_i940)
           {
-            _elem931 = iprot.readString();
-            struct.subDirectoryList.add(_elem931);
+            _elem939 = iprot.readString();
+            struct.subDirectoryList.add(_elem939);
           }
         }
         struct.setSubDirectoryListIsSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list933 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partitionVal = new java.util.ArrayList<java.lang.String>(_list933.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem934;
-          for (int _i935 = 0; _i935 < _list933.size; ++_i935)
+          org.apache.thrift.protocol.TList _list941 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partitionVal = new java.util.ArrayList<java.lang.String>(_list941.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem942;
+          for (int _i943 = 0; _i943 < _list941.size; ++_i943)
           {
-            _elem934 = iprot.readString();
-            struct.partitionVal.add(_elem934);
+            _elem942 = iprot.readString();
+            struct.partitionVal.add(_elem942);
           }
         }
         struct.setPartitionValIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/LockRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/LockRequest.java
@@ -740,14 +740,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COMPONENT
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list814 = iprot.readListBegin();
-                struct.component = new java.util.ArrayList<LockComponent>(_list814.size);
-                @org.apache.thrift.annotation.Nullable LockComponent _elem815;
-                for (int _i816 = 0; _i816 < _list814.size; ++_i816)
+                org.apache.thrift.protocol.TList _list822 = iprot.readListBegin();
+                struct.component = new java.util.ArrayList<LockComponent>(_list822.size);
+                @org.apache.thrift.annotation.Nullable LockComponent _elem823;
+                for (int _i824 = 0; _i824 < _list822.size; ++_i824)
                 {
-                  _elem815 = new LockComponent();
-                  _elem815.read(iprot);
-                  struct.component.add(_elem815);
+                  _elem823 = new LockComponent();
+                  _elem823.read(iprot);
+                  struct.component.add(_elem823);
                 }
                 iprot.readListEnd();
               }
@@ -813,9 +813,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COMPONENT_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.component.size()));
-          for (LockComponent _iter817 : struct.component)
+          for (LockComponent _iter825 : struct.component)
           {
-            _iter817.write(oprot);
+            _iter825.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -867,9 +867,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.component.size());
-        for (LockComponent _iter818 : struct.component)
+        for (LockComponent _iter826 : struct.component)
         {
-          _iter818.write(oprot);
+          _iter826.write(oprot);
         }
       }
       oprot.writeString(struct.user);
@@ -900,14 +900,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, LockRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list819 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.component = new java.util.ArrayList<LockComponent>(_list819.size);
-        @org.apache.thrift.annotation.Nullable LockComponent _elem820;
-        for (int _i821 = 0; _i821 < _list819.size; ++_i821)
+        org.apache.thrift.protocol.TList _list827 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.component = new java.util.ArrayList<LockComponent>(_list827.size);
+        @org.apache.thrift.annotation.Nullable LockComponent _elem828;
+        for (int _i829 = 0; _i829 < _list827.size; ++_i829)
         {
-          _elem820 = new LockComponent();
-          _elem820.read(iprot);
-          struct.component.add(_elem820);
+          _elem828 = new LockComponent();
+          _elem828.read(iprot);
+          struct.component.add(_elem828);
         }
       }
       struct.setComponentIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotNullConstraintsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotNullConstraintsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // NOT_NULL_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list450 = iprot.readListBegin();
-                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list450.size);
-                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem451;
-                for (int _i452 = 0; _i452 < _list450.size; ++_i452)
+                org.apache.thrift.protocol.TList _list458 = iprot.readListBegin();
+                struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list458.size);
+                @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem459;
+                for (int _i460 = 0; _i460 < _list458.size; ++_i460)
                 {
-                  _elem451 = new SQLNotNullConstraint();
-                  _elem451.read(iprot);
-                  struct.notNullConstraints.add(_elem451);
+                  _elem459 = new SQLNotNullConstraint();
+                  _elem459.read(iprot);
+                  struct.notNullConstraints.add(_elem459);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(NOT_NULL_CONSTRAINTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.notNullConstraints.size()));
-          for (SQLNotNullConstraint _iter453 : struct.notNullConstraints)
+          for (SQLNotNullConstraint _iter461 : struct.notNullConstraints)
           {
-            _iter453.write(oprot);
+            _iter461.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.notNullConstraints.size());
-        for (SQLNotNullConstraint _iter454 : struct.notNullConstraints)
+        for (SQLNotNullConstraint _iter462 : struct.notNullConstraints)
         {
-          _iter454.write(oprot);
+          _iter462.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, NotNullConstraintsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list455 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list455.size);
-        @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem456;
-        for (int _i457 = 0; _i457 < _list455.size; ++_i457)
+        org.apache.thrift.protocol.TList _list463 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.notNullConstraints = new java.util.ArrayList<SQLNotNullConstraint>(_list463.size);
+        @org.apache.thrift.annotation.Nullable SQLNotNullConstraint _elem464;
+        for (int _i465 = 0; _i465 < _list463.size; ++_i465)
         {
-          _elem456 = new SQLNotNullConstraint();
-          _elem456.read(iprot);
-          struct.notNullConstraints.add(_elem456);
+          _elem464 = new SQLNotNullConstraint();
+          _elem464.read(iprot);
+          struct.notNullConstraints.add(_elem464);
         }
       }
       struct.setNotNullConstraintsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotificationEventRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotificationEventRequest.java
@@ -496,13 +496,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // EVENT_TYPE_SKIP_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list888 = iprot.readListBegin();
-                struct.eventTypeSkipList = new java.util.ArrayList<java.lang.String>(_list888.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem889;
-                for (int _i890 = 0; _i890 < _list888.size; ++_i890)
+                org.apache.thrift.protocol.TList _list896 = iprot.readListBegin();
+                struct.eventTypeSkipList = new java.util.ArrayList<java.lang.String>(_list896.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem897;
+                for (int _i898 = 0; _i898 < _list896.size; ++_i898)
                 {
-                  _elem889 = iprot.readString();
-                  struct.eventTypeSkipList.add(_elem889);
+                  _elem897 = iprot.readString();
+                  struct.eventTypeSkipList.add(_elem897);
                 }
                 iprot.readListEnd();
               }
@@ -537,9 +537,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(EVENT_TYPE_SKIP_LIST_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.eventTypeSkipList.size()));
-            for (java.lang.String _iter891 : struct.eventTypeSkipList)
+            for (java.lang.String _iter899 : struct.eventTypeSkipList)
             {
-              oprot.writeString(_iter891);
+              oprot.writeString(_iter899);
             }
             oprot.writeListEnd();
           }
@@ -578,9 +578,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetEventTypeSkipList()) {
         {
           oprot.writeI32(struct.eventTypeSkipList.size());
-          for (java.lang.String _iter892 : struct.eventTypeSkipList)
+          for (java.lang.String _iter900 : struct.eventTypeSkipList)
           {
-            oprot.writeString(_iter892);
+            oprot.writeString(_iter900);
           }
         }
       }
@@ -598,13 +598,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list893 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.eventTypeSkipList = new java.util.ArrayList<java.lang.String>(_list893.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem894;
-          for (int _i895 = 0; _i895 < _list893.size; ++_i895)
+          org.apache.thrift.protocol.TList _list901 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.eventTypeSkipList = new java.util.ArrayList<java.lang.String>(_list901.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem902;
+          for (int _i903 = 0; _i903 < _list901.size; ++_i903)
           {
-            _elem894 = iprot.readString();
-            struct.eventTypeSkipList.add(_elem894);
+            _elem902 = iprot.readString();
+            struct.eventTypeSkipList.add(_elem902);
           }
         }
         struct.setEventTypeSkipListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotificationEventResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/NotificationEventResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // EVENTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list896 = iprot.readListBegin();
-                struct.events = new java.util.ArrayList<NotificationEvent>(_list896.size);
-                @org.apache.thrift.annotation.Nullable NotificationEvent _elem897;
-                for (int _i898 = 0; _i898 < _list896.size; ++_i898)
+                org.apache.thrift.protocol.TList _list904 = iprot.readListBegin();
+                struct.events = new java.util.ArrayList<NotificationEvent>(_list904.size);
+                @org.apache.thrift.annotation.Nullable NotificationEvent _elem905;
+                for (int _i906 = 0; _i906 < _list904.size; ++_i906)
                 {
-                  _elem897 = new NotificationEvent();
-                  _elem897.read(iprot);
-                  struct.events.add(_elem897);
+                  _elem905 = new NotificationEvent();
+                  _elem905.read(iprot);
+                  struct.events.add(_elem905);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(EVENTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.events.size()));
-          for (NotificationEvent _iter899 : struct.events)
+          for (NotificationEvent _iter907 : struct.events)
           {
-            _iter899.write(oprot);
+            _iter907.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.events.size());
-        for (NotificationEvent _iter900 : struct.events)
+        for (NotificationEvent _iter908 : struct.events)
         {
-          _iter900.write(oprot);
+          _iter908.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, NotificationEventResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list901 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.events = new java.util.ArrayList<NotificationEvent>(_list901.size);
-        @org.apache.thrift.annotation.Nullable NotificationEvent _elem902;
-        for (int _i903 = 0; _i903 < _list901.size; ++_i903)
+        org.apache.thrift.protocol.TList _list909 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.events = new java.util.ArrayList<NotificationEvent>(_list909.size);
+        @org.apache.thrift.annotation.Nullable NotificationEvent _elem910;
+        for (int _i911 = 0; _i911 < _list909.size; ++_i911)
         {
-          _elem902 = new NotificationEvent();
-          _elem902.read(iprot);
-          struct.events.add(_elem902);
+          _elem910 = new NotificationEvent();
+          _elem910.read(iprot);
+          struct.events.add(_elem910);
         }
       }
       struct.setEventsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ObjectDictionary.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ObjectDictionary.java
@@ -334,25 +334,25 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map288 = iprot.readMapBegin();
-                struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map288.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key289;
-                @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val290;
-                for (int _i291 = 0; _i291 < _map288.size; ++_i291)
+                org.apache.thrift.protocol.TMap _map296 = iprot.readMapBegin();
+                struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map296.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key297;
+                @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val298;
+                for (int _i299 = 0; _i299 < _map296.size; ++_i299)
                 {
-                  _key289 = iprot.readString();
+                  _key297 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list292 = iprot.readListBegin();
-                    _val290 = new java.util.ArrayList<java.nio.ByteBuffer>(_list292.size);
-                    @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem293;
-                    for (int _i294 = 0; _i294 < _list292.size; ++_i294)
+                    org.apache.thrift.protocol.TList _list300 = iprot.readListBegin();
+                    _val298 = new java.util.ArrayList<java.nio.ByteBuffer>(_list300.size);
+                    @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem301;
+                    for (int _i302 = 0; _i302 < _list300.size; ++_i302)
                     {
-                      _elem293 = iprot.readBinary();
-                      _val290.add(_elem293);
+                      _elem301 = iprot.readBinary();
+                      _val298.add(_elem301);
                     }
                     iprot.readListEnd();
                   }
-                  struct.values.put(_key289, _val290);
+                  struct.values.put(_key297, _val298);
                 }
                 iprot.readMapEnd();
               }
@@ -378,14 +378,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.values.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter295 : struct.values.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter303 : struct.values.entrySet())
           {
-            oprot.writeString(_iter295.getKey());
+            oprot.writeString(_iter303.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter295.getValue().size()));
-              for (java.nio.ByteBuffer _iter296 : _iter295.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, _iter303.getValue().size()));
+              for (java.nio.ByteBuffer _iter304 : _iter303.getValue())
               {
-                oprot.writeBinary(_iter296);
+                oprot.writeBinary(_iter304);
               }
               oprot.writeListEnd();
             }
@@ -413,14 +413,14 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.values.size());
-        for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter297 : struct.values.entrySet())
+        for (java.util.Map.Entry<java.lang.String, java.util.List<java.nio.ByteBuffer>> _iter305 : struct.values.entrySet())
         {
-          oprot.writeString(_iter297.getKey());
+          oprot.writeString(_iter305.getKey());
           {
-            oprot.writeI32(_iter297.getValue().size());
-            for (java.nio.ByteBuffer _iter298 : _iter297.getValue())
+            oprot.writeI32(_iter305.getValue().size());
+            for (java.nio.ByteBuffer _iter306 : _iter305.getValue())
             {
-              oprot.writeBinary(_iter298);
+              oprot.writeBinary(_iter306);
             }
           }
         }
@@ -431,24 +431,24 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ObjectDictionary struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map299 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-        struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map299.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _key300;
-        @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val301;
-        for (int _i302 = 0; _i302 < _map299.size; ++_i302)
+        org.apache.thrift.protocol.TMap _map307 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+        struct.values = new java.util.HashMap<java.lang.String,java.util.List<java.nio.ByteBuffer>>(2*_map307.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _key308;
+        @org.apache.thrift.annotation.Nullable java.util.List<java.nio.ByteBuffer> _val309;
+        for (int _i310 = 0; _i310 < _map307.size; ++_i310)
         {
-          _key300 = iprot.readString();
+          _key308 = iprot.readString();
           {
-            org.apache.thrift.protocol.TList _list303 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-            _val301 = new java.util.ArrayList<java.nio.ByteBuffer>(_list303.size);
-            @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem304;
-            for (int _i305 = 0; _i305 < _list303.size; ++_i305)
+            org.apache.thrift.protocol.TList _list311 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+            _val309 = new java.util.ArrayList<java.nio.ByteBuffer>(_list311.size);
+            @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem312;
+            for (int _i313 = 0; _i313 < _list311.size; ++_i313)
             {
-              _elem304 = iprot.readBinary();
-              _val301.add(_elem304);
+              _elem312 = iprot.readBinary();
+              _val309.add(_elem312);
             }
           }
-          struct.values.put(_key300, _val301);
+          struct.values.put(_key308, _val309);
         }
       }
       struct.setValuesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/OpenTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/OpenTxnRequest.java
@@ -876,13 +876,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // REPL_SRC_TXN_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list718 = iprot.readListBegin();
-                struct.replSrcTxnIds = new java.util.ArrayList<java.lang.Long>(_list718.size);
-                long _elem719;
-                for (int _i720 = 0; _i720 < _list718.size; ++_i720)
+                org.apache.thrift.protocol.TList _list726 = iprot.readListBegin();
+                struct.replSrcTxnIds = new java.util.ArrayList<java.lang.Long>(_list726.size);
+                long _elem727;
+                for (int _i728 = 0; _i728 < _list726.size; ++_i728)
                 {
-                  _elem719 = iprot.readI64();
-                  struct.replSrcTxnIds.add(_elem719);
+                  _elem727 = iprot.readI64();
+                  struct.replSrcTxnIds.add(_elem727);
                 }
                 iprot.readListEnd();
               }
@@ -944,9 +944,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REPL_SRC_TXN_IDS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.replSrcTxnIds.size()));
-            for (long _iter721 : struct.replSrcTxnIds)
+            for (long _iter729 : struct.replSrcTxnIds)
             {
-              oprot.writeI64(_iter721);
+              oprot.writeI64(_iter729);
             }
             oprot.writeListEnd();
           }
@@ -1003,9 +1003,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetReplSrcTxnIds()) {
         {
           oprot.writeI32(struct.replSrcTxnIds.size());
-          for (long _iter722 : struct.replSrcTxnIds)
+          for (long _iter730 : struct.replSrcTxnIds)
           {
-            oprot.writeI64(_iter722);
+            oprot.writeI64(_iter730);
           }
         }
       }
@@ -1034,13 +1034,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list723 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-          struct.replSrcTxnIds = new java.util.ArrayList<java.lang.Long>(_list723.size);
-          long _elem724;
-          for (int _i725 = 0; _i725 < _list723.size; ++_i725)
+          org.apache.thrift.protocol.TList _list731 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+          struct.replSrcTxnIds = new java.util.ArrayList<java.lang.Long>(_list731.size);
+          long _elem732;
+          for (int _i733 = 0; _i733 < _list731.size; ++_i733)
           {
-            _elem724 = iprot.readI64();
-            struct.replSrcTxnIds.add(_elem724);
+            _elem732 = iprot.readI64();
+            struct.replSrcTxnIds.add(_elem732);
           }
         }
         struct.setReplSrcTxnIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/OpenTxnsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/OpenTxnsResponse.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TXN_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list726 = iprot.readListBegin();
-                struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list726.size);
-                long _elem727;
-                for (int _i728 = 0; _i728 < _list726.size; ++_i728)
+                org.apache.thrift.protocol.TList _list734 = iprot.readListBegin();
+                struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list734.size);
+                long _elem735;
+                for (int _i736 = 0; _i736 < _list734.size; ++_i736)
                 {
-                  _elem727 = iprot.readI64();
-                  struct.txn_ids.add(_elem727);
+                  _elem735 = iprot.readI64();
+                  struct.txn_ids.add(_elem735);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TXN_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.txn_ids.size()));
-          for (long _iter729 : struct.txn_ids)
+          for (long _iter737 : struct.txn_ids)
           {
-            oprot.writeI64(_iter729);
+            oprot.writeI64(_iter737);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.txn_ids.size());
-        for (long _iter730 : struct.txn_ids)
+        for (long _iter738 : struct.txn_ids)
         {
-          oprot.writeI64(_iter730);
+          oprot.writeI64(_iter738);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, OpenTxnsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list731 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list731.size);
-        long _elem732;
-        for (int _i733 = 0; _i733 < _list731.size; ++_i733)
+        org.apache.thrift.protocol.TList _list739 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.txn_ids = new java.util.ArrayList<java.lang.Long>(_list739.size);
+        long _elem740;
+        for (int _i741 = 0; _i741 < _list739.size; ++_i741)
         {
-          _elem732 = iprot.readI64();
-          struct.txn_ids.add(_elem732);
+          _elem740 = iprot.readI64();
+          struct.txn_ids.add(_elem740);
         }
       }
       struct.setTxn_idsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
@@ -1301,13 +1301,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list340 = iprot.readListBegin();
-                struct.values = new java.util.ArrayList<java.lang.String>(_list340.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem341;
-                for (int _i342 = 0; _i342 < _list340.size; ++_i342)
+                org.apache.thrift.protocol.TList _list348 = iprot.readListBegin();
+                struct.values = new java.util.ArrayList<java.lang.String>(_list348.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem349;
+                for (int _i350 = 0; _i350 < _list348.size; ++_i350)
                 {
-                  _elem341 = iprot.readString();
-                  struct.values.add(_elem341);
+                  _elem349 = iprot.readString();
+                  struct.values.add(_elem349);
                 }
                 iprot.readListEnd();
               }
@@ -1360,15 +1360,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 7: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map343 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map343.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key344;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val345;
-                for (int _i346 = 0; _i346 < _map343.size; ++_i346)
+                org.apache.thrift.protocol.TMap _map351 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map351.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key352;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val353;
+                for (int _i354 = 0; _i354 < _map351.size; ++_i354)
                 {
-                  _key344 = iprot.readString();
-                  _val345 = iprot.readString();
-                  struct.parameters.put(_key344, _val345);
+                  _key352 = iprot.readString();
+                  _val353 = iprot.readString();
+                  struct.parameters.put(_key352, _val353);
                 }
                 iprot.readMapEnd();
               }
@@ -1445,9 +1445,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.values.size()));
-          for (java.lang.String _iter347 : struct.values)
+          for (java.lang.String _iter355 : struct.values)
           {
-            oprot.writeString(_iter347);
+            oprot.writeString(_iter355);
           }
           oprot.writeListEnd();
         }
@@ -1478,10 +1478,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter348 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter356 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter348.getKey());
-            oprot.writeString(_iter348.getValue());
+            oprot.writeString(_iter356.getKey());
+            oprot.writeString(_iter356.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -1586,9 +1586,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
-          for (java.lang.String _iter349 : struct.values)
+          for (java.lang.String _iter357 : struct.values)
           {
-            oprot.writeString(_iter349);
+            oprot.writeString(_iter357);
           }
         }
       }
@@ -1610,10 +1610,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter350 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter358 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter350.getKey());
-            oprot.writeString(_iter350.getValue());
+            oprot.writeString(_iter358.getKey());
+            oprot.writeString(_iter358.getValue());
           }
         }
       }
@@ -1643,13 +1643,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(13);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list351 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.values = new java.util.ArrayList<java.lang.String>(_list351.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem352;
-          for (int _i353 = 0; _i353 < _list351.size; ++_i353)
+          org.apache.thrift.protocol.TList _list359 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.values = new java.util.ArrayList<java.lang.String>(_list359.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem360;
+          for (int _i361 = 0; _i361 < _list359.size; ++_i361)
           {
-            _elem352 = iprot.readString();
-            struct.values.add(_elem352);
+            _elem360 = iprot.readString();
+            struct.values.add(_elem360);
           }
         }
         struct.setValuesIsSet(true);
@@ -1677,15 +1677,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TMap _map354 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map354.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key355;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val356;
-          for (int _i357 = 0; _i357 < _map354.size; ++_i357)
+          org.apache.thrift.protocol.TMap _map362 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map362.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key363;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val364;
+          for (int _i365 = 0; _i365 < _map362.size; ++_i365)
           {
-            _key355 = iprot.readString();
-            _val356 = iprot.readString();
-            struct.parameters.put(_key355, _val356);
+            _key363 = iprot.readString();
+            _val364 = iprot.readString();
+            struct.parameters.put(_key363, _val364);
           }
         }
         struct.parameters = org.apache.hadoop.hive.metastore.utils.StringUtils.intern(struct.parameters); struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionListComposingSpec.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionListComposingSpec.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list384 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list384.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem385;
-                for (int _i386 = 0; _i386 < _list384.size; ++_i386)
+                org.apache.thrift.protocol.TList _list392 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list392.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem393;
+                for (int _i394 = 0; _i394 < _list392.size; ++_i394)
                 {
-                  _elem385 = new Partition();
-                  _elem385.read(iprot);
-                  struct.partitions.add(_elem385);
+                  _elem393 = new Partition();
+                  _elem393.read(iprot);
+                  struct.partitions.add(_elem393);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter387 : struct.partitions)
+          for (Partition _iter395 : struct.partitions)
           {
-            _iter387.write(oprot);
+            _iter395.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (Partition _iter388 : struct.partitions)
+          for (Partition _iter396 : struct.partitions)
           {
-            _iter388.write(oprot);
+            _iter396.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list389 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<Partition>(_list389.size);
-          @org.apache.thrift.annotation.Nullable Partition _elem390;
-          for (int _i391 = 0; _i391 < _list389.size; ++_i391)
+          org.apache.thrift.protocol.TList _list397 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<Partition>(_list397.size);
+          @org.apache.thrift.annotation.Nullable Partition _elem398;
+          for (int _i399 = 0; _i399 < _list397.size; ++_i399)
           {
-            _elem390 = new Partition();
-            _elem390.read(iprot);
-            struct.partitions.add(_elem390);
+            _elem398 = new Partition();
+            _elem398.read(iprot);
+            struct.partitions.add(_elem398);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpecWithSharedSD.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpecWithSharedSD.java
@@ -409,14 +409,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list376 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list376.size);
-                @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem377;
-                for (int _i378 = 0; _i378 < _list376.size; ++_i378)
+                org.apache.thrift.protocol.TList _list384 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list384.size);
+                @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem385;
+                for (int _i386 = 0; _i386 < _list384.size; ++_i386)
                 {
-                  _elem377 = new PartitionWithoutSD();
-                  _elem377.read(iprot);
-                  struct.partitions.add(_elem377);
+                  _elem385 = new PartitionWithoutSD();
+                  _elem385.read(iprot);
+                  struct.partitions.add(_elem385);
                 }
                 iprot.readListEnd();
               }
@@ -451,9 +451,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (PartitionWithoutSD _iter379 : struct.partitions)
+          for (PartitionWithoutSD _iter387 : struct.partitions)
           {
-            _iter379.write(oprot);
+            _iter387.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -492,9 +492,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitions()) {
         {
           oprot.writeI32(struct.partitions.size());
-          for (PartitionWithoutSD _iter380 : struct.partitions)
+          for (PartitionWithoutSD _iter388 : struct.partitions)
           {
-            _iter380.write(oprot);
+            _iter388.write(oprot);
           }
         }
       }
@@ -509,14 +509,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list381 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list381.size);
-          @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem382;
-          for (int _i383 = 0; _i383 < _list381.size; ++_i383)
+          org.apache.thrift.protocol.TList _list389 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitions = new java.util.ArrayList<PartitionWithoutSD>(_list389.size);
+          @org.apache.thrift.annotation.Nullable PartitionWithoutSD _elem390;
+          for (int _i391 = 0; _i391 < _list389.size; ++_i391)
           {
-            _elem382 = new PartitionWithoutSD();
-            _elem382.read(iprot);
-            struct.partitions.add(_elem382);
+            _elem390 = new PartitionWithoutSD();
+            _elem390.read(iprot);
+            struct.partitions.add(_elem390);
           }
         }
         struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRequest.java
@@ -1096,14 +1096,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // PARTITION_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list628 = iprot.readListBegin();
-                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list628.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem629;
-                for (int _i630 = 0; _i630 < _list628.size; ++_i630)
+                org.apache.thrift.protocol.TList _list636 = iprot.readListBegin();
+                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list636.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem637;
+                for (int _i638 = 0; _i638 < _list636.size; ++_i638)
                 {
-                  _elem629 = new FieldSchema();
-                  _elem629.read(iprot);
-                  struct.partitionKeys.add(_elem629);
+                  _elem637 = new FieldSchema();
+                  _elem637.read(iprot);
+                  struct.partitionKeys.add(_elem637);
                 }
                 iprot.readListEnd();
               }
@@ -1131,14 +1131,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // PARTITION_ORDER
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list631 = iprot.readListBegin();
-                struct.partitionOrder = new java.util.ArrayList<FieldSchema>(_list631.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem632;
-                for (int _i633 = 0; _i633 < _list631.size; ++_i633)
+                org.apache.thrift.protocol.TList _list639 = iprot.readListBegin();
+                struct.partitionOrder = new java.util.ArrayList<FieldSchema>(_list639.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem640;
+                for (int _i641 = 0; _i641 < _list639.size; ++_i641)
                 {
-                  _elem632 = new FieldSchema();
-                  _elem632.read(iprot);
-                  struct.partitionOrder.add(_elem632);
+                  _elem640 = new FieldSchema();
+                  _elem640.read(iprot);
+                  struct.partitionOrder.add(_elem640);
                 }
                 iprot.readListEnd();
               }
@@ -1206,9 +1206,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITION_KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionKeys.size()));
-          for (FieldSchema _iter634 : struct.partitionKeys)
+          for (FieldSchema _iter642 : struct.partitionKeys)
           {
-            _iter634.write(oprot);
+            _iter642.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -1231,9 +1231,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITION_ORDER_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionOrder.size()));
-            for (FieldSchema _iter635 : struct.partitionOrder)
+            for (FieldSchema _iter643 : struct.partitionOrder)
             {
-              _iter635.write(oprot);
+              _iter643.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1285,9 +1285,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.partitionKeys.size());
-        for (FieldSchema _iter636 : struct.partitionKeys)
+        for (FieldSchema _iter644 : struct.partitionKeys)
         {
-          _iter636.write(oprot);
+          _iter644.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -1322,9 +1322,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionOrder()) {
         {
           oprot.writeI32(struct.partitionOrder.size());
-          for (FieldSchema _iter637 : struct.partitionOrder)
+          for (FieldSchema _iter645 : struct.partitionOrder)
           {
-            _iter637.write(oprot);
+            _iter645.write(oprot);
           }
         }
       }
@@ -1350,14 +1350,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list638 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list638.size);
-        @org.apache.thrift.annotation.Nullable FieldSchema _elem639;
-        for (int _i640 = 0; _i640 < _list638.size; ++_i640)
+        org.apache.thrift.protocol.TList _list646 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list646.size);
+        @org.apache.thrift.annotation.Nullable FieldSchema _elem647;
+        for (int _i648 = 0; _i648 < _list646.size; ++_i648)
         {
-          _elem639 = new FieldSchema();
-          _elem639.read(iprot);
-          struct.partitionKeys.add(_elem639);
+          _elem647 = new FieldSchema();
+          _elem647.read(iprot);
+          struct.partitionKeys.add(_elem647);
         }
       }
       struct.setPartitionKeysIsSet(true);
@@ -1372,14 +1372,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list641 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitionOrder = new java.util.ArrayList<FieldSchema>(_list641.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem642;
-          for (int _i643 = 0; _i643 < _list641.size; ++_i643)
+          org.apache.thrift.protocol.TList _list649 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitionOrder = new java.util.ArrayList<FieldSchema>(_list649.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem650;
+          for (int _i651 = 0; _i651 < _list649.size; ++_i651)
           {
-            _elem642 = new FieldSchema();
-            _elem642.read(iprot);
-            struct.partitionOrder.add(_elem642);
+            _elem650 = new FieldSchema();
+            _elem650.read(iprot);
+            struct.partitionOrder.add(_elem650);
           }
         }
         struct.setPartitionOrderIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITION_VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list652 = iprot.readListBegin();
-                struct.partitionValues = new java.util.ArrayList<PartitionValuesRow>(_list652.size);
-                @org.apache.thrift.annotation.Nullable PartitionValuesRow _elem653;
-                for (int _i654 = 0; _i654 < _list652.size; ++_i654)
+                org.apache.thrift.protocol.TList _list660 = iprot.readListBegin();
+                struct.partitionValues = new java.util.ArrayList<PartitionValuesRow>(_list660.size);
+                @org.apache.thrift.annotation.Nullable PartitionValuesRow _elem661;
+                for (int _i662 = 0; _i662 < _list660.size; ++_i662)
                 {
-                  _elem653 = new PartitionValuesRow();
-                  _elem653.read(iprot);
-                  struct.partitionValues.add(_elem653);
+                  _elem661 = new PartitionValuesRow();
+                  _elem661.read(iprot);
+                  struct.partitionValues.add(_elem661);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITION_VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionValues.size()));
-          for (PartitionValuesRow _iter655 : struct.partitionValues)
+          for (PartitionValuesRow _iter663 : struct.partitionValues)
           {
-            _iter655.write(oprot);
+            _iter663.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitionValues.size());
-        for (PartitionValuesRow _iter656 : struct.partitionValues)
+        for (PartitionValuesRow _iter664 : struct.partitionValues)
         {
-          _iter656.write(oprot);
+          _iter664.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionValuesResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list657 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitionValues = new java.util.ArrayList<PartitionValuesRow>(_list657.size);
-        @org.apache.thrift.annotation.Nullable PartitionValuesRow _elem658;
-        for (int _i659 = 0; _i659 < _list657.size; ++_i659)
+        org.apache.thrift.protocol.TList _list665 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitionValues = new java.util.ArrayList<PartitionValuesRow>(_list665.size);
+        @org.apache.thrift.annotation.Nullable PartitionValuesRow _elem666;
+        for (int _i667 = 0; _i667 < _list665.size; ++_i667)
         {
-          _elem658 = new PartitionValuesRow();
-          _elem658.read(iprot);
-          struct.partitionValues.add(_elem658);
+          _elem666 = new PartitionValuesRow();
+          _elem666.read(iprot);
+          struct.partitionValues.add(_elem666);
         }
       }
       struct.setPartitionValuesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRow.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRow.java
@@ -326,13 +326,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // ROW
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list644 = iprot.readListBegin();
-                struct.row = new java.util.ArrayList<java.lang.String>(_list644.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem645;
-                for (int _i646 = 0; _i646 < _list644.size; ++_i646)
+                org.apache.thrift.protocol.TList _list652 = iprot.readListBegin();
+                struct.row = new java.util.ArrayList<java.lang.String>(_list652.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem653;
+                for (int _i654 = 0; _i654 < _list652.size; ++_i654)
                 {
-                  _elem645 = iprot.readString();
-                  struct.row.add(_elem645);
+                  _elem653 = iprot.readString();
+                  struct.row.add(_elem653);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(ROW_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.row.size()));
-          for (java.lang.String _iter647 : struct.row)
+          for (java.lang.String _iter655 : struct.row)
           {
-            oprot.writeString(_iter647);
+            oprot.writeString(_iter655);
           }
           oprot.writeListEnd();
         }
@@ -385,9 +385,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.row.size());
-        for (java.lang.String _iter648 : struct.row)
+        for (java.lang.String _iter656 : struct.row)
         {
-          oprot.writeString(_iter648);
+          oprot.writeString(_iter656);
         }
       }
     }
@@ -396,13 +396,13 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionValuesRow struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list649 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.row = new java.util.ArrayList<java.lang.String>(_list649.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem650;
-        for (int _i651 = 0; _i651 < _list649.size; ++_i651)
+        org.apache.thrift.protocol.TList _list657 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.row = new java.util.ArrayList<java.lang.String>(_list657.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem658;
+        for (int _i659 = 0; _i659 < _list657.size; ++_i659)
         {
-          _elem650 = iprot.readString();
-          struct.row.add(_elem650);
+          _elem658 = iprot.readString();
+          struct.row.add(_elem658);
         }
       }
       struct.setRowIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
@@ -735,13 +735,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // VALUES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list358 = iprot.readListBegin();
-                struct.values = new java.util.ArrayList<java.lang.String>(_list358.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem359;
-                for (int _i360 = 0; _i360 < _list358.size; ++_i360)
+                org.apache.thrift.protocol.TList _list366 = iprot.readListBegin();
+                struct.values = new java.util.ArrayList<java.lang.String>(_list366.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem367;
+                for (int _i368 = 0; _i368 < _list366.size; ++_i368)
                 {
-                  _elem359 = iprot.readString();
-                  struct.values.add(_elem359);
+                  _elem367 = iprot.readString();
+                  struct.values.add(_elem367);
                 }
                 iprot.readListEnd();
               }
@@ -777,15 +777,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map361 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map361.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key362;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val363;
-                for (int _i364 = 0; _i364 < _map361.size; ++_i364)
+                org.apache.thrift.protocol.TMap _map369 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map369.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key370;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val371;
+                for (int _i372 = 0; _i372 < _map369.size; ++_i372)
                 {
-                  _key362 = iprot.readString();
-                  _val363 = iprot.readString();
-                  struct.parameters.put(_key362, _val363);
+                  _key370 = iprot.readString();
+                  _val371 = iprot.readString();
+                  struct.parameters.put(_key370, _val371);
                 }
                 iprot.readMapEnd();
               }
@@ -820,9 +820,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(VALUES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.values.size()));
-          for (java.lang.String _iter365 : struct.values)
+          for (java.lang.String _iter373 : struct.values)
           {
-            oprot.writeString(_iter365);
+            oprot.writeString(_iter373);
           }
           oprot.writeListEnd();
         }
@@ -843,10 +843,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter366 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter374 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter366.getKey());
-            oprot.writeString(_iter366.getValue());
+            oprot.writeString(_iter374.getKey());
+            oprot.writeString(_iter374.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -899,9 +899,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
-          for (java.lang.String _iter367 : struct.values)
+          for (java.lang.String _iter375 : struct.values)
           {
-            oprot.writeString(_iter367);
+            oprot.writeString(_iter375);
           }
         }
       }
@@ -917,10 +917,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter368 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter376 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter368.getKey());
-            oprot.writeString(_iter368.getValue());
+            oprot.writeString(_iter376.getKey());
+            oprot.writeString(_iter376.getValue());
           }
         }
       }
@@ -935,13 +935,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list369 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.values = new java.util.ArrayList<java.lang.String>(_list369.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem370;
-          for (int _i371 = 0; _i371 < _list369.size; ++_i371)
+          org.apache.thrift.protocol.TList _list377 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.values = new java.util.ArrayList<java.lang.String>(_list377.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem378;
+          for (int _i379 = 0; _i379 < _list377.size; ++_i379)
           {
-            _elem370 = iprot.readString();
-            struct.values.add(_elem370);
+            _elem378 = iprot.readString();
+            struct.values.add(_elem378);
           }
         }
         struct.setValuesIsSet(true);
@@ -960,15 +960,15 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TMap _map372 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map372.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key373;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val374;
-          for (int _i375 = 0; _i375 < _map372.size; ++_i375)
+          org.apache.thrift.protocol.TMap _map380 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map380.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key381;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val382;
+          for (int _i383 = 0; _i383 < _map380.size; ++_i383)
           {
-            _key373 = iprot.readString();
-            _val374 = iprot.readString();
-            struct.parameters.put(_key373, _val374);
+            _key381 = iprot.readString();
+            _val382 = iprot.readString();
+            struct.parameters.put(_key381, _val382);
           }
         }
         struct.setParametersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsByExprResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsByExprResult.java
@@ -411,14 +411,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list522 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list522.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem523;
-                for (int _i524 = 0; _i524 < _list522.size; ++_i524)
+                org.apache.thrift.protocol.TList _list530 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list530.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem531;
+                for (int _i532 = 0; _i532 < _list530.size; ++_i532)
                 {
-                  _elem523 = new Partition();
-                  _elem523.read(iprot);
-                  struct.partitions.add(_elem523);
+                  _elem531 = new Partition();
+                  _elem531.read(iprot);
+                  struct.partitions.add(_elem531);
                 }
                 iprot.readListEnd();
               }
@@ -452,9 +452,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter525 : struct.partitions)
+          for (Partition _iter533 : struct.partitions)
           {
-            _iter525.write(oprot);
+            _iter533.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -482,9 +482,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitions.size());
-        for (Partition _iter526 : struct.partitions)
+        for (Partition _iter534 : struct.partitions)
         {
-          _iter526.write(oprot);
+          _iter534.write(oprot);
         }
       }
       oprot.writeBool(struct.hasUnknownPartitions);
@@ -494,14 +494,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionsByExprResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list527 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitions = new java.util.ArrayList<Partition>(_list527.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem528;
-        for (int _i529 = 0; _i529 < _list527.size; ++_i529)
+        org.apache.thrift.protocol.TList _list535 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitions = new java.util.ArrayList<Partition>(_list535.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem536;
+        for (int _i537 = 0; _i537 < _list535.size; ++_i537)
         {
-          _elem528 = new Partition();
-          _elem528.read(iprot);
-          struct.partitions.add(_elem528);
+          _elem536 = new Partition();
+          _elem536.read(iprot);
+          struct.partitions.add(_elem536);
         }
       }
       struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1350 = iprot.readListBegin();
-                struct.partitions = new java.util.ArrayList<Partition>(_list1350.size);
-                @org.apache.thrift.annotation.Nullable Partition _elem1351;
-                for (int _i1352 = 0; _i1352 < _list1350.size; ++_i1352)
+                org.apache.thrift.protocol.TList _list1358 = iprot.readListBegin();
+                struct.partitions = new java.util.ArrayList<Partition>(_list1358.size);
+                @org.apache.thrift.annotation.Nullable Partition _elem1359;
+                for (int _i1360 = 0; _i1360 < _list1358.size; ++_i1360)
                 {
-                  _elem1351 = new Partition();
-                  _elem1351.read(iprot);
-                  struct.partitions.add(_elem1351);
+                  _elem1359 = new Partition();
+                  _elem1359.read(iprot);
+                  struct.partitions.add(_elem1359);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitions.size()));
-          for (Partition _iter1353 : struct.partitions)
+          for (Partition _iter1361 : struct.partitions)
           {
-            _iter1353.write(oprot);
+            _iter1361.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitions.size());
-        for (Partition _iter1354 : struct.partitions)
+        for (Partition _iter1362 : struct.partitions)
         {
-          _iter1354.write(oprot);
+          _iter1362.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1355 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitions = new java.util.ArrayList<Partition>(_list1355.size);
-        @org.apache.thrift.annotation.Nullable Partition _elem1356;
-        for (int _i1357 = 0; _i1357 < _list1355.size; ++_i1357)
+        org.apache.thrift.protocol.TList _list1363 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitions = new java.util.ArrayList<Partition>(_list1363.size);
+        @org.apache.thrift.annotation.Nullable Partition _elem1364;
+        for (int _i1365 = 0; _i1365 < _list1363.size; ++_i1365)
         {
-          _elem1356 = new Partition();
-          _elem1356.read(iprot);
-          struct.partitions.add(_elem1356);
+          _elem1364 = new Partition();
+          _elem1364.read(iprot);
+          struct.partitions.add(_elem1364);
         }
       }
       struct.setPartitionsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsSpecByExprResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsSpecByExprResult.java
@@ -411,14 +411,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PARTITIONS_SPEC
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list530 = iprot.readListBegin();
-                struct.partitionsSpec = new java.util.ArrayList<PartitionSpec>(_list530.size);
-                @org.apache.thrift.annotation.Nullable PartitionSpec _elem531;
-                for (int _i532 = 0; _i532 < _list530.size; ++_i532)
+                org.apache.thrift.protocol.TList _list538 = iprot.readListBegin();
+                struct.partitionsSpec = new java.util.ArrayList<PartitionSpec>(_list538.size);
+                @org.apache.thrift.annotation.Nullable PartitionSpec _elem539;
+                for (int _i540 = 0; _i540 < _list538.size; ++_i540)
                 {
-                  _elem531 = new PartitionSpec();
-                  _elem531.read(iprot);
-                  struct.partitionsSpec.add(_elem531);
+                  _elem539 = new PartitionSpec();
+                  _elem539.read(iprot);
+                  struct.partitionsSpec.add(_elem539);
                 }
                 iprot.readListEnd();
               }
@@ -452,9 +452,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITIONS_SPEC_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionsSpec.size()));
-          for (PartitionSpec _iter533 : struct.partitionsSpec)
+          for (PartitionSpec _iter541 : struct.partitionsSpec)
           {
-            _iter533.write(oprot);
+            _iter541.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -482,9 +482,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partitionsSpec.size());
-        for (PartitionSpec _iter534 : struct.partitionsSpec)
+        for (PartitionSpec _iter542 : struct.partitionsSpec)
         {
-          _iter534.write(oprot);
+          _iter542.write(oprot);
         }
       }
       oprot.writeBool(struct.hasUnknownPartitions);
@@ -494,14 +494,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionsSpecByExprResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list535 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.partitionsSpec = new java.util.ArrayList<PartitionSpec>(_list535.size);
-        @org.apache.thrift.annotation.Nullable PartitionSpec _elem536;
-        for (int _i537 = 0; _i537 < _list535.size; ++_i537)
+        org.apache.thrift.protocol.TList _list543 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.partitionsSpec = new java.util.ArrayList<PartitionSpec>(_list543.size);
+        @org.apache.thrift.annotation.Nullable PartitionSpec _elem544;
+        for (int _i545 = 0; _i545 < _list543.size; ++_i545)
         {
-          _elem536 = new PartitionSpec();
-          _elem536.read(iprot);
-          struct.partitionsSpec.add(_elem536);
+          _elem544 = new PartitionSpec();
+          _elem544.read(iprot);
+          struct.partitionsSpec.add(_elem544);
         }
       }
       struct.setPartitionsSpecIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsRequest.java
@@ -863,13 +863,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // COL_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list572 = iprot.readListBegin();
-                struct.colNames = new java.util.ArrayList<java.lang.String>(_list572.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem573;
-                for (int _i574 = 0; _i574 < _list572.size; ++_i574)
+                org.apache.thrift.protocol.TList _list580 = iprot.readListBegin();
+                struct.colNames = new java.util.ArrayList<java.lang.String>(_list580.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem581;
+                for (int _i582 = 0; _i582 < _list580.size; ++_i582)
                 {
-                  _elem573 = iprot.readString();
-                  struct.colNames.add(_elem573);
+                  _elem581 = iprot.readString();
+                  struct.colNames.add(_elem581);
                 }
                 iprot.readListEnd();
               }
@@ -881,13 +881,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list575 = iprot.readListBegin();
-                struct.partNames = new java.util.ArrayList<java.lang.String>(_list575.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem576;
-                for (int _i577 = 0; _i577 < _list575.size; ++_i577)
+                org.apache.thrift.protocol.TList _list583 = iprot.readListBegin();
+                struct.partNames = new java.util.ArrayList<java.lang.String>(_list583.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem584;
+                for (int _i585 = 0; _i585 < _list583.size; ++_i585)
                 {
-                  _elem576 = iprot.readString();
-                  struct.partNames.add(_elem576);
+                  _elem584 = iprot.readString();
+                  struct.partNames.add(_elem584);
                 }
                 iprot.readListEnd();
               }
@@ -947,9 +947,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.colNames.size()));
-          for (java.lang.String _iter578 : struct.colNames)
+          for (java.lang.String _iter586 : struct.colNames)
           {
-            oprot.writeString(_iter578);
+            oprot.writeString(_iter586);
           }
           oprot.writeListEnd();
         }
@@ -959,9 +959,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PART_NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partNames.size()));
-          for (java.lang.String _iter579 : struct.partNames)
+          for (java.lang.String _iter587 : struct.partNames)
           {
-            oprot.writeString(_iter579);
+            oprot.writeString(_iter587);
           }
           oprot.writeListEnd();
         }
@@ -1007,16 +1007,16 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.colNames.size());
-        for (java.lang.String _iter580 : struct.colNames)
+        for (java.lang.String _iter588 : struct.colNames)
         {
-          oprot.writeString(_iter580);
+          oprot.writeString(_iter588);
         }
       }
       {
         oprot.writeI32(struct.partNames.size());
-        for (java.lang.String _iter581 : struct.partNames)
+        for (java.lang.String _iter589 : struct.partNames)
         {
-          oprot.writeString(_iter581);
+          oprot.writeString(_iter589);
         }
       }
       oprot.writeString(struct.engine);
@@ -1044,24 +1044,24 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list582 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.colNames = new java.util.ArrayList<java.lang.String>(_list582.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem583;
-        for (int _i584 = 0; _i584 < _list582.size; ++_i584)
+        org.apache.thrift.protocol.TList _list590 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.colNames = new java.util.ArrayList<java.lang.String>(_list590.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem591;
+        for (int _i592 = 0; _i592 < _list590.size; ++_i592)
         {
-          _elem583 = iprot.readString();
-          struct.colNames.add(_elem583);
+          _elem591 = iprot.readString();
+          struct.colNames.add(_elem591);
         }
       }
       struct.setColNamesIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list585 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.partNames = new java.util.ArrayList<java.lang.String>(_list585.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem586;
-        for (int _i587 = 0; _i587 < _list585.size; ++_i587)
+        org.apache.thrift.protocol.TList _list593 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.partNames = new java.util.ArrayList<java.lang.String>(_list593.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem594;
+        for (int _i595 = 0; _i595 < _list593.size; ++_i595)
         {
-          _elem586 = iprot.readString();
-          struct.partNames.add(_elem586);
+          _elem594 = iprot.readString();
+          struct.partNames.add(_elem594);
         }
       }
       struct.setPartNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsResult.java
@@ -417,26 +417,26 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PART_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map546 = iprot.readMapBegin();
-                struct.partStats = new java.util.HashMap<java.lang.String,java.util.List<ColumnStatisticsObj>>(2*_map546.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key547;
-                @org.apache.thrift.annotation.Nullable java.util.List<ColumnStatisticsObj> _val548;
-                for (int _i549 = 0; _i549 < _map546.size; ++_i549)
+                org.apache.thrift.protocol.TMap _map554 = iprot.readMapBegin();
+                struct.partStats = new java.util.HashMap<java.lang.String,java.util.List<ColumnStatisticsObj>>(2*_map554.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key555;
+                @org.apache.thrift.annotation.Nullable java.util.List<ColumnStatisticsObj> _val556;
+                for (int _i557 = 0; _i557 < _map554.size; ++_i557)
                 {
-                  _key547 = iprot.readString();
+                  _key555 = iprot.readString();
                   {
-                    org.apache.thrift.protocol.TList _list550 = iprot.readListBegin();
-                    _val548 = new java.util.ArrayList<ColumnStatisticsObj>(_list550.size);
-                    @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem551;
-                    for (int _i552 = 0; _i552 < _list550.size; ++_i552)
+                    org.apache.thrift.protocol.TList _list558 = iprot.readListBegin();
+                    _val556 = new java.util.ArrayList<ColumnStatisticsObj>(_list558.size);
+                    @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem559;
+                    for (int _i560 = 0; _i560 < _list558.size; ++_i560)
                     {
-                      _elem551 = new ColumnStatisticsObj();
-                      _elem551.read(iprot);
-                      _val548.add(_elem551);
+                      _elem559 = new ColumnStatisticsObj();
+                      _elem559.read(iprot);
+                      _val556.add(_elem559);
                     }
                     iprot.readListEnd();
                   }
-                  struct.partStats.put(_key547, _val548);
+                  struct.partStats.put(_key555, _val556);
                 }
                 iprot.readMapEnd();
               }
@@ -470,14 +470,14 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PART_STATS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST, struct.partStats.size()));
-          for (java.util.Map.Entry<java.lang.String, java.util.List<ColumnStatisticsObj>> _iter553 : struct.partStats.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.util.List<ColumnStatisticsObj>> _iter561 : struct.partStats.entrySet())
           {
-            oprot.writeString(_iter553.getKey());
+            oprot.writeString(_iter561.getKey());
             {
-              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter553.getValue().size()));
-              for (ColumnStatisticsObj _iter554 : _iter553.getValue())
+              oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, _iter561.getValue().size()));
+              for (ColumnStatisticsObj _iter562 : _iter561.getValue())
               {
-                _iter554.write(oprot);
+                _iter562.write(oprot);
               }
               oprot.writeListEnd();
             }
@@ -510,14 +510,14 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.partStats.size());
-        for (java.util.Map.Entry<java.lang.String, java.util.List<ColumnStatisticsObj>> _iter555 : struct.partStats.entrySet())
+        for (java.util.Map.Entry<java.lang.String, java.util.List<ColumnStatisticsObj>> _iter563 : struct.partStats.entrySet())
         {
-          oprot.writeString(_iter555.getKey());
+          oprot.writeString(_iter563.getKey());
           {
-            oprot.writeI32(_iter555.getValue().size());
-            for (ColumnStatisticsObj _iter556 : _iter555.getValue())
+            oprot.writeI32(_iter563.getValue().size());
+            for (ColumnStatisticsObj _iter564 : _iter563.getValue())
             {
-              _iter556.write(oprot);
+              _iter564.write(oprot);
             }
           }
         }
@@ -536,25 +536,25 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionsStatsResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map557 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
-        struct.partStats = new java.util.HashMap<java.lang.String,java.util.List<ColumnStatisticsObj>>(2*_map557.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _key558;
-        @org.apache.thrift.annotation.Nullable java.util.List<ColumnStatisticsObj> _val559;
-        for (int _i560 = 0; _i560 < _map557.size; ++_i560)
+        org.apache.thrift.protocol.TMap _map565 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.LIST); 
+        struct.partStats = new java.util.HashMap<java.lang.String,java.util.List<ColumnStatisticsObj>>(2*_map565.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _key566;
+        @org.apache.thrift.annotation.Nullable java.util.List<ColumnStatisticsObj> _val567;
+        for (int _i568 = 0; _i568 < _map565.size; ++_i568)
         {
-          _key558 = iprot.readString();
+          _key566 = iprot.readString();
           {
-            org.apache.thrift.protocol.TList _list561 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-            _val559 = new java.util.ArrayList<ColumnStatisticsObj>(_list561.size);
-            @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem562;
-            for (int _i563 = 0; _i563 < _list561.size; ++_i563)
+            org.apache.thrift.protocol.TList _list569 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+            _val567 = new java.util.ArrayList<ColumnStatisticsObj>(_list569.size);
+            @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem570;
+            for (int _i571 = 0; _i571 < _list569.size; ++_i571)
             {
-              _elem562 = new ColumnStatisticsObj();
-              _elem562.read(iprot);
-              _val559.add(_elem562);
+              _elem570 = new ColumnStatisticsObj();
+              _elem570.read(iprot);
+              _val567.add(_elem570);
             }
           }
-          struct.partStats.put(_key558, _val559);
+          struct.partStats.put(_key566, _val567);
         }
       }
       struct.setPartStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrimaryKeysResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PrimaryKeysResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // PRIMARY_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list426 = iprot.readListBegin();
-                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list426.size);
-                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem427;
-                for (int _i428 = 0; _i428 < _list426.size; ++_i428)
+                org.apache.thrift.protocol.TList _list434 = iprot.readListBegin();
+                struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list434.size);
+                @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem435;
+                for (int _i436 = 0; _i436 < _list434.size; ++_i436)
                 {
-                  _elem427 = new SQLPrimaryKey();
-                  _elem427.read(iprot);
-                  struct.primaryKeys.add(_elem427);
+                  _elem435 = new SQLPrimaryKey();
+                  _elem435.read(iprot);
+                  struct.primaryKeys.add(_elem435);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PRIMARY_KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.primaryKeys.size()));
-          for (SQLPrimaryKey _iter429 : struct.primaryKeys)
+          for (SQLPrimaryKey _iter437 : struct.primaryKeys)
           {
-            _iter429.write(oprot);
+            _iter437.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.primaryKeys.size());
-        for (SQLPrimaryKey _iter430 : struct.primaryKeys)
+        for (SQLPrimaryKey _iter438 : struct.primaryKeys)
         {
-          _iter430.write(oprot);
+          _iter438.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PrimaryKeysResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list431 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list431.size);
-        @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem432;
-        for (int _i433 = 0; _i433 < _list431.size; ++_i433)
+        org.apache.thrift.protocol.TList _list439 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.primaryKeys = new java.util.ArrayList<SQLPrimaryKey>(_list439.size);
+        @org.apache.thrift.annotation.Nullable SQLPrimaryKey _elem440;
+        for (int _i441 = 0; _i441 < _list439.size; ++_i441)
         {
-          _elem432 = new SQLPrimaryKey();
-          _elem432.read(iprot);
-          struct.primaryKeys.add(_elem432);
+          _elem440 = new SQLPrimaryKey();
+          _elem440.read(iprot);
+          struct.primaryKeys.add(_elem440);
         }
       }
       struct.setPrimaryKeysIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PutFileMetadataRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PutFileMetadataRequest.java
@@ -523,13 +523,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FILE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1012 = iprot.readListBegin();
-                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1012.size);
-                long _elem1013;
-                for (int _i1014 = 0; _i1014 < _list1012.size; ++_i1014)
+                org.apache.thrift.protocol.TList _list1020 = iprot.readListBegin();
+                struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1020.size);
+                long _elem1021;
+                for (int _i1022 = 0; _i1022 < _list1020.size; ++_i1022)
                 {
-                  _elem1013 = iprot.readI64();
-                  struct.fileIds.add(_elem1013);
+                  _elem1021 = iprot.readI64();
+                  struct.fileIds.add(_elem1021);
                 }
                 iprot.readListEnd();
               }
@@ -541,13 +541,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // METADATA
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1015 = iprot.readListBegin();
-                struct.metadata = new java.util.ArrayList<java.nio.ByteBuffer>(_list1015.size);
-                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem1016;
-                for (int _i1017 = 0; _i1017 < _list1015.size; ++_i1017)
+                org.apache.thrift.protocol.TList _list1023 = iprot.readListBegin();
+                struct.metadata = new java.util.ArrayList<java.nio.ByteBuffer>(_list1023.size);
+                @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem1024;
+                for (int _i1025 = 0; _i1025 < _list1023.size; ++_i1025)
                 {
-                  _elem1016 = iprot.readBinary();
-                  struct.metadata.add(_elem1016);
+                  _elem1024 = iprot.readBinary();
+                  struct.metadata.add(_elem1024);
                 }
                 iprot.readListEnd();
               }
@@ -581,9 +581,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FILE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.fileIds.size()));
-          for (long _iter1018 : struct.fileIds)
+          for (long _iter1026 : struct.fileIds)
           {
-            oprot.writeI64(_iter1018);
+            oprot.writeI64(_iter1026);
           }
           oprot.writeListEnd();
         }
@@ -593,9 +593,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(METADATA_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.metadata.size()));
-          for (java.nio.ByteBuffer _iter1019 : struct.metadata)
+          for (java.nio.ByteBuffer _iter1027 : struct.metadata)
           {
-            oprot.writeBinary(_iter1019);
+            oprot.writeBinary(_iter1027);
           }
           oprot.writeListEnd();
         }
@@ -627,16 +627,16 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.fileIds.size());
-        for (long _iter1020 : struct.fileIds)
+        for (long _iter1028 : struct.fileIds)
         {
-          oprot.writeI64(_iter1020);
+          oprot.writeI64(_iter1028);
         }
       }
       {
         oprot.writeI32(struct.metadata.size());
-        for (java.nio.ByteBuffer _iter1021 : struct.metadata)
+        for (java.nio.ByteBuffer _iter1029 : struct.metadata)
         {
-          oprot.writeBinary(_iter1021);
+          oprot.writeBinary(_iter1029);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -653,24 +653,24 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, PutFileMetadataRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1022 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1022.size);
-        long _elem1023;
-        for (int _i1024 = 0; _i1024 < _list1022.size; ++_i1024)
+        org.apache.thrift.protocol.TList _list1030 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.fileIds = new java.util.ArrayList<java.lang.Long>(_list1030.size);
+        long _elem1031;
+        for (int _i1032 = 0; _i1032 < _list1030.size; ++_i1032)
         {
-          _elem1023 = iprot.readI64();
-          struct.fileIds.add(_elem1023);
+          _elem1031 = iprot.readI64();
+          struct.fileIds.add(_elem1031);
         }
       }
       struct.setFileIdsIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list1025 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.metadata = new java.util.ArrayList<java.nio.ByteBuffer>(_list1025.size);
-        @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem1026;
-        for (int _i1027 = 0; _i1027 < _list1025.size; ++_i1027)
+        org.apache.thrift.protocol.TList _list1033 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.metadata = new java.util.ArrayList<java.nio.ByteBuffer>(_list1033.size);
+        @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer _elem1034;
+        for (int _i1035 = 0; _i1035 < _list1033.size; ++_i1035)
         {
-          _elem1026 = iprot.readBinary();
-          struct.metadata.add(_elem1026);
+          _elem1034 = iprot.readBinary();
+          struct.metadata.add(_elem1034);
         }
       }
       struct.setMetadataIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/RenamePartitionRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/RenamePartitionRequest.java
@@ -771,13 +771,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // PART_VALS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1278 = iprot.readListBegin();
-                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1278.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1279;
-                for (int _i1280 = 0; _i1280 < _list1278.size; ++_i1280)
+                org.apache.thrift.protocol.TList _list1286 = iprot.readListBegin();
+                struct.partVals = new java.util.ArrayList<java.lang.String>(_list1286.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1287;
+                for (int _i1288 = 0; _i1288 < _list1286.size; ++_i1288)
                 {
-                  _elem1279 = iprot.readString();
-                  struct.partVals.add(_elem1279);
+                  _elem1287 = iprot.readString();
+                  struct.partVals.add(_elem1287);
                 }
                 iprot.readListEnd();
               }
@@ -837,9 +837,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PART_VALS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partVals.size()));
-          for (java.lang.String _iter1281 : struct.partVals)
+          for (java.lang.String _iter1289 : struct.partVals)
           {
-            oprot.writeString(_iter1281);
+            oprot.writeString(_iter1289);
           }
           oprot.writeListEnd();
         }
@@ -878,9 +878,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tableName);
       {
         oprot.writeI32(struct.partVals.size());
-        for (java.lang.String _iter1282 : struct.partVals)
+        for (java.lang.String _iter1290 : struct.partVals)
         {
-          oprot.writeString(_iter1282);
+          oprot.writeString(_iter1290);
         }
       }
       struct.newPart.write(oprot);
@@ -908,13 +908,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tableName = iprot.readString();
       struct.setTableNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list1283 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.partVals = new java.util.ArrayList<java.lang.String>(_list1283.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem1284;
-        for (int _i1285 = 0; _i1285 < _list1283.size; ++_i1285)
+        org.apache.thrift.protocol.TList _list1291 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.partVals = new java.util.ArrayList<java.lang.String>(_list1291.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem1292;
+        for (int _i1293 = 0; _i1293 < _list1291.size; ++_i1293)
         {
-          _elem1284 = iprot.readString();
-          struct.partVals.add(_elem1284);
+          _elem1292 = iprot.readString();
+          struct.partVals.add(_elem1292);
         }
       }
       struct.setPartValsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplLastIdInfo.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplLastIdInfo.java
@@ -684,13 +684,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // PARTITION_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list742 = iprot.readListBegin();
-                struct.partitionList = new java.util.ArrayList<java.lang.String>(_list742.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem743;
-                for (int _i744 = 0; _i744 < _list742.size; ++_i744)
+                org.apache.thrift.protocol.TList _list750 = iprot.readListBegin();
+                struct.partitionList = new java.util.ArrayList<java.lang.String>(_list750.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem751;
+                for (int _i752 = 0; _i752 < _list750.size; ++_i752)
                 {
-                  _elem743 = iprot.readString();
-                  struct.partitionList.add(_elem743);
+                  _elem751 = iprot.readString();
+                  struct.partitionList.add(_elem751);
                 }
                 iprot.readListEnd();
               }
@@ -739,9 +739,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITION_LIST_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionList.size()));
-            for (java.lang.String _iter745 : struct.partitionList)
+            for (java.lang.String _iter753 : struct.partitionList)
             {
-              oprot.writeString(_iter745);
+              oprot.writeString(_iter753);
             }
             oprot.writeListEnd();
           }
@@ -787,9 +787,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionList()) {
         {
           oprot.writeI32(struct.partitionList.size());
-          for (java.lang.String _iter746 : struct.partitionList)
+          for (java.lang.String _iter754 : struct.partitionList)
           {
-            oprot.writeString(_iter746);
+            oprot.writeString(_iter754);
           }
         }
       }
@@ -813,13 +813,13 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list747 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partitionList = new java.util.ArrayList<java.lang.String>(_list747.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem748;
-          for (int _i749 = 0; _i749 < _list747.size; ++_i749)
+          org.apache.thrift.protocol.TList _list755 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partitionList = new java.util.ArrayList<java.lang.String>(_list755.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem756;
+          for (int _i757 = 0; _i757 < _list755.size; ++_i757)
           {
-            _elem748 = iprot.readString();
-            struct.partitionList.add(_elem748);
+            _elem756 = iprot.readString();
+            struct.partitionList.add(_elem756);
           }
         }
         struct.setPartitionListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplTblWriteIdStateRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplTblWriteIdStateRequest.java
@@ -788,13 +788,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // PART_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list758 = iprot.readListBegin();
-                struct.partNames = new java.util.ArrayList<java.lang.String>(_list758.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem759;
-                for (int _i760 = 0; _i760 < _list758.size; ++_i760)
+                org.apache.thrift.protocol.TList _list766 = iprot.readListBegin();
+                struct.partNames = new java.util.ArrayList<java.lang.String>(_list766.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem767;
+                for (int _i768 = 0; _i768 < _list766.size; ++_i768)
                 {
-                  _elem759 = iprot.readString();
-                  struct.partNames.add(_elem759);
+                  _elem767 = iprot.readString();
+                  struct.partNames.add(_elem767);
                 }
                 iprot.readListEnd();
               }
@@ -846,9 +846,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PART_NAMES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partNames.size()));
-            for (java.lang.String _iter761 : struct.partNames)
+            for (java.lang.String _iter769 : struct.partNames)
             {
-              oprot.writeString(_iter761);
+              oprot.writeString(_iter769);
             }
             oprot.writeListEnd();
           }
@@ -885,9 +885,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartNames()) {
         {
           oprot.writeI32(struct.partNames.size());
-          for (java.lang.String _iter762 : struct.partNames)
+          for (java.lang.String _iter770 : struct.partNames)
           {
-            oprot.writeString(_iter762);
+            oprot.writeString(_iter770);
           }
         }
       }
@@ -909,13 +909,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list763 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partNames = new java.util.ArrayList<java.lang.String>(_list763.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem764;
-          for (int _i765 = 0; _i765 < _list763.size; ++_i765)
+          org.apache.thrift.protocol.TList _list771 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partNames = new java.util.ArrayList<java.lang.String>(_list771.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem772;
+          for (int _i773 = 0; _i773 < _list771.size; ++_i773)
           {
-            _elem764 = iprot.readString();
-            struct.partNames.add(_elem764);
+            _elem772 = iprot.readString();
+            struct.partNames.add(_elem772);
           }
         }
         struct.setPartNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplicationMetricList.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ReplicationMetricList.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // REPLICATION_METRIC_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1398 = iprot.readListBegin();
-                struct.replicationMetricList = new java.util.ArrayList<ReplicationMetrics>(_list1398.size);
-                @org.apache.thrift.annotation.Nullable ReplicationMetrics _elem1399;
-                for (int _i1400 = 0; _i1400 < _list1398.size; ++_i1400)
+                org.apache.thrift.protocol.TList _list1406 = iprot.readListBegin();
+                struct.replicationMetricList = new java.util.ArrayList<ReplicationMetrics>(_list1406.size);
+                @org.apache.thrift.annotation.Nullable ReplicationMetrics _elem1407;
+                for (int _i1408 = 0; _i1408 < _list1406.size; ++_i1408)
                 {
-                  _elem1399 = new ReplicationMetrics();
-                  _elem1399.read(iprot);
-                  struct.replicationMetricList.add(_elem1399);
+                  _elem1407 = new ReplicationMetrics();
+                  _elem1407.read(iprot);
+                  struct.replicationMetricList.add(_elem1407);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(REPLICATION_METRIC_LIST_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.replicationMetricList.size()));
-          for (ReplicationMetrics _iter1401 : struct.replicationMetricList)
+          for (ReplicationMetrics _iter1409 : struct.replicationMetricList)
           {
-            _iter1401.write(oprot);
+            _iter1409.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.replicationMetricList.size());
-        for (ReplicationMetrics _iter1402 : struct.replicationMetricList)
+        for (ReplicationMetrics _iter1410 : struct.replicationMetricList)
         {
-          _iter1402.write(oprot);
+          _iter1410.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ReplicationMetricList struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list1403 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.replicationMetricList = new java.util.ArrayList<ReplicationMetrics>(_list1403.size);
-        @org.apache.thrift.annotation.Nullable ReplicationMetrics _elem1404;
-        for (int _i1405 = 0; _i1405 < _list1403.size; ++_i1405)
+        org.apache.thrift.protocol.TList _list1411 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.replicationMetricList = new java.util.ArrayList<ReplicationMetrics>(_list1411.size);
+        @org.apache.thrift.annotation.Nullable ReplicationMetrics _elem1412;
+        for (int _i1413 = 0; _i1413 < _list1411.size; ++_i1413)
         {
-          _elem1404 = new ReplicationMetrics();
-          _elem1404.read(iprot);
-          struct.replicationMetricList.add(_elem1404);
+          _elem1412 = new ReplicationMetrics();
+          _elem1412.read(iprot);
+          struct.replicationMetricList.add(_elem1412);
         }
       }
       struct.setReplicationMetricListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/RequestPartsSpec.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/RequestPartsSpec.java
@@ -144,13 +144,13 @@ package org.apache.hadoop.hive.metastore.api;
           if (field.type == NAMES_FIELD_DESC.type) {
             java.util.List<java.lang.String> names;
             {
-              org.apache.thrift.protocol.TList _list612 = iprot.readListBegin();
-              names = new java.util.ArrayList<java.lang.String>(_list612.size);
-              @org.apache.thrift.annotation.Nullable java.lang.String _elem613;
-              for (int _i614 = 0; _i614 < _list612.size; ++_i614)
+              org.apache.thrift.protocol.TList _list620 = iprot.readListBegin();
+              names = new java.util.ArrayList<java.lang.String>(_list620.size);
+              @org.apache.thrift.annotation.Nullable java.lang.String _elem621;
+              for (int _i622 = 0; _i622 < _list620.size; ++_i622)
               {
-                _elem613 = iprot.readString();
-                names.add(_elem613);
+                _elem621 = iprot.readString();
+                names.add(_elem621);
               }
               iprot.readListEnd();
             }
@@ -163,14 +163,14 @@ package org.apache.hadoop.hive.metastore.api;
           if (field.type == EXPRS_FIELD_DESC.type) {
             java.util.List<DropPartitionsExpr> exprs;
             {
-              org.apache.thrift.protocol.TList _list615 = iprot.readListBegin();
-              exprs = new java.util.ArrayList<DropPartitionsExpr>(_list615.size);
-              @org.apache.thrift.annotation.Nullable DropPartitionsExpr _elem616;
-              for (int _i617 = 0; _i617 < _list615.size; ++_i617)
+              org.apache.thrift.protocol.TList _list623 = iprot.readListBegin();
+              exprs = new java.util.ArrayList<DropPartitionsExpr>(_list623.size);
+              @org.apache.thrift.annotation.Nullable DropPartitionsExpr _elem624;
+              for (int _i625 = 0; _i625 < _list623.size; ++_i625)
               {
-                _elem616 = new DropPartitionsExpr();
-                _elem616.read(iprot);
-                exprs.add(_elem616);
+                _elem624 = new DropPartitionsExpr();
+                _elem624.read(iprot);
+                exprs.add(_elem624);
               }
               iprot.readListEnd();
             }
@@ -195,9 +195,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<java.lang.String> names = (java.util.List<java.lang.String>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, names.size()));
-          for (java.lang.String _iter618 : names)
+          for (java.lang.String _iter626 : names)
           {
-            oprot.writeString(_iter618);
+            oprot.writeString(_iter626);
           }
           oprot.writeListEnd();
         }
@@ -206,9 +206,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<DropPartitionsExpr> exprs = (java.util.List<DropPartitionsExpr>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, exprs.size()));
-          for (DropPartitionsExpr _iter619 : exprs)
+          for (DropPartitionsExpr _iter627 : exprs)
           {
-            _iter619.write(oprot);
+            _iter627.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -226,13 +226,13 @@ package org.apache.hadoop.hive.metastore.api;
         case NAMES:
           java.util.List<java.lang.String> names;
           {
-            org.apache.thrift.protocol.TList _list620 = iprot.readListBegin();
-            names = new java.util.ArrayList<java.lang.String>(_list620.size);
-            @org.apache.thrift.annotation.Nullable java.lang.String _elem621;
-            for (int _i622 = 0; _i622 < _list620.size; ++_i622)
+            org.apache.thrift.protocol.TList _list628 = iprot.readListBegin();
+            names = new java.util.ArrayList<java.lang.String>(_list628.size);
+            @org.apache.thrift.annotation.Nullable java.lang.String _elem629;
+            for (int _i630 = 0; _i630 < _list628.size; ++_i630)
             {
-              _elem621 = iprot.readString();
-              names.add(_elem621);
+              _elem629 = iprot.readString();
+              names.add(_elem629);
             }
             iprot.readListEnd();
           }
@@ -240,14 +240,14 @@ package org.apache.hadoop.hive.metastore.api;
         case EXPRS:
           java.util.List<DropPartitionsExpr> exprs;
           {
-            org.apache.thrift.protocol.TList _list623 = iprot.readListBegin();
-            exprs = new java.util.ArrayList<DropPartitionsExpr>(_list623.size);
-            @org.apache.thrift.annotation.Nullable DropPartitionsExpr _elem624;
-            for (int _i625 = 0; _i625 < _list623.size; ++_i625)
+            org.apache.thrift.protocol.TList _list631 = iprot.readListBegin();
+            exprs = new java.util.ArrayList<DropPartitionsExpr>(_list631.size);
+            @org.apache.thrift.annotation.Nullable DropPartitionsExpr _elem632;
+            for (int _i633 = 0; _i633 < _list631.size; ++_i633)
             {
-              _elem624 = new DropPartitionsExpr();
-              _elem624.read(iprot);
-              exprs.add(_elem624);
+              _elem632 = new DropPartitionsExpr();
+              _elem632.read(iprot);
+              exprs.add(_elem632);
             }
             iprot.readListEnd();
           }
@@ -267,9 +267,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<java.lang.String> names = (java.util.List<java.lang.String>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, names.size()));
-          for (java.lang.String _iter626 : names)
+          for (java.lang.String _iter634 : names)
           {
-            oprot.writeString(_iter626);
+            oprot.writeString(_iter634);
           }
           oprot.writeListEnd();
         }
@@ -278,9 +278,9 @@ package org.apache.hadoop.hive.metastore.api;
         java.util.List<DropPartitionsExpr> exprs = (java.util.List<DropPartitionsExpr>)value_;
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, exprs.size()));
-          for (DropPartitionsExpr _iter627 : exprs)
+          for (DropPartitionsExpr _iter635 : exprs)
           {
-            _iter627.write(oprot);
+            _iter635.write(oprot);
           }
           oprot.writeListEnd();
         }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Schema.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Schema.java
@@ -420,14 +420,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // FIELD_SCHEMAS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list408 = iprot.readListBegin();
-                struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list408.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem409;
-                for (int _i410 = 0; _i410 < _list408.size; ++_i410)
+                org.apache.thrift.protocol.TList _list416 = iprot.readListBegin();
+                struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list416.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem417;
+                for (int _i418 = 0; _i418 < _list416.size; ++_i418)
                 {
-                  _elem409 = new FieldSchema();
-                  _elem409.read(iprot);
-                  struct.fieldSchemas.add(_elem409);
+                  _elem417 = new FieldSchema();
+                  _elem417.read(iprot);
+                  struct.fieldSchemas.add(_elem417);
                 }
                 iprot.readListEnd();
               }
@@ -439,15 +439,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // PROPERTIES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map411 = iprot.readMapBegin();
-                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map411.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key412;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val413;
-                for (int _i414 = 0; _i414 < _map411.size; ++_i414)
+                org.apache.thrift.protocol.TMap _map419 = iprot.readMapBegin();
+                struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map419.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key420;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val421;
+                for (int _i422 = 0; _i422 < _map419.size; ++_i422)
                 {
-                  _key412 = iprot.readString();
-                  _val413 = iprot.readString();
-                  struct.properties.put(_key412, _val413);
+                  _key420 = iprot.readString();
+                  _val421 = iprot.readString();
+                  struct.properties.put(_key420, _val421);
                 }
                 iprot.readMapEnd();
               }
@@ -473,9 +473,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(FIELD_SCHEMAS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.fieldSchemas.size()));
-          for (FieldSchema _iter415 : struct.fieldSchemas)
+          for (FieldSchema _iter423 : struct.fieldSchemas)
           {
-            _iter415.write(oprot);
+            _iter423.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -485,10 +485,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PROPERTIES_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.properties.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter416 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter424 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter416.getKey());
-            oprot.writeString(_iter416.getValue());
+            oprot.writeString(_iter424.getKey());
+            oprot.writeString(_iter424.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -522,19 +522,19 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetFieldSchemas()) {
         {
           oprot.writeI32(struct.fieldSchemas.size());
-          for (FieldSchema _iter417 : struct.fieldSchemas)
+          for (FieldSchema _iter425 : struct.fieldSchemas)
           {
-            _iter417.write(oprot);
+            _iter425.write(oprot);
           }
         }
       }
       if (struct.isSetProperties()) {
         {
           oprot.writeI32(struct.properties.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter418 : struct.properties.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter426 : struct.properties.entrySet())
           {
-            oprot.writeString(_iter418.getKey());
-            oprot.writeString(_iter418.getValue());
+            oprot.writeString(_iter426.getKey());
+            oprot.writeString(_iter426.getValue());
           }
         }
       }
@@ -546,29 +546,29 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list419 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list419.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem420;
-          for (int _i421 = 0; _i421 < _list419.size; ++_i421)
+          org.apache.thrift.protocol.TList _list427 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.fieldSchemas = new java.util.ArrayList<FieldSchema>(_list427.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem428;
+          for (int _i429 = 0; _i429 < _list427.size; ++_i429)
           {
-            _elem420 = new FieldSchema();
-            _elem420.read(iprot);
-            struct.fieldSchemas.add(_elem420);
+            _elem428 = new FieldSchema();
+            _elem428.read(iprot);
+            struct.fieldSchemas.add(_elem428);
           }
         }
         struct.setFieldSchemasIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TMap _map422 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map422.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key423;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val424;
-          for (int _i425 = 0; _i425 < _map422.size; ++_i425)
+          org.apache.thrift.protocol.TMap _map430 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.properties = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map430.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key431;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val432;
+          for (int _i433 = 0; _i433 < _map430.size; ++_i433)
           {
-            _key423 = iprot.readString();
-            _val424 = iprot.readString();
-            struct.properties.put(_key423, _val424);
+            _key431 = iprot.readString();
+            _val432 = iprot.readString();
+            struct.properties.put(_key431, _val432);
           }
         }
         struct.setPropertiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SchemaVersion.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SchemaVersion.java
@@ -1088,14 +1088,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // COLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1188 = iprot.readListBegin();
-                struct.cols = new java.util.ArrayList<FieldSchema>(_list1188.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem1189;
-                for (int _i1190 = 0; _i1190 < _list1188.size; ++_i1190)
+                org.apache.thrift.protocol.TList _list1196 = iprot.readListBegin();
+                struct.cols = new java.util.ArrayList<FieldSchema>(_list1196.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem1197;
+                for (int _i1198 = 0; _i1198 < _list1196.size; ++_i1198)
                 {
-                  _elem1189 = new FieldSchema();
-                  _elem1189.read(iprot);
-                  struct.cols.add(_elem1189);
+                  _elem1197 = new FieldSchema();
+                  _elem1197.read(iprot);
+                  struct.cols.add(_elem1197);
                 }
                 iprot.readListEnd();
               }
@@ -1181,9 +1181,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.cols.size()));
-          for (FieldSchema _iter1191 : struct.cols)
+          for (FieldSchema _iter1199 : struct.cols)
           {
-            _iter1191.write(oprot);
+            _iter1199.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -1292,9 +1292,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetCols()) {
         {
           oprot.writeI32(struct.cols.size());
-          for (FieldSchema _iter1192 : struct.cols)
+          for (FieldSchema _iter1200 : struct.cols)
           {
-            _iter1192.write(oprot);
+            _iter1200.write(oprot);
           }
         }
       }
@@ -1337,14 +1337,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TList _list1193 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.cols = new java.util.ArrayList<FieldSchema>(_list1193.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem1194;
-          for (int _i1195 = 0; _i1195 < _list1193.size; ++_i1195)
+          org.apache.thrift.protocol.TList _list1201 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.cols = new java.util.ArrayList<FieldSchema>(_list1201.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem1202;
+          for (int _i1203 = 0; _i1203 < _list1201.size; ++_i1203)
           {
-            _elem1194 = new FieldSchema();
-            _elem1194.read(iprot);
-            struct.cols.add(_elem1194);
+            _elem1202 = new FieldSchema();
+            _elem1202.read(iprot);
+            struct.cols.add(_elem1202);
           }
         }
         struct.setColsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SetPartitionsStatsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/SetPartitionsStatsRequest.java
@@ -652,14 +652,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COL_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list400 = iprot.readListBegin();
-                struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list400.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatistics _elem401;
-                for (int _i402 = 0; _i402 < _list400.size; ++_i402)
+                org.apache.thrift.protocol.TList _list408 = iprot.readListBegin();
+                struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list408.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatistics _elem409;
+                for (int _i410 = 0; _i410 < _list408.size; ++_i410)
                 {
-                  _elem401 = new ColumnStatistics();
-                  _elem401.read(iprot);
-                  struct.colStats.add(_elem401);
+                  _elem409 = new ColumnStatistics();
+                  _elem409.read(iprot);
+                  struct.colStats.add(_elem409);
                 }
                 iprot.readListEnd();
               }
@@ -717,9 +717,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_STATS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.colStats.size()));
-          for (ColumnStatistics _iter403 : struct.colStats)
+          for (ColumnStatistics _iter411 : struct.colStats)
           {
-            _iter403.write(oprot);
+            _iter411.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -766,9 +766,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.colStats.size());
-        for (ColumnStatistics _iter404 : struct.colStats)
+        for (ColumnStatistics _iter412 : struct.colStats)
         {
-          _iter404.write(oprot);
+          _iter412.write(oprot);
         }
       }
       oprot.writeString(struct.engine);
@@ -798,14 +798,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, SetPartitionsStatsRequest struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list405 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list405.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatistics _elem406;
-        for (int _i407 = 0; _i407 < _list405.size; ++_i407)
+        org.apache.thrift.protocol.TList _list413 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.colStats = new java.util.ArrayList<ColumnStatistics>(_list413.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatistics _elem414;
+        for (int _i415 = 0; _i415 < _list413.size; ++_i415)
         {
-          _elem406 = new ColumnStatistics();
-          _elem406.read(iprot);
-          struct.colStats.add(_elem406);
+          _elem414 = new ColumnStatistics();
+          _elem414.read(iprot);
+          struct.colStats.add(_elem414);
         }
       }
       struct.setColStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ShowCompactResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ShowCompactResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // COMPACTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list856 = iprot.readListBegin();
-                struct.compacts = new java.util.ArrayList<ShowCompactResponseElement>(_list856.size);
-                @org.apache.thrift.annotation.Nullable ShowCompactResponseElement _elem857;
-                for (int _i858 = 0; _i858 < _list856.size; ++_i858)
+                org.apache.thrift.protocol.TList _list864 = iprot.readListBegin();
+                struct.compacts = new java.util.ArrayList<ShowCompactResponseElement>(_list864.size);
+                @org.apache.thrift.annotation.Nullable ShowCompactResponseElement _elem865;
+                for (int _i866 = 0; _i866 < _list864.size; ++_i866)
                 {
-                  _elem857 = new ShowCompactResponseElement();
-                  _elem857.read(iprot);
-                  struct.compacts.add(_elem857);
+                  _elem865 = new ShowCompactResponseElement();
+                  _elem865.read(iprot);
+                  struct.compacts.add(_elem865);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COMPACTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.compacts.size()));
-          for (ShowCompactResponseElement _iter859 : struct.compacts)
+          for (ShowCompactResponseElement _iter867 : struct.compacts)
           {
-            _iter859.write(oprot);
+            _iter867.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.compacts.size());
-        for (ShowCompactResponseElement _iter860 : struct.compacts)
+        for (ShowCompactResponseElement _iter868 : struct.compacts)
         {
-          _iter860.write(oprot);
+          _iter868.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, ShowCompactResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list861 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.compacts = new java.util.ArrayList<ShowCompactResponseElement>(_list861.size);
-        @org.apache.thrift.annotation.Nullable ShowCompactResponseElement _elem862;
-        for (int _i863 = 0; _i863 < _list861.size; ++_i863)
+        org.apache.thrift.protocol.TList _list869 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.compacts = new java.util.ArrayList<ShowCompactResponseElement>(_list869.size);
+        @org.apache.thrift.annotation.Nullable ShowCompactResponseElement _elem870;
+        for (int _i871 = 0; _i871 < _list869.size; ++_i871)
         {
-          _elem862 = new ShowCompactResponseElement();
-          _elem862.read(iprot);
-          struct.compacts.add(_elem862);
+          _elem870 = new ShowCompactResponseElement();
+          _elem870.read(iprot);
+          struct.compacts.add(_elem870);
         }
       }
       struct.setCompactsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ShowLocksResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ShowLocksResponse.java
@@ -325,14 +325,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // LOCKS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list822 = iprot.readListBegin();
-                struct.locks = new java.util.ArrayList<ShowLocksResponseElement>(_list822.size);
-                @org.apache.thrift.annotation.Nullable ShowLocksResponseElement _elem823;
-                for (int _i824 = 0; _i824 < _list822.size; ++_i824)
+                org.apache.thrift.protocol.TList _list830 = iprot.readListBegin();
+                struct.locks = new java.util.ArrayList<ShowLocksResponseElement>(_list830.size);
+                @org.apache.thrift.annotation.Nullable ShowLocksResponseElement _elem831;
+                for (int _i832 = 0; _i832 < _list830.size; ++_i832)
                 {
-                  _elem823 = new ShowLocksResponseElement();
-                  _elem823.read(iprot);
-                  struct.locks.add(_elem823);
+                  _elem831 = new ShowLocksResponseElement();
+                  _elem831.read(iprot);
+                  struct.locks.add(_elem831);
                 }
                 iprot.readListEnd();
               }
@@ -358,9 +358,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(LOCKS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.locks.size()));
-          for (ShowLocksResponseElement _iter825 : struct.locks)
+          for (ShowLocksResponseElement _iter833 : struct.locks)
           {
-            _iter825.write(oprot);
+            _iter833.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -391,9 +391,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetLocks()) {
         {
           oprot.writeI32(struct.locks.size());
-          for (ShowLocksResponseElement _iter826 : struct.locks)
+          for (ShowLocksResponseElement _iter834 : struct.locks)
           {
-            _iter826.write(oprot);
+            _iter834.write(oprot);
           }
         }
       }
@@ -405,14 +405,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list827 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.locks = new java.util.ArrayList<ShowLocksResponseElement>(_list827.size);
-          @org.apache.thrift.annotation.Nullable ShowLocksResponseElement _elem828;
-          for (int _i829 = 0; _i829 < _list827.size; ++_i829)
+          org.apache.thrift.protocol.TList _list835 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.locks = new java.util.ArrayList<ShowLocksResponseElement>(_list835.size);
+          @org.apache.thrift.annotation.Nullable ShowLocksResponseElement _elem836;
+          for (int _i837 = 0; _i837 < _list835.size; ++_i837)
           {
-            _elem828 = new ShowLocksResponseElement();
-            _elem828.read(iprot);
-            struct.locks.add(_elem828);
+            _elem836 = new ShowLocksResponseElement();
+            _elem836.read(iprot);
+            struct.locks.add(_elem836);
           }
         }
         struct.setLocksIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
@@ -2523,14 +2523,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 8: // PARTITION_KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list306 = iprot.readListBegin();
-                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list306.size);
-                @org.apache.thrift.annotation.Nullable FieldSchema _elem307;
-                for (int _i308 = 0; _i308 < _list306.size; ++_i308)
+                org.apache.thrift.protocol.TList _list314 = iprot.readListBegin();
+                struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list314.size);
+                @org.apache.thrift.annotation.Nullable FieldSchema _elem315;
+                for (int _i316 = 0; _i316 < _list314.size; ++_i316)
                 {
-                  _elem307 = new FieldSchema();
-                  _elem307.read(iprot);
-                  struct.partitionKeys.add(_elem307);
+                  _elem315 = new FieldSchema();
+                  _elem315.read(iprot);
+                  struct.partitionKeys.add(_elem315);
                 }
                 iprot.readListEnd();
               }
@@ -2542,15 +2542,15 @@ package org.apache.hadoop.hive.metastore.api;
           case 9: // PARAMETERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map309 = iprot.readMapBegin();
-                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map309.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _key310;
-                @org.apache.thrift.annotation.Nullable java.lang.String _val311;
-                for (int _i312 = 0; _i312 < _map309.size; ++_i312)
+                org.apache.thrift.protocol.TMap _map317 = iprot.readMapBegin();
+                struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map317.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _key318;
+                @org.apache.thrift.annotation.Nullable java.lang.String _val319;
+                for (int _i320 = 0; _i320 < _map317.size; ++_i320)
                 {
-                  _key310 = iprot.readString();
-                  _val311 = iprot.readString();
-                  struct.parameters.put(_key310, _val311);
+                  _key318 = iprot.readString();
+                  _val319 = iprot.readString();
+                  struct.parameters.put(_key318, _val319);
                 }
                 iprot.readMapEnd();
               }
@@ -2669,13 +2669,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 23: // REQUIRED_READ_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list313 = iprot.readListBegin();
-                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list313.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem314;
-                for (int _i315 = 0; _i315 < _list313.size; ++_i315)
+                org.apache.thrift.protocol.TList _list321 = iprot.readListBegin();
+                struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list321.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem322;
+                for (int _i323 = 0; _i323 < _list321.size; ++_i323)
                 {
-                  _elem314 = iprot.readString();
-                  struct.requiredReadCapabilities.add(_elem314);
+                  _elem322 = iprot.readString();
+                  struct.requiredReadCapabilities.add(_elem322);
                 }
                 iprot.readListEnd();
               }
@@ -2687,13 +2687,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 24: // REQUIRED_WRITE_CAPABILITIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list316 = iprot.readListBegin();
-                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list316.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem317;
-                for (int _i318 = 0; _i318 < _list316.size; ++_i318)
+                org.apache.thrift.protocol.TList _list324 = iprot.readListBegin();
+                struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list324.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem325;
+                for (int _i326 = 0; _i326 < _list324.size; ++_i326)
                 {
-                  _elem317 = iprot.readString();
-                  struct.requiredWriteCapabilities.add(_elem317);
+                  _elem325 = iprot.readString();
+                  struct.requiredWriteCapabilities.add(_elem325);
                 }
                 iprot.readListEnd();
               }
@@ -2774,9 +2774,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARTITION_KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.partitionKeys.size()));
-          for (FieldSchema _iter319 : struct.partitionKeys)
+          for (FieldSchema _iter327 : struct.partitionKeys)
           {
-            _iter319.write(oprot);
+            _iter327.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -2786,10 +2786,10 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(PARAMETERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.parameters.size()));
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter320 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter328 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter320.getKey());
-            oprot.writeString(_iter320.getValue());
+            oprot.writeString(_iter328.getKey());
+            oprot.writeString(_iter328.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -2875,9 +2875,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_READ_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredReadCapabilities.size()));
-            for (java.lang.String _iter321 : struct.requiredReadCapabilities)
+            for (java.lang.String _iter329 : struct.requiredReadCapabilities)
             {
-              oprot.writeString(_iter321);
+              oprot.writeString(_iter329);
             }
             oprot.writeListEnd();
           }
@@ -2889,9 +2889,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(REQUIRED_WRITE_CAPABILITIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.requiredWriteCapabilities.size()));
-            for (java.lang.String _iter322 : struct.requiredWriteCapabilities)
+            for (java.lang.String _iter330 : struct.requiredWriteCapabilities)
             {
-              oprot.writeString(_iter322);
+              oprot.writeString(_iter330);
             }
             oprot.writeListEnd();
           }
@@ -3041,19 +3041,19 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionKeys()) {
         {
           oprot.writeI32(struct.partitionKeys.size());
-          for (FieldSchema _iter323 : struct.partitionKeys)
+          for (FieldSchema _iter331 : struct.partitionKeys)
           {
-            _iter323.write(oprot);
+            _iter331.write(oprot);
           }
         }
       }
       if (struct.isSetParameters()) {
         {
           oprot.writeI32(struct.parameters.size());
-          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter324 : struct.parameters.entrySet())
+          for (java.util.Map.Entry<java.lang.String, java.lang.String> _iter332 : struct.parameters.entrySet())
           {
-            oprot.writeString(_iter324.getKey());
-            oprot.writeString(_iter324.getValue());
+            oprot.writeString(_iter332.getKey());
+            oprot.writeString(_iter332.getValue());
           }
         }
       }
@@ -3099,18 +3099,18 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetRequiredReadCapabilities()) {
         {
           oprot.writeI32(struct.requiredReadCapabilities.size());
-          for (java.lang.String _iter325 : struct.requiredReadCapabilities)
+          for (java.lang.String _iter333 : struct.requiredReadCapabilities)
           {
-            oprot.writeString(_iter325);
+            oprot.writeString(_iter333);
           }
         }
       }
       if (struct.isSetRequiredWriteCapabilities()) {
         {
           oprot.writeI32(struct.requiredWriteCapabilities.size());
-          for (java.lang.String _iter326 : struct.requiredWriteCapabilities)
+          for (java.lang.String _iter334 : struct.requiredWriteCapabilities)
           {
-            oprot.writeString(_iter326);
+            oprot.writeString(_iter334);
           }
         }
       }
@@ -3160,29 +3160,29 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list327 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list327.size);
-          @org.apache.thrift.annotation.Nullable FieldSchema _elem328;
-          for (int _i329 = 0; _i329 < _list327.size; ++_i329)
+          org.apache.thrift.protocol.TList _list335 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.partitionKeys = new java.util.ArrayList<FieldSchema>(_list335.size);
+          @org.apache.thrift.annotation.Nullable FieldSchema _elem336;
+          for (int _i337 = 0; _i337 < _list335.size; ++_i337)
           {
-            _elem328 = new FieldSchema();
-            _elem328.read(iprot);
-            struct.partitionKeys.add(_elem328);
+            _elem336 = new FieldSchema();
+            _elem336.read(iprot);
+            struct.partitionKeys.add(_elem336);
           }
         }
         struct.setPartitionKeysIsSet(true);
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TMap _map330 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
-          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map330.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _key331;
-          @org.apache.thrift.annotation.Nullable java.lang.String _val332;
-          for (int _i333 = 0; _i333 < _map330.size; ++_i333)
+          org.apache.thrift.protocol.TMap _map338 = iprot.readMapBegin(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING); 
+          struct.parameters = new java.util.HashMap<java.lang.String,java.lang.String>(2*_map338.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _key339;
+          @org.apache.thrift.annotation.Nullable java.lang.String _val340;
+          for (int _i341 = 0; _i341 < _map338.size; ++_i341)
           {
-            _key331 = iprot.readString();
-            _val332 = iprot.readString();
-            struct.parameters.put(_key331, _val332);
+            _key339 = iprot.readString();
+            _val340 = iprot.readString();
+            struct.parameters.put(_key339, _val340);
           }
         }
         struct.setParametersIsSet(true);
@@ -3244,26 +3244,26 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (incoming.get(22)) {
         {
-          org.apache.thrift.protocol.TList _list334 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list334.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem335;
-          for (int _i336 = 0; _i336 < _list334.size; ++_i336)
+          org.apache.thrift.protocol.TList _list342 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredReadCapabilities = new java.util.ArrayList<java.lang.String>(_list342.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem343;
+          for (int _i344 = 0; _i344 < _list342.size; ++_i344)
           {
-            _elem335 = iprot.readString();
-            struct.requiredReadCapabilities.add(_elem335);
+            _elem343 = iprot.readString();
+            struct.requiredReadCapabilities.add(_elem343);
           }
         }
         struct.setRequiredReadCapabilitiesIsSet(true);
       }
       if (incoming.get(23)) {
         {
-          org.apache.thrift.protocol.TList _list337 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list337.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem338;
-          for (int _i339 = 0; _i339 < _list337.size; ++_i339)
+          org.apache.thrift.protocol.TList _list345 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.requiredWriteCapabilities = new java.util.ArrayList<java.lang.String>(_list345.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem346;
+          for (int _i347 = 0; _i347 < _list345.size; ++_i347)
           {
-            _elem338 = iprot.readString();
-            struct.requiredWriteCapabilities.add(_elem338);
+            _elem346 = iprot.readString();
+            struct.requiredWriteCapabilities.add(_elem346);
           }
         }
         struct.setRequiredWriteCapabilitiesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableStatsRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableStatsRequest.java
@@ -841,13 +841,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // COL_NAMES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list564 = iprot.readListBegin();
-                struct.colNames = new java.util.ArrayList<java.lang.String>(_list564.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem565;
-                for (int _i566 = 0; _i566 < _list564.size; ++_i566)
+                org.apache.thrift.protocol.TList _list572 = iprot.readListBegin();
+                struct.colNames = new java.util.ArrayList<java.lang.String>(_list572.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem573;
+                for (int _i574 = 0; _i574 < _list572.size; ++_i574)
                 {
-                  _elem565 = iprot.readString();
-                  struct.colNames.add(_elem565);
+                  _elem573 = iprot.readString();
+                  struct.colNames.add(_elem573);
                 }
                 iprot.readListEnd();
               }
@@ -915,9 +915,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(COL_NAMES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.colNames.size()));
-          for (java.lang.String _iter567 : struct.colNames)
+          for (java.lang.String _iter575 : struct.colNames)
           {
-            oprot.writeString(_iter567);
+            oprot.writeString(_iter575);
           }
           oprot.writeListEnd();
         }
@@ -968,9 +968,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.tblName);
       {
         oprot.writeI32(struct.colNames.size());
-        for (java.lang.String _iter568 : struct.colNames)
+        for (java.lang.String _iter576 : struct.colNames)
         {
-          oprot.writeString(_iter568);
+          oprot.writeString(_iter576);
         }
       }
       oprot.writeString(struct.engine);
@@ -1004,13 +1004,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.tblName = iprot.readString();
       struct.setTblNameIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list569 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-        struct.colNames = new java.util.ArrayList<java.lang.String>(_list569.size);
-        @org.apache.thrift.annotation.Nullable java.lang.String _elem570;
-        for (int _i571 = 0; _i571 < _list569.size; ++_i571)
+        org.apache.thrift.protocol.TList _list577 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+        struct.colNames = new java.util.ArrayList<java.lang.String>(_list577.size);
+        @org.apache.thrift.annotation.Nullable java.lang.String _elem578;
+        for (int _i579 = 0; _i579 < _list577.size; ++_i579)
         {
-          _elem570 = iprot.readString();
-          struct.colNames.add(_elem570);
+          _elem578 = iprot.readString();
+          struct.colNames.add(_elem578);
         }
       }
       struct.setColNamesIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableStatsResult.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableStatsResult.java
@@ -409,14 +409,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TABLE_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list538 = iprot.readListBegin();
-                struct.tableStats = new java.util.ArrayList<ColumnStatisticsObj>(_list538.size);
-                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem539;
-                for (int _i540 = 0; _i540 < _list538.size; ++_i540)
+                org.apache.thrift.protocol.TList _list546 = iprot.readListBegin();
+                struct.tableStats = new java.util.ArrayList<ColumnStatisticsObj>(_list546.size);
+                @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem547;
+                for (int _i548 = 0; _i548 < _list546.size; ++_i548)
                 {
-                  _elem539 = new ColumnStatisticsObj();
-                  _elem539.read(iprot);
-                  struct.tableStats.add(_elem539);
+                  _elem547 = new ColumnStatisticsObj();
+                  _elem547.read(iprot);
+                  struct.tableStats.add(_elem547);
                 }
                 iprot.readListEnd();
               }
@@ -450,9 +450,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(TABLE_STATS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.tableStats.size()));
-          for (ColumnStatisticsObj _iter541 : struct.tableStats)
+          for (ColumnStatisticsObj _iter549 : struct.tableStats)
           {
-            _iter541.write(oprot);
+            _iter549.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -482,9 +482,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.tableStats.size());
-        for (ColumnStatisticsObj _iter542 : struct.tableStats)
+        for (ColumnStatisticsObj _iter550 : struct.tableStats)
         {
-          _iter542.write(oprot);
+          _iter550.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -501,14 +501,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, TableStatsResult struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list543 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.tableStats = new java.util.ArrayList<ColumnStatisticsObj>(_list543.size);
-        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem544;
-        for (int _i545 = 0; _i545 < _list543.size; ++_i545)
+        org.apache.thrift.protocol.TList _list551 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.tableStats = new java.util.ArrayList<ColumnStatisticsObj>(_list551.size);
+        @org.apache.thrift.annotation.Nullable ColumnStatisticsObj _elem552;
+        for (int _i553 = 0; _i553 < _list551.size; ++_i553)
         {
-          _elem544 = new ColumnStatisticsObj();
-          _elem544.read(iprot);
-          struct.tableStats.add(_elem544);
+          _elem552 = new ColumnStatisticsObj();
+          _elem552.read(iprot);
+          struct.tableStats.add(_elem552);
         }
       }
       struct.setTableStatsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableValidWriteIds.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TableValidWriteIds.java
@@ -682,13 +682,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // INVALID_WRITE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list774 = iprot.readListBegin();
-                struct.invalidWriteIds = new java.util.ArrayList<java.lang.Long>(_list774.size);
-                long _elem775;
-                for (int _i776 = 0; _i776 < _list774.size; ++_i776)
+                org.apache.thrift.protocol.TList _list782 = iprot.readListBegin();
+                struct.invalidWriteIds = new java.util.ArrayList<java.lang.Long>(_list782.size);
+                long _elem783;
+                for (int _i784 = 0; _i784 < _list782.size; ++_i784)
                 {
-                  _elem775 = iprot.readI64();
-                  struct.invalidWriteIds.add(_elem775);
+                  _elem783 = iprot.readI64();
+                  struct.invalidWriteIds.add(_elem783);
                 }
                 iprot.readListEnd();
               }
@@ -738,9 +738,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(INVALID_WRITE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.invalidWriteIds.size()));
-          for (long _iter777 : struct.invalidWriteIds)
+          for (long _iter785 : struct.invalidWriteIds)
           {
-            oprot.writeI64(_iter777);
+            oprot.writeI64(_iter785);
           }
           oprot.writeListEnd();
         }
@@ -777,9 +777,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeI64(struct.writeIdHighWaterMark);
       {
         oprot.writeI32(struct.invalidWriteIds.size());
-        for (long _iter778 : struct.invalidWriteIds)
+        for (long _iter786 : struct.invalidWriteIds)
         {
-          oprot.writeI64(_iter778);
+          oprot.writeI64(_iter786);
         }
       }
       oprot.writeBinary(struct.abortedBits);
@@ -801,13 +801,13 @@ package org.apache.hadoop.hive.metastore.api;
       struct.writeIdHighWaterMark = iprot.readI64();
       struct.setWriteIdHighWaterMarkIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list779 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
-        struct.invalidWriteIds = new java.util.ArrayList<java.lang.Long>(_list779.size);
-        long _elem780;
-        for (int _i781 = 0; _i781 < _list779.size; ++_i781)
+        org.apache.thrift.protocol.TList _list787 = iprot.readListBegin(org.apache.thrift.protocol.TType.I64);
+        struct.invalidWriteIds = new java.util.ArrayList<java.lang.Long>(_list787.size);
+        long _elem788;
+        for (int _i789 = 0; _i789 < _list787.size; ++_i789)
         {
-          _elem780 = iprot.readI64();
-          struct.invalidWriteIds.add(_elem780);
+          _elem788 = iprot.readI64();
+          struct.invalidWriteIds.add(_elem788);
         }
       }
       struct.setInvalidWriteIdsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/UniqueConstraintsResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/UniqueConstraintsResponse.java
@@ -329,14 +329,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // UNIQUE_CONSTRAINTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list442 = iprot.readListBegin();
-                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list442.size);
-                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem443;
-                for (int _i444 = 0; _i444 < _list442.size; ++_i444)
+                org.apache.thrift.protocol.TList _list450 = iprot.readListBegin();
+                struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list450.size);
+                @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem451;
+                for (int _i452 = 0; _i452 < _list450.size; ++_i452)
                 {
-                  _elem443 = new SQLUniqueConstraint();
-                  _elem443.read(iprot);
-                  struct.uniqueConstraints.add(_elem443);
+                  _elem451 = new SQLUniqueConstraint();
+                  _elem451.read(iprot);
+                  struct.uniqueConstraints.add(_elem451);
                 }
                 iprot.readListEnd();
               }
@@ -362,9 +362,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(UNIQUE_CONSTRAINTS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.uniqueConstraints.size()));
-          for (SQLUniqueConstraint _iter445 : struct.uniqueConstraints)
+          for (SQLUniqueConstraint _iter453 : struct.uniqueConstraints)
           {
-            _iter445.write(oprot);
+            _iter453.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
         oprot.writeI32(struct.uniqueConstraints.size());
-        for (SQLUniqueConstraint _iter446 : struct.uniqueConstraints)
+        for (SQLUniqueConstraint _iter454 : struct.uniqueConstraints)
         {
-          _iter446.write(oprot);
+          _iter454.write(oprot);
         }
       }
     }
@@ -400,14 +400,14 @@ package org.apache.hadoop.hive.metastore.api;
     public void read(org.apache.thrift.protocol.TProtocol prot, UniqueConstraintsResponse struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list447 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list447.size);
-        @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem448;
-        for (int _i449 = 0; _i449 < _list447.size; ++_i449)
+        org.apache.thrift.protocol.TList _list455 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.uniqueConstraints = new java.util.ArrayList<SQLUniqueConstraint>(_list455.size);
+        @org.apache.thrift.annotation.Nullable SQLUniqueConstraint _elem456;
+        for (int _i457 = 0; _i457 < _list455.size; ++_i457)
         {
-          _elem448 = new SQLUniqueConstraint();
-          _elem448.read(iprot);
-          struct.uniqueConstraints.add(_elem448);
+          _elem456 = new SQLUniqueConstraint();
+          _elem456.read(iprot);
+          struct.uniqueConstraints.add(_elem456);
         }
       }
       struct.setUniqueConstraintsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMFullResourcePlan.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMFullResourcePlan.java
@@ -733,14 +733,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // POOLS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1124 = iprot.readListBegin();
-                struct.pools = new java.util.ArrayList<WMPool>(_list1124.size);
-                @org.apache.thrift.annotation.Nullable WMPool _elem1125;
-                for (int _i1126 = 0; _i1126 < _list1124.size; ++_i1126)
+                org.apache.thrift.protocol.TList _list1132 = iprot.readListBegin();
+                struct.pools = new java.util.ArrayList<WMPool>(_list1132.size);
+                @org.apache.thrift.annotation.Nullable WMPool _elem1133;
+                for (int _i1134 = 0; _i1134 < _list1132.size; ++_i1134)
                 {
-                  _elem1125 = new WMPool();
-                  _elem1125.read(iprot);
-                  struct.pools.add(_elem1125);
+                  _elem1133 = new WMPool();
+                  _elem1133.read(iprot);
+                  struct.pools.add(_elem1133);
                 }
                 iprot.readListEnd();
               }
@@ -752,14 +752,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 3: // MAPPINGS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1127 = iprot.readListBegin();
-                struct.mappings = new java.util.ArrayList<WMMapping>(_list1127.size);
-                @org.apache.thrift.annotation.Nullable WMMapping _elem1128;
-                for (int _i1129 = 0; _i1129 < _list1127.size; ++_i1129)
+                org.apache.thrift.protocol.TList _list1135 = iprot.readListBegin();
+                struct.mappings = new java.util.ArrayList<WMMapping>(_list1135.size);
+                @org.apache.thrift.annotation.Nullable WMMapping _elem1136;
+                for (int _i1137 = 0; _i1137 < _list1135.size; ++_i1137)
                 {
-                  _elem1128 = new WMMapping();
-                  _elem1128.read(iprot);
-                  struct.mappings.add(_elem1128);
+                  _elem1136 = new WMMapping();
+                  _elem1136.read(iprot);
+                  struct.mappings.add(_elem1136);
                 }
                 iprot.readListEnd();
               }
@@ -771,14 +771,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // TRIGGERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1130 = iprot.readListBegin();
-                struct.triggers = new java.util.ArrayList<WMTrigger>(_list1130.size);
-                @org.apache.thrift.annotation.Nullable WMTrigger _elem1131;
-                for (int _i1132 = 0; _i1132 < _list1130.size; ++_i1132)
+                org.apache.thrift.protocol.TList _list1138 = iprot.readListBegin();
+                struct.triggers = new java.util.ArrayList<WMTrigger>(_list1138.size);
+                @org.apache.thrift.annotation.Nullable WMTrigger _elem1139;
+                for (int _i1140 = 0; _i1140 < _list1138.size; ++_i1140)
                 {
-                  _elem1131 = new WMTrigger();
-                  _elem1131.read(iprot);
-                  struct.triggers.add(_elem1131);
+                  _elem1139 = new WMTrigger();
+                  _elem1139.read(iprot);
+                  struct.triggers.add(_elem1139);
                 }
                 iprot.readListEnd();
               }
@@ -790,14 +790,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 5: // POOL_TRIGGERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1133 = iprot.readListBegin();
-                struct.poolTriggers = new java.util.ArrayList<WMPoolTrigger>(_list1133.size);
-                @org.apache.thrift.annotation.Nullable WMPoolTrigger _elem1134;
-                for (int _i1135 = 0; _i1135 < _list1133.size; ++_i1135)
+                org.apache.thrift.protocol.TList _list1141 = iprot.readListBegin();
+                struct.poolTriggers = new java.util.ArrayList<WMPoolTrigger>(_list1141.size);
+                @org.apache.thrift.annotation.Nullable WMPoolTrigger _elem1142;
+                for (int _i1143 = 0; _i1143 < _list1141.size; ++_i1143)
                 {
-                  _elem1134 = new WMPoolTrigger();
-                  _elem1134.read(iprot);
-                  struct.poolTriggers.add(_elem1134);
+                  _elem1142 = new WMPoolTrigger();
+                  _elem1142.read(iprot);
+                  struct.poolTriggers.add(_elem1142);
                 }
                 iprot.readListEnd();
               }
@@ -828,9 +828,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(POOLS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.pools.size()));
-          for (WMPool _iter1136 : struct.pools)
+          for (WMPool _iter1144 : struct.pools)
           {
-            _iter1136.write(oprot);
+            _iter1144.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -841,9 +841,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(MAPPINGS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.mappings.size()));
-            for (WMMapping _iter1137 : struct.mappings)
+            for (WMMapping _iter1145 : struct.mappings)
             {
-              _iter1137.write(oprot);
+              _iter1145.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -855,9 +855,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(TRIGGERS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.triggers.size()));
-            for (WMTrigger _iter1138 : struct.triggers)
+            for (WMTrigger _iter1146 : struct.triggers)
             {
-              _iter1138.write(oprot);
+              _iter1146.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -869,9 +869,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(POOL_TRIGGERS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.poolTriggers.size()));
-            for (WMPoolTrigger _iter1139 : struct.poolTriggers)
+            for (WMPoolTrigger _iter1147 : struct.poolTriggers)
             {
-              _iter1139.write(oprot);
+              _iter1147.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -898,9 +898,9 @@ package org.apache.hadoop.hive.metastore.api;
       struct.plan.write(oprot);
       {
         oprot.writeI32(struct.pools.size());
-        for (WMPool _iter1140 : struct.pools)
+        for (WMPool _iter1148 : struct.pools)
         {
-          _iter1140.write(oprot);
+          _iter1148.write(oprot);
         }
       }
       java.util.BitSet optionals = new java.util.BitSet();
@@ -917,27 +917,27 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetMappings()) {
         {
           oprot.writeI32(struct.mappings.size());
-          for (WMMapping _iter1141 : struct.mappings)
+          for (WMMapping _iter1149 : struct.mappings)
           {
-            _iter1141.write(oprot);
+            _iter1149.write(oprot);
           }
         }
       }
       if (struct.isSetTriggers()) {
         {
           oprot.writeI32(struct.triggers.size());
-          for (WMTrigger _iter1142 : struct.triggers)
+          for (WMTrigger _iter1150 : struct.triggers)
           {
-            _iter1142.write(oprot);
+            _iter1150.write(oprot);
           }
         }
       }
       if (struct.isSetPoolTriggers()) {
         {
           oprot.writeI32(struct.poolTriggers.size());
-          for (WMPoolTrigger _iter1143 : struct.poolTriggers)
+          for (WMPoolTrigger _iter1151 : struct.poolTriggers)
           {
-            _iter1143.write(oprot);
+            _iter1151.write(oprot);
           }
         }
       }
@@ -950,56 +950,56 @@ package org.apache.hadoop.hive.metastore.api;
       struct.plan.read(iprot);
       struct.setPlanIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list1144 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.pools = new java.util.ArrayList<WMPool>(_list1144.size);
-        @org.apache.thrift.annotation.Nullable WMPool _elem1145;
-        for (int _i1146 = 0; _i1146 < _list1144.size; ++_i1146)
+        org.apache.thrift.protocol.TList _list1152 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.pools = new java.util.ArrayList<WMPool>(_list1152.size);
+        @org.apache.thrift.annotation.Nullable WMPool _elem1153;
+        for (int _i1154 = 0; _i1154 < _list1152.size; ++_i1154)
         {
-          _elem1145 = new WMPool();
-          _elem1145.read(iprot);
-          struct.pools.add(_elem1145);
+          _elem1153 = new WMPool();
+          _elem1153.read(iprot);
+          struct.pools.add(_elem1153);
         }
       }
       struct.setPoolsIsSet(true);
       java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1147 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.mappings = new java.util.ArrayList<WMMapping>(_list1147.size);
-          @org.apache.thrift.annotation.Nullable WMMapping _elem1148;
-          for (int _i1149 = 0; _i1149 < _list1147.size; ++_i1149)
+          org.apache.thrift.protocol.TList _list1155 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.mappings = new java.util.ArrayList<WMMapping>(_list1155.size);
+          @org.apache.thrift.annotation.Nullable WMMapping _elem1156;
+          for (int _i1157 = 0; _i1157 < _list1155.size; ++_i1157)
           {
-            _elem1148 = new WMMapping();
-            _elem1148.read(iprot);
-            struct.mappings.add(_elem1148);
+            _elem1156 = new WMMapping();
+            _elem1156.read(iprot);
+            struct.mappings.add(_elem1156);
           }
         }
         struct.setMappingsIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1150 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.triggers = new java.util.ArrayList<WMTrigger>(_list1150.size);
-          @org.apache.thrift.annotation.Nullable WMTrigger _elem1151;
-          for (int _i1152 = 0; _i1152 < _list1150.size; ++_i1152)
+          org.apache.thrift.protocol.TList _list1158 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.triggers = new java.util.ArrayList<WMTrigger>(_list1158.size);
+          @org.apache.thrift.annotation.Nullable WMTrigger _elem1159;
+          for (int _i1160 = 0; _i1160 < _list1158.size; ++_i1160)
           {
-            _elem1151 = new WMTrigger();
-            _elem1151.read(iprot);
-            struct.triggers.add(_elem1151);
+            _elem1159 = new WMTrigger();
+            _elem1159.read(iprot);
+            struct.triggers.add(_elem1159);
           }
         }
         struct.setTriggersIsSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list1153 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.poolTriggers = new java.util.ArrayList<WMPoolTrigger>(_list1153.size);
-          @org.apache.thrift.annotation.Nullable WMPoolTrigger _elem1154;
-          for (int _i1155 = 0; _i1155 < _list1153.size; ++_i1155)
+          org.apache.thrift.protocol.TList _list1161 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.poolTriggers = new java.util.ArrayList<WMPoolTrigger>(_list1161.size);
+          @org.apache.thrift.annotation.Nullable WMPoolTrigger _elem1162;
+          for (int _i1163 = 0; _i1163 < _list1161.size; ++_i1163)
           {
-            _elem1154 = new WMPoolTrigger();
-            _elem1154.read(iprot);
-            struct.poolTriggers.add(_elem1154);
+            _elem1162 = new WMPoolTrigger();
+            _elem1162.read(iprot);
+            struct.poolTriggers.add(_elem1162);
           }
         }
         struct.setPoolTriggersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMGetAllResourcePlanResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMGetAllResourcePlanResponse.java
@@ -321,14 +321,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // RESOURCE_PLANS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1156 = iprot.readListBegin();
-                struct.resourcePlans = new java.util.ArrayList<WMResourcePlan>(_list1156.size);
-                @org.apache.thrift.annotation.Nullable WMResourcePlan _elem1157;
-                for (int _i1158 = 0; _i1158 < _list1156.size; ++_i1158)
+                org.apache.thrift.protocol.TList _list1164 = iprot.readListBegin();
+                struct.resourcePlans = new java.util.ArrayList<WMResourcePlan>(_list1164.size);
+                @org.apache.thrift.annotation.Nullable WMResourcePlan _elem1165;
+                for (int _i1166 = 0; _i1166 < _list1164.size; ++_i1166)
                 {
-                  _elem1157 = new WMResourcePlan();
-                  _elem1157.read(iprot);
-                  struct.resourcePlans.add(_elem1157);
+                  _elem1165 = new WMResourcePlan();
+                  _elem1165.read(iprot);
+                  struct.resourcePlans.add(_elem1165);
                 }
                 iprot.readListEnd();
               }
@@ -355,9 +355,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(RESOURCE_PLANS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.resourcePlans.size()));
-            for (WMResourcePlan _iter1159 : struct.resourcePlans)
+            for (WMResourcePlan _iter1167 : struct.resourcePlans)
             {
-              _iter1159.write(oprot);
+              _iter1167.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetResourcePlans()) {
         {
           oprot.writeI32(struct.resourcePlans.size());
-          for (WMResourcePlan _iter1160 : struct.resourcePlans)
+          for (WMResourcePlan _iter1168 : struct.resourcePlans)
           {
-            _iter1160.write(oprot);
+            _iter1168.write(oprot);
           }
         }
       }
@@ -403,14 +403,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1161 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.resourcePlans = new java.util.ArrayList<WMResourcePlan>(_list1161.size);
-          @org.apache.thrift.annotation.Nullable WMResourcePlan _elem1162;
-          for (int _i1163 = 0; _i1163 < _list1161.size; ++_i1163)
+          org.apache.thrift.protocol.TList _list1169 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.resourcePlans = new java.util.ArrayList<WMResourcePlan>(_list1169.size);
+          @org.apache.thrift.annotation.Nullable WMResourcePlan _elem1170;
+          for (int _i1171 = 0; _i1171 < _list1169.size; ++_i1171)
           {
-            _elem1162 = new WMResourcePlan();
-            _elem1162.read(iprot);
-            struct.resourcePlans.add(_elem1162);
+            _elem1170 = new WMResourcePlan();
+            _elem1170.read(iprot);
+            struct.resourcePlans.add(_elem1170);
           }
         }
         struct.setResourcePlansIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMGetTriggersForResourePlanResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMGetTriggersForResourePlanResponse.java
@@ -321,14 +321,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // TRIGGERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1180 = iprot.readListBegin();
-                struct.triggers = new java.util.ArrayList<WMTrigger>(_list1180.size);
-                @org.apache.thrift.annotation.Nullable WMTrigger _elem1181;
-                for (int _i1182 = 0; _i1182 < _list1180.size; ++_i1182)
+                org.apache.thrift.protocol.TList _list1188 = iprot.readListBegin();
+                struct.triggers = new java.util.ArrayList<WMTrigger>(_list1188.size);
+                @org.apache.thrift.annotation.Nullable WMTrigger _elem1189;
+                for (int _i1190 = 0; _i1190 < _list1188.size; ++_i1190)
                 {
-                  _elem1181 = new WMTrigger();
-                  _elem1181.read(iprot);
-                  struct.triggers.add(_elem1181);
+                  _elem1189 = new WMTrigger();
+                  _elem1189.read(iprot);
+                  struct.triggers.add(_elem1189);
                 }
                 iprot.readListEnd();
               }
@@ -355,9 +355,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(TRIGGERS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.triggers.size()));
-            for (WMTrigger _iter1183 : struct.triggers)
+            for (WMTrigger _iter1191 : struct.triggers)
             {
-              _iter1183.write(oprot);
+              _iter1191.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -389,9 +389,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetTriggers()) {
         {
           oprot.writeI32(struct.triggers.size());
-          for (WMTrigger _iter1184 : struct.triggers)
+          for (WMTrigger _iter1192 : struct.triggers)
           {
-            _iter1184.write(oprot);
+            _iter1192.write(oprot);
           }
         }
       }
@@ -403,14 +403,14 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1185 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-          struct.triggers = new java.util.ArrayList<WMTrigger>(_list1185.size);
-          @org.apache.thrift.annotation.Nullable WMTrigger _elem1186;
-          for (int _i1187 = 0; _i1187 < _list1185.size; ++_i1187)
+          org.apache.thrift.protocol.TList _list1193 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+          struct.triggers = new java.util.ArrayList<WMTrigger>(_list1193.size);
+          @org.apache.thrift.annotation.Nullable WMTrigger _elem1194;
+          for (int _i1195 = 0; _i1195 < _list1193.size; ++_i1195)
           {
-            _elem1186 = new WMTrigger();
-            _elem1186.read(iprot);
-            struct.triggers.add(_elem1186);
+            _elem1194 = new WMTrigger();
+            _elem1194.read(iprot);
+            struct.triggers.add(_elem1194);
           }
         }
         struct.setTriggersIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMValidateResourcePlanResponse.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WMValidateResourcePlanResponse.java
@@ -417,13 +417,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 1: // ERRORS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1164 = iprot.readListBegin();
-                struct.errors = new java.util.ArrayList<java.lang.String>(_list1164.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1165;
-                for (int _i1166 = 0; _i1166 < _list1164.size; ++_i1166)
+                org.apache.thrift.protocol.TList _list1172 = iprot.readListBegin();
+                struct.errors = new java.util.ArrayList<java.lang.String>(_list1172.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1173;
+                for (int _i1174 = 0; _i1174 < _list1172.size; ++_i1174)
                 {
-                  _elem1165 = iprot.readString();
-                  struct.errors.add(_elem1165);
+                  _elem1173 = iprot.readString();
+                  struct.errors.add(_elem1173);
                 }
                 iprot.readListEnd();
               }
@@ -435,13 +435,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 2: // WARNINGS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list1167 = iprot.readListBegin();
-                struct.warnings = new java.util.ArrayList<java.lang.String>(_list1167.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem1168;
-                for (int _i1169 = 0; _i1169 < _list1167.size; ++_i1169)
+                org.apache.thrift.protocol.TList _list1175 = iprot.readListBegin();
+                struct.warnings = new java.util.ArrayList<java.lang.String>(_list1175.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem1176;
+                for (int _i1177 = 0; _i1177 < _list1175.size; ++_i1177)
                 {
-                  _elem1168 = iprot.readString();
-                  struct.warnings.add(_elem1168);
+                  _elem1176 = iprot.readString();
+                  struct.warnings.add(_elem1176);
                 }
                 iprot.readListEnd();
               }
@@ -468,9 +468,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(ERRORS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.errors.size()));
-            for (java.lang.String _iter1170 : struct.errors)
+            for (java.lang.String _iter1178 : struct.errors)
             {
-              oprot.writeString(_iter1170);
+              oprot.writeString(_iter1178);
             }
             oprot.writeListEnd();
           }
@@ -482,9 +482,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(WARNINGS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.warnings.size()));
-            for (java.lang.String _iter1171 : struct.warnings)
+            for (java.lang.String _iter1179 : struct.warnings)
             {
-              oprot.writeString(_iter1171);
+              oprot.writeString(_iter1179);
             }
             oprot.writeListEnd();
           }
@@ -519,18 +519,18 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetErrors()) {
         {
           oprot.writeI32(struct.errors.size());
-          for (java.lang.String _iter1172 : struct.errors)
+          for (java.lang.String _iter1180 : struct.errors)
           {
-            oprot.writeString(_iter1172);
+            oprot.writeString(_iter1180);
           }
         }
       }
       if (struct.isSetWarnings()) {
         {
           oprot.writeI32(struct.warnings.size());
-          for (java.lang.String _iter1173 : struct.warnings)
+          for (java.lang.String _iter1181 : struct.warnings)
           {
-            oprot.writeString(_iter1173);
+            oprot.writeString(_iter1181);
           }
         }
       }
@@ -542,26 +542,26 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list1174 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.errors = new java.util.ArrayList<java.lang.String>(_list1174.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1175;
-          for (int _i1176 = 0; _i1176 < _list1174.size; ++_i1176)
+          org.apache.thrift.protocol.TList _list1182 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.errors = new java.util.ArrayList<java.lang.String>(_list1182.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1183;
+          for (int _i1184 = 0; _i1184 < _list1182.size; ++_i1184)
           {
-            _elem1175 = iprot.readString();
-            struct.errors.add(_elem1175);
+            _elem1183 = iprot.readString();
+            struct.errors.add(_elem1183);
           }
         }
         struct.setErrorsIsSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list1177 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.warnings = new java.util.ArrayList<java.lang.String>(_list1177.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem1178;
-          for (int _i1179 = 0; _i1179 < _list1177.size; ++_i1179)
+          org.apache.thrift.protocol.TList _list1185 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.warnings = new java.util.ArrayList<java.lang.String>(_list1185.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem1186;
+          for (int _i1187 = 0; _i1187 < _list1185.size; ++_i1187)
           {
-            _elem1178 = iprot.readString();
-            struct.warnings.add(_elem1178);
+            _elem1186 = iprot.readString();
+            struct.warnings.add(_elem1186);
           }
         }
         struct.setWarningsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WriteNotificationLogBatchRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WriteNotificationLogBatchRequest.java
@@ -608,14 +608,14 @@ package org.apache.hadoop.hive.metastore.api;
           case 4: // REQUEST_LIST
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list968 = iprot.readListBegin();
-                struct.requestList = new java.util.ArrayList<WriteNotificationLogRequest>(_list968.size);
-                @org.apache.thrift.annotation.Nullable WriteNotificationLogRequest _elem969;
-                for (int _i970 = 0; _i970 < _list968.size; ++_i970)
+                org.apache.thrift.protocol.TList _list976 = iprot.readListBegin();
+                struct.requestList = new java.util.ArrayList<WriteNotificationLogRequest>(_list976.size);
+                @org.apache.thrift.annotation.Nullable WriteNotificationLogRequest _elem977;
+                for (int _i978 = 0; _i978 < _list976.size; ++_i978)
                 {
-                  _elem969 = new WriteNotificationLogRequest();
-                  _elem969.read(iprot);
-                  struct.requestList.add(_elem969);
+                  _elem977 = new WriteNotificationLogRequest();
+                  _elem977.read(iprot);
+                  struct.requestList.add(_elem977);
                 }
                 iprot.readListEnd();
               }
@@ -656,9 +656,9 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeFieldBegin(REQUEST_LIST_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.requestList.size()));
-          for (WriteNotificationLogRequest _iter971 : struct.requestList)
+          for (WriteNotificationLogRequest _iter979 : struct.requestList)
           {
-            _iter971.write(oprot);
+            _iter979.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -686,9 +686,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeString(struct.table);
       {
         oprot.writeI32(struct.requestList.size());
-        for (WriteNotificationLogRequest _iter972 : struct.requestList)
+        for (WriteNotificationLogRequest _iter980 : struct.requestList)
         {
-          _iter972.write(oprot);
+          _iter980.write(oprot);
         }
       }
     }
@@ -703,14 +703,14 @@ package org.apache.hadoop.hive.metastore.api;
       struct.table = iprot.readString();
       struct.setTableIsSet(true);
       {
-        org.apache.thrift.protocol.TList _list973 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-        struct.requestList = new java.util.ArrayList<WriteNotificationLogRequest>(_list973.size);
-        @org.apache.thrift.annotation.Nullable WriteNotificationLogRequest _elem974;
-        for (int _i975 = 0; _i975 < _list973.size; ++_i975)
+        org.apache.thrift.protocol.TList _list981 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+        struct.requestList = new java.util.ArrayList<WriteNotificationLogRequest>(_list981.size);
+        @org.apache.thrift.annotation.Nullable WriteNotificationLogRequest _elem982;
+        for (int _i983 = 0; _i983 < _list981.size; ++_i983)
         {
-          _elem974 = new WriteNotificationLogRequest();
-          _elem974.read(iprot);
-          struct.requestList.add(_elem974);
+          _elem982 = new WriteNotificationLogRequest();
+          _elem982.read(iprot);
+          struct.requestList.add(_elem982);
         }
       }
       struct.setRequestListIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WriteNotificationLogRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/WriteNotificationLogRequest.java
@@ -782,13 +782,13 @@ package org.apache.hadoop.hive.metastore.api;
           case 6: // PARTITION_VALS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list960 = iprot.readListBegin();
-                struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list960.size);
-                @org.apache.thrift.annotation.Nullable java.lang.String _elem961;
-                for (int _i962 = 0; _i962 < _list960.size; ++_i962)
+                org.apache.thrift.protocol.TList _list968 = iprot.readListBegin();
+                struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list968.size);
+                @org.apache.thrift.annotation.Nullable java.lang.String _elem969;
+                for (int _i970 = 0; _i970 < _list968.size; ++_i970)
                 {
-                  _elem961 = iprot.readString();
-                  struct.partitionVals.add(_elem961);
+                  _elem969 = iprot.readString();
+                  struct.partitionVals.add(_elem969);
                 }
                 iprot.readListEnd();
               }
@@ -836,9 +836,9 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldBegin(PARTITION_VALS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.partitionVals.size()));
-            for (java.lang.String _iter963 : struct.partitionVals)
+            for (java.lang.String _iter971 : struct.partitionVals)
             {
-              oprot.writeString(_iter963);
+              oprot.writeString(_iter971);
             }
             oprot.writeListEnd();
           }
@@ -875,9 +875,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPartitionVals()) {
         {
           oprot.writeI32(struct.partitionVals.size());
-          for (java.lang.String _iter964 : struct.partitionVals)
+          for (java.lang.String _iter972 : struct.partitionVals)
           {
-            oprot.writeString(_iter964);
+            oprot.writeString(_iter972);
           }
         }
       }
@@ -900,13 +900,13 @@ package org.apache.hadoop.hive.metastore.api;
       java.util.BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list965 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
-          struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list965.size);
-          @org.apache.thrift.annotation.Nullable java.lang.String _elem966;
-          for (int _i967 = 0; _i967 < _list965.size; ++_i967)
+          org.apache.thrift.protocol.TList _list973 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+          struct.partitionVals = new java.util.ArrayList<java.lang.String>(_list973.size);
+          @org.apache.thrift.annotation.Nullable java.lang.String _elem974;
+          for (int _i975 = 0; _i975 < _list973.size; ++_i975)
           {
-            _elem966 = iprot.readString();
-            struct.partitionVals.add(_elem966);
+            _elem974 = iprot.readString();
+            struct.partitionVals.add(_elem974);
           }
         }
         struct.setPartitionValsIsSet(true);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AbortTxnsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AbortTxnsRequest.php
@@ -68,13 +68,13 @@ class AbortTxnsRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->txn_ids = array();
-                        $_size647 = 0;
-                        $_etype650 = 0;
-                        $xfer += $input->readListBegin($_etype650, $_size647);
-                        for ($_i651 = 0; $_i651 < $_size647; ++$_i651) {
-                            $elem652 = null;
-                            $xfer += $input->readI64($elem652);
-                            $this->txn_ids []= $elem652;
+                        $_size655 = 0;
+                        $_etype658 = 0;
+                        $xfer += $input->readListBegin($_etype658, $_size655);
+                        for ($_i659 = 0; $_i659 < $_size655; ++$_i659) {
+                            $elem660 = null;
+                            $xfer += $input->readI64($elem660);
+                            $this->txn_ids []= $elem660;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class AbortTxnsRequest
             }
             $xfer += $output->writeFieldBegin('txn_ids', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->txn_ids));
-            foreach ($this->txn_ids as $iter653) {
-                $xfer += $output->writeI64($iter653);
+            foreach ($this->txn_ids as $iter661) {
+                $xfer += $output->writeI64($iter661);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddCheckConstraintRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddCheckConstraintRequest.php
@@ -69,14 +69,14 @@ class AddCheckConstraintRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->checkConstraintCols = array();
-                        $_size454 = 0;
-                        $_etype457 = 0;
-                        $xfer += $input->readListBegin($_etype457, $_size454);
-                        for ($_i458 = 0; $_i458 < $_size454; ++$_i458) {
-                            $elem459 = null;
-                            $elem459 = new \metastore\SQLCheckConstraint();
-                            $xfer += $elem459->read($input);
-                            $this->checkConstraintCols []= $elem459;
+                        $_size462 = 0;
+                        $_etype465 = 0;
+                        $xfer += $input->readListBegin($_etype465, $_size462);
+                        for ($_i466 = 0; $_i466 < $_size462; ++$_i466) {
+                            $elem467 = null;
+                            $elem467 = new \metastore\SQLCheckConstraint();
+                            $xfer += $elem467->read($input);
+                            $this->checkConstraintCols []= $elem467;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddCheckConstraintRequest
             }
             $xfer += $output->writeFieldBegin('checkConstraintCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->checkConstraintCols));
-            foreach ($this->checkConstraintCols as $iter460) {
-                $xfer += $iter460->write($output);
+            foreach ($this->checkConstraintCols as $iter468) {
+                $xfer += $iter468->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddDefaultConstraintRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddDefaultConstraintRequest.php
@@ -69,14 +69,14 @@ class AddDefaultConstraintRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->defaultConstraintCols = array();
-                        $_size447 = 0;
-                        $_etype450 = 0;
-                        $xfer += $input->readListBegin($_etype450, $_size447);
-                        for ($_i451 = 0; $_i451 < $_size447; ++$_i451) {
-                            $elem452 = null;
-                            $elem452 = new \metastore\SQLDefaultConstraint();
-                            $xfer += $elem452->read($input);
-                            $this->defaultConstraintCols []= $elem452;
+                        $_size455 = 0;
+                        $_etype458 = 0;
+                        $xfer += $input->readListBegin($_etype458, $_size455);
+                        for ($_i459 = 0; $_i459 < $_size455; ++$_i459) {
+                            $elem460 = null;
+                            $elem460 = new \metastore\SQLDefaultConstraint();
+                            $xfer += $elem460->read($input);
+                            $this->defaultConstraintCols []= $elem460;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddDefaultConstraintRequest
             }
             $xfer += $output->writeFieldBegin('defaultConstraintCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->defaultConstraintCols));
-            foreach ($this->defaultConstraintCols as $iter453) {
-                $xfer += $iter453->write($output);
+            foreach ($this->defaultConstraintCols as $iter461) {
+                $xfer += $iter461->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddDynamicPartitions.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddDynamicPartitions.php
@@ -157,13 +157,13 @@ class AddDynamicPartitions
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->partitionnames = array();
-                        $_size777 = 0;
-                        $_etype780 = 0;
-                        $xfer += $input->readListBegin($_etype780, $_size777);
-                        for ($_i781 = 0; $_i781 < $_size777; ++$_i781) {
-                            $elem782 = null;
-                            $xfer += $input->readString($elem782);
-                            $this->partitionnames []= $elem782;
+                        $_size785 = 0;
+                        $_etype788 = 0;
+                        $xfer += $input->readListBegin($_etype788, $_size785);
+                        for ($_i789 = 0; $_i789 < $_size785; ++$_i789) {
+                            $elem790 = null;
+                            $xfer += $input->readString($elem790);
+                            $this->partitionnames []= $elem790;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -217,8 +217,8 @@ class AddDynamicPartitions
             }
             $xfer += $output->writeFieldBegin('partitionnames', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->partitionnames));
-            foreach ($this->partitionnames as $iter783) {
-                $xfer += $output->writeString($iter783);
+            foreach ($this->partitionnames as $iter791) {
+                $xfer += $output->writeString($iter791);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddForeignKeyRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddForeignKeyRequest.php
@@ -69,14 +69,14 @@ class AddForeignKeyRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->foreignKeyCols = array();
-                        $_size426 = 0;
-                        $_etype429 = 0;
-                        $xfer += $input->readListBegin($_etype429, $_size426);
-                        for ($_i430 = 0; $_i430 < $_size426; ++$_i430) {
-                            $elem431 = null;
-                            $elem431 = new \metastore\SQLForeignKey();
-                            $xfer += $elem431->read($input);
-                            $this->foreignKeyCols []= $elem431;
+                        $_size434 = 0;
+                        $_etype437 = 0;
+                        $xfer += $input->readListBegin($_etype437, $_size434);
+                        for ($_i438 = 0; $_i438 < $_size434; ++$_i438) {
+                            $elem439 = null;
+                            $elem439 = new \metastore\SQLForeignKey();
+                            $xfer += $elem439->read($input);
+                            $this->foreignKeyCols []= $elem439;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddForeignKeyRequest
             }
             $xfer += $output->writeFieldBegin('foreignKeyCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->foreignKeyCols));
-            foreach ($this->foreignKeyCols as $iter432) {
-                $xfer += $iter432->write($output);
+            foreach ($this->foreignKeyCols as $iter440) {
+                $xfer += $iter440->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddNotNullConstraintRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddNotNullConstraintRequest.php
@@ -69,14 +69,14 @@ class AddNotNullConstraintRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->notNullConstraintCols = array();
-                        $_size440 = 0;
-                        $_etype443 = 0;
-                        $xfer += $input->readListBegin($_etype443, $_size440);
-                        for ($_i444 = 0; $_i444 < $_size440; ++$_i444) {
-                            $elem445 = null;
-                            $elem445 = new \metastore\SQLNotNullConstraint();
-                            $xfer += $elem445->read($input);
-                            $this->notNullConstraintCols []= $elem445;
+                        $_size448 = 0;
+                        $_etype451 = 0;
+                        $xfer += $input->readListBegin($_etype451, $_size448);
+                        for ($_i452 = 0; $_i452 < $_size448; ++$_i452) {
+                            $elem453 = null;
+                            $elem453 = new \metastore\SQLNotNullConstraint();
+                            $xfer += $elem453->read($input);
+                            $this->notNullConstraintCols []= $elem453;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddNotNullConstraintRequest
             }
             $xfer += $output->writeFieldBegin('notNullConstraintCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->notNullConstraintCols));
-            foreach ($this->notNullConstraintCols as $iter446) {
-                $xfer += $iter446->write($output);
+            foreach ($this->notNullConstraintCols as $iter454) {
+                $xfer += $iter454->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPartitionsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPartitionsRequest.php
@@ -155,14 +155,14 @@ class AddPartitionsRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->parts = array();
-                        $_size526 = 0;
-                        $_etype529 = 0;
-                        $xfer += $input->readListBegin($_etype529, $_size526);
-                        for ($_i530 = 0; $_i530 < $_size526; ++$_i530) {
-                            $elem531 = null;
-                            $elem531 = new \metastore\Partition();
-                            $xfer += $elem531->read($input);
-                            $this->parts []= $elem531;
+                        $_size534 = 0;
+                        $_etype537 = 0;
+                        $xfer += $input->readListBegin($_etype537, $_size534);
+                        for ($_i538 = 0; $_i538 < $_size534; ++$_i538) {
+                            $elem539 = null;
+                            $elem539 = new \metastore\Partition();
+                            $xfer += $elem539->read($input);
+                            $this->parts []= $elem539;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -227,8 +227,8 @@ class AddPartitionsRequest
             }
             $xfer += $output->writeFieldBegin('parts', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->parts));
-            foreach ($this->parts as $iter532) {
-                $xfer += $iter532->write($output);
+            foreach ($this->parts as $iter540) {
+                $xfer += $iter540->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPartitionsResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPartitionsResult.php
@@ -81,14 +81,14 @@ class AddPartitionsResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size519 = 0;
-                        $_etype522 = 0;
-                        $xfer += $input->readListBegin($_etype522, $_size519);
-                        for ($_i523 = 0; $_i523 < $_size519; ++$_i523) {
-                            $elem524 = null;
-                            $elem524 = new \metastore\Partition();
-                            $xfer += $elem524->read($input);
-                            $this->partitions []= $elem524;
+                        $_size527 = 0;
+                        $_etype530 = 0;
+                        $xfer += $input->readListBegin($_etype530, $_size527);
+                        for ($_i531 = 0; $_i531 < $_size527; ++$_i531) {
+                            $elem532 = null;
+                            $elem532 = new \metastore\Partition();
+                            $xfer += $elem532->read($input);
+                            $this->partitions []= $elem532;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class AddPartitionsResult
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter525) {
-                $xfer += $iter525->write($output);
+            foreach ($this->partitions as $iter533) {
+                $xfer += $iter533->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPrimaryKeyRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddPrimaryKeyRequest.php
@@ -69,14 +69,14 @@ class AddPrimaryKeyRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->primaryKeyCols = array();
-                        $_size419 = 0;
-                        $_etype422 = 0;
-                        $xfer += $input->readListBegin($_etype422, $_size419);
-                        for ($_i423 = 0; $_i423 < $_size419; ++$_i423) {
-                            $elem424 = null;
-                            $elem424 = new \metastore\SQLPrimaryKey();
-                            $xfer += $elem424->read($input);
-                            $this->primaryKeyCols []= $elem424;
+                        $_size427 = 0;
+                        $_etype430 = 0;
+                        $xfer += $input->readListBegin($_etype430, $_size427);
+                        for ($_i431 = 0; $_i431 < $_size427; ++$_i431) {
+                            $elem432 = null;
+                            $elem432 = new \metastore\SQLPrimaryKey();
+                            $xfer += $elem432->read($input);
+                            $this->primaryKeyCols []= $elem432;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddPrimaryKeyRequest
             }
             $xfer += $output->writeFieldBegin('primaryKeyCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->primaryKeyCols));
-            foreach ($this->primaryKeyCols as $iter425) {
-                $xfer += $iter425->write($output);
+            foreach ($this->primaryKeyCols as $iter433) {
+                $xfer += $iter433->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddUniqueConstraintRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AddUniqueConstraintRequest.php
@@ -69,14 +69,14 @@ class AddUniqueConstraintRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->uniqueConstraintCols = array();
-                        $_size433 = 0;
-                        $_etype436 = 0;
-                        $xfer += $input->readListBegin($_etype436, $_size433);
-                        for ($_i437 = 0; $_i437 < $_size433; ++$_i437) {
-                            $elem438 = null;
-                            $elem438 = new \metastore\SQLUniqueConstraint();
-                            $xfer += $elem438->read($input);
-                            $this->uniqueConstraintCols []= $elem438;
+                        $_size441 = 0;
+                        $_etype444 = 0;
+                        $xfer += $input->readListBegin($_etype444, $_size441);
+                        for ($_i445 = 0; $_i445 < $_size441; ++$_i445) {
+                            $elem446 = null;
+                            $elem446 = new \metastore\SQLUniqueConstraint();
+                            $xfer += $elem446->read($input);
+                            $this->uniqueConstraintCols []= $elem446;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AddUniqueConstraintRequest
             }
             $xfer += $output->writeFieldBegin('uniqueConstraintCols', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->uniqueConstraintCols));
-            foreach ($this->uniqueConstraintCols as $iter439) {
-                $xfer += $iter439->write($output);
+            foreach ($this->uniqueConstraintCols as $iter447) {
+                $xfer += $iter447->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AggrStats.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AggrStats.php
@@ -93,14 +93,14 @@ class AggrStats
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->colStats = array();
-                        $_size347 = 0;
-                        $_etype350 = 0;
-                        $xfer += $input->readListBegin($_etype350, $_size347);
-                        for ($_i351 = 0; $_i351 < $_size347; ++$_i351) {
-                            $elem352 = null;
-                            $elem352 = new \metastore\ColumnStatisticsObj();
-                            $xfer += $elem352->read($input);
-                            $this->colStats []= $elem352;
+                        $_size355 = 0;
+                        $_etype358 = 0;
+                        $xfer += $input->readListBegin($_etype358, $_size355);
+                        for ($_i359 = 0; $_i359 < $_size355; ++$_i359) {
+                            $elem360 = null;
+                            $elem360 = new \metastore\ColumnStatisticsObj();
+                            $xfer += $elem360->read($input);
+                            $this->colStats []= $elem360;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -141,8 +141,8 @@ class AggrStats
             }
             $xfer += $output->writeFieldBegin('colStats', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->colStats));
-            foreach ($this->colStats as $iter353) {
-                $xfer += $iter353->write($output);
+            foreach ($this->colStats as $iter361) {
+                $xfer += $iter361->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AllocateTableWriteIdsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AllocateTableWriteIdsRequest.php
@@ -135,13 +135,13 @@ class AllocateTableWriteIdsRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->txnIds = array();
-                        $_size696 = 0;
-                        $_etype699 = 0;
-                        $xfer += $input->readListBegin($_etype699, $_size696);
-                        for ($_i700 = 0; $_i700 < $_size696; ++$_i700) {
-                            $elem701 = null;
-                            $xfer += $input->readI64($elem701);
-                            $this->txnIds []= $elem701;
+                        $_size704 = 0;
+                        $_etype707 = 0;
+                        $xfer += $input->readListBegin($_etype707, $_size704);
+                        for ($_i708 = 0; $_i708 < $_size704; ++$_i708) {
+                            $elem709 = null;
+                            $xfer += $input->readI64($elem709);
+                            $this->txnIds []= $elem709;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -158,14 +158,14 @@ class AllocateTableWriteIdsRequest
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->srcTxnToWriteIdList = array();
-                        $_size702 = 0;
-                        $_etype705 = 0;
-                        $xfer += $input->readListBegin($_etype705, $_size702);
-                        for ($_i706 = 0; $_i706 < $_size702; ++$_i706) {
-                            $elem707 = null;
-                            $elem707 = new \metastore\TxnToWriteId();
-                            $xfer += $elem707->read($input);
-                            $this->srcTxnToWriteIdList []= $elem707;
+                        $_size710 = 0;
+                        $_etype713 = 0;
+                        $xfer += $input->readListBegin($_etype713, $_size710);
+                        for ($_i714 = 0; $_i714 < $_size710; ++$_i714) {
+                            $elem715 = null;
+                            $elem715 = new \metastore\TxnToWriteId();
+                            $xfer += $elem715->read($input);
+                            $this->srcTxnToWriteIdList []= $elem715;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -202,8 +202,8 @@ class AllocateTableWriteIdsRequest
             }
             $xfer += $output->writeFieldBegin('txnIds', TType::LST, 3);
             $output->writeListBegin(TType::I64, count($this->txnIds));
-            foreach ($this->txnIds as $iter708) {
-                $xfer += $output->writeI64($iter708);
+            foreach ($this->txnIds as $iter716) {
+                $xfer += $output->writeI64($iter716);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -219,8 +219,8 @@ class AllocateTableWriteIdsRequest
             }
             $xfer += $output->writeFieldBegin('srcTxnToWriteIdList', TType::LST, 5);
             $output->writeListBegin(TType::STRUCT, count($this->srcTxnToWriteIdList));
-            foreach ($this->srcTxnToWriteIdList as $iter709) {
-                $xfer += $iter709->write($output);
+            foreach ($this->srcTxnToWriteIdList as $iter717) {
+                $xfer += $iter717->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AllocateTableWriteIdsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AllocateTableWriteIdsResponse.php
@@ -69,14 +69,14 @@ class AllocateTableWriteIdsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->txnToWriteIds = array();
-                        $_size710 = 0;
-                        $_etype713 = 0;
-                        $xfer += $input->readListBegin($_etype713, $_size710);
-                        for ($_i714 = 0; $_i714 < $_size710; ++$_i714) {
-                            $elem715 = null;
-                            $elem715 = new \metastore\TxnToWriteId();
-                            $xfer += $elem715->read($input);
-                            $this->txnToWriteIds []= $elem715;
+                        $_size718 = 0;
+                        $_etype721 = 0;
+                        $xfer += $input->readListBegin($_etype721, $_size718);
+                        for ($_i722 = 0; $_i722 < $_size718; ++$_i722) {
+                            $elem723 = null;
+                            $elem723 = new \metastore\TxnToWriteId();
+                            $xfer += $elem723->read($input);
+                            $this->txnToWriteIds []= $elem723;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class AllocateTableWriteIdsResponse
             }
             $xfer += $output->writeFieldBegin('txnToWriteIds', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->txnToWriteIds));
-            foreach ($this->txnToWriteIds as $iter716) {
-                $xfer += $iter716->write($output);
+            foreach ($this->txnToWriteIds as $iter724) {
+                $xfer += $iter724->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AlterPartitionsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AlterPartitionsRequest.php
@@ -163,14 +163,14 @@ class AlterPartitionsRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size1119 = 0;
-                        $_etype1122 = 0;
-                        $xfer += $input->readListBegin($_etype1122, $_size1119);
-                        for ($_i1123 = 0; $_i1123 < $_size1119; ++$_i1123) {
-                            $elem1124 = null;
-                            $elem1124 = new \metastore\Partition();
-                            $xfer += $elem1124->read($input);
-                            $this->partitions []= $elem1124;
+                        $_size1127 = 0;
+                        $_etype1130 = 0;
+                        $xfer += $input->readListBegin($_etype1130, $_size1127);
+                        for ($_i1131 = 0; $_i1131 < $_size1127; ++$_i1131) {
+                            $elem1132 = null;
+                            $elem1132 = new \metastore\Partition();
+                            $xfer += $elem1132->read($input);
+                            $this->partitions []= $elem1132;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -234,8 +234,8 @@ class AlterPartitionsRequest
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter1125) {
-                $xfer += $iter1125->write($output);
+            foreach ($this->partitions as $iter1133) {
+                $xfer += $iter1133->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AlterTableRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AlterTableRequest.php
@@ -217,13 +217,13 @@ class AlterTableRequest
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size1133 = 0;
-                        $_etype1136 = 0;
-                        $xfer += $input->readListBegin($_etype1136, $_size1133);
-                        for ($_i1137 = 0; $_i1137 < $_size1133; ++$_i1137) {
-                            $elem1138 = null;
-                            $xfer += $input->readString($elem1138);
-                            $this->processorCapabilities []= $elem1138;
+                        $_size1141 = 0;
+                        $_etype1144 = 0;
+                        $xfer += $input->readListBegin($_etype1144, $_size1141);
+                        for ($_i1145 = 0; $_i1145 < $_size1141; ++$_i1145) {
+                            $elem1146 = null;
+                            $xfer += $input->readString($elem1146);
+                            $this->processorCapabilities []= $elem1146;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -298,8 +298,8 @@ class AlterTableRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 8);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter1139) {
-                $xfer += $output->writeString($iter1139);
+            foreach ($this->processorCapabilities as $iter1147) {
+                $xfer += $output->writeString($iter1147);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CheckConstraintsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CheckConstraintsResponse.php
@@ -69,14 +69,14 @@ class CheckConstraintsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->checkConstraints = array();
-                        $_size412 = 0;
-                        $_etype415 = 0;
-                        $xfer += $input->readListBegin($_etype415, $_size412);
-                        for ($_i416 = 0; $_i416 < $_size412; ++$_i416) {
-                            $elem417 = null;
-                            $elem417 = new \metastore\SQLCheckConstraint();
-                            $xfer += $elem417->read($input);
-                            $this->checkConstraints []= $elem417;
+                        $_size420 = 0;
+                        $_etype423 = 0;
+                        $xfer += $input->readListBegin($_etype423, $_size420);
+                        for ($_i424 = 0; $_i424 < $_size420; ++$_i424) {
+                            $elem425 = null;
+                            $elem425 = new \metastore\SQLCheckConstraint();
+                            $xfer += $elem425->read($input);
+                            $this->checkConstraints []= $elem425;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class CheckConstraintsResponse
             }
             $xfer += $output->writeFieldBegin('checkConstraints', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->checkConstraints));
-            foreach ($this->checkConstraints as $iter418) {
-                $xfer += $iter418->write($output);
+            foreach ($this->checkConstraints as $iter426) {
+                $xfer += $iter426->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ClearFileMetadataRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ClearFileMetadataRequest.php
@@ -68,13 +68,13 @@ class ClearFileMetadataRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fileIds = array();
-                        $_size907 = 0;
-                        $_etype910 = 0;
-                        $xfer += $input->readListBegin($_etype910, $_size907);
-                        for ($_i911 = 0; $_i911 < $_size907; ++$_i911) {
-                            $elem912 = null;
-                            $xfer += $input->readI64($elem912);
-                            $this->fileIds []= $elem912;
+                        $_size915 = 0;
+                        $_etype918 = 0;
+                        $xfer += $input->readListBegin($_etype918, $_size915);
+                        for ($_i919 = 0; $_i919 < $_size915; ++$_i919) {
+                            $elem920 = null;
+                            $xfer += $input->readI64($elem920);
+                            $this->fileIds []= $elem920;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class ClearFileMetadataRequest
             }
             $xfer += $output->writeFieldBegin('fileIds', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->fileIds));
-            foreach ($this->fileIds as $iter913) {
-                $xfer += $output->writeI64($iter913);
+            foreach ($this->fileIds as $iter921) {
+                $xfer += $output->writeI64($iter921);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ClientCapabilities.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ClientCapabilities.php
@@ -69,13 +69,13 @@ class ClientCapabilities
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->values = array();
-                        $_size921 = 0;
-                        $_etype924 = 0;
-                        $xfer += $input->readListBegin($_etype924, $_size921);
-                        for ($_i925 = 0; $_i925 < $_size921; ++$_i925) {
-                            $elem926 = null;
-                            $xfer += $input->readI32($elem926);
-                            $this->values []= $elem926;
+                        $_size929 = 0;
+                        $_etype932 = 0;
+                        $xfer += $input->readListBegin($_etype932, $_size929);
+                        for ($_i933 = 0; $_i933 < $_size929; ++$_i933) {
+                            $elem934 = null;
+                            $xfer += $input->readI32($elem934);
+                            $this->values []= $elem934;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -102,8 +102,8 @@ class ClientCapabilities
             }
             $xfer += $output->writeFieldBegin('values', TType::LST, 1);
             $output->writeListBegin(TType::I32, count($this->values));
-            foreach ($this->values as $iter927) {
-                $xfer += $output->writeI32($iter927);
+            foreach ($this->values as $iter935) {
+                $xfer += $output->writeI32($iter935);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ColumnStatistics.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ColumnStatistics.php
@@ -114,14 +114,14 @@ class ColumnStatistics
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->statsObj = array();
-                        $_size241 = 0;
-                        $_etype244 = 0;
-                        $xfer += $input->readListBegin($_etype244, $_size241);
-                        for ($_i245 = 0; $_i245 < $_size241; ++$_i245) {
-                            $elem246 = null;
-                            $elem246 = new \metastore\ColumnStatisticsObj();
-                            $xfer += $elem246->read($input);
-                            $this->statsObj []= $elem246;
+                        $_size249 = 0;
+                        $_etype252 = 0;
+                        $xfer += $input->readListBegin($_etype252, $_size249);
+                        for ($_i253 = 0; $_i253 < $_size249; ++$_i253) {
+                            $elem254 = null;
+                            $elem254 = new \metastore\ColumnStatisticsObj();
+                            $xfer += $elem254->read($input);
+                            $this->statsObj []= $elem254;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -170,8 +170,8 @@ class ColumnStatistics
             }
             $xfer += $output->writeFieldBegin('statsObj', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->statsObj));
-            foreach ($this->statsObj as $iter247) {
-                $xfer += $iter247->write($output);
+            foreach ($this->statsObj as $iter255) {
+                $xfer += $iter255->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CommitTxnRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CommitTxnRequest.php
@@ -158,14 +158,14 @@ class CommitTxnRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->writeEventInfos = array();
-                        $_size661 = 0;
-                        $_etype664 = 0;
-                        $xfer += $input->readListBegin($_etype664, $_size661);
-                        for ($_i665 = 0; $_i665 < $_size661; ++$_i665) {
-                            $elem666 = null;
-                            $elem666 = new \metastore\WriteEventInfo();
-                            $xfer += $elem666->read($input);
-                            $this->writeEventInfos []= $elem666;
+                        $_size669 = 0;
+                        $_etype672 = 0;
+                        $xfer += $input->readListBegin($_etype672, $_size669);
+                        for ($_i673 = 0; $_i673 < $_size669; ++$_i673) {
+                            $elem674 = null;
+                            $elem674 = new \metastore\WriteEventInfo();
+                            $xfer += $elem674->read($input);
+                            $this->writeEventInfos []= $elem674;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -232,8 +232,8 @@ class CommitTxnRequest
             }
             $xfer += $output->writeFieldBegin('writeEventInfos', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->writeEventInfos));
-            foreach ($this->writeEventInfos as $iter667) {
-                $xfer += $iter667->write($output);
+            foreach ($this->writeEventInfos as $iter675) {
+                $xfer += $iter675->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CompactionRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CompactionRequest.php
@@ -192,16 +192,16 @@ class CompactionRequest
                 case 6:
                     if ($ftype == TType::MAP) {
                         $this->properties = array();
-                        $_size747 = 0;
-                        $_ktype748 = 0;
-                        $_vtype749 = 0;
-                        $xfer += $input->readMapBegin($_ktype748, $_vtype749, $_size747);
-                        for ($_i751 = 0; $_i751 < $_size747; ++$_i751) {
-                            $key752 = '';
-                            $val753 = '';
-                            $xfer += $input->readString($key752);
-                            $xfer += $input->readString($val753);
-                            $this->properties[$key752] = $val753;
+                        $_size755 = 0;
+                        $_ktype756 = 0;
+                        $_vtype757 = 0;
+                        $xfer += $input->readMapBegin($_ktype756, $_vtype757, $_size755);
+                        for ($_i759 = 0; $_i759 < $_size755; ++$_i759) {
+                            $key760 = '';
+                            $val761 = '';
+                            $xfer += $input->readString($key760);
+                            $xfer += $input->readString($val761);
+                            $this->properties[$key760] = $val761;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -267,9 +267,9 @@ class CompactionRequest
             }
             $xfer += $output->writeFieldBegin('properties', TType::MAP, 6);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->properties));
-            foreach ($this->properties as $kiter754 => $viter755) {
-                $xfer += $output->writeString($kiter754);
-                $xfer += $output->writeString($viter755);
+            foreach ($this->properties as $kiter762 => $viter763) {
+                $xfer += $output->writeString($kiter762);
+                $xfer += $output->writeString($viter763);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreateDatabaseRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreateDatabaseRequest.php
@@ -227,16 +227,16 @@ class CreateDatabaseRequest
                 case 4:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size1110 = 0;
-                        $_ktype1111 = 0;
-                        $_vtype1112 = 0;
-                        $xfer += $input->readMapBegin($_ktype1111, $_vtype1112, $_size1110);
-                        for ($_i1114 = 0; $_i1114 < $_size1110; ++$_i1114) {
-                            $key1115 = '';
-                            $val1116 = '';
-                            $xfer += $input->readString($key1115);
-                            $xfer += $input->readString($val1116);
-                            $this->parameters[$key1115] = $val1116;
+                        $_size1118 = 0;
+                        $_ktype1119 = 0;
+                        $_vtype1120 = 0;
+                        $xfer += $input->readMapBegin($_ktype1119, $_vtype1120, $_size1118);
+                        for ($_i1122 = 0; $_i1122 < $_size1118; ++$_i1122) {
+                            $key1123 = '';
+                            $val1124 = '';
+                            $xfer += $input->readString($key1123);
+                            $xfer += $input->readString($val1124);
+                            $this->parameters[$key1123] = $val1124;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -335,9 +335,9 @@ class CreateDatabaseRequest
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 4);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter1117 => $viter1118) {
-                $xfer += $output->writeString($kiter1117);
-                $xfer += $output->writeString($viter1118);
+            foreach ($this->parameters as $kiter1125 => $viter1126) {
+                $xfer += $output->writeString($kiter1125);
+                $xfer += $output->writeString($viter1126);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreateTableRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreateTableRequest.php
@@ -224,14 +224,14 @@ class CreateTableRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->primaryKeys = array();
-                        $_size1061 = 0;
-                        $_etype1064 = 0;
-                        $xfer += $input->readListBegin($_etype1064, $_size1061);
-                        for ($_i1065 = 0; $_i1065 < $_size1061; ++$_i1065) {
-                            $elem1066 = null;
-                            $elem1066 = new \metastore\SQLPrimaryKey();
-                            $xfer += $elem1066->read($input);
-                            $this->primaryKeys []= $elem1066;
+                        $_size1069 = 0;
+                        $_etype1072 = 0;
+                        $xfer += $input->readListBegin($_etype1072, $_size1069);
+                        for ($_i1073 = 0; $_i1073 < $_size1069; ++$_i1073) {
+                            $elem1074 = null;
+                            $elem1074 = new \metastore\SQLPrimaryKey();
+                            $xfer += $elem1074->read($input);
+                            $this->primaryKeys []= $elem1074;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -241,14 +241,14 @@ class CreateTableRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->foreignKeys = array();
-                        $_size1067 = 0;
-                        $_etype1070 = 0;
-                        $xfer += $input->readListBegin($_etype1070, $_size1067);
-                        for ($_i1071 = 0; $_i1071 < $_size1067; ++$_i1071) {
-                            $elem1072 = null;
-                            $elem1072 = new \metastore\SQLForeignKey();
-                            $xfer += $elem1072->read($input);
-                            $this->foreignKeys []= $elem1072;
+                        $_size1075 = 0;
+                        $_etype1078 = 0;
+                        $xfer += $input->readListBegin($_etype1078, $_size1075);
+                        for ($_i1079 = 0; $_i1079 < $_size1075; ++$_i1079) {
+                            $elem1080 = null;
+                            $elem1080 = new \metastore\SQLForeignKey();
+                            $xfer += $elem1080->read($input);
+                            $this->foreignKeys []= $elem1080;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -258,14 +258,14 @@ class CreateTableRequest
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->uniqueConstraints = array();
-                        $_size1073 = 0;
-                        $_etype1076 = 0;
-                        $xfer += $input->readListBegin($_etype1076, $_size1073);
-                        for ($_i1077 = 0; $_i1077 < $_size1073; ++$_i1077) {
-                            $elem1078 = null;
-                            $elem1078 = new \metastore\SQLUniqueConstraint();
-                            $xfer += $elem1078->read($input);
-                            $this->uniqueConstraints []= $elem1078;
+                        $_size1081 = 0;
+                        $_etype1084 = 0;
+                        $xfer += $input->readListBegin($_etype1084, $_size1081);
+                        for ($_i1085 = 0; $_i1085 < $_size1081; ++$_i1085) {
+                            $elem1086 = null;
+                            $elem1086 = new \metastore\SQLUniqueConstraint();
+                            $xfer += $elem1086->read($input);
+                            $this->uniqueConstraints []= $elem1086;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -275,14 +275,14 @@ class CreateTableRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->notNullConstraints = array();
-                        $_size1079 = 0;
-                        $_etype1082 = 0;
-                        $xfer += $input->readListBegin($_etype1082, $_size1079);
-                        for ($_i1083 = 0; $_i1083 < $_size1079; ++$_i1083) {
-                            $elem1084 = null;
-                            $elem1084 = new \metastore\SQLNotNullConstraint();
-                            $xfer += $elem1084->read($input);
-                            $this->notNullConstraints []= $elem1084;
+                        $_size1087 = 0;
+                        $_etype1090 = 0;
+                        $xfer += $input->readListBegin($_etype1090, $_size1087);
+                        for ($_i1091 = 0; $_i1091 < $_size1087; ++$_i1091) {
+                            $elem1092 = null;
+                            $elem1092 = new \metastore\SQLNotNullConstraint();
+                            $xfer += $elem1092->read($input);
+                            $this->notNullConstraints []= $elem1092;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -292,14 +292,14 @@ class CreateTableRequest
                 case 7:
                     if ($ftype == TType::LST) {
                         $this->defaultConstraints = array();
-                        $_size1085 = 0;
-                        $_etype1088 = 0;
-                        $xfer += $input->readListBegin($_etype1088, $_size1085);
-                        for ($_i1089 = 0; $_i1089 < $_size1085; ++$_i1089) {
-                            $elem1090 = null;
-                            $elem1090 = new \metastore\SQLDefaultConstraint();
-                            $xfer += $elem1090->read($input);
-                            $this->defaultConstraints []= $elem1090;
+                        $_size1093 = 0;
+                        $_etype1096 = 0;
+                        $xfer += $input->readListBegin($_etype1096, $_size1093);
+                        for ($_i1097 = 0; $_i1097 < $_size1093; ++$_i1097) {
+                            $elem1098 = null;
+                            $elem1098 = new \metastore\SQLDefaultConstraint();
+                            $xfer += $elem1098->read($input);
+                            $this->defaultConstraints []= $elem1098;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -309,14 +309,14 @@ class CreateTableRequest
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->checkConstraints = array();
-                        $_size1091 = 0;
-                        $_etype1094 = 0;
-                        $xfer += $input->readListBegin($_etype1094, $_size1091);
-                        for ($_i1095 = 0; $_i1095 < $_size1091; ++$_i1095) {
-                            $elem1096 = null;
-                            $elem1096 = new \metastore\SQLCheckConstraint();
-                            $xfer += $elem1096->read($input);
-                            $this->checkConstraints []= $elem1096;
+                        $_size1099 = 0;
+                        $_etype1102 = 0;
+                        $xfer += $input->readListBegin($_etype1102, $_size1099);
+                        for ($_i1103 = 0; $_i1103 < $_size1099; ++$_i1103) {
+                            $elem1104 = null;
+                            $elem1104 = new \metastore\SQLCheckConstraint();
+                            $xfer += $elem1104->read($input);
+                            $this->checkConstraints []= $elem1104;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -326,13 +326,13 @@ class CreateTableRequest
                 case 9:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size1097 = 0;
-                        $_etype1100 = 0;
-                        $xfer += $input->readListBegin($_etype1100, $_size1097);
-                        for ($_i1101 = 0; $_i1101 < $_size1097; ++$_i1101) {
-                            $elem1102 = null;
-                            $xfer += $input->readString($elem1102);
-                            $this->processorCapabilities []= $elem1102;
+                        $_size1105 = 0;
+                        $_etype1108 = 0;
+                        $xfer += $input->readListBegin($_etype1108, $_size1105);
+                        for ($_i1109 = 0; $_i1109 < $_size1105; ++$_i1109) {
+                            $elem1110 = null;
+                            $xfer += $input->readString($elem1110);
+                            $this->processorCapabilities []= $elem1110;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -382,8 +382,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('primaryKeys', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->primaryKeys));
-            foreach ($this->primaryKeys as $iter1103) {
-                $xfer += $iter1103->write($output);
+            foreach ($this->primaryKeys as $iter1111) {
+                $xfer += $iter1111->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -394,8 +394,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('foreignKeys', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->foreignKeys));
-            foreach ($this->foreignKeys as $iter1104) {
-                $xfer += $iter1104->write($output);
+            foreach ($this->foreignKeys as $iter1112) {
+                $xfer += $iter1112->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -406,8 +406,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('uniqueConstraints', TType::LST, 5);
             $output->writeListBegin(TType::STRUCT, count($this->uniqueConstraints));
-            foreach ($this->uniqueConstraints as $iter1105) {
-                $xfer += $iter1105->write($output);
+            foreach ($this->uniqueConstraints as $iter1113) {
+                $xfer += $iter1113->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -418,8 +418,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('notNullConstraints', TType::LST, 6);
             $output->writeListBegin(TType::STRUCT, count($this->notNullConstraints));
-            foreach ($this->notNullConstraints as $iter1106) {
-                $xfer += $iter1106->write($output);
+            foreach ($this->notNullConstraints as $iter1114) {
+                $xfer += $iter1114->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -430,8 +430,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('defaultConstraints', TType::LST, 7);
             $output->writeListBegin(TType::STRUCT, count($this->defaultConstraints));
-            foreach ($this->defaultConstraints as $iter1107) {
-                $xfer += $iter1107->write($output);
+            foreach ($this->defaultConstraints as $iter1115) {
+                $xfer += $iter1115->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -442,8 +442,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('checkConstraints', TType::LST, 8);
             $output->writeListBegin(TType::STRUCT, count($this->checkConstraints));
-            foreach ($this->checkConstraints as $iter1108) {
-                $xfer += $iter1108->write($output);
+            foreach ($this->checkConstraints as $iter1116) {
+                $xfer += $iter1116->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -454,8 +454,8 @@ class CreateTableRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 9);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter1109) {
-                $xfer += $output->writeString($iter1109);
+            foreach ($this->processorCapabilities as $iter1117) {
+                $xfer += $output->writeString($iter1117);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreationMetadata.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CreationMetadata.php
@@ -40,10 +40,9 @@ class CreationMetadata
             'var' => 'tablesUsed',
             'isRequired' => true,
             'type' => TType::SET,
-            'etype' => TType::STRUCT,
+            'etype' => TType::STRING,
             'elem' => array(
-                'type' => TType::STRUCT,
-                'class' => '\metastore\SourceTable',
+                'type' => TType::STRING,
                 ),
         ),
         5 => array(
@@ -55,6 +54,16 @@ class CreationMetadata
             'var' => 'materializationTime',
             'isRequired' => false,
             'type' => TType::I64,
+        ),
+        7 => array(
+            'var' => 'sourceTables',
+            'isRequired' => false,
+            'type' => TType::SET,
+            'etype' => TType::STRUCT,
+            'elem' => array(
+                'type' => TType::STRUCT,
+                'class' => '\metastore\SourceTable',
+                ),
         ),
     );
 
@@ -71,7 +80,7 @@ class CreationMetadata
      */
     public $tblName = null;
     /**
-     * @var \metastore\SourceTable[]
+     * @var string[]
      */
     public $tablesUsed = null;
     /**
@@ -82,6 +91,10 @@ class CreationMetadata
      * @var int
      */
     public $materializationTime = null;
+    /**
+     * @var \metastore\SourceTable[]
+     */
+    public $sourceTables = null;
 
     public function __construct($vals = null)
     {
@@ -103,6 +116,9 @@ class CreationMetadata
             }
             if (isset($vals['materializationTime'])) {
                 $this->materializationTime = $vals['materializationTime'];
+            }
+            if (isset($vals['sourceTables'])) {
+                $this->sourceTables = $vals['sourceTables'];
             }
         }
     }
@@ -155,9 +171,8 @@ class CreationMetadata
                         $xfer += $input->readSetBegin($_etype236, $_size233);
                         for ($_i237 = 0; $_i237 < $_size233; ++$_i237) {
                             $elem238 = null;
-                            $elem238 = new \metastore\SourceTable();
-                            $xfer += $elem238->read($input);
-                            $this->tablesUsed[] = $elem238;
+                            $xfer += $input->readString($elem238);
+                            $this->tablesUsed[$elem238] = true;
                         }
                         $xfer += $input->readSetEnd();
                     } else {
@@ -174,6 +189,23 @@ class CreationMetadata
                 case 6:
                     if ($ftype == TType::I64) {
                         $xfer += $input->readI64($this->materializationTime);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
+                case 7:
+                    if ($ftype == TType::SET) {
+                        $this->sourceTables = array();
+                        $_size239 = 0;
+                        $_etype242 = 0;
+                        $xfer += $input->readSetBegin($_etype242, $_size239);
+                        for ($_i243 = 0; $_i243 < $_size239; ++$_i243) {
+                            $elem244 = null;
+                            $elem244 = new \metastore\SourceTable();
+                            $xfer += $elem244->read($input);
+                            $this->sourceTables[] = $elem244;
+                        }
+                        $xfer += $input->readSetEnd();
                     } else {
                         $xfer += $input->skip($ftype);
                     }
@@ -212,9 +244,9 @@ class CreationMetadata
                 throw new TProtocolException('Bad type in structure.', TProtocolException::INVALID_DATA);
             }
             $xfer += $output->writeFieldBegin('tablesUsed', TType::SET, 4);
-            $output->writeSetBegin(TType::STRUCT, count($this->tablesUsed));
-            foreach ($this->tablesUsed as $iter239 => $iter240) {
-                $xfer += $iter240->write($output);
+            $output->writeSetBegin(TType::STRING, count($this->tablesUsed));
+            foreach ($this->tablesUsed as $iter245 => $iter246) {
+                $xfer += $output->writeString($iter245);
             }
             $output->writeSetEnd();
             $xfer += $output->writeFieldEnd();
@@ -227,6 +259,18 @@ class CreationMetadata
         if ($this->materializationTime !== null) {
             $xfer += $output->writeFieldBegin('materializationTime', TType::I64, 6);
             $xfer += $output->writeI64($this->materializationTime);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->sourceTables !== null) {
+            if (!is_array($this->sourceTables)) {
+                throw new TProtocolException('Bad type in structure.', TProtocolException::INVALID_DATA);
+            }
+            $xfer += $output->writeFieldBegin('sourceTables', TType::SET, 7);
+            $output->writeSetBegin(TType::STRUCT, count($this->sourceTables));
+            foreach ($this->sourceTables as $iter247 => $iter248) {
+                $xfer += $iter248->write($output);
+            }
+            $output->writeSetEnd();
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DataConnector.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DataConnector.php
@@ -185,16 +185,16 @@ class DataConnector
                 case 5:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size603 = 0;
-                        $_ktype604 = 0;
-                        $_vtype605 = 0;
-                        $xfer += $input->readMapBegin($_ktype604, $_vtype605, $_size603);
-                        for ($_i607 = 0; $_i607 < $_size603; ++$_i607) {
-                            $key608 = '';
-                            $val609 = '';
-                            $xfer += $input->readString($key608);
-                            $xfer += $input->readString($val609);
-                            $this->parameters[$key608] = $val609;
+                        $_size611 = 0;
+                        $_ktype612 = 0;
+                        $_vtype613 = 0;
+                        $xfer += $input->readMapBegin($_ktype612, $_vtype613, $_size611);
+                        for ($_i615 = 0; $_i615 < $_size611; ++$_i615) {
+                            $key616 = '';
+                            $val617 = '';
+                            $xfer += $input->readString($key616);
+                            $xfer += $input->readString($val617);
+                            $this->parameters[$key616] = $val617;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -262,9 +262,9 @@ class DataConnector
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 5);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter610 => $viter611) {
-                $xfer += $output->writeString($kiter610);
-                $xfer += $output->writeString($viter611);
+            foreach ($this->parameters as $kiter618 => $viter619) {
+                $xfer += $output->writeString($kiter618);
+                $xfer += $output->writeString($viter619);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DefaultConstraintsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DefaultConstraintsResponse.php
@@ -69,14 +69,14 @@ class DefaultConstraintsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->defaultConstraints = array();
-                        $_size405 = 0;
-                        $_etype408 = 0;
-                        $xfer += $input->readListBegin($_etype408, $_size405);
-                        for ($_i409 = 0; $_i409 < $_size405; ++$_i409) {
-                            $elem410 = null;
-                            $elem410 = new \metastore\SQLDefaultConstraint();
-                            $xfer += $elem410->read($input);
-                            $this->defaultConstraints []= $elem410;
+                        $_size413 = 0;
+                        $_etype416 = 0;
+                        $xfer += $input->readListBegin($_etype416, $_size413);
+                        for ($_i417 = 0; $_i417 < $_size413; ++$_i417) {
+                            $elem418 = null;
+                            $elem418 = new \metastore\SQLDefaultConstraint();
+                            $xfer += $elem418->read($input);
+                            $this->defaultConstraints []= $elem418;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class DefaultConstraintsResponse
             }
             $xfer += $output->writeFieldBegin('defaultConstraints', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->defaultConstraints));
-            foreach ($this->defaultConstraints as $iter411) {
-                $xfer += $iter411->write($output);
+            foreach ($this->defaultConstraints as $iter419) {
+                $xfer += $iter419->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DropPartitionsResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/DropPartitionsResult.php
@@ -69,14 +69,14 @@ class DropPartitionsResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size533 = 0;
-                        $_etype536 = 0;
-                        $xfer += $input->readListBegin($_etype536, $_size533);
-                        for ($_i537 = 0; $_i537 < $_size533; ++$_i537) {
-                            $elem538 = null;
-                            $elem538 = new \metastore\Partition();
-                            $xfer += $elem538->read($input);
-                            $this->partitions []= $elem538;
+                        $_size541 = 0;
+                        $_etype544 = 0;
+                        $xfer += $input->readListBegin($_etype544, $_size541);
+                        for ($_i545 = 0; $_i545 < $_size541; ++$_i545) {
+                            $elem546 = null;
+                            $elem546 = new \metastore\Partition();
+                            $xfer += $elem546->read($input);
+                            $this->partitions []= $elem546;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class DropPartitionsResult
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter539) {
-                $xfer += $iter539->write($output);
+            foreach ($this->partitions as $iter547) {
+                $xfer += $iter547->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ExtendedTableInfo.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ExtendedTableInfo.php
@@ -122,13 +122,13 @@ class ExtendedTableInfo
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->requiredReadCapabilities = array();
-                        $_size970 = 0;
-                        $_etype973 = 0;
-                        $xfer += $input->readListBegin($_etype973, $_size970);
-                        for ($_i974 = 0; $_i974 < $_size970; ++$_i974) {
-                            $elem975 = null;
-                            $xfer += $input->readString($elem975);
-                            $this->requiredReadCapabilities []= $elem975;
+                        $_size978 = 0;
+                        $_etype981 = 0;
+                        $xfer += $input->readListBegin($_etype981, $_size978);
+                        for ($_i982 = 0; $_i982 < $_size978; ++$_i982) {
+                            $elem983 = null;
+                            $xfer += $input->readString($elem983);
+                            $this->requiredReadCapabilities []= $elem983;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -138,13 +138,13 @@ class ExtendedTableInfo
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->requiredWriteCapabilities = array();
-                        $_size976 = 0;
-                        $_etype979 = 0;
-                        $xfer += $input->readListBegin($_etype979, $_size976);
-                        for ($_i980 = 0; $_i980 < $_size976; ++$_i980) {
-                            $elem981 = null;
-                            $xfer += $input->readString($elem981);
-                            $this->requiredWriteCapabilities []= $elem981;
+                        $_size984 = 0;
+                        $_etype987 = 0;
+                        $xfer += $input->readListBegin($_etype987, $_size984);
+                        for ($_i988 = 0; $_i988 < $_size984; ++$_i988) {
+                            $elem989 = null;
+                            $xfer += $input->readString($elem989);
+                            $this->requiredWriteCapabilities []= $elem989;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -181,8 +181,8 @@ class ExtendedTableInfo
             }
             $xfer += $output->writeFieldBegin('requiredReadCapabilities', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->requiredReadCapabilities));
-            foreach ($this->requiredReadCapabilities as $iter982) {
-                $xfer += $output->writeString($iter982);
+            foreach ($this->requiredReadCapabilities as $iter990) {
+                $xfer += $output->writeString($iter990);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -193,8 +193,8 @@ class ExtendedTableInfo
             }
             $xfer += $output->writeFieldBegin('requiredWriteCapabilities', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->requiredWriteCapabilities));
-            foreach ($this->requiredWriteCapabilities as $iter983) {
-                $xfer += $output->writeString($iter983);
+            foreach ($this->requiredWriteCapabilities as $iter991) {
+                $xfer += $output->writeString($iter991);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FileMetadata.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FileMetadata.php
@@ -106,13 +106,13 @@ class FileMetadata
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->data = array();
-                        $_size248 = 0;
-                        $_etype251 = 0;
-                        $xfer += $input->readListBegin($_etype251, $_size248);
-                        for ($_i252 = 0; $_i252 < $_size248; ++$_i252) {
-                            $elem253 = null;
-                            $xfer += $input->readString($elem253);
-                            $this->data []= $elem253;
+                        $_size256 = 0;
+                        $_etype259 = 0;
+                        $xfer += $input->readListBegin($_etype259, $_size256);
+                        for ($_i260 = 0; $_i260 < $_size256; ++$_i260) {
+                            $elem261 = null;
+                            $xfer += $input->readString($elem261);
+                            $this->data []= $elem261;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class FileMetadata
             }
             $xfer += $output->writeFieldBegin('data', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->data));
-            foreach ($this->data as $iter254) {
-                $xfer += $output->writeString($iter254);
+            foreach ($this->data as $iter262) {
+                $xfer += $output->writeString($iter262);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FindSchemasByColsResp.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FindSchemasByColsResp.php
@@ -69,14 +69,14 @@ class FindSchemasByColsResp
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->schemaVersions = array();
-                        $_size1054 = 0;
-                        $_etype1057 = 0;
-                        $xfer += $input->readListBegin($_etype1057, $_size1054);
-                        for ($_i1058 = 0; $_i1058 < $_size1054; ++$_i1058) {
-                            $elem1059 = null;
-                            $elem1059 = new \metastore\SchemaVersionDescriptor();
-                            $xfer += $elem1059->read($input);
-                            $this->schemaVersions []= $elem1059;
+                        $_size1062 = 0;
+                        $_etype1065 = 0;
+                        $xfer += $input->readListBegin($_etype1065, $_size1062);
+                        for ($_i1066 = 0; $_i1066 < $_size1062; ++$_i1066) {
+                            $elem1067 = null;
+                            $elem1067 = new \metastore\SchemaVersionDescriptor();
+                            $xfer += $elem1067->read($input);
+                            $this->schemaVersions []= $elem1067;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class FindSchemasByColsResp
             }
             $xfer += $output->writeFieldBegin('schemaVersions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->schemaVersions));
-            foreach ($this->schemaVersions as $iter1060) {
-                $xfer += $iter1060->write($output);
+            foreach ($this->schemaVersions as $iter1068) {
+                $xfer += $iter1068->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventRequest.php
@@ -158,13 +158,13 @@ class FireEventRequest
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->partitionVals = array();
-                        $_size833 = 0;
-                        $_etype836 = 0;
-                        $xfer += $input->readListBegin($_etype836, $_size833);
-                        for ($_i837 = 0; $_i837 < $_size833; ++$_i837) {
-                            $elem838 = null;
-                            $xfer += $input->readString($elem838);
-                            $this->partitionVals []= $elem838;
+                        $_size841 = 0;
+                        $_etype844 = 0;
+                        $xfer += $input->readListBegin($_etype844, $_size841);
+                        for ($_i845 = 0; $_i845 < $_size841; ++$_i845) {
+                            $elem846 = null;
+                            $xfer += $input->readString($elem846);
+                            $this->partitionVals []= $elem846;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -221,8 +221,8 @@ class FireEventRequest
             }
             $xfer += $output->writeFieldBegin('partitionVals', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->partitionVals));
-            foreach ($this->partitionVals as $iter839) {
-                $xfer += $output->writeString($iter839);
+            foreach ($this->partitionVals as $iter847) {
+                $xfer += $output->writeString($iter847);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventRequestData.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventRequestData.php
@@ -90,14 +90,14 @@ class FireEventRequestData
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->insertDatas = array();
-                        $_size826 = 0;
-                        $_etype829 = 0;
-                        $xfer += $input->readListBegin($_etype829, $_size826);
-                        for ($_i830 = 0; $_i830 < $_size826; ++$_i830) {
-                            $elem831 = null;
-                            $elem831 = new \metastore\InsertEventRequestData();
-                            $xfer += $elem831->read($input);
-                            $this->insertDatas []= $elem831;
+                        $_size834 = 0;
+                        $_etype837 = 0;
+                        $xfer += $input->readListBegin($_etype837, $_size834);
+                        for ($_i838 = 0; $_i838 < $_size834; ++$_i838) {
+                            $elem839 = null;
+                            $elem839 = new \metastore\InsertEventRequestData();
+                            $xfer += $elem839->read($input);
+                            $this->insertDatas []= $elem839;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -132,8 +132,8 @@ class FireEventRequestData
             }
             $xfer += $output->writeFieldBegin('insertDatas', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->insertDatas));
-            foreach ($this->insertDatas as $iter832) {
-                $xfer += $iter832->write($output);
+            foreach ($this->insertDatas as $iter840) {
+                $xfer += $iter840->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/FireEventResponse.php
@@ -68,13 +68,13 @@ class FireEventResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->eventIds = array();
-                        $_size840 = 0;
-                        $_etype843 = 0;
-                        $xfer += $input->readListBegin($_etype843, $_size840);
-                        for ($_i844 = 0; $_i844 < $_size840; ++$_i844) {
-                            $elem845 = null;
-                            $xfer += $input->readI64($elem845);
-                            $this->eventIds []= $elem845;
+                        $_size848 = 0;
+                        $_etype851 = 0;
+                        $xfer += $input->readListBegin($_etype851, $_size848);
+                        for ($_i852 = 0; $_i852 < $_size848; ++$_i852) {
+                            $elem853 = null;
+                            $xfer += $input->readI64($elem853);
+                            $this->eventIds []= $elem853;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class FireEventResponse
             }
             $xfer += $output->writeFieldBegin('eventIds', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->eventIds));
-            foreach ($this->eventIds as $iter846) {
-                $xfer += $output->writeI64($iter846);
+            foreach ($this->eventIds as $iter854) {
+                $xfer += $output->writeI64($iter854);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ForeignKeysResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ForeignKeysResponse.php
@@ -69,14 +69,14 @@ class ForeignKeysResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->foreignKeys = array();
-                        $_size384 = 0;
-                        $_etype387 = 0;
-                        $xfer += $input->readListBegin($_etype387, $_size384);
-                        for ($_i388 = 0; $_i388 < $_size384; ++$_i388) {
-                            $elem389 = null;
-                            $elem389 = new \metastore\SQLForeignKey();
-                            $xfer += $elem389->read($input);
-                            $this->foreignKeys []= $elem389;
+                        $_size392 = 0;
+                        $_etype395 = 0;
+                        $xfer += $input->readListBegin($_etype395, $_size392);
+                        for ($_i396 = 0; $_i396 < $_size392; ++$_i396) {
+                            $elem397 = null;
+                            $elem397 = new \metastore\SQLForeignKey();
+                            $xfer += $elem397->read($input);
+                            $this->foreignKeys []= $elem397;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ForeignKeysResponse
             }
             $xfer += $output->writeFieldBegin('foreignKeys', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->foreignKeys));
-            foreach ($this->foreignKeys as $iter390) {
-                $xfer += $iter390->write($output);
+            foreach ($this->foreignKeys as $iter398) {
+                $xfer += $iter398->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Function.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Function.php
@@ -216,14 +216,14 @@ class Function
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->resourceUris = array();
-                        $_size612 = 0;
-                        $_etype615 = 0;
-                        $xfer += $input->readListBegin($_etype615, $_size612);
-                        for ($_i616 = 0; $_i616 < $_size612; ++$_i616) {
-                            $elem617 = null;
-                            $elem617 = new \metastore\ResourceUri();
-                            $xfer += $elem617->read($input);
-                            $this->resourceUris []= $elem617;
+                        $_size620 = 0;
+                        $_etype623 = 0;
+                        $xfer += $input->readListBegin($_etype623, $_size620);
+                        for ($_i624 = 0; $_i624 < $_size620; ++$_i624) {
+                            $elem625 = null;
+                            $elem625 = new \metastore\ResourceUri();
+                            $xfer += $elem625->read($input);
+                            $this->resourceUris []= $elem625;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -292,8 +292,8 @@ class Function
             }
             $xfer += $output->writeFieldBegin('resourceUris', TType::LST, 8);
             $output->writeListBegin(TType::STRUCT, count($this->resourceUris));
-            foreach ($this->resourceUris as $iter618) {
-                $xfer += $iter618->write($output);
+            foreach ($this->resourceUris as $iter626) {
+                $xfer += $iter626->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetAllFunctionsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetAllFunctionsResponse.php
@@ -69,14 +69,14 @@ class GetAllFunctionsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->functions = array();
-                        $_size914 = 0;
-                        $_etype917 = 0;
-                        $xfer += $input->readListBegin($_etype917, $_size914);
-                        for ($_i918 = 0; $_i918 < $_size914; ++$_i918) {
-                            $elem919 = null;
-                            $elem919 = new \metastore\Function();
-                            $xfer += $elem919->read($input);
-                            $this->functions []= $elem919;
+                        $_size922 = 0;
+                        $_etype925 = 0;
+                        $xfer += $input->readListBegin($_etype925, $_size922);
+                        for ($_i926 = 0; $_i926 < $_size922; ++$_i926) {
+                            $elem927 = null;
+                            $elem927 = new \metastore\Function();
+                            $xfer += $elem927->read($input);
+                            $this->functions []= $elem927;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetAllFunctionsResponse
             }
             $xfer += $output->writeFieldBegin('functions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->functions));
-            foreach ($this->functions as $iter920) {
-                $xfer += $iter920->write($output);
+            foreach ($this->functions as $iter928) {
+                $xfer += $iter928->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetDatabaseRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetDatabaseRequest.php
@@ -118,13 +118,13 @@ class GetDatabaseRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size984 = 0;
-                        $_etype987 = 0;
-                        $xfer += $input->readListBegin($_etype987, $_size984);
-                        for ($_i988 = 0; $_i988 < $_size984; ++$_i988) {
-                            $elem989 = null;
-                            $xfer += $input->readString($elem989);
-                            $this->processorCapabilities []= $elem989;
+                        $_size992 = 0;
+                        $_etype995 = 0;
+                        $xfer += $input->readListBegin($_etype995, $_size992);
+                        for ($_i996 = 0; $_i996 < $_size992; ++$_i996) {
+                            $elem997 = null;
+                            $xfer += $input->readString($elem997);
+                            $this->processorCapabilities []= $elem997;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -168,8 +168,8 @@ class GetDatabaseRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter990) {
-                $xfer += $output->writeString($iter990);
+            foreach ($this->processorCapabilities as $iter998) {
+                $xfer += $output->writeString($iter998);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFieldsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFieldsResponse.php
@@ -69,14 +69,14 @@ class GetFieldsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fields = array();
-                        $_size1168 = 0;
-                        $_etype1171 = 0;
-                        $xfer += $input->readListBegin($_etype1171, $_size1168);
-                        for ($_i1172 = 0; $_i1172 < $_size1168; ++$_i1172) {
-                            $elem1173 = null;
-                            $elem1173 = new \metastore\FieldSchema();
-                            $xfer += $elem1173->read($input);
-                            $this->fields []= $elem1173;
+                        $_size1176 = 0;
+                        $_etype1179 = 0;
+                        $xfer += $input->readListBegin($_etype1179, $_size1176);
+                        for ($_i1180 = 0; $_i1180 < $_size1176; ++$_i1180) {
+                            $elem1181 = null;
+                            $elem1181 = new \metastore\FieldSchema();
+                            $xfer += $elem1181->read($input);
+                            $this->fields []= $elem1181;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetFieldsResponse
             }
             $xfer += $output->writeFieldBegin('fields', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->fields));
-            foreach ($this->fields as $iter1174) {
-                $xfer += $iter1174->write($output);
+            foreach ($this->fields as $iter1182) {
+                $xfer += $iter1182->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataByExprRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataByExprRequest.php
@@ -105,13 +105,13 @@ class GetFileMetadataByExprRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fileIds = array();
-                        $_size870 = 0;
-                        $_etype873 = 0;
-                        $xfer += $input->readListBegin($_etype873, $_size870);
-                        for ($_i874 = 0; $_i874 < $_size870; ++$_i874) {
-                            $elem875 = null;
-                            $xfer += $input->readI64($elem875);
-                            $this->fileIds []= $elem875;
+                        $_size878 = 0;
+                        $_etype881 = 0;
+                        $xfer += $input->readListBegin($_etype881, $_size878);
+                        for ($_i882 = 0; $_i882 < $_size878; ++$_i882) {
+                            $elem883 = null;
+                            $xfer += $input->readI64($elem883);
+                            $this->fileIds []= $elem883;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -159,8 +159,8 @@ class GetFileMetadataByExprRequest
             }
             $xfer += $output->writeFieldBegin('fileIds', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->fileIds));
-            foreach ($this->fileIds as $iter876) {
-                $xfer += $output->writeI64($iter876);
+            foreach ($this->fileIds as $iter884) {
+                $xfer += $output->writeI64($iter884);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataByExprResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataByExprResult.php
@@ -85,17 +85,17 @@ class GetFileMetadataByExprResult
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->metadata = array();
-                        $_size861 = 0;
-                        $_ktype862 = 0;
-                        $_vtype863 = 0;
-                        $xfer += $input->readMapBegin($_ktype862, $_vtype863, $_size861);
-                        for ($_i865 = 0; $_i865 < $_size861; ++$_i865) {
-                            $key866 = 0;
-                            $val867 = new \metastore\MetadataPpdResult();
-                            $xfer += $input->readI64($key866);
-                            $val867 = new \metastore\MetadataPpdResult();
-                            $xfer += $val867->read($input);
-                            $this->metadata[$key866] = $val867;
+                        $_size869 = 0;
+                        $_ktype870 = 0;
+                        $_vtype871 = 0;
+                        $xfer += $input->readMapBegin($_ktype870, $_vtype871, $_size869);
+                        for ($_i873 = 0; $_i873 < $_size869; ++$_i873) {
+                            $key874 = 0;
+                            $val875 = new \metastore\MetadataPpdResult();
+                            $xfer += $input->readI64($key874);
+                            $val875 = new \metastore\MetadataPpdResult();
+                            $xfer += $val875->read($input);
+                            $this->metadata[$key874] = $val875;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -129,9 +129,9 @@ class GetFileMetadataByExprResult
             }
             $xfer += $output->writeFieldBegin('metadata', TType::MAP, 1);
             $output->writeMapBegin(TType::I64, TType::STRUCT, count($this->metadata));
-            foreach ($this->metadata as $kiter868 => $viter869) {
-                $xfer += $output->writeI64($kiter868);
-                $xfer += $viter869->write($output);
+            foreach ($this->metadata as $kiter876 => $viter877) {
+                $xfer += $output->writeI64($kiter876);
+                $xfer += $viter877->write($output);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataRequest.php
@@ -68,13 +68,13 @@ class GetFileMetadataRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fileIds = array();
-                        $_size886 = 0;
-                        $_etype889 = 0;
-                        $xfer += $input->readListBegin($_etype889, $_size886);
-                        for ($_i890 = 0; $_i890 < $_size886; ++$_i890) {
-                            $elem891 = null;
-                            $xfer += $input->readI64($elem891);
-                            $this->fileIds []= $elem891;
+                        $_size894 = 0;
+                        $_etype897 = 0;
+                        $xfer += $input->readListBegin($_etype897, $_size894);
+                        for ($_i898 = 0; $_i898 < $_size894; ++$_i898) {
+                            $elem899 = null;
+                            $xfer += $input->readI64($elem899);
+                            $this->fileIds []= $elem899;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class GetFileMetadataRequest
             }
             $xfer += $output->writeFieldBegin('fileIds', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->fileIds));
-            foreach ($this->fileIds as $iter892) {
-                $xfer += $output->writeI64($iter892);
+            foreach ($this->fileIds as $iter900) {
+                $xfer += $output->writeI64($iter900);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetFileMetadataResult.php
@@ -84,16 +84,16 @@ class GetFileMetadataResult
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->metadata = array();
-                        $_size877 = 0;
-                        $_ktype878 = 0;
-                        $_vtype879 = 0;
-                        $xfer += $input->readMapBegin($_ktype878, $_vtype879, $_size877);
-                        for ($_i881 = 0; $_i881 < $_size877; ++$_i881) {
-                            $key882 = 0;
-                            $val883 = '';
-                            $xfer += $input->readI64($key882);
-                            $xfer += $input->readString($val883);
-                            $this->metadata[$key882] = $val883;
+                        $_size885 = 0;
+                        $_ktype886 = 0;
+                        $_vtype887 = 0;
+                        $xfer += $input->readMapBegin($_ktype886, $_vtype887, $_size885);
+                        for ($_i889 = 0; $_i889 < $_size885; ++$_i889) {
+                            $key890 = 0;
+                            $val891 = '';
+                            $xfer += $input->readI64($key890);
+                            $xfer += $input->readString($val891);
+                            $this->metadata[$key890] = $val891;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -127,9 +127,9 @@ class GetFileMetadataResult
             }
             $xfer += $output->writeFieldBegin('metadata', TType::MAP, 1);
             $output->writeMapBegin(TType::I64, TType::STRING, count($this->metadata));
-            foreach ($this->metadata as $kiter884 => $viter885) {
-                $xfer += $output->writeI64($kiter884);
-                $xfer += $output->writeString($viter885);
+            foreach ($this->metadata as $kiter892 => $viter893) {
+                $xfer += $output->writeI64($kiter892);
+                $xfer += $output->writeString($viter893);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetLatestCommittedCompactionInfoRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetLatestCommittedCompactionInfoRequest.php
@@ -106,13 +106,13 @@ class GetLatestCommittedCompactionInfoRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->partitionnames = array();
-                        $_size763 = 0;
-                        $_etype766 = 0;
-                        $xfer += $input->readListBegin($_etype766, $_size763);
-                        for ($_i767 = 0; $_i767 < $_size763; ++$_i767) {
-                            $elem768 = null;
-                            $xfer += $input->readString($elem768);
-                            $this->partitionnames []= $elem768;
+                        $_size771 = 0;
+                        $_etype774 = 0;
+                        $xfer += $input->readListBegin($_etype774, $_size771);
+                        for ($_i775 = 0; $_i775 < $_size771; ++$_i775) {
+                            $elem776 = null;
+                            $xfer += $input->readString($elem776);
+                            $this->partitionnames []= $elem776;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class GetLatestCommittedCompactionInfoRequest
             }
             $xfer += $output->writeFieldBegin('partitionnames', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->partitionnames));
-            foreach ($this->partitionnames as $iter769) {
-                $xfer += $output->writeString($iter769);
+            foreach ($this->partitionnames as $iter777) {
+                $xfer += $output->writeString($iter777);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetLatestCommittedCompactionInfoResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetLatestCommittedCompactionInfoResponse.php
@@ -69,14 +69,14 @@ class GetLatestCommittedCompactionInfoResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->compactions = array();
-                        $_size770 = 0;
-                        $_etype773 = 0;
-                        $xfer += $input->readListBegin($_etype773, $_size770);
-                        for ($_i774 = 0; $_i774 < $_size770; ++$_i774) {
-                            $elem775 = null;
-                            $elem775 = new \metastore\CompactionInfoStruct();
-                            $xfer += $elem775->read($input);
-                            $this->compactions []= $elem775;
+                        $_size778 = 0;
+                        $_etype781 = 0;
+                        $xfer += $input->readListBegin($_etype781, $_size778);
+                        for ($_i782 = 0; $_i782 < $_size778; ++$_i782) {
+                            $elem783 = null;
+                            $elem783 = new \metastore\CompactionInfoStruct();
+                            $xfer += $elem783->read($input);
+                            $this->compactions []= $elem783;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetLatestCommittedCompactionInfoResponse
             }
             $xfer += $output->writeFieldBegin('compactions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->compactions));
-            foreach ($this->compactions as $iter776) {
-                $xfer += $iter776->write($output);
+            foreach ($this->compactions as $iter784) {
+                $xfer += $iter784->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsInfoResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsInfoResponse.php
@@ -88,14 +88,14 @@ class GetOpenTxnsInfoResponse
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->open_txns = array();
-                        $_size619 = 0;
-                        $_etype622 = 0;
-                        $xfer += $input->readListBegin($_etype622, $_size619);
-                        for ($_i623 = 0; $_i623 < $_size619; ++$_i623) {
-                            $elem624 = null;
-                            $elem624 = new \metastore\TxnInfo();
-                            $xfer += $elem624->read($input);
-                            $this->open_txns []= $elem624;
+                        $_size627 = 0;
+                        $_etype630 = 0;
+                        $xfer += $input->readListBegin($_etype630, $_size627);
+                        for ($_i631 = 0; $_i631 < $_size627; ++$_i631) {
+                            $elem632 = null;
+                            $elem632 = new \metastore\TxnInfo();
+                            $xfer += $elem632->read($input);
+                            $this->open_txns []= $elem632;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -127,8 +127,8 @@ class GetOpenTxnsInfoResponse
             }
             $xfer += $output->writeFieldBegin('open_txns', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->open_txns));
-            foreach ($this->open_txns as $iter625) {
-                $xfer += $iter625->write($output);
+            foreach ($this->open_txns as $iter633) {
+                $xfer += $iter633->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsRequest.php
@@ -69,13 +69,13 @@ class GetOpenTxnsRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->excludeTxnTypes = array();
-                        $_size1238 = 0;
-                        $_etype1241 = 0;
-                        $xfer += $input->readListBegin($_etype1241, $_size1238);
-                        for ($_i1242 = 0; $_i1242 < $_size1238; ++$_i1242) {
-                            $elem1243 = null;
-                            $xfer += $input->readI32($elem1243);
-                            $this->excludeTxnTypes []= $elem1243;
+                        $_size1246 = 0;
+                        $_etype1249 = 0;
+                        $xfer += $input->readListBegin($_etype1249, $_size1246);
+                        for ($_i1250 = 0; $_i1250 < $_size1246; ++$_i1250) {
+                            $elem1251 = null;
+                            $xfer += $input->readI32($elem1251);
+                            $this->excludeTxnTypes []= $elem1251;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -102,8 +102,8 @@ class GetOpenTxnsRequest
             }
             $xfer += $output->writeFieldBegin('excludeTxnTypes', TType::LST, 1);
             $output->writeListBegin(TType::I32, count($this->excludeTxnTypes));
-            foreach ($this->excludeTxnTypes as $iter1244) {
-                $xfer += $output->writeI32($iter1244);
+            foreach ($this->excludeTxnTypes as $iter1252) {
+                $xfer += $output->writeI32($iter1252);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetOpenTxnsResponse.php
@@ -111,13 +111,13 @@ class GetOpenTxnsResponse
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->open_txns = array();
-                        $_size626 = 0;
-                        $_etype629 = 0;
-                        $xfer += $input->readListBegin($_etype629, $_size626);
-                        for ($_i630 = 0; $_i630 < $_size626; ++$_i630) {
-                            $elem631 = null;
-                            $xfer += $input->readI64($elem631);
-                            $this->open_txns []= $elem631;
+                        $_size634 = 0;
+                        $_etype637 = 0;
+                        $xfer += $input->readListBegin($_etype637, $_size634);
+                        for ($_i638 = 0; $_i638 < $_size634; ++$_i638) {
+                            $elem639 = null;
+                            $xfer += $input->readI64($elem639);
+                            $this->open_txns []= $elem639;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -163,8 +163,8 @@ class GetOpenTxnsResponse
             }
             $xfer += $output->writeFieldBegin('open_txns', TType::LST, 2);
             $output->writeListBegin(TType::I64, count($this->open_txns));
-            foreach ($this->open_txns as $iter632) {
-                $xfer += $output->writeI64($iter632);
+            foreach ($this->open_txns as $iter640) {
+                $xfer += $output->writeI64($iter640);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionNamesPsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionNamesPsRequest.php
@@ -161,13 +161,13 @@ class GetPartitionNamesPsRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partValues = array();
-                        $_size1196 = 0;
-                        $_etype1199 = 0;
-                        $xfer += $input->readListBegin($_etype1199, $_size1196);
-                        for ($_i1200 = 0; $_i1200 < $_size1196; ++$_i1200) {
-                            $elem1201 = null;
-                            $xfer += $input->readString($elem1201);
-                            $this->partValues []= $elem1201;
+                        $_size1204 = 0;
+                        $_etype1207 = 0;
+                        $xfer += $input->readListBegin($_etype1207, $_size1204);
+                        for ($_i1208 = 0; $_i1208 < $_size1204; ++$_i1208) {
+                            $elem1209 = null;
+                            $xfer += $input->readString($elem1209);
+                            $this->partValues []= $elem1209;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -230,8 +230,8 @@ class GetPartitionNamesPsRequest
             }
             $xfer += $output->writeFieldBegin('partValues', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partValues));
-            foreach ($this->partValues as $iter1202) {
-                $xfer += $output->writeString($iter1202);
+            foreach ($this->partValues as $iter1210) {
+                $xfer += $output->writeString($iter1210);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionNamesPsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionNamesPsResponse.php
@@ -68,13 +68,13 @@ class GetPartitionNamesPsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->names = array();
-                        $_size1203 = 0;
-                        $_etype1206 = 0;
-                        $xfer += $input->readListBegin($_etype1206, $_size1203);
-                        for ($_i1207 = 0; $_i1207 < $_size1203; ++$_i1207) {
-                            $elem1208 = null;
-                            $xfer += $input->readString($elem1208);
-                            $this->names []= $elem1208;
+                        $_size1211 = 0;
+                        $_etype1214 = 0;
+                        $xfer += $input->readListBegin($_etype1214, $_size1211);
+                        for ($_i1215 = 0; $_i1215 < $_size1211; ++$_i1215) {
+                            $elem1216 = null;
+                            $xfer += $input->readString($elem1216);
+                            $this->names []= $elem1216;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class GetPartitionNamesPsResponse
             }
             $xfer += $output->writeFieldBegin('names', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->names));
-            foreach ($this->names as $iter1209) {
-                $xfer += $output->writeString($iter1209);
+            foreach ($this->names as $iter1217) {
+                $xfer += $output->writeString($iter1217);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionRequest.php
@@ -149,13 +149,13 @@ class GetPartitionRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partVals = array();
-                        $_size1182 = 0;
-                        $_etype1185 = 0;
-                        $xfer += $input->readListBegin($_etype1185, $_size1182);
-                        for ($_i1186 = 0; $_i1186 < $_size1182; ++$_i1186) {
-                            $elem1187 = null;
-                            $xfer += $input->readString($elem1187);
-                            $this->partVals []= $elem1187;
+                        $_size1190 = 0;
+                        $_etype1193 = 0;
+                        $xfer += $input->readListBegin($_etype1193, $_size1190);
+                        for ($_i1194 = 0; $_i1194 < $_size1190; ++$_i1194) {
+                            $elem1195 = null;
+                            $xfer += $input->readString($elem1195);
+                            $this->partVals []= $elem1195;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -211,8 +211,8 @@ class GetPartitionRequest
             }
             $xfer += $output->writeFieldBegin('partVals', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partVals));
-            foreach ($this->partVals as $iter1188) {
-                $xfer += $output->writeString($iter1188);
+            foreach ($this->partVals as $iter1196) {
+                $xfer += $output->writeString($iter1196);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesRequest.php
@@ -194,13 +194,13 @@ class GetPartitionsByNamesRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->names = array();
-                        $_size582 = 0;
-                        $_etype585 = 0;
-                        $xfer += $input->readListBegin($_etype585, $_size582);
-                        for ($_i586 = 0; $_i586 < $_size582; ++$_i586) {
-                            $elem587 = null;
-                            $xfer += $input->readString($elem587);
-                            $this->names []= $elem587;
+                        $_size590 = 0;
+                        $_etype593 = 0;
+                        $xfer += $input->readListBegin($_etype593, $_size590);
+                        for ($_i594 = 0; $_i594 < $_size590; ++$_i594) {
+                            $elem595 = null;
+                            $xfer += $input->readString($elem595);
+                            $this->names []= $elem595;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -217,13 +217,13 @@ class GetPartitionsByNamesRequest
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size588 = 0;
-                        $_etype591 = 0;
-                        $xfer += $input->readListBegin($_etype591, $_size588);
-                        for ($_i592 = 0; $_i592 < $_size588; ++$_i592) {
-                            $elem593 = null;
-                            $xfer += $input->readString($elem593);
-                            $this->processorCapabilities []= $elem593;
+                        $_size596 = 0;
+                        $_etype599 = 0;
+                        $xfer += $input->readListBegin($_etype599, $_size596);
+                        for ($_i600 = 0; $_i600 < $_size596; ++$_i600) {
+                            $elem601 = null;
+                            $xfer += $input->readString($elem601);
+                            $this->processorCapabilities []= $elem601;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -295,8 +295,8 @@ class GetPartitionsByNamesRequest
             }
             $xfer += $output->writeFieldBegin('names', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->names));
-            foreach ($this->names as $iter594) {
-                $xfer += $output->writeString($iter594);
+            foreach ($this->names as $iter602) {
+                $xfer += $output->writeString($iter602);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -312,8 +312,8 @@ class GetPartitionsByNamesRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter595) {
-                $xfer += $output->writeString($iter595);
+            foreach ($this->processorCapabilities as $iter603) {
+                $xfer += $output->writeString($iter603);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesResult.php
@@ -82,14 +82,14 @@ class GetPartitionsByNamesResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size596 = 0;
-                        $_etype599 = 0;
-                        $xfer += $input->readListBegin($_etype599, $_size596);
-                        for ($_i600 = 0; $_i600 < $_size596; ++$_i600) {
-                            $elem601 = null;
-                            $elem601 = new \metastore\Partition();
-                            $xfer += $elem601->read($input);
-                            $this->partitions []= $elem601;
+                        $_size604 = 0;
+                        $_etype607 = 0;
+                        $xfer += $input->readListBegin($_etype607, $_size604);
+                        for ($_i608 = 0; $_i608 < $_size604; ++$_i608) {
+                            $elem609 = null;
+                            $elem609 = new \metastore\Partition();
+                            $xfer += $elem609->read($input);
+                            $this->partitions []= $elem609;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class GetPartitionsByNamesResult
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter602) {
-                $xfer += $iter602->write($output);
+            foreach ($this->partitions as $iter610) {
+                $xfer += $iter610->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsFilterSpec.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsFilterSpec.php
@@ -88,13 +88,13 @@ class GetPartitionsFilterSpec
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->filters = array();
-                        $_size1140 = 0;
-                        $_etype1143 = 0;
-                        $xfer += $input->readListBegin($_etype1143, $_size1140);
-                        for ($_i1144 = 0; $_i1144 < $_size1140; ++$_i1144) {
-                            $elem1145 = null;
-                            $xfer += $input->readString($elem1145);
-                            $this->filters []= $elem1145;
+                        $_size1148 = 0;
+                        $_etype1151 = 0;
+                        $xfer += $input->readListBegin($_etype1151, $_size1148);
+                        for ($_i1152 = 0; $_i1152 < $_size1148; ++$_i1152) {
+                            $elem1153 = null;
+                            $xfer += $input->readString($elem1153);
+                            $this->filters []= $elem1153;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -126,8 +126,8 @@ class GetPartitionsFilterSpec
             }
             $xfer += $output->writeFieldBegin('filters', TType::LST, 8);
             $output->writeListBegin(TType::STRING, count($this->filters));
-            foreach ($this->filters as $iter1146) {
-                $xfer += $output->writeString($iter1146);
+            foreach ($this->filters as $iter1154) {
+                $xfer += $output->writeString($iter1154);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsPsWithAuthRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsPsWithAuthRequest.php
@@ -189,13 +189,13 @@ class GetPartitionsPsWithAuthRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partVals = array();
-                        $_size1210 = 0;
-                        $_etype1213 = 0;
-                        $xfer += $input->readListBegin($_etype1213, $_size1210);
-                        for ($_i1214 = 0; $_i1214 < $_size1210; ++$_i1214) {
-                            $elem1215 = null;
-                            $xfer += $input->readString($elem1215);
-                            $this->partVals []= $elem1215;
+                        $_size1218 = 0;
+                        $_etype1221 = 0;
+                        $xfer += $input->readListBegin($_etype1221, $_size1218);
+                        for ($_i1222 = 0; $_i1222 < $_size1218; ++$_i1222) {
+                            $elem1223 = null;
+                            $xfer += $input->readString($elem1223);
+                            $this->partVals []= $elem1223;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -219,13 +219,13 @@ class GetPartitionsPsWithAuthRequest
                 case 7:
                     if ($ftype == TType::LST) {
                         $this->groupNames = array();
-                        $_size1216 = 0;
-                        $_etype1219 = 0;
-                        $xfer += $input->readListBegin($_etype1219, $_size1216);
-                        for ($_i1220 = 0; $_i1220 < $_size1216; ++$_i1220) {
-                            $elem1221 = null;
-                            $xfer += $input->readString($elem1221);
-                            $this->groupNames []= $elem1221;
+                        $_size1224 = 0;
+                        $_etype1227 = 0;
+                        $xfer += $input->readListBegin($_etype1227, $_size1224);
+                        for ($_i1228 = 0; $_i1228 < $_size1224; ++$_i1228) {
+                            $elem1229 = null;
+                            $xfer += $input->readString($elem1229);
+                            $this->groupNames []= $elem1229;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -281,8 +281,8 @@ class GetPartitionsPsWithAuthRequest
             }
             $xfer += $output->writeFieldBegin('partVals', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partVals));
-            foreach ($this->partVals as $iter1222) {
-                $xfer += $output->writeString($iter1222);
+            foreach ($this->partVals as $iter1230) {
+                $xfer += $output->writeString($iter1230);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -303,8 +303,8 @@ class GetPartitionsPsWithAuthRequest
             }
             $xfer += $output->writeFieldBegin('groupNames', TType::LST, 7);
             $output->writeListBegin(TType::STRING, count($this->groupNames));
-            foreach ($this->groupNames as $iter1223) {
-                $xfer += $output->writeString($iter1223);
+            foreach ($this->groupNames as $iter1231) {
+                $xfer += $output->writeString($iter1231);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsPsWithAuthResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsPsWithAuthResponse.php
@@ -69,14 +69,14 @@ class GetPartitionsPsWithAuthResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size1224 = 0;
-                        $_etype1227 = 0;
-                        $xfer += $input->readListBegin($_etype1227, $_size1224);
-                        for ($_i1228 = 0; $_i1228 < $_size1224; ++$_i1228) {
-                            $elem1229 = null;
-                            $elem1229 = new \metastore\Partition();
-                            $xfer += $elem1229->read($input);
-                            $this->partitions []= $elem1229;
+                        $_size1232 = 0;
+                        $_etype1235 = 0;
+                        $xfer += $input->readListBegin($_etype1235, $_size1232);
+                        for ($_i1236 = 0; $_i1236 < $_size1232; ++$_i1236) {
+                            $elem1237 = null;
+                            $elem1237 = new \metastore\Partition();
+                            $xfer += $elem1237->read($input);
+                            $this->partitions []= $elem1237;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetPartitionsPsWithAuthResponse
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter1230) {
-                $xfer += $iter1230->write($output);
+            foreach ($this->partitions as $iter1238) {
+                $xfer += $iter1238->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsRequest.php
@@ -229,13 +229,13 @@ class GetPartitionsRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->groupNames = array();
-                        $_size1154 = 0;
-                        $_etype1157 = 0;
-                        $xfer += $input->readListBegin($_etype1157, $_size1154);
-                        for ($_i1158 = 0; $_i1158 < $_size1154; ++$_i1158) {
-                            $elem1159 = null;
-                            $xfer += $input->readString($elem1159);
-                            $this->groupNames []= $elem1159;
+                        $_size1162 = 0;
+                        $_etype1165 = 0;
+                        $xfer += $input->readListBegin($_etype1165, $_size1162);
+                        for ($_i1166 = 0; $_i1166 < $_size1162; ++$_i1166) {
+                            $elem1167 = null;
+                            $xfer += $input->readString($elem1167);
+                            $this->groupNames []= $elem1167;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -261,13 +261,13 @@ class GetPartitionsRequest
                 case 9:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size1160 = 0;
-                        $_etype1163 = 0;
-                        $xfer += $input->readListBegin($_etype1163, $_size1160);
-                        for ($_i1164 = 0; $_i1164 < $_size1160; ++$_i1164) {
-                            $elem1165 = null;
-                            $xfer += $input->readString($elem1165);
-                            $this->processorCapabilities []= $elem1165;
+                        $_size1168 = 0;
+                        $_etype1171 = 0;
+                        $xfer += $input->readListBegin($_etype1171, $_size1168);
+                        for ($_i1172 = 0; $_i1172 < $_size1168; ++$_i1172) {
+                            $elem1173 = null;
+                            $xfer += $input->readString($elem1173);
+                            $this->processorCapabilities []= $elem1173;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -333,8 +333,8 @@ class GetPartitionsRequest
             }
             $xfer += $output->writeFieldBegin('groupNames', TType::LST, 6);
             $output->writeListBegin(TType::STRING, count($this->groupNames));
-            foreach ($this->groupNames as $iter1166) {
-                $xfer += $output->writeString($iter1166);
+            foreach ($this->groupNames as $iter1174) {
+                $xfer += $output->writeString($iter1174);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -361,8 +361,8 @@ class GetPartitionsRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 9);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter1167) {
-                $xfer += $output->writeString($iter1167);
+            foreach ($this->processorCapabilities as $iter1175) {
+                $xfer += $output->writeString($iter1175);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsResponse.php
@@ -69,14 +69,14 @@ class GetPartitionsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitionSpec = array();
-                        $_size1147 = 0;
-                        $_etype1150 = 0;
-                        $xfer += $input->readListBegin($_etype1150, $_size1147);
-                        for ($_i1151 = 0; $_i1151 < $_size1147; ++$_i1151) {
-                            $elem1152 = null;
-                            $elem1152 = new \metastore\PartitionSpec();
-                            $xfer += $elem1152->read($input);
-                            $this->partitionSpec []= $elem1152;
+                        $_size1155 = 0;
+                        $_etype1158 = 0;
+                        $xfer += $input->readListBegin($_etype1158, $_size1155);
+                        for ($_i1159 = 0; $_i1159 < $_size1155; ++$_i1159) {
+                            $elem1160 = null;
+                            $elem1160 = new \metastore\PartitionSpec();
+                            $xfer += $elem1160->read($input);
+                            $this->partitionSpec []= $elem1160;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetPartitionsResponse
             }
             $xfer += $output->writeFieldBegin('partitionSpec', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitionSpec));
-            foreach ($this->partitionSpec as $iter1153) {
-                $xfer += $iter1153->write($output);
+            foreach ($this->partitionSpec as $iter1161) {
+                $xfer += $iter1161->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetProjectionsSpec.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetProjectionsSpec.php
@@ -92,13 +92,13 @@ class GetProjectionsSpec
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fieldList = array();
-                        $_size928 = 0;
-                        $_etype931 = 0;
-                        $xfer += $input->readListBegin($_etype931, $_size928);
-                        for ($_i932 = 0; $_i932 < $_size928; ++$_i932) {
-                            $elem933 = null;
-                            $xfer += $input->readString($elem933);
-                            $this->fieldList []= $elem933;
+                        $_size936 = 0;
+                        $_etype939 = 0;
+                        $xfer += $input->readListBegin($_etype939, $_size936);
+                        for ($_i940 = 0; $_i940 < $_size936; ++$_i940) {
+                            $elem941 = null;
+                            $xfer += $input->readString($elem941);
+                            $this->fieldList []= $elem941;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -139,8 +139,8 @@ class GetProjectionsSpec
             }
             $xfer += $output->writeFieldBegin('fieldList', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->fieldList));
-            foreach ($this->fieldList as $iter934) {
-                $xfer += $output->writeString($iter934);
+            foreach ($this->fieldList as $iter942) {
+                $xfer += $output->writeString($iter942);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetSchemaResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetSchemaResponse.php
@@ -69,14 +69,14 @@ class GetSchemaResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fields = array();
-                        $_size1175 = 0;
-                        $_etype1178 = 0;
-                        $xfer += $input->readListBegin($_etype1178, $_size1175);
-                        for ($_i1179 = 0; $_i1179 < $_size1175; ++$_i1179) {
-                            $elem1180 = null;
-                            $elem1180 = new \metastore\FieldSchema();
-                            $xfer += $elem1180->read($input);
-                            $this->fields []= $elem1180;
+                        $_size1183 = 0;
+                        $_etype1186 = 0;
+                        $xfer += $input->readListBegin($_etype1186, $_size1183);
+                        for ($_i1187 = 0; $_i1187 < $_size1183; ++$_i1187) {
+                            $elem1188 = null;
+                            $elem1188 = new \metastore\FieldSchema();
+                            $xfer += $elem1188->read($input);
+                            $this->fields []= $elem1188;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetSchemaResponse
             }
             $xfer += $output->writeFieldBegin('fields', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->fields));
-            foreach ($this->fields as $iter1181) {
-                $xfer += $iter1181->write($output);
+            foreach ($this->fields as $iter1189) {
+                $xfer += $iter1189->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTableRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTableRequest.php
@@ -220,13 +220,13 @@ class GetTableRequest
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size935 = 0;
-                        $_etype938 = 0;
-                        $xfer += $input->readListBegin($_etype938, $_size935);
-                        for ($_i939 = 0; $_i939 < $_size935; ++$_i939) {
-                            $elem940 = null;
-                            $xfer += $input->readString($elem940);
-                            $this->processorCapabilities []= $elem940;
+                        $_size943 = 0;
+                        $_etype946 = 0;
+                        $xfer += $input->readListBegin($_etype946, $_size943);
+                        for ($_i947 = 0; $_i947 < $_size943; ++$_i947) {
+                            $elem948 = null;
+                            $xfer += $input->readString($elem948);
+                            $this->processorCapabilities []= $elem948;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -307,8 +307,8 @@ class GetTableRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 8);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter941) {
-                $xfer += $output->writeString($iter941);
+            foreach ($this->processorCapabilities as $iter949) {
+                $xfer += $output->writeString($iter949);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesExtRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesExtRequest.php
@@ -175,13 +175,13 @@ class GetTablesExtRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size963 = 0;
-                        $_etype966 = 0;
-                        $xfer += $input->readListBegin($_etype966, $_size963);
-                        for ($_i967 = 0; $_i967 < $_size963; ++$_i967) {
-                            $elem968 = null;
-                            $xfer += $input->readString($elem968);
-                            $this->processorCapabilities []= $elem968;
+                        $_size971 = 0;
+                        $_etype974 = 0;
+                        $xfer += $input->readListBegin($_etype974, $_size971);
+                        for ($_i975 = 0; $_i975 < $_size971; ++$_i975) {
+                            $elem976 = null;
+                            $xfer += $input->readString($elem976);
+                            $this->processorCapabilities []= $elem976;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -240,8 +240,8 @@ class GetTablesExtRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 6);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter969) {
-                $xfer += $output->writeString($iter969);
+            foreach ($this->processorCapabilities as $iter977) {
+                $xfer += $output->writeString($iter977);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesRequest.php
@@ -165,13 +165,13 @@ class GetTablesRequest
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->tblNames = array();
-                        $_size942 = 0;
-                        $_etype945 = 0;
-                        $xfer += $input->readListBegin($_etype945, $_size942);
-                        for ($_i946 = 0; $_i946 < $_size942; ++$_i946) {
-                            $elem947 = null;
-                            $xfer += $input->readString($elem947);
-                            $this->tblNames []= $elem947;
+                        $_size950 = 0;
+                        $_etype953 = 0;
+                        $xfer += $input->readListBegin($_etype953, $_size950);
+                        for ($_i954 = 0; $_i954 < $_size950; ++$_i954) {
+                            $elem955 = null;
+                            $xfer += $input->readString($elem955);
+                            $this->tblNames []= $elem955;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -196,13 +196,13 @@ class GetTablesRequest
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->processorCapabilities = array();
-                        $_size948 = 0;
-                        $_etype951 = 0;
-                        $xfer += $input->readListBegin($_etype951, $_size948);
-                        for ($_i952 = 0; $_i952 < $_size948; ++$_i952) {
-                            $elem953 = null;
-                            $xfer += $input->readString($elem953);
-                            $this->processorCapabilities []= $elem953;
+                        $_size956 = 0;
+                        $_etype959 = 0;
+                        $xfer += $input->readListBegin($_etype959, $_size956);
+                        for ($_i960 = 0; $_i960 < $_size956; ++$_i960) {
+                            $elem961 = null;
+                            $xfer += $input->readString($elem961);
+                            $this->processorCapabilities []= $elem961;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -256,8 +256,8 @@ class GetTablesRequest
             }
             $xfer += $output->writeFieldBegin('tblNames', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->tblNames));
-            foreach ($this->tblNames as $iter954) {
-                $xfer += $output->writeString($iter954);
+            foreach ($this->tblNames as $iter962) {
+                $xfer += $output->writeString($iter962);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -281,8 +281,8 @@ class GetTablesRequest
             }
             $xfer += $output->writeFieldBegin('processorCapabilities', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->processorCapabilities));
-            foreach ($this->processorCapabilities as $iter955) {
-                $xfer += $output->writeString($iter955);
+            foreach ($this->processorCapabilities as $iter963) {
+                $xfer += $output->writeString($iter963);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesResult.php
@@ -69,14 +69,14 @@ class GetTablesResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->tables = array();
-                        $_size956 = 0;
-                        $_etype959 = 0;
-                        $xfer += $input->readListBegin($_etype959, $_size956);
-                        for ($_i960 = 0; $_i960 < $_size956; ++$_i960) {
-                            $elem961 = null;
-                            $elem961 = new \metastore\Table();
-                            $xfer += $elem961->read($input);
-                            $this->tables []= $elem961;
+                        $_size964 = 0;
+                        $_etype967 = 0;
+                        $xfer += $input->readListBegin($_etype967, $_size964);
+                        for ($_i968 = 0; $_i968 < $_size964; ++$_i968) {
+                            $elem969 = null;
+                            $elem969 = new \metastore\Table();
+                            $xfer += $elem969->read($input);
+                            $this->tables []= $elem969;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetTablesResult
             }
             $xfer += $output->writeFieldBegin('tables', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->tables));
-            foreach ($this->tables as $iter962) {
-                $xfer += $iter962->write($output);
+            foreach ($this->tables as $iter970) {
+                $xfer += $iter970->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetValidWriteIdsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetValidWriteIdsRequest.php
@@ -92,13 +92,13 @@ class GetValidWriteIdsRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fullTableNames = array();
-                        $_size675 = 0;
-                        $_etype678 = 0;
-                        $xfer += $input->readListBegin($_etype678, $_size675);
-                        for ($_i679 = 0; $_i679 < $_size675; ++$_i679) {
-                            $elem680 = null;
-                            $xfer += $input->readString($elem680);
-                            $this->fullTableNames []= $elem680;
+                        $_size683 = 0;
+                        $_etype686 = 0;
+                        $xfer += $input->readListBegin($_etype686, $_size683);
+                        for ($_i687 = 0; $_i687 < $_size683; ++$_i687) {
+                            $elem688 = null;
+                            $xfer += $input->readString($elem688);
+                            $this->fullTableNames []= $elem688;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -139,8 +139,8 @@ class GetValidWriteIdsRequest
             }
             $xfer += $output->writeFieldBegin('fullTableNames', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->fullTableNames));
-            foreach ($this->fullTableNames as $iter681) {
-                $xfer += $output->writeString($iter681);
+            foreach ($this->fullTableNames as $iter689) {
+                $xfer += $output->writeString($iter689);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetValidWriteIdsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetValidWriteIdsResponse.php
@@ -69,14 +69,14 @@ class GetValidWriteIdsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->tblValidWriteIds = array();
-                        $_size689 = 0;
-                        $_etype692 = 0;
-                        $xfer += $input->readListBegin($_etype692, $_size689);
-                        for ($_i693 = 0; $_i693 < $_size689; ++$_i693) {
-                            $elem694 = null;
-                            $elem694 = new \metastore\TableValidWriteIds();
-                            $xfer += $elem694->read($input);
-                            $this->tblValidWriteIds []= $elem694;
+                        $_size697 = 0;
+                        $_etype700 = 0;
+                        $xfer += $input->readListBegin($_etype700, $_size697);
+                        for ($_i701 = 0; $_i701 < $_size697; ++$_i701) {
+                            $elem702 = null;
+                            $elem702 = new \metastore\TableValidWriteIds();
+                            $xfer += $elem702->read($input);
+                            $this->tblValidWriteIds []= $elem702;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class GetValidWriteIdsResponse
             }
             $xfer += $output->writeFieldBegin('tblValidWriteIds', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->tblValidWriteIds));
-            foreach ($this->tblValidWriteIds as $iter695) {
-                $xfer += $iter695->write($output);
+            foreach ($this->tblValidWriteIds as $iter703) {
+                $xfer += $iter703->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/HeartbeatTxnRangeResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/HeartbeatTxnRangeResponse.php
@@ -84,13 +84,13 @@ class HeartbeatTxnRangeResponse
                 case 1:
                     if ($ftype == TType::SET) {
                         $this->aborted = array();
-                        $_size731 = 0;
-                        $_etype734 = 0;
-                        $xfer += $input->readSetBegin($_etype734, $_size731);
-                        for ($_i735 = 0; $_i735 < $_size731; ++$_i735) {
-                            $elem736 = null;
-                            $xfer += $input->readI64($elem736);
-                            $this->aborted[$elem736] = true;
+                        $_size739 = 0;
+                        $_etype742 = 0;
+                        $xfer += $input->readSetBegin($_etype742, $_size739);
+                        for ($_i743 = 0; $_i743 < $_size739; ++$_i743) {
+                            $elem744 = null;
+                            $xfer += $input->readI64($elem744);
+                            $this->aborted[$elem744] = true;
                         }
                         $xfer += $input->readSetEnd();
                     } else {
@@ -100,13 +100,13 @@ class HeartbeatTxnRangeResponse
                 case 2:
                     if ($ftype == TType::SET) {
                         $this->nosuch = array();
-                        $_size737 = 0;
-                        $_etype740 = 0;
-                        $xfer += $input->readSetBegin($_etype740, $_size737);
-                        for ($_i741 = 0; $_i741 < $_size737; ++$_i741) {
-                            $elem742 = null;
-                            $xfer += $input->readI64($elem742);
-                            $this->nosuch[$elem742] = true;
+                        $_size745 = 0;
+                        $_etype748 = 0;
+                        $xfer += $input->readSetBegin($_etype748, $_size745);
+                        for ($_i749 = 0; $_i749 < $_size745; ++$_i749) {
+                            $elem750 = null;
+                            $xfer += $input->readI64($elem750);
+                            $this->nosuch[$elem750] = true;
                         }
                         $xfer += $input->readSetEnd();
                     } else {
@@ -133,8 +133,8 @@ class HeartbeatTxnRangeResponse
             }
             $xfer += $output->writeFieldBegin('aborted', TType::SET, 1);
             $output->writeSetBegin(TType::I64, count($this->aborted));
-            foreach ($this->aborted as $iter743 => $iter744) {
-                $xfer += $output->writeI64($iter743);
+            foreach ($this->aborted as $iter751 => $iter752) {
+                $xfer += $output->writeI64($iter751);
             }
             $output->writeSetEnd();
             $xfer += $output->writeFieldEnd();
@@ -145,8 +145,8 @@ class HeartbeatTxnRangeResponse
             }
             $xfer += $output->writeFieldBegin('nosuch', TType::SET, 2);
             $output->writeSetBegin(TType::I64, count($this->nosuch));
-            foreach ($this->nosuch as $iter745 => $iter746) {
-                $xfer += $output->writeI64($iter745);
+            foreach ($this->nosuch as $iter753 => $iter754) {
+                $xfer += $output->writeI64($iter753);
             }
             $output->writeSetEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/InsertEventRequestData.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/InsertEventRequestData.php
@@ -135,13 +135,13 @@ class InsertEventRequestData
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->filesAdded = array();
-                        $_size798 = 0;
-                        $_etype801 = 0;
-                        $xfer += $input->readListBegin($_etype801, $_size798);
-                        for ($_i802 = 0; $_i802 < $_size798; ++$_i802) {
-                            $elem803 = null;
-                            $xfer += $input->readString($elem803);
-                            $this->filesAdded []= $elem803;
+                        $_size806 = 0;
+                        $_etype809 = 0;
+                        $xfer += $input->readListBegin($_etype809, $_size806);
+                        for ($_i810 = 0; $_i810 < $_size806; ++$_i810) {
+                            $elem811 = null;
+                            $xfer += $input->readString($elem811);
+                            $this->filesAdded []= $elem811;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -151,13 +151,13 @@ class InsertEventRequestData
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->filesAddedChecksum = array();
-                        $_size804 = 0;
-                        $_etype807 = 0;
-                        $xfer += $input->readListBegin($_etype807, $_size804);
-                        for ($_i808 = 0; $_i808 < $_size804; ++$_i808) {
-                            $elem809 = null;
-                            $xfer += $input->readString($elem809);
-                            $this->filesAddedChecksum []= $elem809;
+                        $_size812 = 0;
+                        $_etype815 = 0;
+                        $xfer += $input->readListBegin($_etype815, $_size812);
+                        for ($_i816 = 0; $_i816 < $_size812; ++$_i816) {
+                            $elem817 = null;
+                            $xfer += $input->readString($elem817);
+                            $this->filesAddedChecksum []= $elem817;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -167,13 +167,13 @@ class InsertEventRequestData
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->subDirectoryList = array();
-                        $_size810 = 0;
-                        $_etype813 = 0;
-                        $xfer += $input->readListBegin($_etype813, $_size810);
-                        for ($_i814 = 0; $_i814 < $_size810; ++$_i814) {
-                            $elem815 = null;
-                            $xfer += $input->readString($elem815);
-                            $this->subDirectoryList []= $elem815;
+                        $_size818 = 0;
+                        $_etype821 = 0;
+                        $xfer += $input->readListBegin($_etype821, $_size818);
+                        for ($_i822 = 0; $_i822 < $_size818; ++$_i822) {
+                            $elem823 = null;
+                            $xfer += $input->readString($elem823);
+                            $this->subDirectoryList []= $elem823;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -183,13 +183,13 @@ class InsertEventRequestData
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->partitionVal = array();
-                        $_size816 = 0;
-                        $_etype819 = 0;
-                        $xfer += $input->readListBegin($_etype819, $_size816);
-                        for ($_i820 = 0; $_i820 < $_size816; ++$_i820) {
-                            $elem821 = null;
-                            $xfer += $input->readString($elem821);
-                            $this->partitionVal []= $elem821;
+                        $_size824 = 0;
+                        $_etype827 = 0;
+                        $xfer += $input->readListBegin($_etype827, $_size824);
+                        for ($_i828 = 0; $_i828 < $_size824; ++$_i828) {
+                            $elem829 = null;
+                            $xfer += $input->readString($elem829);
+                            $this->partitionVal []= $elem829;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -221,8 +221,8 @@ class InsertEventRequestData
             }
             $xfer += $output->writeFieldBegin('filesAdded', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->filesAdded));
-            foreach ($this->filesAdded as $iter822) {
-                $xfer += $output->writeString($iter822);
+            foreach ($this->filesAdded as $iter830) {
+                $xfer += $output->writeString($iter830);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -233,8 +233,8 @@ class InsertEventRequestData
             }
             $xfer += $output->writeFieldBegin('filesAddedChecksum', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->filesAddedChecksum));
-            foreach ($this->filesAddedChecksum as $iter823) {
-                $xfer += $output->writeString($iter823);
+            foreach ($this->filesAddedChecksum as $iter831) {
+                $xfer += $output->writeString($iter831);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -245,8 +245,8 @@ class InsertEventRequestData
             }
             $xfer += $output->writeFieldBegin('subDirectoryList', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->subDirectoryList));
-            foreach ($this->subDirectoryList as $iter824) {
-                $xfer += $output->writeString($iter824);
+            foreach ($this->subDirectoryList as $iter832) {
+                $xfer += $output->writeString($iter832);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -257,8 +257,8 @@ class InsertEventRequestData
             }
             $xfer += $output->writeFieldBegin('partitionVal', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->partitionVal));
-            foreach ($this->partitionVal as $iter825) {
-                $xfer += $output->writeString($iter825);
+            foreach ($this->partitionVal as $iter833) {
+                $xfer += $output->writeString($iter833);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/LockRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/LockRequest.php
@@ -129,14 +129,14 @@ class LockRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->component = array();
-                        $_size717 = 0;
-                        $_etype720 = 0;
-                        $xfer += $input->readListBegin($_etype720, $_size717);
-                        for ($_i721 = 0; $_i721 < $_size717; ++$_i721) {
-                            $elem722 = null;
-                            $elem722 = new \metastore\LockComponent();
-                            $xfer += $elem722->read($input);
-                            $this->component []= $elem722;
+                        $_size725 = 0;
+                        $_etype728 = 0;
+                        $xfer += $input->readListBegin($_etype728, $_size725);
+                        for ($_i729 = 0; $_i729 < $_size725; ++$_i729) {
+                            $elem730 = null;
+                            $elem730 = new \metastore\LockComponent();
+                            $xfer += $elem730->read($input);
+                            $this->component []= $elem730;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -198,8 +198,8 @@ class LockRequest
             }
             $xfer += $output->writeFieldBegin('component', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->component));
-            foreach ($this->component as $iter723) {
-                $xfer += $iter723->write($output);
+            foreach ($this->component as $iter731) {
+                $xfer += $iter731->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotNullConstraintsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotNullConstraintsResponse.php
@@ -69,14 +69,14 @@ class NotNullConstraintsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->notNullConstraints = array();
-                        $_size398 = 0;
-                        $_etype401 = 0;
-                        $xfer += $input->readListBegin($_etype401, $_size398);
-                        for ($_i402 = 0; $_i402 < $_size398; ++$_i402) {
-                            $elem403 = null;
-                            $elem403 = new \metastore\SQLNotNullConstraint();
-                            $xfer += $elem403->read($input);
-                            $this->notNullConstraints []= $elem403;
+                        $_size406 = 0;
+                        $_etype409 = 0;
+                        $xfer += $input->readListBegin($_etype409, $_size406);
+                        for ($_i410 = 0; $_i410 < $_size406; ++$_i410) {
+                            $elem411 = null;
+                            $elem411 = new \metastore\SQLNotNullConstraint();
+                            $xfer += $elem411->read($input);
+                            $this->notNullConstraints []= $elem411;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class NotNullConstraintsResponse
             }
             $xfer += $output->writeFieldBegin('notNullConstraints', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->notNullConstraints));
-            foreach ($this->notNullConstraints as $iter404) {
-                $xfer += $iter404->write($output);
+            foreach ($this->notNullConstraints as $iter412) {
+                $xfer += $iter412->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotificationEventRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotificationEventRequest.php
@@ -106,13 +106,13 @@ class NotificationEventRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->eventTypeSkipList = array();
-                        $_size784 = 0;
-                        $_etype787 = 0;
-                        $xfer += $input->readListBegin($_etype787, $_size784);
-                        for ($_i788 = 0; $_i788 < $_size784; ++$_i788) {
-                            $elem789 = null;
-                            $xfer += $input->readString($elem789);
-                            $this->eventTypeSkipList []= $elem789;
+                        $_size792 = 0;
+                        $_etype795 = 0;
+                        $xfer += $input->readListBegin($_etype795, $_size792);
+                        for ($_i796 = 0; $_i796 < $_size792; ++$_i796) {
+                            $elem797 = null;
+                            $xfer += $input->readString($elem797);
+                            $this->eventTypeSkipList []= $elem797;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class NotificationEventRequest
             }
             $xfer += $output->writeFieldBegin('eventTypeSkipList', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->eventTypeSkipList));
-            foreach ($this->eventTypeSkipList as $iter790) {
-                $xfer += $output->writeString($iter790);
+            foreach ($this->eventTypeSkipList as $iter798) {
+                $xfer += $output->writeString($iter798);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotificationEventResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/NotificationEventResponse.php
@@ -69,14 +69,14 @@ class NotificationEventResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->events = array();
-                        $_size791 = 0;
-                        $_etype794 = 0;
-                        $xfer += $input->readListBegin($_etype794, $_size791);
-                        for ($_i795 = 0; $_i795 < $_size791; ++$_i795) {
-                            $elem796 = null;
-                            $elem796 = new \metastore\NotificationEvent();
-                            $xfer += $elem796->read($input);
-                            $this->events []= $elem796;
+                        $_size799 = 0;
+                        $_etype802 = 0;
+                        $xfer += $input->readListBegin($_etype802, $_size799);
+                        for ($_i803 = 0; $_i803 < $_size799; ++$_i803) {
+                            $elem804 = null;
+                            $elem804 = new \metastore\NotificationEvent();
+                            $xfer += $elem804->read($input);
+                            $this->events []= $elem804;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class NotificationEventResponse
             }
             $xfer += $output->writeFieldBegin('events', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->events));
-            foreach ($this->events as $iter797) {
-                $xfer += $iter797->write($output);
+            foreach ($this->events as $iter805) {
+                $xfer += $iter805->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ObjectDictionary.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ObjectDictionary.php
@@ -76,25 +76,25 @@ class ObjectDictionary
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->values = array();
-                        $_size255 = 0;
-                        $_ktype256 = 0;
-                        $_vtype257 = 0;
-                        $xfer += $input->readMapBegin($_ktype256, $_vtype257, $_size255);
-                        for ($_i259 = 0; $_i259 < $_size255; ++$_i259) {
-                            $key260 = '';
-                            $val261 = array();
-                            $xfer += $input->readString($key260);
-                            $val261 = array();
-                            $_size262 = 0;
-                            $_etype265 = 0;
-                            $xfer += $input->readListBegin($_etype265, $_size262);
-                            for ($_i266 = 0; $_i266 < $_size262; ++$_i266) {
-                                $elem267 = null;
-                                $xfer += $input->readString($elem267);
-                                $val261 []= $elem267;
+                        $_size263 = 0;
+                        $_ktype264 = 0;
+                        $_vtype265 = 0;
+                        $xfer += $input->readMapBegin($_ktype264, $_vtype265, $_size263);
+                        for ($_i267 = 0; $_i267 < $_size263; ++$_i267) {
+                            $key268 = '';
+                            $val269 = array();
+                            $xfer += $input->readString($key268);
+                            $val269 = array();
+                            $_size270 = 0;
+                            $_etype273 = 0;
+                            $xfer += $input->readListBegin($_etype273, $_size270);
+                            for ($_i274 = 0; $_i274 < $_size270; ++$_i274) {
+                                $elem275 = null;
+                                $xfer += $input->readString($elem275);
+                                $val269 []= $elem275;
                             }
                             $xfer += $input->readListEnd();
-                            $this->values[$key260] = $val261;
+                            $this->values[$key268] = $val269;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -121,11 +121,11 @@ class ObjectDictionary
             }
             $xfer += $output->writeFieldBegin('values', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->values));
-            foreach ($this->values as $kiter268 => $viter269) {
-                $xfer += $output->writeString($kiter268);
-                $output->writeListBegin(TType::STRING, count($viter269));
-                foreach ($viter269 as $iter270) {
-                    $xfer += $output->writeString($iter270);
+            foreach ($this->values as $kiter276 => $viter277) {
+                $xfer += $output->writeString($kiter276);
+                $output->writeListBegin(TType::STRING, count($viter277));
+                foreach ($viter277 as $iter278) {
+                    $xfer += $output->writeString($iter278);
                 }
                 $output->writeListEnd();
             }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/OpenTxnRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/OpenTxnRequest.php
@@ -176,13 +176,13 @@ class OpenTxnRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->replSrcTxnIds = array();
-                        $_size633 = 0;
-                        $_etype636 = 0;
-                        $xfer += $input->readListBegin($_etype636, $_size633);
-                        for ($_i637 = 0; $_i637 < $_size633; ++$_i637) {
-                            $elem638 = null;
-                            $xfer += $input->readI64($elem638);
-                            $this->replSrcTxnIds []= $elem638;
+                        $_size641 = 0;
+                        $_etype644 = 0;
+                        $xfer += $input->readListBegin($_etype644, $_size641);
+                        for ($_i645 = 0; $_i645 < $_size641; ++$_i645) {
+                            $elem646 = null;
+                            $xfer += $input->readI64($elem646);
+                            $this->replSrcTxnIds []= $elem646;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -241,8 +241,8 @@ class OpenTxnRequest
             }
             $xfer += $output->writeFieldBegin('replSrcTxnIds', TType::LST, 6);
             $output->writeListBegin(TType::I64, count($this->replSrcTxnIds));
-            foreach ($this->replSrcTxnIds as $iter639) {
-                $xfer += $output->writeI64($iter639);
+            foreach ($this->replSrcTxnIds as $iter647) {
+                $xfer += $output->writeI64($iter647);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/OpenTxnsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/OpenTxnsResponse.php
@@ -68,13 +68,13 @@ class OpenTxnsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->txn_ids = array();
-                        $_size640 = 0;
-                        $_etype643 = 0;
-                        $xfer += $input->readListBegin($_etype643, $_size640);
-                        for ($_i644 = 0; $_i644 < $_size640; ++$_i644) {
-                            $elem645 = null;
-                            $xfer += $input->readI64($elem645);
-                            $this->txn_ids []= $elem645;
+                        $_size648 = 0;
+                        $_etype651 = 0;
+                        $xfer += $input->readListBegin($_etype651, $_size648);
+                        for ($_i652 = 0; $_i652 < $_size648; ++$_i652) {
+                            $elem653 = null;
+                            $xfer += $input->readI64($elem653);
+                            $this->txn_ids []= $elem653;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class OpenTxnsResponse
             }
             $xfer += $output->writeFieldBegin('txn_ids', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->txn_ids));
-            foreach ($this->txn_ids as $iter646) {
-                $xfer += $output->writeI64($iter646);
+            foreach ($this->txn_ids as $iter654) {
+                $xfer += $output->writeI64($iter654);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
@@ -224,13 +224,13 @@ class Partition
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->values = array();
-                        $_size301 = 0;
-                        $_etype304 = 0;
-                        $xfer += $input->readListBegin($_etype304, $_size301);
-                        for ($_i305 = 0; $_i305 < $_size301; ++$_i305) {
-                            $elem306 = null;
-                            $xfer += $input->readString($elem306);
-                            $this->values []= $elem306;
+                        $_size309 = 0;
+                        $_etype312 = 0;
+                        $xfer += $input->readListBegin($_etype312, $_size309);
+                        for ($_i313 = 0; $_i313 < $_size309; ++$_i313) {
+                            $elem314 = null;
+                            $xfer += $input->readString($elem314);
+                            $this->values []= $elem314;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -276,16 +276,16 @@ class Partition
                 case 7:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size307 = 0;
-                        $_ktype308 = 0;
-                        $_vtype309 = 0;
-                        $xfer += $input->readMapBegin($_ktype308, $_vtype309, $_size307);
-                        for ($_i311 = 0; $_i311 < $_size307; ++$_i311) {
-                            $key312 = '';
-                            $val313 = '';
-                            $xfer += $input->readString($key312);
-                            $xfer += $input->readString($val313);
-                            $this->parameters[$key312] = $val313;
+                        $_size315 = 0;
+                        $_ktype316 = 0;
+                        $_vtype317 = 0;
+                        $xfer += $input->readMapBegin($_ktype316, $_vtype317, $_size315);
+                        for ($_i319 = 0; $_i319 < $_size315; ++$_i319) {
+                            $key320 = '';
+                            $val321 = '';
+                            $xfer += $input->readString($key320);
+                            $xfer += $input->readString($val321);
+                            $this->parameters[$key320] = $val321;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -357,8 +357,8 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('values', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->values));
-            foreach ($this->values as $iter314) {
-                $xfer += $output->writeString($iter314);
+            foreach ($this->values as $iter322) {
+                $xfer += $output->writeString($iter322);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -397,9 +397,9 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 7);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter315 => $viter316) {
-                $xfer += $output->writeString($kiter315);
-                $xfer += $output->writeString($viter316);
+            foreach ($this->parameters as $kiter323 => $viter324) {
+                $xfer += $output->writeString($kiter323);
+                $xfer += $output->writeString($viter324);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionListComposingSpec.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionListComposingSpec.php
@@ -69,14 +69,14 @@ class PartitionListComposingSpec
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size340 = 0;
-                        $_etype343 = 0;
-                        $xfer += $input->readListBegin($_etype343, $_size340);
-                        for ($_i344 = 0; $_i344 < $_size340; ++$_i344) {
-                            $elem345 = null;
-                            $elem345 = new \metastore\Partition();
-                            $xfer += $elem345->read($input);
-                            $this->partitions []= $elem345;
+                        $_size348 = 0;
+                        $_etype351 = 0;
+                        $xfer += $input->readListBegin($_etype351, $_size348);
+                        for ($_i352 = 0; $_i352 < $_size348; ++$_i352) {
+                            $elem353 = null;
+                            $elem353 = new \metastore\Partition();
+                            $xfer += $elem353->read($input);
+                            $this->partitions []= $elem353;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PartitionListComposingSpec
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter346) {
-                $xfer += $iter346->write($output);
+            foreach ($this->partitions as $iter354) {
+                $xfer += $iter354->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionSpecWithSharedSD.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionSpecWithSharedSD.php
@@ -82,14 +82,14 @@ class PartitionSpecWithSharedSD
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size333 = 0;
-                        $_etype336 = 0;
-                        $xfer += $input->readListBegin($_etype336, $_size333);
-                        for ($_i337 = 0; $_i337 < $_size333; ++$_i337) {
-                            $elem338 = null;
-                            $elem338 = new \metastore\PartitionWithoutSD();
-                            $xfer += $elem338->read($input);
-                            $this->partitions []= $elem338;
+                        $_size341 = 0;
+                        $_etype344 = 0;
+                        $xfer += $input->readListBegin($_etype344, $_size341);
+                        for ($_i345 = 0; $_i345 < $_size341; ++$_i345) {
+                            $elem346 = null;
+                            $elem346 = new \metastore\PartitionWithoutSD();
+                            $xfer += $elem346->read($input);
+                            $this->partitions []= $elem346;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class PartitionSpecWithSharedSD
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter339) {
-                $xfer += $iter339->write($output);
+            foreach ($this->partitions as $iter347) {
+                $xfer += $iter347->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesRequest.php
@@ -196,14 +196,14 @@ class PartitionValuesRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->partitionKeys = array();
-                        $_size554 = 0;
-                        $_etype557 = 0;
-                        $xfer += $input->readListBegin($_etype557, $_size554);
-                        for ($_i558 = 0; $_i558 < $_size554; ++$_i558) {
-                            $elem559 = null;
-                            $elem559 = new \metastore\FieldSchema();
-                            $xfer += $elem559->read($input);
-                            $this->partitionKeys []= $elem559;
+                        $_size562 = 0;
+                        $_etype565 = 0;
+                        $xfer += $input->readListBegin($_etype565, $_size562);
+                        for ($_i566 = 0; $_i566 < $_size562; ++$_i566) {
+                            $elem567 = null;
+                            $elem567 = new \metastore\FieldSchema();
+                            $xfer += $elem567->read($input);
+                            $this->partitionKeys []= $elem567;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -227,14 +227,14 @@ class PartitionValuesRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->partitionOrder = array();
-                        $_size560 = 0;
-                        $_etype563 = 0;
-                        $xfer += $input->readListBegin($_etype563, $_size560);
-                        for ($_i564 = 0; $_i564 < $_size560; ++$_i564) {
-                            $elem565 = null;
-                            $elem565 = new \metastore\FieldSchema();
-                            $xfer += $elem565->read($input);
-                            $this->partitionOrder []= $elem565;
+                        $_size568 = 0;
+                        $_etype571 = 0;
+                        $xfer += $input->readListBegin($_etype571, $_size568);
+                        for ($_i572 = 0; $_i572 < $_size568; ++$_i572) {
+                            $elem573 = null;
+                            $elem573 = new \metastore\FieldSchema();
+                            $xfer += $elem573->read($input);
+                            $this->partitionOrder []= $elem573;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -299,8 +299,8 @@ class PartitionValuesRequest
             }
             $xfer += $output->writeFieldBegin('partitionKeys', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->partitionKeys));
-            foreach ($this->partitionKeys as $iter566) {
-                $xfer += $iter566->write($output);
+            foreach ($this->partitionKeys as $iter574) {
+                $xfer += $iter574->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -321,8 +321,8 @@ class PartitionValuesRequest
             }
             $xfer += $output->writeFieldBegin('partitionOrder', TType::LST, 6);
             $output->writeListBegin(TType::STRUCT, count($this->partitionOrder));
-            foreach ($this->partitionOrder as $iter567) {
-                $xfer += $iter567->write($output);
+            foreach ($this->partitionOrder as $iter575) {
+                $xfer += $iter575->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesResponse.php
@@ -69,14 +69,14 @@ class PartitionValuesResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitionValues = array();
-                        $_size575 = 0;
-                        $_etype578 = 0;
-                        $xfer += $input->readListBegin($_etype578, $_size575);
-                        for ($_i579 = 0; $_i579 < $_size575; ++$_i579) {
-                            $elem580 = null;
-                            $elem580 = new \metastore\PartitionValuesRow();
-                            $xfer += $elem580->read($input);
-                            $this->partitionValues []= $elem580;
+                        $_size583 = 0;
+                        $_etype586 = 0;
+                        $xfer += $input->readListBegin($_etype586, $_size583);
+                        for ($_i587 = 0; $_i587 < $_size583; ++$_i587) {
+                            $elem588 = null;
+                            $elem588 = new \metastore\PartitionValuesRow();
+                            $xfer += $elem588->read($input);
+                            $this->partitionValues []= $elem588;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PartitionValuesResponse
             }
             $xfer += $output->writeFieldBegin('partitionValues', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitionValues));
-            foreach ($this->partitionValues as $iter581) {
-                $xfer += $iter581->write($output);
+            foreach ($this->partitionValues as $iter589) {
+                $xfer += $iter589->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesRow.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionValuesRow.php
@@ -68,13 +68,13 @@ class PartitionValuesRow
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->row = array();
-                        $_size568 = 0;
-                        $_etype571 = 0;
-                        $xfer += $input->readListBegin($_etype571, $_size568);
-                        for ($_i572 = 0; $_i572 < $_size568; ++$_i572) {
-                            $elem573 = null;
-                            $xfer += $input->readString($elem573);
-                            $this->row []= $elem573;
+                        $_size576 = 0;
+                        $_etype579 = 0;
+                        $xfer += $input->readListBegin($_etype579, $_size576);
+                        for ($_i580 = 0; $_i580 < $_size576; ++$_i580) {
+                            $elem581 = null;
+                            $xfer += $input->readString($elem581);
+                            $this->row []= $elem581;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class PartitionValuesRow
             }
             $xfer += $output->writeFieldBegin('row', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->row));
-            foreach ($this->row as $iter574) {
-                $xfer += $output->writeString($iter574);
+            foreach ($this->row as $iter582) {
+                $xfer += $output->writeString($iter582);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
@@ -137,13 +137,13 @@ class PartitionWithoutSD
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->values = array();
-                        $_size317 = 0;
-                        $_etype320 = 0;
-                        $xfer += $input->readListBegin($_etype320, $_size317);
-                        for ($_i321 = 0; $_i321 < $_size317; ++$_i321) {
-                            $elem322 = null;
-                            $xfer += $input->readString($elem322);
-                            $this->values []= $elem322;
+                        $_size325 = 0;
+                        $_etype328 = 0;
+                        $xfer += $input->readListBegin($_etype328, $_size325);
+                        for ($_i329 = 0; $_i329 < $_size325; ++$_i329) {
+                            $elem330 = null;
+                            $xfer += $input->readString($elem330);
+                            $this->values []= $elem330;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -174,16 +174,16 @@ class PartitionWithoutSD
                 case 5:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size323 = 0;
-                        $_ktype324 = 0;
-                        $_vtype325 = 0;
-                        $xfer += $input->readMapBegin($_ktype324, $_vtype325, $_size323);
-                        for ($_i327 = 0; $_i327 < $_size323; ++$_i327) {
-                            $key328 = '';
-                            $val329 = '';
-                            $xfer += $input->readString($key328);
-                            $xfer += $input->readString($val329);
-                            $this->parameters[$key328] = $val329;
+                        $_size331 = 0;
+                        $_ktype332 = 0;
+                        $_vtype333 = 0;
+                        $xfer += $input->readMapBegin($_ktype332, $_vtype333, $_size331);
+                        for ($_i335 = 0; $_i335 < $_size331; ++$_i335) {
+                            $key336 = '';
+                            $val337 = '';
+                            $xfer += $input->readString($key336);
+                            $xfer += $input->readString($val337);
+                            $this->parameters[$key336] = $val337;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -218,8 +218,8 @@ class PartitionWithoutSD
             }
             $xfer += $output->writeFieldBegin('values', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->values));
-            foreach ($this->values as $iter330) {
-                $xfer += $output->writeString($iter330);
+            foreach ($this->values as $iter338) {
+                $xfer += $output->writeString($iter338);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -245,9 +245,9 @@ class PartitionWithoutSD
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 5);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter331 => $viter332) {
-                $xfer += $output->writeString($kiter331);
-                $xfer += $output->writeString($viter332);
+            foreach ($this->parameters as $kiter339 => $viter340) {
+                $xfer += $output->writeString($kiter339);
+                $xfer += $output->writeString($viter340);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsByExprResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsByExprResult.php
@@ -81,14 +81,14 @@ class PartitionsByExprResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size461 = 0;
-                        $_etype464 = 0;
-                        $xfer += $input->readListBegin($_etype464, $_size461);
-                        for ($_i465 = 0; $_i465 < $_size461; ++$_i465) {
-                            $elem466 = null;
-                            $elem466 = new \metastore\Partition();
-                            $xfer += $elem466->read($input);
-                            $this->partitions []= $elem466;
+                        $_size469 = 0;
+                        $_etype472 = 0;
+                        $xfer += $input->readListBegin($_etype472, $_size469);
+                        for ($_i473 = 0; $_i473 < $_size469; ++$_i473) {
+                            $elem474 = null;
+                            $elem474 = new \metastore\Partition();
+                            $xfer += $elem474->read($input);
+                            $this->partitions []= $elem474;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class PartitionsByExprResult
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter467) {
-                $xfer += $iter467->write($output);
+            foreach ($this->partitions as $iter475) {
+                $xfer += $iter475->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsResponse.php
@@ -69,14 +69,14 @@ class PartitionsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitions = array();
-                        $_size1189 = 0;
-                        $_etype1192 = 0;
-                        $xfer += $input->readListBegin($_etype1192, $_size1189);
-                        for ($_i1193 = 0; $_i1193 < $_size1189; ++$_i1193) {
-                            $elem1194 = null;
-                            $elem1194 = new \metastore\Partition();
-                            $xfer += $elem1194->read($input);
-                            $this->partitions []= $elem1194;
+                        $_size1197 = 0;
+                        $_etype1200 = 0;
+                        $xfer += $input->readListBegin($_etype1200, $_size1197);
+                        for ($_i1201 = 0; $_i1201 < $_size1197; ++$_i1201) {
+                            $elem1202 = null;
+                            $elem1202 = new \metastore\Partition();
+                            $xfer += $elem1202->read($input);
+                            $this->partitions []= $elem1202;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PartitionsResponse
             }
             $xfer += $output->writeFieldBegin('partitions', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitions));
-            foreach ($this->partitions as $iter1195) {
-                $xfer += $iter1195->write($output);
+            foreach ($this->partitions as $iter1203) {
+                $xfer += $iter1203->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsSpecByExprResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsSpecByExprResult.php
@@ -81,14 +81,14 @@ class PartitionsSpecByExprResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->partitionsSpec = array();
-                        $_size468 = 0;
-                        $_etype471 = 0;
-                        $xfer += $input->readListBegin($_etype471, $_size468);
-                        for ($_i472 = 0; $_i472 < $_size468; ++$_i472) {
-                            $elem473 = null;
-                            $elem473 = new \metastore\PartitionSpec();
-                            $xfer += $elem473->read($input);
-                            $this->partitionsSpec []= $elem473;
+                        $_size476 = 0;
+                        $_etype479 = 0;
+                        $xfer += $input->readListBegin($_etype479, $_size476);
+                        for ($_i480 = 0; $_i480 < $_size476; ++$_i480) {
+                            $elem481 = null;
+                            $elem481 = new \metastore\PartitionSpec();
+                            $xfer += $elem481->read($input);
+                            $this->partitionsSpec []= $elem481;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class PartitionsSpecByExprResult
             }
             $xfer += $output->writeFieldBegin('partitionsSpec', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->partitionsSpec));
-            foreach ($this->partitionsSpec as $iter474) {
-                $xfer += $iter474->write($output);
+            foreach ($this->partitionsSpec as $iter482) {
+                $xfer += $iter482->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsStatsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsStatsRequest.php
@@ -158,13 +158,13 @@ class PartitionsStatsRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->colNames = array();
-                        $_size505 = 0;
-                        $_etype508 = 0;
-                        $xfer += $input->readListBegin($_etype508, $_size505);
-                        for ($_i509 = 0; $_i509 < $_size505; ++$_i509) {
-                            $elem510 = null;
-                            $xfer += $input->readString($elem510);
-                            $this->colNames []= $elem510;
+                        $_size513 = 0;
+                        $_etype516 = 0;
+                        $xfer += $input->readListBegin($_etype516, $_size513);
+                        for ($_i517 = 0; $_i517 < $_size513; ++$_i517) {
+                            $elem518 = null;
+                            $xfer += $input->readString($elem518);
+                            $this->colNames []= $elem518;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -174,13 +174,13 @@ class PartitionsStatsRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partNames = array();
-                        $_size511 = 0;
-                        $_etype514 = 0;
-                        $xfer += $input->readListBegin($_etype514, $_size511);
-                        for ($_i515 = 0; $_i515 < $_size511; ++$_i515) {
-                            $elem516 = null;
-                            $xfer += $input->readString($elem516);
-                            $this->partNames []= $elem516;
+                        $_size519 = 0;
+                        $_etype522 = 0;
+                        $xfer += $input->readListBegin($_etype522, $_size519);
+                        for ($_i523 = 0; $_i523 < $_size519; ++$_i523) {
+                            $elem524 = null;
+                            $xfer += $input->readString($elem524);
+                            $this->partNames []= $elem524;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -238,8 +238,8 @@ class PartitionsStatsRequest
             }
             $xfer += $output->writeFieldBegin('colNames', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->colNames));
-            foreach ($this->colNames as $iter517) {
-                $xfer += $output->writeString($iter517);
+            foreach ($this->colNames as $iter525) {
+                $xfer += $output->writeString($iter525);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -250,8 +250,8 @@ class PartitionsStatsRequest
             }
             $xfer += $output->writeFieldBegin('partNames', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partNames));
-            foreach ($this->partNames as $iter518) {
-                $xfer += $output->writeString($iter518);
+            foreach ($this->partNames as $iter526) {
+                $xfer += $output->writeString($iter526);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsStatsResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionsStatsResult.php
@@ -89,26 +89,26 @@ class PartitionsStatsResult
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->partStats = array();
-                        $_size482 = 0;
-                        $_ktype483 = 0;
-                        $_vtype484 = 0;
-                        $xfer += $input->readMapBegin($_ktype483, $_vtype484, $_size482);
-                        for ($_i486 = 0; $_i486 < $_size482; ++$_i486) {
-                            $key487 = '';
-                            $val488 = array();
-                            $xfer += $input->readString($key487);
-                            $val488 = array();
-                            $_size489 = 0;
-                            $_etype492 = 0;
-                            $xfer += $input->readListBegin($_etype492, $_size489);
-                            for ($_i493 = 0; $_i493 < $_size489; ++$_i493) {
-                                $elem494 = null;
-                                $elem494 = new \metastore\ColumnStatisticsObj();
-                                $xfer += $elem494->read($input);
-                                $val488 []= $elem494;
+                        $_size490 = 0;
+                        $_ktype491 = 0;
+                        $_vtype492 = 0;
+                        $xfer += $input->readMapBegin($_ktype491, $_vtype492, $_size490);
+                        for ($_i494 = 0; $_i494 < $_size490; ++$_i494) {
+                            $key495 = '';
+                            $val496 = array();
+                            $xfer += $input->readString($key495);
+                            $val496 = array();
+                            $_size497 = 0;
+                            $_etype500 = 0;
+                            $xfer += $input->readListBegin($_etype500, $_size497);
+                            for ($_i501 = 0; $_i501 < $_size497; ++$_i501) {
+                                $elem502 = null;
+                                $elem502 = new \metastore\ColumnStatisticsObj();
+                                $xfer += $elem502->read($input);
+                                $val496 []= $elem502;
                             }
                             $xfer += $input->readListEnd();
-                            $this->partStats[$key487] = $val488;
+                            $this->partStats[$key495] = $val496;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -142,11 +142,11 @@ class PartitionsStatsResult
             }
             $xfer += $output->writeFieldBegin('partStats', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::LST, count($this->partStats));
-            foreach ($this->partStats as $kiter495 => $viter496) {
-                $xfer += $output->writeString($kiter495);
-                $output->writeListBegin(TType::STRUCT, count($viter496));
-                foreach ($viter496 as $iter497) {
-                    $xfer += $iter497->write($output);
+            foreach ($this->partStats as $kiter503 => $viter504) {
+                $xfer += $output->writeString($kiter503);
+                $output->writeListBegin(TType::STRUCT, count($viter504));
+                foreach ($viter504 as $iter505) {
+                    $xfer += $iter505->write($output);
                 }
                 $output->writeListEnd();
             }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrimaryKeysResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PrimaryKeysResponse.php
@@ -69,14 +69,14 @@ class PrimaryKeysResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->primaryKeys = array();
-                        $_size377 = 0;
-                        $_etype380 = 0;
-                        $xfer += $input->readListBegin($_etype380, $_size377);
-                        for ($_i381 = 0; $_i381 < $_size377; ++$_i381) {
-                            $elem382 = null;
-                            $elem382 = new \metastore\SQLPrimaryKey();
-                            $xfer += $elem382->read($input);
-                            $this->primaryKeys []= $elem382;
+                        $_size385 = 0;
+                        $_etype388 = 0;
+                        $xfer += $input->readListBegin($_etype388, $_size385);
+                        for ($_i389 = 0; $_i389 < $_size385; ++$_i389) {
+                            $elem390 = null;
+                            $elem390 = new \metastore\SQLPrimaryKey();
+                            $xfer += $elem390->read($input);
+                            $this->primaryKeys []= $elem390;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class PrimaryKeysResponse
             }
             $xfer += $output->writeFieldBegin('primaryKeys', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->primaryKeys));
-            foreach ($this->primaryKeys as $iter383) {
-                $xfer += $iter383->write($output);
+            foreach ($this->primaryKeys as $iter391) {
+                $xfer += $iter391->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PutFileMetadataRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PutFileMetadataRequest.php
@@ -97,13 +97,13 @@ class PutFileMetadataRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fileIds = array();
-                        $_size893 = 0;
-                        $_etype896 = 0;
-                        $xfer += $input->readListBegin($_etype896, $_size893);
-                        for ($_i897 = 0; $_i897 < $_size893; ++$_i897) {
-                            $elem898 = null;
-                            $xfer += $input->readI64($elem898);
-                            $this->fileIds []= $elem898;
+                        $_size901 = 0;
+                        $_etype904 = 0;
+                        $xfer += $input->readListBegin($_etype904, $_size901);
+                        for ($_i905 = 0; $_i905 < $_size901; ++$_i905) {
+                            $elem906 = null;
+                            $xfer += $input->readI64($elem906);
+                            $this->fileIds []= $elem906;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -113,13 +113,13 @@ class PutFileMetadataRequest
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->metadata = array();
-                        $_size899 = 0;
-                        $_etype902 = 0;
-                        $xfer += $input->readListBegin($_etype902, $_size899);
-                        for ($_i903 = 0; $_i903 < $_size899; ++$_i903) {
-                            $elem904 = null;
-                            $xfer += $input->readString($elem904);
-                            $this->metadata []= $elem904;
+                        $_size907 = 0;
+                        $_etype910 = 0;
+                        $xfer += $input->readListBegin($_etype910, $_size907);
+                        for ($_i911 = 0; $_i911 < $_size907; ++$_i911) {
+                            $elem912 = null;
+                            $xfer += $input->readString($elem912);
+                            $this->metadata []= $elem912;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -153,8 +153,8 @@ class PutFileMetadataRequest
             }
             $xfer += $output->writeFieldBegin('fileIds', TType::LST, 1);
             $output->writeListBegin(TType::I64, count($this->fileIds));
-            foreach ($this->fileIds as $iter905) {
-                $xfer += $output->writeI64($iter905);
+            foreach ($this->fileIds as $iter913) {
+                $xfer += $output->writeI64($iter913);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -165,8 +165,8 @@ class PutFileMetadataRequest
             }
             $xfer += $output->writeFieldBegin('metadata', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->metadata));
-            foreach ($this->metadata as $iter906) {
-                $xfer += $output->writeString($iter906);
+            foreach ($this->metadata as $iter914) {
+                $xfer += $output->writeString($iter914);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/RenamePartitionRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/RenamePartitionRequest.php
@@ -150,13 +150,13 @@ class RenamePartitionRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->partVals = array();
-                        $_size1126 = 0;
-                        $_etype1129 = 0;
-                        $xfer += $input->readListBegin($_etype1129, $_size1126);
-                        for ($_i1130 = 0; $_i1130 < $_size1126; ++$_i1130) {
-                            $elem1131 = null;
-                            $xfer += $input->readString($elem1131);
-                            $this->partVals []= $elem1131;
+                        $_size1134 = 0;
+                        $_etype1137 = 0;
+                        $xfer += $input->readListBegin($_etype1137, $_size1134);
+                        for ($_i1138 = 0; $_i1138 < $_size1134; ++$_i1138) {
+                            $elem1139 = null;
+                            $xfer += $input->readString($elem1139);
+                            $this->partVals []= $elem1139;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -213,8 +213,8 @@ class RenamePartitionRequest
             }
             $xfer += $output->writeFieldBegin('partVals', TType::LST, 4);
             $output->writeListBegin(TType::STRING, count($this->partVals));
-            foreach ($this->partVals as $iter1132) {
-                $xfer += $output->writeString($iter1132);
+            foreach ($this->partVals as $iter1140) {
+                $xfer += $output->writeString($iter1140);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplLastIdInfo.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplLastIdInfo.php
@@ -144,13 +144,13 @@ class ReplLastIdInfo
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->partitionList = array();
-                        $_size654 = 0;
-                        $_etype657 = 0;
-                        $xfer += $input->readListBegin($_etype657, $_size654);
-                        for ($_i658 = 0; $_i658 < $_size654; ++$_i658) {
-                            $elem659 = null;
-                            $xfer += $input->readString($elem659);
-                            $this->partitionList []= $elem659;
+                        $_size662 = 0;
+                        $_etype665 = 0;
+                        $xfer += $input->readListBegin($_etype665, $_size662);
+                        for ($_i666 = 0; $_i666 < $_size662; ++$_i666) {
+                            $elem667 = null;
+                            $xfer += $input->readString($elem667);
+                            $this->partitionList []= $elem667;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -197,8 +197,8 @@ class ReplLastIdInfo
             }
             $xfer += $output->writeFieldBegin('partitionList', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->partitionList));
-            foreach ($this->partitionList as $iter660) {
-                $xfer += $output->writeString($iter660);
+            foreach ($this->partitionList as $iter668) {
+                $xfer += $output->writeString($iter668);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplTblWriteIdStateRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplTblWriteIdStateRequest.php
@@ -163,13 +163,13 @@ class ReplTblWriteIdStateRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->partNames = array();
-                        $_size668 = 0;
-                        $_etype671 = 0;
-                        $xfer += $input->readListBegin($_etype671, $_size668);
-                        for ($_i672 = 0; $_i672 < $_size668; ++$_i672) {
-                            $elem673 = null;
-                            $xfer += $input->readString($elem673);
-                            $this->partNames []= $elem673;
+                        $_size676 = 0;
+                        $_etype679 = 0;
+                        $xfer += $input->readListBegin($_etype679, $_size676);
+                        for ($_i680 = 0; $_i680 < $_size676; ++$_i680) {
+                            $elem681 = null;
+                            $xfer += $input->readString($elem681);
+                            $this->partNames []= $elem681;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -221,8 +221,8 @@ class ReplTblWriteIdStateRequest
             }
             $xfer += $output->writeFieldBegin('partNames', TType::LST, 6);
             $output->writeListBegin(TType::STRING, count($this->partNames));
-            foreach ($this->partNames as $iter674) {
-                $xfer += $output->writeString($iter674);
+            foreach ($this->partNames as $iter682) {
+                $xfer += $output->writeString($iter682);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplicationMetricList.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ReplicationMetricList.php
@@ -69,14 +69,14 @@ class ReplicationMetricList
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->replicationMetricList = array();
-                        $_size1231 = 0;
-                        $_etype1234 = 0;
-                        $xfer += $input->readListBegin($_etype1234, $_size1231);
-                        for ($_i1235 = 0; $_i1235 < $_size1231; ++$_i1235) {
-                            $elem1236 = null;
-                            $elem1236 = new \metastore\ReplicationMetrics();
-                            $xfer += $elem1236->read($input);
-                            $this->replicationMetricList []= $elem1236;
+                        $_size1239 = 0;
+                        $_etype1242 = 0;
+                        $xfer += $input->readListBegin($_etype1242, $_size1239);
+                        for ($_i1243 = 0; $_i1243 < $_size1239; ++$_i1243) {
+                            $elem1244 = null;
+                            $elem1244 = new \metastore\ReplicationMetrics();
+                            $xfer += $elem1244->read($input);
+                            $this->replicationMetricList []= $elem1244;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ReplicationMetricList
             }
             $xfer += $output->writeFieldBegin('replicationMetricList', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->replicationMetricList));
-            foreach ($this->replicationMetricList as $iter1237) {
-                $xfer += $iter1237->write($output);
+            foreach ($this->replicationMetricList as $iter1245) {
+                $xfer += $iter1245->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/RequestPartsSpec.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/RequestPartsSpec.php
@@ -85,13 +85,13 @@ class RequestPartsSpec
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->names = array();
-                        $_size540 = 0;
-                        $_etype543 = 0;
-                        $xfer += $input->readListBegin($_etype543, $_size540);
-                        for ($_i544 = 0; $_i544 < $_size540; ++$_i544) {
-                            $elem545 = null;
-                            $xfer += $input->readString($elem545);
-                            $this->names []= $elem545;
+                        $_size548 = 0;
+                        $_etype551 = 0;
+                        $xfer += $input->readListBegin($_etype551, $_size548);
+                        for ($_i552 = 0; $_i552 < $_size548; ++$_i552) {
+                            $elem553 = null;
+                            $xfer += $input->readString($elem553);
+                            $this->names []= $elem553;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,14 +101,14 @@ class RequestPartsSpec
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->exprs = array();
-                        $_size546 = 0;
-                        $_etype549 = 0;
-                        $xfer += $input->readListBegin($_etype549, $_size546);
-                        for ($_i550 = 0; $_i550 < $_size546; ++$_i550) {
-                            $elem551 = null;
-                            $elem551 = new \metastore\DropPartitionsExpr();
-                            $xfer += $elem551->read($input);
-                            $this->exprs []= $elem551;
+                        $_size554 = 0;
+                        $_etype557 = 0;
+                        $xfer += $input->readListBegin($_etype557, $_size554);
+                        for ($_i558 = 0; $_i558 < $_size554; ++$_i558) {
+                            $elem559 = null;
+                            $elem559 = new \metastore\DropPartitionsExpr();
+                            $xfer += $elem559->read($input);
+                            $this->exprs []= $elem559;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -135,8 +135,8 @@ class RequestPartsSpec
             }
             $xfer += $output->writeFieldBegin('names', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->names));
-            foreach ($this->names as $iter552) {
-                $xfer += $output->writeString($iter552);
+            foreach ($this->names as $iter560) {
+                $xfer += $output->writeString($iter560);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -147,8 +147,8 @@ class RequestPartsSpec
             }
             $xfer += $output->writeFieldBegin('exprs', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->exprs));
-            foreach ($this->exprs as $iter553) {
-                $xfer += $iter553->write($output);
+            foreach ($this->exprs as $iter561) {
+                $xfer += $iter561->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Schema.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Schema.php
@@ -89,14 +89,14 @@ class Schema
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->fieldSchemas = array();
-                        $_size361 = 0;
-                        $_etype364 = 0;
-                        $xfer += $input->readListBegin($_etype364, $_size361);
-                        for ($_i365 = 0; $_i365 < $_size361; ++$_i365) {
-                            $elem366 = null;
-                            $elem366 = new \metastore\FieldSchema();
-                            $xfer += $elem366->read($input);
-                            $this->fieldSchemas []= $elem366;
+                        $_size369 = 0;
+                        $_etype372 = 0;
+                        $xfer += $input->readListBegin($_etype372, $_size369);
+                        for ($_i373 = 0; $_i373 < $_size369; ++$_i373) {
+                            $elem374 = null;
+                            $elem374 = new \metastore\FieldSchema();
+                            $xfer += $elem374->read($input);
+                            $this->fieldSchemas []= $elem374;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -106,16 +106,16 @@ class Schema
                 case 2:
                     if ($ftype == TType::MAP) {
                         $this->properties = array();
-                        $_size367 = 0;
-                        $_ktype368 = 0;
-                        $_vtype369 = 0;
-                        $xfer += $input->readMapBegin($_ktype368, $_vtype369, $_size367);
-                        for ($_i371 = 0; $_i371 < $_size367; ++$_i371) {
-                            $key372 = '';
-                            $val373 = '';
-                            $xfer += $input->readString($key372);
-                            $xfer += $input->readString($val373);
-                            $this->properties[$key372] = $val373;
+                        $_size375 = 0;
+                        $_ktype376 = 0;
+                        $_vtype377 = 0;
+                        $xfer += $input->readMapBegin($_ktype376, $_vtype377, $_size375);
+                        for ($_i379 = 0; $_i379 < $_size375; ++$_i379) {
+                            $key380 = '';
+                            $val381 = '';
+                            $xfer += $input->readString($key380);
+                            $xfer += $input->readString($val381);
+                            $this->properties[$key380] = $val381;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -142,8 +142,8 @@ class Schema
             }
             $xfer += $output->writeFieldBegin('fieldSchemas', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->fieldSchemas));
-            foreach ($this->fieldSchemas as $iter374) {
-                $xfer += $iter374->write($output);
+            foreach ($this->fieldSchemas as $iter382) {
+                $xfer += $iter382->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -154,9 +154,9 @@ class Schema
             }
             $xfer += $output->writeFieldBegin('properties', TType::MAP, 2);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->properties));
-            foreach ($this->properties as $kiter375 => $viter376) {
-                $xfer += $output->writeString($kiter375);
-                $xfer += $output->writeString($viter376);
+            foreach ($this->properties as $kiter383 => $viter384) {
+                $xfer += $output->writeString($kiter383);
+                $xfer += $output->writeString($viter384);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SchemaVersion.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SchemaVersion.php
@@ -202,14 +202,14 @@ class SchemaVersion
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->cols = array();
-                        $_size1047 = 0;
-                        $_etype1050 = 0;
-                        $xfer += $input->readListBegin($_etype1050, $_size1047);
-                        for ($_i1051 = 0; $_i1051 < $_size1047; ++$_i1051) {
-                            $elem1052 = null;
-                            $elem1052 = new \metastore\FieldSchema();
-                            $xfer += $elem1052->read($input);
-                            $this->cols []= $elem1052;
+                        $_size1055 = 0;
+                        $_etype1058 = 0;
+                        $xfer += $input->readListBegin($_etype1058, $_size1055);
+                        for ($_i1059 = 0; $_i1059 < $_size1055; ++$_i1059) {
+                            $elem1060 = null;
+                            $elem1060 = new \metastore\FieldSchema();
+                            $xfer += $elem1060->read($input);
+                            $this->cols []= $elem1060;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -297,8 +297,8 @@ class SchemaVersion
             }
             $xfer += $output->writeFieldBegin('cols', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->cols));
-            foreach ($this->cols as $iter1053) {
-                $xfer += $iter1053->write($output);
+            foreach ($this->cols as $iter1061) {
+                $xfer += $iter1061->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SetPartitionsStatsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/SetPartitionsStatsRequest.php
@@ -117,14 +117,14 @@ class SetPartitionsStatsRequest
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->colStats = array();
-                        $_size354 = 0;
-                        $_etype357 = 0;
-                        $xfer += $input->readListBegin($_etype357, $_size354);
-                        for ($_i358 = 0; $_i358 < $_size354; ++$_i358) {
-                            $elem359 = null;
-                            $elem359 = new \metastore\ColumnStatistics();
-                            $xfer += $elem359->read($input);
-                            $this->colStats []= $elem359;
+                        $_size362 = 0;
+                        $_etype365 = 0;
+                        $xfer += $input->readListBegin($_etype365, $_size362);
+                        for ($_i366 = 0; $_i366 < $_size362; ++$_i366) {
+                            $elem367 = null;
+                            $elem367 = new \metastore\ColumnStatistics();
+                            $xfer += $elem367->read($input);
+                            $this->colStats []= $elem367;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -179,8 +179,8 @@ class SetPartitionsStatsRequest
             }
             $xfer += $output->writeFieldBegin('colStats', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->colStats));
-            foreach ($this->colStats as $iter360) {
-                $xfer += $iter360->write($output);
+            foreach ($this->colStats as $iter368) {
+                $xfer += $iter368->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ShowCompactResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ShowCompactResponse.php
@@ -69,14 +69,14 @@ class ShowCompactResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->compacts = array();
-                        $_size756 = 0;
-                        $_etype759 = 0;
-                        $xfer += $input->readListBegin($_etype759, $_size756);
-                        for ($_i760 = 0; $_i760 < $_size756; ++$_i760) {
-                            $elem761 = null;
-                            $elem761 = new \metastore\ShowCompactResponseElement();
-                            $xfer += $elem761->read($input);
-                            $this->compacts []= $elem761;
+                        $_size764 = 0;
+                        $_etype767 = 0;
+                        $xfer += $input->readListBegin($_etype767, $_size764);
+                        for ($_i768 = 0; $_i768 < $_size764; ++$_i768) {
+                            $elem769 = null;
+                            $elem769 = new \metastore\ShowCompactResponseElement();
+                            $xfer += $elem769->read($input);
+                            $this->compacts []= $elem769;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ShowCompactResponse
             }
             $xfer += $output->writeFieldBegin('compacts', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->compacts));
-            foreach ($this->compacts as $iter762) {
-                $xfer += $iter762->write($output);
+            foreach ($this->compacts as $iter770) {
+                $xfer += $iter770->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ShowLocksResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ShowLocksResponse.php
@@ -69,14 +69,14 @@ class ShowLocksResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->locks = array();
-                        $_size724 = 0;
-                        $_etype727 = 0;
-                        $xfer += $input->readListBegin($_etype727, $_size724);
-                        for ($_i728 = 0; $_i728 < $_size724; ++$_i728) {
-                            $elem729 = null;
-                            $elem729 = new \metastore\ShowLocksResponseElement();
-                            $xfer += $elem729->read($input);
-                            $this->locks []= $elem729;
+                        $_size732 = 0;
+                        $_etype735 = 0;
+                        $xfer += $input->readListBegin($_etype735, $_size732);
+                        for ($_i736 = 0; $_i736 < $_size732; ++$_i736) {
+                            $elem737 = null;
+                            $elem737 = new \metastore\ShowLocksResponseElement();
+                            $xfer += $elem737->read($input);
+                            $this->locks []= $elem737;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ShowLocksResponse
             }
             $xfer += $output->writeFieldBegin('locks', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->locks));
-            foreach ($this->locks as $iter730) {
-                $xfer += $iter730->write($output);
+            foreach ($this->locks as $iter738) {
+                $xfer += $iter738->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Table.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Table.php
@@ -454,14 +454,14 @@ class Table
                 case 8:
                     if ($ftype == TType::LST) {
                         $this->partitionKeys = array();
-                        $_size271 = 0;
-                        $_etype274 = 0;
-                        $xfer += $input->readListBegin($_etype274, $_size271);
-                        for ($_i275 = 0; $_i275 < $_size271; ++$_i275) {
-                            $elem276 = null;
-                            $elem276 = new \metastore\FieldSchema();
-                            $xfer += $elem276->read($input);
-                            $this->partitionKeys []= $elem276;
+                        $_size279 = 0;
+                        $_etype282 = 0;
+                        $xfer += $input->readListBegin($_etype282, $_size279);
+                        for ($_i283 = 0; $_i283 < $_size279; ++$_i283) {
+                            $elem284 = null;
+                            $elem284 = new \metastore\FieldSchema();
+                            $xfer += $elem284->read($input);
+                            $this->partitionKeys []= $elem284;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -471,16 +471,16 @@ class Table
                 case 9:
                     if ($ftype == TType::MAP) {
                         $this->parameters = array();
-                        $_size277 = 0;
-                        $_ktype278 = 0;
-                        $_vtype279 = 0;
-                        $xfer += $input->readMapBegin($_ktype278, $_vtype279, $_size277);
-                        for ($_i281 = 0; $_i281 < $_size277; ++$_i281) {
-                            $key282 = '';
-                            $val283 = '';
-                            $xfer += $input->readString($key282);
-                            $xfer += $input->readString($val283);
-                            $this->parameters[$key282] = $val283;
+                        $_size285 = 0;
+                        $_ktype286 = 0;
+                        $_vtype287 = 0;
+                        $xfer += $input->readMapBegin($_ktype286, $_vtype287, $_size285);
+                        for ($_i289 = 0; $_i289 < $_size285; ++$_i289) {
+                            $key290 = '';
+                            $val291 = '';
+                            $xfer += $input->readString($key290);
+                            $xfer += $input->readString($val291);
+                            $this->parameters[$key290] = $val291;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -584,13 +584,13 @@ class Table
                 case 23:
                     if ($ftype == TType::LST) {
                         $this->requiredReadCapabilities = array();
-                        $_size284 = 0;
-                        $_etype287 = 0;
-                        $xfer += $input->readListBegin($_etype287, $_size284);
-                        for ($_i288 = 0; $_i288 < $_size284; ++$_i288) {
-                            $elem289 = null;
-                            $xfer += $input->readString($elem289);
-                            $this->requiredReadCapabilities []= $elem289;
+                        $_size292 = 0;
+                        $_etype295 = 0;
+                        $xfer += $input->readListBegin($_etype295, $_size292);
+                        for ($_i296 = 0; $_i296 < $_size292; ++$_i296) {
+                            $elem297 = null;
+                            $xfer += $input->readString($elem297);
+                            $this->requiredReadCapabilities []= $elem297;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -600,13 +600,13 @@ class Table
                 case 24:
                     if ($ftype == TType::LST) {
                         $this->requiredWriteCapabilities = array();
-                        $_size290 = 0;
-                        $_etype293 = 0;
-                        $xfer += $input->readListBegin($_etype293, $_size290);
-                        for ($_i294 = 0; $_i294 < $_size290; ++$_i294) {
-                            $elem295 = null;
-                            $xfer += $input->readString($elem295);
-                            $this->requiredWriteCapabilities []= $elem295;
+                        $_size298 = 0;
+                        $_etype301 = 0;
+                        $xfer += $input->readListBegin($_etype301, $_size298);
+                        for ($_i302 = 0; $_i302 < $_size298; ++$_i302) {
+                            $elem303 = null;
+                            $xfer += $input->readString($elem303);
+                            $this->requiredWriteCapabilities []= $elem303;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -694,8 +694,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('partitionKeys', TType::LST, 8);
             $output->writeListBegin(TType::STRUCT, count($this->partitionKeys));
-            foreach ($this->partitionKeys as $iter296) {
-                $xfer += $iter296->write($output);
+            foreach ($this->partitionKeys as $iter304) {
+                $xfer += $iter304->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -706,9 +706,9 @@ class Table
             }
             $xfer += $output->writeFieldBegin('parameters', TType::MAP, 9);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->parameters));
-            foreach ($this->parameters as $kiter297 => $viter298) {
-                $xfer += $output->writeString($kiter297);
-                $xfer += $output->writeString($viter298);
+            foreach ($this->parameters as $kiter305 => $viter306) {
+                $xfer += $output->writeString($kiter305);
+                $xfer += $output->writeString($viter306);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();
@@ -793,8 +793,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('requiredReadCapabilities', TType::LST, 23);
             $output->writeListBegin(TType::STRING, count($this->requiredReadCapabilities));
-            foreach ($this->requiredReadCapabilities as $iter299) {
-                $xfer += $output->writeString($iter299);
+            foreach ($this->requiredReadCapabilities as $iter307) {
+                $xfer += $output->writeString($iter307);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -805,8 +805,8 @@ class Table
             }
             $xfer += $output->writeFieldBegin('requiredWriteCapabilities', TType::LST, 24);
             $output->writeListBegin(TType::STRING, count($this->requiredWriteCapabilities));
-            foreach ($this->requiredWriteCapabilities as $iter300) {
-                $xfer += $output->writeString($iter300);
+            foreach ($this->requiredWriteCapabilities as $iter308) {
+                $xfer += $output->writeString($iter308);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableStatsRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableStatsRequest.php
@@ -154,13 +154,13 @@ class TableStatsRequest
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->colNames = array();
-                        $_size498 = 0;
-                        $_etype501 = 0;
-                        $xfer += $input->readListBegin($_etype501, $_size498);
-                        for ($_i502 = 0; $_i502 < $_size498; ++$_i502) {
-                            $elem503 = null;
-                            $xfer += $input->readString($elem503);
-                            $this->colNames []= $elem503;
+                        $_size506 = 0;
+                        $_etype509 = 0;
+                        $xfer += $input->readListBegin($_etype509, $_size506);
+                        for ($_i510 = 0; $_i510 < $_size506; ++$_i510) {
+                            $elem511 = null;
+                            $xfer += $input->readString($elem511);
+                            $this->colNames []= $elem511;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -225,8 +225,8 @@ class TableStatsRequest
             }
             $xfer += $output->writeFieldBegin('colNames', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->colNames));
-            foreach ($this->colNames as $iter504) {
-                $xfer += $output->writeString($iter504);
+            foreach ($this->colNames as $iter512) {
+                $xfer += $output->writeString($iter512);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableStatsResult.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableStatsResult.php
@@ -81,14 +81,14 @@ class TableStatsResult
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->tableStats = array();
-                        $_size475 = 0;
-                        $_etype478 = 0;
-                        $xfer += $input->readListBegin($_etype478, $_size475);
-                        for ($_i479 = 0; $_i479 < $_size475; ++$_i479) {
-                            $elem480 = null;
-                            $elem480 = new \metastore\ColumnStatisticsObj();
-                            $xfer += $elem480->read($input);
-                            $this->tableStats []= $elem480;
+                        $_size483 = 0;
+                        $_etype486 = 0;
+                        $xfer += $input->readListBegin($_etype486, $_size483);
+                        for ($_i487 = 0; $_i487 < $_size483; ++$_i487) {
+                            $elem488 = null;
+                            $elem488 = new \metastore\ColumnStatisticsObj();
+                            $xfer += $elem488->read($input);
+                            $this->tableStats []= $elem488;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class TableStatsResult
             }
             $xfer += $output->writeFieldBegin('tableStats', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->tableStats));
-            foreach ($this->tableStats as $iter481) {
-                $xfer += $iter481->write($output);
+            foreach ($this->tableStats as $iter489) {
+                $xfer += $iter489->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableValidWriteIds.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TableValidWriteIds.php
@@ -130,13 +130,13 @@ class TableValidWriteIds
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->invalidWriteIds = array();
-                        $_size682 = 0;
-                        $_etype685 = 0;
-                        $xfer += $input->readListBegin($_etype685, $_size682);
-                        for ($_i686 = 0; $_i686 < $_size682; ++$_i686) {
-                            $elem687 = null;
-                            $xfer += $input->readI64($elem687);
-                            $this->invalidWriteIds []= $elem687;
+                        $_size690 = 0;
+                        $_etype693 = 0;
+                        $xfer += $input->readListBegin($_etype693, $_size690);
+                        for ($_i694 = 0; $_i694 < $_size690; ++$_i694) {
+                            $elem695 = null;
+                            $xfer += $input->readI64($elem695);
+                            $this->invalidWriteIds []= $elem695;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -187,8 +187,8 @@ class TableValidWriteIds
             }
             $xfer += $output->writeFieldBegin('invalidWriteIds', TType::LST, 3);
             $output->writeListBegin(TType::I64, count($this->invalidWriteIds));
-            foreach ($this->invalidWriteIds as $iter688) {
-                $xfer += $output->writeI64($iter688);
+            foreach ($this->invalidWriteIds as $iter696) {
+                $xfer += $output->writeI64($iter696);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreClient.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreClient.php
@@ -3643,16 +3643,17 @@ class ThriftHiveMetastoreClient extends \FacebookServiceClient implements \metas
         throw new \Exception("get_table_objects_by_name_req failed: unknown result");
     }
 
-    public function get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata)
+    public function get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata, $validTxnList)
     {
-        $this->send_get_materialization_invalidation_info($creation_metadata);
+        $this->send_get_materialization_invalidation_info($creation_metadata, $validTxnList);
         return $this->recv_get_materialization_invalidation_info();
     }
 
-    public function send_get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata)
+    public function send_get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata, $validTxnList)
     {
         $args = new \metastore\ThriftHiveMetastore_get_materialization_invalidation_info_args();
         $args->creation_metadata = $creation_metadata;
+        $args->validTxnList = $validTxnList;
         $bin_accel = ($this->output_ instanceof TBinaryProtocolAccelerated) && function_exists('thrift_protocol_write_binary');
         if ($bin_accel) {
             thrift_protocol_write_binary(

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreIf.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreIf.php
@@ -428,12 +428,13 @@ interface ThriftHiveMetastoreIf extends \FacebookServiceIf
     public function get_table_objects_by_name_req(\metastore\GetTablesRequest $req);
     /**
      * @param \metastore\CreationMetadata $creation_metadata
+     * @param string $validTxnList
      * @return \metastore\Materialization
      * @throws \metastore\MetaException
      * @throws \metastore\InvalidOperationException
      * @throws \metastore\UnknownDBException
      */
-    public function get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata);
+    public function get_materialization_invalidation_info(\metastore\CreationMetadata $creation_metadata, $validTxnList);
     /**
      * @param string $catName
      * @param string $dbname

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_add_partitions_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_add_partitions_args.php
@@ -69,14 +69,14 @@ class ThriftHiveMetastore_add_partitions_args
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->new_parts = array();
-                        $_size1429 = 0;
-                        $_etype1432 = 0;
-                        $xfer += $input->readListBegin($_etype1432, $_size1429);
-                        for ($_i1433 = 0; $_i1433 < $_size1429; ++$_i1433) {
-                            $elem1434 = null;
-                            $elem1434 = new \metastore\Partition();
-                            $xfer += $elem1434->read($input);
-                            $this->new_parts []= $elem1434;
+                        $_size1437 = 0;
+                        $_etype1440 = 0;
+                        $xfer += $input->readListBegin($_etype1440, $_size1437);
+                        for ($_i1441 = 0; $_i1441 < $_size1437; ++$_i1441) {
+                            $elem1442 = null;
+                            $elem1442 = new \metastore\Partition();
+                            $xfer += $elem1442->read($input);
+                            $this->new_parts []= $elem1442;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ThriftHiveMetastore_add_partitions_args
             }
             $xfer += $output->writeFieldBegin('new_parts', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->new_parts));
-            foreach ($this->new_parts as $iter1435) {
-                $xfer += $iter1435->write($output);
+            foreach ($this->new_parts as $iter1443) {
+                $xfer += $iter1443->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_add_partitions_pspec_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_add_partitions_pspec_args.php
@@ -69,14 +69,14 @@ class ThriftHiveMetastore_add_partitions_pspec_args
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->new_parts = array();
-                        $_size1436 = 0;
-                        $_etype1439 = 0;
-                        $xfer += $input->readListBegin($_etype1439, $_size1436);
-                        for ($_i1440 = 0; $_i1440 < $_size1436; ++$_i1440) {
-                            $elem1441 = null;
-                            $elem1441 = new \metastore\PartitionSpec();
-                            $xfer += $elem1441->read($input);
-                            $this->new_parts []= $elem1441;
+                        $_size1444 = 0;
+                        $_etype1447 = 0;
+                        $xfer += $input->readListBegin($_etype1447, $_size1444);
+                        for ($_i1448 = 0; $_i1448 < $_size1444; ++$_i1448) {
+                            $elem1449 = null;
+                            $elem1449 = new \metastore\PartitionSpec();
+                            $xfer += $elem1449->read($input);
+                            $this->new_parts []= $elem1449;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ThriftHiveMetastore_add_partitions_pspec_args
             }
             $xfer += $output->writeFieldBegin('new_parts', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->new_parts));
-            foreach ($this->new_parts as $iter1442) {
-                $xfer += $iter1442->write($output);
+            foreach ($this->new_parts as $iter1450) {
+                $xfer += $iter1450->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_alter_partitions_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_alter_partitions_args.php
@@ -107,14 +107,14 @@ class ThriftHiveMetastore_alter_partitions_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->new_parts = array();
-                        $_size1636 = 0;
-                        $_etype1639 = 0;
-                        $xfer += $input->readListBegin($_etype1639, $_size1636);
-                        for ($_i1640 = 0; $_i1640 < $_size1636; ++$_i1640) {
-                            $elem1641 = null;
-                            $elem1641 = new \metastore\Partition();
-                            $xfer += $elem1641->read($input);
-                            $this->new_parts []= $elem1641;
+                        $_size1644 = 0;
+                        $_etype1647 = 0;
+                        $xfer += $input->readListBegin($_etype1647, $_size1644);
+                        for ($_i1648 = 0; $_i1648 < $_size1644; ++$_i1648) {
+                            $elem1649 = null;
+                            $elem1649 = new \metastore\Partition();
+                            $xfer += $elem1649->read($input);
+                            $this->new_parts []= $elem1649;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -151,8 +151,8 @@ class ThriftHiveMetastore_alter_partitions_args
             }
             $xfer += $output->writeFieldBegin('new_parts', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->new_parts));
-            foreach ($this->new_parts as $iter1642) {
-                $xfer += $iter1642->write($output);
+            foreach ($this->new_parts as $iter1650) {
+                $xfer += $iter1650->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_alter_partitions_with_environment_context_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_alter_partitions_with_environment_context_args.php
@@ -120,14 +120,14 @@ class ThriftHiveMetastore_alter_partitions_with_environment_context_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->new_parts = array();
-                        $_size1643 = 0;
-                        $_etype1646 = 0;
-                        $xfer += $input->readListBegin($_etype1646, $_size1643);
-                        for ($_i1647 = 0; $_i1647 < $_size1643; ++$_i1647) {
-                            $elem1648 = null;
-                            $elem1648 = new \metastore\Partition();
-                            $xfer += $elem1648->read($input);
-                            $this->new_parts []= $elem1648;
+                        $_size1651 = 0;
+                        $_etype1654 = 0;
+                        $xfer += $input->readListBegin($_etype1654, $_size1651);
+                        for ($_i1655 = 0; $_i1655 < $_size1651; ++$_i1655) {
+                            $elem1656 = null;
+                            $elem1656 = new \metastore\Partition();
+                            $xfer += $elem1656->read($input);
+                            $this->new_parts []= $elem1656;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -172,8 +172,8 @@ class ThriftHiveMetastore_alter_partitions_with_environment_context_args
             }
             $xfer += $output->writeFieldBegin('new_parts', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->new_parts));
-            foreach ($this->new_parts as $iter1649) {
-                $xfer += $iter1649->write($output);
+            foreach ($this->new_parts as $iter1657) {
+                $xfer += $iter1657->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_append_partition_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_append_partition_args.php
@@ -106,13 +106,13 @@ class ThriftHiveMetastore_append_partition_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1443 = 0;
-                        $_etype1446 = 0;
-                        $xfer += $input->readListBegin($_etype1446, $_size1443);
-                        for ($_i1447 = 0; $_i1447 < $_size1443; ++$_i1447) {
-                            $elem1448 = null;
-                            $xfer += $input->readString($elem1448);
-                            $this->part_vals []= $elem1448;
+                        $_size1451 = 0;
+                        $_etype1454 = 0;
+                        $xfer += $input->readListBegin($_etype1454, $_size1451);
+                        for ($_i1455 = 0; $_i1455 < $_size1451; ++$_i1455) {
+                            $elem1456 = null;
+                            $xfer += $input->readString($elem1456);
+                            $this->part_vals []= $elem1456;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class ThriftHiveMetastore_append_partition_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1449) {
-                $xfer += $output->writeString($iter1449);
+            foreach ($this->part_vals as $iter1457) {
+                $xfer += $output->writeString($iter1457);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_append_partition_with_environment_context_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_append_partition_with_environment_context_args.php
@@ -119,13 +119,13 @@ class ThriftHiveMetastore_append_partition_with_environment_context_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1450 = 0;
-                        $_etype1453 = 0;
-                        $xfer += $input->readListBegin($_etype1453, $_size1450);
-                        for ($_i1454 = 0; $_i1454 < $_size1450; ++$_i1454) {
-                            $elem1455 = null;
-                            $xfer += $input->readString($elem1455);
-                            $this->part_vals []= $elem1455;
+                        $_size1458 = 0;
+                        $_etype1461 = 0;
+                        $xfer += $input->readListBegin($_etype1461, $_size1458);
+                        for ($_i1462 = 0; $_i1462 < $_size1458; ++$_i1462) {
+                            $elem1463 = null;
+                            $xfer += $input->readString($elem1463);
+                            $this->part_vals []= $elem1463;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -170,8 +170,8 @@ class ThriftHiveMetastore_append_partition_with_environment_context_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1456) {
-                $xfer += $output->writeString($iter1456);
+            foreach ($this->part_vals as $iter1464) {
+                $xfer += $output->writeString($iter1464);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_create_table_with_constraints_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_create_table_with_constraints_args.php
@@ -175,14 +175,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->primaryKeys = array();
-                        $_size1303 = 0;
-                        $_etype1306 = 0;
-                        $xfer += $input->readListBegin($_etype1306, $_size1303);
-                        for ($_i1307 = 0; $_i1307 < $_size1303; ++$_i1307) {
-                            $elem1308 = null;
-                            $elem1308 = new \metastore\SQLPrimaryKey();
-                            $xfer += $elem1308->read($input);
-                            $this->primaryKeys []= $elem1308;
+                        $_size1311 = 0;
+                        $_etype1314 = 0;
+                        $xfer += $input->readListBegin($_etype1314, $_size1311);
+                        for ($_i1315 = 0; $_i1315 < $_size1311; ++$_i1315) {
+                            $elem1316 = null;
+                            $elem1316 = new \metastore\SQLPrimaryKey();
+                            $xfer += $elem1316->read($input);
+                            $this->primaryKeys []= $elem1316;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -192,14 +192,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->foreignKeys = array();
-                        $_size1309 = 0;
-                        $_etype1312 = 0;
-                        $xfer += $input->readListBegin($_etype1312, $_size1309);
-                        for ($_i1313 = 0; $_i1313 < $_size1309; ++$_i1313) {
-                            $elem1314 = null;
-                            $elem1314 = new \metastore\SQLForeignKey();
-                            $xfer += $elem1314->read($input);
-                            $this->foreignKeys []= $elem1314;
+                        $_size1317 = 0;
+                        $_etype1320 = 0;
+                        $xfer += $input->readListBegin($_etype1320, $_size1317);
+                        for ($_i1321 = 0; $_i1321 < $_size1317; ++$_i1321) {
+                            $elem1322 = null;
+                            $elem1322 = new \metastore\SQLForeignKey();
+                            $xfer += $elem1322->read($input);
+                            $this->foreignKeys []= $elem1322;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -209,14 +209,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->uniqueConstraints = array();
-                        $_size1315 = 0;
-                        $_etype1318 = 0;
-                        $xfer += $input->readListBegin($_etype1318, $_size1315);
-                        for ($_i1319 = 0; $_i1319 < $_size1315; ++$_i1319) {
-                            $elem1320 = null;
-                            $elem1320 = new \metastore\SQLUniqueConstraint();
-                            $xfer += $elem1320->read($input);
-                            $this->uniqueConstraints []= $elem1320;
+                        $_size1323 = 0;
+                        $_etype1326 = 0;
+                        $xfer += $input->readListBegin($_etype1326, $_size1323);
+                        for ($_i1327 = 0; $_i1327 < $_size1323; ++$_i1327) {
+                            $elem1328 = null;
+                            $elem1328 = new \metastore\SQLUniqueConstraint();
+                            $xfer += $elem1328->read($input);
+                            $this->uniqueConstraints []= $elem1328;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -226,14 +226,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->notNullConstraints = array();
-                        $_size1321 = 0;
-                        $_etype1324 = 0;
-                        $xfer += $input->readListBegin($_etype1324, $_size1321);
-                        for ($_i1325 = 0; $_i1325 < $_size1321; ++$_i1325) {
-                            $elem1326 = null;
-                            $elem1326 = new \metastore\SQLNotNullConstraint();
-                            $xfer += $elem1326->read($input);
-                            $this->notNullConstraints []= $elem1326;
+                        $_size1329 = 0;
+                        $_etype1332 = 0;
+                        $xfer += $input->readListBegin($_etype1332, $_size1329);
+                        for ($_i1333 = 0; $_i1333 < $_size1329; ++$_i1333) {
+                            $elem1334 = null;
+                            $elem1334 = new \metastore\SQLNotNullConstraint();
+                            $xfer += $elem1334->read($input);
+                            $this->notNullConstraints []= $elem1334;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -243,14 +243,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->defaultConstraints = array();
-                        $_size1327 = 0;
-                        $_etype1330 = 0;
-                        $xfer += $input->readListBegin($_etype1330, $_size1327);
-                        for ($_i1331 = 0; $_i1331 < $_size1327; ++$_i1331) {
-                            $elem1332 = null;
-                            $elem1332 = new \metastore\SQLDefaultConstraint();
-                            $xfer += $elem1332->read($input);
-                            $this->defaultConstraints []= $elem1332;
+                        $_size1335 = 0;
+                        $_etype1338 = 0;
+                        $xfer += $input->readListBegin($_etype1338, $_size1335);
+                        for ($_i1339 = 0; $_i1339 < $_size1335; ++$_i1339) {
+                            $elem1340 = null;
+                            $elem1340 = new \metastore\SQLDefaultConstraint();
+                            $xfer += $elem1340->read($input);
+                            $this->defaultConstraints []= $elem1340;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -260,14 +260,14 @@ class ThriftHiveMetastore_create_table_with_constraints_args
                 case 7:
                     if ($ftype == TType::LST) {
                         $this->checkConstraints = array();
-                        $_size1333 = 0;
-                        $_etype1336 = 0;
-                        $xfer += $input->readListBegin($_etype1336, $_size1333);
-                        for ($_i1337 = 0; $_i1337 < $_size1333; ++$_i1337) {
-                            $elem1338 = null;
-                            $elem1338 = new \metastore\SQLCheckConstraint();
-                            $xfer += $elem1338->read($input);
-                            $this->checkConstraints []= $elem1338;
+                        $_size1341 = 0;
+                        $_etype1344 = 0;
+                        $xfer += $input->readListBegin($_etype1344, $_size1341);
+                        for ($_i1345 = 0; $_i1345 < $_size1341; ++$_i1345) {
+                            $elem1346 = null;
+                            $elem1346 = new \metastore\SQLCheckConstraint();
+                            $xfer += $elem1346->read($input);
+                            $this->checkConstraints []= $elem1346;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -302,8 +302,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('primaryKeys', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->primaryKeys));
-            foreach ($this->primaryKeys as $iter1339) {
-                $xfer += $iter1339->write($output);
+            foreach ($this->primaryKeys as $iter1347) {
+                $xfer += $iter1347->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -314,8 +314,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('foreignKeys', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->foreignKeys));
-            foreach ($this->foreignKeys as $iter1340) {
-                $xfer += $iter1340->write($output);
+            foreach ($this->foreignKeys as $iter1348) {
+                $xfer += $iter1348->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -326,8 +326,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('uniqueConstraints', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->uniqueConstraints));
-            foreach ($this->uniqueConstraints as $iter1341) {
-                $xfer += $iter1341->write($output);
+            foreach ($this->uniqueConstraints as $iter1349) {
+                $xfer += $iter1349->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -338,8 +338,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('notNullConstraints', TType::LST, 5);
             $output->writeListBegin(TType::STRUCT, count($this->notNullConstraints));
-            foreach ($this->notNullConstraints as $iter1342) {
-                $xfer += $iter1342->write($output);
+            foreach ($this->notNullConstraints as $iter1350) {
+                $xfer += $iter1350->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -350,8 +350,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('defaultConstraints', TType::LST, 6);
             $output->writeListBegin(TType::STRUCT, count($this->defaultConstraints));
-            foreach ($this->defaultConstraints as $iter1343) {
-                $xfer += $iter1343->write($output);
+            foreach ($this->defaultConstraints as $iter1351) {
+                $xfer += $iter1351->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -362,8 +362,8 @@ class ThriftHiveMetastore_create_table_with_constraints_args
             }
             $xfer += $output->writeFieldBegin('checkConstraints', TType::LST, 7);
             $output->writeListBegin(TType::STRUCT, count($this->checkConstraints));
-            foreach ($this->checkConstraints as $iter1344) {
-                $xfer += $iter1344->write($output);
+            foreach ($this->checkConstraints as $iter1352) {
+                $xfer += $iter1352->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_partition_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_partition_args.php
@@ -118,13 +118,13 @@ class ThriftHiveMetastore_drop_partition_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1457 = 0;
-                        $_etype1460 = 0;
-                        $xfer += $input->readListBegin($_etype1460, $_size1457);
-                        for ($_i1461 = 0; $_i1461 < $_size1457; ++$_i1461) {
-                            $elem1462 = null;
-                            $xfer += $input->readString($elem1462);
-                            $this->part_vals []= $elem1462;
+                        $_size1465 = 0;
+                        $_etype1468 = 0;
+                        $xfer += $input->readListBegin($_etype1468, $_size1465);
+                        for ($_i1469 = 0; $_i1469 < $_size1465; ++$_i1469) {
+                            $elem1470 = null;
+                            $xfer += $input->readString($elem1470);
+                            $this->part_vals []= $elem1470;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -168,8 +168,8 @@ class ThriftHiveMetastore_drop_partition_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1463) {
-                $xfer += $output->writeString($iter1463);
+            foreach ($this->part_vals as $iter1471) {
+                $xfer += $output->writeString($iter1471);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_partition_with_environment_context_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_partition_with_environment_context_args.php
@@ -131,13 +131,13 @@ class ThriftHiveMetastore_drop_partition_with_environment_context_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1464 = 0;
-                        $_etype1467 = 0;
-                        $xfer += $input->readListBegin($_etype1467, $_size1464);
-                        for ($_i1468 = 0; $_i1468 < $_size1464; ++$_i1468) {
-                            $elem1469 = null;
-                            $xfer += $input->readString($elem1469);
-                            $this->part_vals []= $elem1469;
+                        $_size1472 = 0;
+                        $_etype1475 = 0;
+                        $xfer += $input->readListBegin($_etype1475, $_size1472);
+                        for ($_i1476 = 0; $_i1476 < $_size1472; ++$_i1476) {
+                            $elem1477 = null;
+                            $xfer += $input->readString($elem1477);
+                            $this->part_vals []= $elem1477;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -189,8 +189,8 @@ class ThriftHiveMetastore_drop_partition_with_environment_context_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1470) {
-                $xfer += $output->writeString($iter1470);
+            foreach ($this->part_vals as $iter1478) {
+                $xfer += $output->writeString($iter1478);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partition_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partition_args.php
@@ -120,16 +120,16 @@ class ThriftHiveMetastore_exchange_partition_args
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->partitionSpecs = array();
-                        $_size1478 = 0;
-                        $_ktype1479 = 0;
-                        $_vtype1480 = 0;
-                        $xfer += $input->readMapBegin($_ktype1479, $_vtype1480, $_size1478);
-                        for ($_i1482 = 0; $_i1482 < $_size1478; ++$_i1482) {
-                            $key1483 = '';
-                            $val1484 = '';
-                            $xfer += $input->readString($key1483);
-                            $xfer += $input->readString($val1484);
-                            $this->partitionSpecs[$key1483] = $val1484;
+                        $_size1486 = 0;
+                        $_ktype1487 = 0;
+                        $_vtype1488 = 0;
+                        $xfer += $input->readMapBegin($_ktype1487, $_vtype1488, $_size1486);
+                        for ($_i1490 = 0; $_i1490 < $_size1486; ++$_i1490) {
+                            $key1491 = '';
+                            $val1492 = '';
+                            $xfer += $input->readString($key1491);
+                            $xfer += $input->readString($val1492);
+                            $this->partitionSpecs[$key1491] = $val1492;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -184,9 +184,9 @@ class ThriftHiveMetastore_exchange_partition_args
             }
             $xfer += $output->writeFieldBegin('partitionSpecs', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->partitionSpecs));
-            foreach ($this->partitionSpecs as $kiter1485 => $viter1486) {
-                $xfer += $output->writeString($kiter1485);
-                $xfer += $output->writeString($viter1486);
+            foreach ($this->partitionSpecs as $kiter1493 => $viter1494) {
+                $xfer += $output->writeString($kiter1493);
+                $xfer += $output->writeString($viter1494);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partitions_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partitions_args.php
@@ -120,16 +120,16 @@ class ThriftHiveMetastore_exchange_partitions_args
                 case 1:
                     if ($ftype == TType::MAP) {
                         $this->partitionSpecs = array();
-                        $_size1487 = 0;
-                        $_ktype1488 = 0;
-                        $_vtype1489 = 0;
-                        $xfer += $input->readMapBegin($_ktype1488, $_vtype1489, $_size1487);
-                        for ($_i1491 = 0; $_i1491 < $_size1487; ++$_i1491) {
-                            $key1492 = '';
-                            $val1493 = '';
-                            $xfer += $input->readString($key1492);
-                            $xfer += $input->readString($val1493);
-                            $this->partitionSpecs[$key1492] = $val1493;
+                        $_size1495 = 0;
+                        $_ktype1496 = 0;
+                        $_vtype1497 = 0;
+                        $xfer += $input->readMapBegin($_ktype1496, $_vtype1497, $_size1495);
+                        for ($_i1499 = 0; $_i1499 < $_size1495; ++$_i1499) {
+                            $key1500 = '';
+                            $val1501 = '';
+                            $xfer += $input->readString($key1500);
+                            $xfer += $input->readString($val1501);
+                            $this->partitionSpecs[$key1500] = $val1501;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -184,9 +184,9 @@ class ThriftHiveMetastore_exchange_partitions_args
             }
             $xfer += $output->writeFieldBegin('partitionSpecs', TType::MAP, 1);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->partitionSpecs));
-            foreach ($this->partitionSpecs as $kiter1494 => $viter1495) {
-                $xfer += $output->writeString($kiter1494);
-                $xfer += $output->writeString($viter1495);
+            foreach ($this->partitionSpecs as $kiter1502 => $viter1503) {
+                $xfer += $output->writeString($kiter1502);
+                $xfer += $output->writeString($viter1503);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partitions_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_exchange_partitions_result.php
@@ -121,14 +121,14 @@ class ThriftHiveMetastore_exchange_partitions_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1496 = 0;
-                        $_etype1499 = 0;
-                        $xfer += $input->readListBegin($_etype1499, $_size1496);
-                        for ($_i1500 = 0; $_i1500 < $_size1496; ++$_i1500) {
-                            $elem1501 = null;
-                            $elem1501 = new \metastore\Partition();
-                            $xfer += $elem1501->read($input);
-                            $this->success []= $elem1501;
+                        $_size1504 = 0;
+                        $_etype1507 = 0;
+                        $xfer += $input->readListBegin($_etype1507, $_size1504);
+                        for ($_i1508 = 0; $_i1508 < $_size1504; ++$_i1508) {
+                            $elem1509 = null;
+                            $elem1509 = new \metastore\Partition();
+                            $xfer += $elem1509->read($input);
+                            $this->success []= $elem1509;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -187,8 +187,8 @@ class ThriftHiveMetastore_exchange_partitions_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1502) {
-                $xfer += $iter1502->write($output);
+            foreach ($this->success as $iter1510) {
+                $xfer += $iter1510->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_find_columns_with_stats_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_find_columns_with_stats_result.php
@@ -68,13 +68,13 @@ class ThriftHiveMetastore_find_columns_with_stats_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1761 = 0;
-                        $_etype1764 = 0;
-                        $xfer += $input->readListBegin($_etype1764, $_size1761);
-                        for ($_i1765 = 0; $_i1765 < $_size1761; ++$_i1765) {
-                            $elem1766 = null;
-                            $xfer += $input->readString($elem1766);
-                            $this->success []= $elem1766;
+                        $_size1769 = 0;
+                        $_etype1772 = 0;
+                        $xfer += $input->readListBegin($_etype1772, $_size1769);
+                        for ($_i1773 = 0; $_i1773 < $_size1769; ++$_i1773) {
+                            $elem1774 = null;
+                            $xfer += $input->readString($elem1774);
+                            $this->success []= $elem1774;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class ThriftHiveMetastore_find_columns_with_stats_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1767) {
-                $xfer += $output->writeString($iter1767);
+            foreach ($this->success as $iter1775) {
+                $xfer += $output->writeString($iter1775);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_databases_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_databases_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_all_databases_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1252 = 0;
-                        $_etype1255 = 0;
-                        $xfer += $input->readListBegin($_etype1255, $_size1252);
-                        for ($_i1256 = 0; $_i1256 < $_size1252; ++$_i1256) {
-                            $elem1257 = null;
-                            $xfer += $input->readString($elem1257);
-                            $this->success []= $elem1257;
+                        $_size1260 = 0;
+                        $_etype1263 = 0;
+                        $xfer += $input->readListBegin($_etype1263, $_size1260);
+                        for ($_i1264 = 0; $_i1264 < $_size1260; ++$_i1264) {
+                            $elem1265 = null;
+                            $xfer += $input->readString($elem1265);
+                            $this->success []= $elem1265;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_all_databases_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1258) {
-                $xfer += $output->writeString($iter1258);
+            foreach ($this->success as $iter1266) {
+                $xfer += $output->writeString($iter1266);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1366 = 0;
-                        $_etype1369 = 0;
-                        $xfer += $input->readListBegin($_etype1369, $_size1366);
-                        for ($_i1370 = 0; $_i1370 < $_size1366; ++$_i1370) {
-                            $elem1371 = null;
-                            $elem1371 = new \metastore\Table();
-                            $xfer += $elem1371->read($input);
-                            $this->success []= $elem1371;
+                        $_size1374 = 0;
+                        $_etype1377 = 0;
+                        $xfer += $input->readListBegin($_etype1377, $_size1374);
+                        for ($_i1378 = 0; $_i1378 < $_size1374; ++$_i1378) {
+                            $elem1379 = null;
+                            $elem1379 = new \metastore\Table();
+                            $xfer += $elem1379->read($input);
+                            $this->success []= $elem1379;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1372) {
-                $xfer += $iter1372->write($output);
+            foreach ($this->success as $iter1380) {
+                $xfer += $iter1380->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_packages_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_packages_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_all_packages_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1789 = 0;
-                        $_etype1792 = 0;
-                        $xfer += $input->readListBegin($_etype1792, $_size1789);
-                        for ($_i1793 = 0; $_i1793 < $_size1789; ++$_i1793) {
-                            $elem1794 = null;
-                            $xfer += $input->readString($elem1794);
-                            $this->success []= $elem1794;
+                        $_size1797 = 0;
+                        $_etype1800 = 0;
+                        $xfer += $input->readListBegin($_etype1800, $_size1797);
+                        for ($_i1801 = 0; $_i1801 < $_size1797; ++$_i1801) {
+                            $elem1802 = null;
+                            $xfer += $input->readString($elem1802);
+                            $this->success []= $elem1802;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_all_packages_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1795) {
-                $xfer += $output->writeString($iter1795);
+            foreach ($this->success as $iter1803) {
+                $xfer += $output->writeString($iter1803);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_stored_procedures_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_stored_procedures_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_all_stored_procedures_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1782 = 0;
-                        $_etype1785 = 0;
-                        $xfer += $input->readListBegin($_etype1785, $_size1782);
-                        for ($_i1786 = 0; $_i1786 < $_size1782; ++$_i1786) {
-                            $elem1787 = null;
-                            $xfer += $input->readString($elem1787);
-                            $this->success []= $elem1787;
+                        $_size1790 = 0;
+                        $_etype1793 = 0;
+                        $xfer += $input->readListBegin($_etype1793, $_size1790);
+                        for ($_i1794 = 0; $_i1794 < $_size1790; ++$_i1794) {
+                            $elem1795 = null;
+                            $xfer += $input->readString($elem1795);
+                            $this->success []= $elem1795;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_all_stored_procedures_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1788) {
-                $xfer += $output->writeString($iter1788);
+            foreach ($this->success as $iter1796) {
+                $xfer += $output->writeString($iter1796);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_tables_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_tables_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_all_tables_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1394 = 0;
-                        $_etype1397 = 0;
-                        $xfer += $input->readListBegin($_etype1397, $_size1394);
-                        for ($_i1398 = 0; $_i1398 < $_size1394; ++$_i1398) {
-                            $elem1399 = null;
-                            $xfer += $input->readString($elem1399);
-                            $this->success []= $elem1399;
+                        $_size1402 = 0;
+                        $_etype1405 = 0;
+                        $xfer += $input->readListBegin($_etype1405, $_size1402);
+                        for ($_i1406 = 0; $_i1406 < $_size1402; ++$_i1406) {
+                            $elem1407 = null;
+                            $xfer += $input->readString($elem1407);
+                            $this->success []= $elem1407;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_all_tables_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1400) {
-                $xfer += $output->writeString($iter1400);
+            foreach ($this->success as $iter1408) {
+                $xfer += $output->writeString($iter1408);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_token_identifiers_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_token_identifiers_result.php
@@ -68,13 +68,13 @@ class ThriftHiveMetastore_get_all_token_identifiers_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1747 = 0;
-                        $_etype1750 = 0;
-                        $xfer += $input->readListBegin($_etype1750, $_size1747);
-                        for ($_i1751 = 0; $_i1751 < $_size1747; ++$_i1751) {
-                            $elem1752 = null;
-                            $xfer += $input->readString($elem1752);
-                            $this->success []= $elem1752;
+                        $_size1755 = 0;
+                        $_etype1758 = 0;
+                        $xfer += $input->readListBegin($_etype1758, $_size1755);
+                        for ($_i1759 = 0; $_i1759 < $_size1755; ++$_i1759) {
+                            $elem1760 = null;
+                            $xfer += $input->readString($elem1760);
+                            $this->success []= $elem1760;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class ThriftHiveMetastore_get_all_token_identifiers_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1753) {
-                $xfer += $output->writeString($iter1753);
+            foreach ($this->success as $iter1761) {
+                $xfer += $output->writeString($iter1761);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_write_event_info_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_all_write_event_info_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_get_all_write_event_info_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1796 = 0;
-                        $_etype1799 = 0;
-                        $xfer += $input->readListBegin($_etype1799, $_size1796);
-                        for ($_i1800 = 0; $_i1800 < $_size1796; ++$_i1800) {
-                            $elem1801 = null;
-                            $elem1801 = new \metastore\WriteEventInfo();
-                            $xfer += $elem1801->read($input);
-                            $this->success []= $elem1801;
+                        $_size1804 = 0;
+                        $_etype1807 = 0;
+                        $xfer += $input->readListBegin($_etype1807, $_size1804);
+                        for ($_i1808 = 0; $_i1808 < $_size1804; ++$_i1808) {
+                            $elem1809 = null;
+                            $elem1809 = new \metastore\WriteEventInfo();
+                            $xfer += $elem1809->read($input);
+                            $this->success []= $elem1809;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_get_all_write_event_info_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1802) {
-                $xfer += $iter1802->write($output);
+            foreach ($this->success as $iter1810) {
+                $xfer += $iter1810->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_databases_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_databases_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_databases_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1245 = 0;
-                        $_etype1248 = 0;
-                        $xfer += $input->readListBegin($_etype1248, $_size1245);
-                        for ($_i1249 = 0; $_i1249 < $_size1245; ++$_i1249) {
-                            $elem1250 = null;
-                            $xfer += $input->readString($elem1250);
-                            $this->success []= $elem1250;
+                        $_size1253 = 0;
+                        $_etype1256 = 0;
+                        $xfer += $input->readListBegin($_etype1256, $_size1253);
+                        for ($_i1257 = 0; $_i1257 < $_size1253; ++$_i1257) {
+                            $elem1258 = null;
+                            $xfer += $input->readString($elem1258);
+                            $this->success []= $elem1258;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_databases_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1251) {
-                $xfer += $output->writeString($iter1251);
+            foreach ($this->success as $iter1259) {
+                $xfer += $output->writeString($iter1259);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_dataconnectors_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_dataconnectors_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_dataconnectors_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1259 = 0;
-                        $_etype1262 = 0;
-                        $xfer += $input->readListBegin($_etype1262, $_size1259);
-                        for ($_i1263 = 0; $_i1263 < $_size1259; ++$_i1263) {
-                            $elem1264 = null;
-                            $xfer += $input->readString($elem1264);
-                            $this->success []= $elem1264;
+                        $_size1267 = 0;
+                        $_etype1270 = 0;
+                        $xfer += $input->readListBegin($_etype1270, $_size1267);
+                        for ($_i1271 = 0; $_i1271 < $_size1267; ++$_i1271) {
+                            $elem1272 = null;
+                            $xfer += $input->readString($elem1272);
+                            $this->success []= $elem1272;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_dataconnectors_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1265) {
-                $xfer += $output->writeString($iter1265);
+            foreach ($this->success as $iter1273) {
+                $xfer += $output->writeString($iter1273);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_fields_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_fields_result.php
@@ -108,14 +108,14 @@ class ThriftHiveMetastore_get_fields_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1275 = 0;
-                        $_etype1278 = 0;
-                        $xfer += $input->readListBegin($_etype1278, $_size1275);
-                        for ($_i1279 = 0; $_i1279 < $_size1275; ++$_i1279) {
-                            $elem1280 = null;
-                            $elem1280 = new \metastore\FieldSchema();
-                            $xfer += $elem1280->read($input);
-                            $this->success []= $elem1280;
+                        $_size1283 = 0;
+                        $_etype1286 = 0;
+                        $xfer += $input->readListBegin($_etype1286, $_size1283);
+                        for ($_i1287 = 0; $_i1287 < $_size1283; ++$_i1287) {
+                            $elem1288 = null;
+                            $elem1288 = new \metastore\FieldSchema();
+                            $xfer += $elem1288->read($input);
+                            $this->success []= $elem1288;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -166,8 +166,8 @@ class ThriftHiveMetastore_get_fields_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1281) {
-                $xfer += $iter1281->write($output);
+            foreach ($this->success as $iter1289) {
+                $xfer += $iter1289->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_fields_with_environment_context_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_fields_with_environment_context_result.php
@@ -108,14 +108,14 @@ class ThriftHiveMetastore_get_fields_with_environment_context_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1282 = 0;
-                        $_etype1285 = 0;
-                        $xfer += $input->readListBegin($_etype1285, $_size1282);
-                        for ($_i1286 = 0; $_i1286 < $_size1282; ++$_i1286) {
-                            $elem1287 = null;
-                            $elem1287 = new \metastore\FieldSchema();
-                            $xfer += $elem1287->read($input);
-                            $this->success []= $elem1287;
+                        $_size1290 = 0;
+                        $_etype1293 = 0;
+                        $xfer += $input->readListBegin($_etype1293, $_size1290);
+                        for ($_i1294 = 0; $_i1294 < $_size1290; ++$_i1294) {
+                            $elem1295 = null;
+                            $elem1295 = new \metastore\FieldSchema();
+                            $xfer += $elem1295->read($input);
+                            $this->success []= $elem1295;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -166,8 +166,8 @@ class ThriftHiveMetastore_get_fields_with_environment_context_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1288) {
-                $xfer += $iter1288->write($output);
+            foreach ($this->success as $iter1296) {
+                $xfer += $iter1296->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_functions_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_functions_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_functions_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1698 = 0;
-                        $_etype1701 = 0;
-                        $xfer += $input->readListBegin($_etype1701, $_size1698);
-                        for ($_i1702 = 0; $_i1702 < $_size1698; ++$_i1702) {
-                            $elem1703 = null;
-                            $xfer += $input->readString($elem1703);
-                            $this->success []= $elem1703;
+                        $_size1706 = 0;
+                        $_etype1709 = 0;
+                        $xfer += $input->readListBegin($_etype1709, $_size1706);
+                        for ($_i1710 = 0; $_i1710 < $_size1706; ++$_i1710) {
+                            $elem1711 = null;
+                            $xfer += $input->readString($elem1711);
+                            $this->success []= $elem1711;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_functions_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1704) {
-                $xfer += $output->writeString($iter1704);
+            foreach ($this->success as $iter1712) {
+                $xfer += $output->writeString($iter1712);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_master_keys_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_master_keys_result.php
@@ -68,13 +68,13 @@ class ThriftHiveMetastore_get_master_keys_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1754 = 0;
-                        $_etype1757 = 0;
-                        $xfer += $input->readListBegin($_etype1757, $_size1754);
-                        for ($_i1758 = 0; $_i1758 < $_size1754; ++$_i1758) {
-                            $elem1759 = null;
-                            $xfer += $input->readString($elem1759);
-                            $this->success []= $elem1759;
+                        $_size1762 = 0;
+                        $_etype1765 = 0;
+                        $xfer += $input->readListBegin($_etype1765, $_size1762);
+                        for ($_i1766 = 0; $_i1766 < $_size1762; ++$_i1766) {
+                            $elem1767 = null;
+                            $xfer += $input->readString($elem1767);
+                            $this->success []= $elem1767;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -101,8 +101,8 @@ class ThriftHiveMetastore_get_master_keys_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1760) {
-                $xfer += $output->writeString($iter1760);
+            foreach ($this->success as $iter1768) {
+                $xfer += $output->writeString($iter1768);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_materialization_invalidation_info_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_materialization_invalidation_info_args.php
@@ -27,18 +27,30 @@ class ThriftHiveMetastore_get_materialization_invalidation_info_args
             'type' => TType::STRUCT,
             'class' => '\metastore\CreationMetadata',
         ),
+        2 => array(
+            'var' => 'validTxnList',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
      * @var \metastore\CreationMetadata
      */
     public $creation_metadata = null;
+    /**
+     * @var string
+     */
+    public $validTxnList = null;
 
     public function __construct($vals = null)
     {
         if (is_array($vals)) {
             if (isset($vals['creation_metadata'])) {
                 $this->creation_metadata = $vals['creation_metadata'];
+            }
+            if (isset($vals['validTxnList'])) {
+                $this->validTxnList = $vals['validTxnList'];
             }
         }
     }
@@ -70,6 +82,13 @@ class ThriftHiveMetastore_get_materialization_invalidation_info_args
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 2:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->validTxnList);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -90,6 +109,11 @@ class ThriftHiveMetastore_get_materialization_invalidation_info_args
             }
             $xfer += $output->writeFieldBegin('creation_metadata', TType::STRUCT, 1);
             $xfer += $this->creation_metadata->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->validTxnList !== null) {
+            $xfer += $output->writeFieldBegin('validTxnList', TType::STRING, 2);
+            $xfer += $output->writeString($this->validTxnList);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_materialized_views_for_rewriting_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_materialized_views_for_rewriting_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_materialized_views_for_rewriting_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1373 = 0;
-                        $_etype1376 = 0;
-                        $xfer += $input->readListBegin($_etype1376, $_size1373);
-                        for ($_i1377 = 0; $_i1377 < $_size1373; ++$_i1377) {
-                            $elem1378 = null;
-                            $xfer += $input->readString($elem1378);
-                            $this->success []= $elem1378;
+                        $_size1381 = 0;
+                        $_etype1384 = 0;
+                        $xfer += $input->readListBegin($_etype1384, $_size1381);
+                        for ($_i1385 = 0; $_i1385 < $_size1381; ++$_i1385) {
+                            $elem1386 = null;
+                            $xfer += $input->readString($elem1386);
+                            $this->success []= $elem1386;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_materialized_views_for_rewriting_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1379) {
-                $xfer += $output->writeString($iter1379);
+            foreach ($this->success as $iter1387) {
+                $xfer += $output->writeString($iter1387);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_part_specs_by_filter_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_part_specs_by_filter_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_part_specs_by_filter_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1615 = 0;
-                        $_etype1618 = 0;
-                        $xfer += $input->readListBegin($_etype1618, $_size1615);
-                        for ($_i1619 = 0; $_i1619 < $_size1615; ++$_i1619) {
-                            $elem1620 = null;
-                            $elem1620 = new \metastore\PartitionSpec();
-                            $xfer += $elem1620->read($input);
-                            $this->success []= $elem1620;
+                        $_size1623 = 0;
+                        $_etype1626 = 0;
+                        $xfer += $input->readListBegin($_etype1626, $_size1623);
+                        for ($_i1627 = 0; $_i1627 < $_size1623; ++$_i1627) {
+                            $elem1628 = null;
+                            $elem1628 = new \metastore\PartitionSpec();
+                            $xfer += $elem1628->read($input);
+                            $this->success []= $elem1628;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_part_specs_by_filter_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1621) {
-                $xfer += $iter1621->write($output);
+            foreach ($this->success as $iter1629) {
+                $xfer += $iter1629->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_args.php
@@ -106,13 +106,13 @@ class ThriftHiveMetastore_get_partition_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1471 = 0;
-                        $_etype1474 = 0;
-                        $xfer += $input->readListBegin($_etype1474, $_size1471);
-                        for ($_i1475 = 0; $_i1475 < $_size1471; ++$_i1475) {
-                            $elem1476 = null;
-                            $xfer += $input->readString($elem1476);
-                            $this->part_vals []= $elem1476;
+                        $_size1479 = 0;
+                        $_etype1482 = 0;
+                        $xfer += $input->readListBegin($_etype1482, $_size1479);
+                        for ($_i1483 = 0; $_i1483 < $_size1479; ++$_i1483) {
+                            $elem1484 = null;
+                            $xfer += $input->readString($elem1484);
+                            $this->part_vals []= $elem1484;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class ThriftHiveMetastore_get_partition_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1477) {
-                $xfer += $output->writeString($iter1477);
+            foreach ($this->part_vals as $iter1485) {
+                $xfer += $output->writeString($iter1485);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_ps_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_ps_args.php
@@ -118,13 +118,13 @@ class ThriftHiveMetastore_get_partition_names_ps_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1587 = 0;
-                        $_etype1590 = 0;
-                        $xfer += $input->readListBegin($_etype1590, $_size1587);
-                        for ($_i1591 = 0; $_i1591 < $_size1587; ++$_i1591) {
-                            $elem1592 = null;
-                            $xfer += $input->readString($elem1592);
-                            $this->part_vals []= $elem1592;
+                        $_size1595 = 0;
+                        $_etype1598 = 0;
+                        $xfer += $input->readListBegin($_etype1598, $_size1595);
+                        for ($_i1599 = 0; $_i1599 < $_size1595; ++$_i1599) {
+                            $elem1600 = null;
+                            $xfer += $input->readString($elem1600);
+                            $this->part_vals []= $elem1600;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -168,8 +168,8 @@ class ThriftHiveMetastore_get_partition_names_ps_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1593) {
-                $xfer += $output->writeString($iter1593);
+            foreach ($this->part_vals as $iter1601) {
+                $xfer += $output->writeString($iter1601);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_ps_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_ps_result.php
@@ -94,13 +94,13 @@ class ThriftHiveMetastore_get_partition_names_ps_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1594 = 0;
-                        $_etype1597 = 0;
-                        $xfer += $input->readListBegin($_etype1597, $_size1594);
-                        for ($_i1598 = 0; $_i1598 < $_size1594; ++$_i1598) {
-                            $elem1599 = null;
-                            $xfer += $input->readString($elem1599);
-                            $this->success []= $elem1599;
+                        $_size1602 = 0;
+                        $_etype1605 = 0;
+                        $xfer += $input->readListBegin($_etype1605, $_size1602);
+                        for ($_i1606 = 0; $_i1606 < $_size1602; ++$_i1606) {
+                            $elem1607 = null;
+                            $xfer += $input->readString($elem1607);
+                            $this->success []= $elem1607;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -143,8 +143,8 @@ class ThriftHiveMetastore_get_partition_names_ps_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1600) {
-                $xfer += $output->writeString($iter1600);
+            foreach ($this->success as $iter1608) {
+                $xfer += $output->writeString($iter1608);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_req_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_req_result.php
@@ -94,13 +94,13 @@ class ThriftHiveMetastore_get_partition_names_req_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1601 = 0;
-                        $_etype1604 = 0;
-                        $xfer += $input->readListBegin($_etype1604, $_size1601);
-                        for ($_i1605 = 0; $_i1605 < $_size1601; ++$_i1605) {
-                            $elem1606 = null;
-                            $xfer += $input->readString($elem1606);
-                            $this->success []= $elem1606;
+                        $_size1609 = 0;
+                        $_etype1612 = 0;
+                        $xfer += $input->readListBegin($_etype1612, $_size1609);
+                        for ($_i1613 = 0; $_i1613 < $_size1609; ++$_i1613) {
+                            $elem1614 = null;
+                            $xfer += $input->readString($elem1614);
+                            $this->success []= $elem1614;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -143,8 +143,8 @@ class ThriftHiveMetastore_get_partition_names_req_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1607) {
-                $xfer += $output->writeString($iter1607);
+            foreach ($this->success as $iter1615) {
+                $xfer += $output->writeString($iter1615);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_names_result.php
@@ -94,13 +94,13 @@ class ThriftHiveMetastore_get_partition_names_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1545 = 0;
-                        $_etype1548 = 0;
-                        $xfer += $input->readListBegin($_etype1548, $_size1545);
-                        for ($_i1549 = 0; $_i1549 < $_size1545; ++$_i1549) {
-                            $elem1550 = null;
-                            $xfer += $input->readString($elem1550);
-                            $this->success []= $elem1550;
+                        $_size1553 = 0;
+                        $_etype1556 = 0;
+                        $xfer += $input->readListBegin($_etype1556, $_size1553);
+                        for ($_i1557 = 0; $_i1557 < $_size1553; ++$_i1557) {
+                            $elem1558 = null;
+                            $xfer += $input->readString($elem1558);
+                            $this->success []= $elem1558;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -143,8 +143,8 @@ class ThriftHiveMetastore_get_partition_names_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1551) {
-                $xfer += $output->writeString($iter1551);
+            foreach ($this->success as $iter1559) {
+                $xfer += $output->writeString($iter1559);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_with_auth_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partition_with_auth_args.php
@@ -134,13 +134,13 @@ class ThriftHiveMetastore_get_partition_with_auth_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1503 = 0;
-                        $_etype1506 = 0;
-                        $xfer += $input->readListBegin($_etype1506, $_size1503);
-                        for ($_i1507 = 0; $_i1507 < $_size1503; ++$_i1507) {
-                            $elem1508 = null;
-                            $xfer += $input->readString($elem1508);
-                            $this->part_vals []= $elem1508;
+                        $_size1511 = 0;
+                        $_etype1514 = 0;
+                        $xfer += $input->readListBegin($_etype1514, $_size1511);
+                        for ($_i1515 = 0; $_i1515 < $_size1511; ++$_i1515) {
+                            $elem1516 = null;
+                            $xfer += $input->readString($elem1516);
+                            $this->part_vals []= $elem1516;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -157,13 +157,13 @@ class ThriftHiveMetastore_get_partition_with_auth_args
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->group_names = array();
-                        $_size1509 = 0;
-                        $_etype1512 = 0;
-                        $xfer += $input->readListBegin($_etype1512, $_size1509);
-                        for ($_i1513 = 0; $_i1513 < $_size1509; ++$_i1513) {
-                            $elem1514 = null;
-                            $xfer += $input->readString($elem1514);
-                            $this->group_names []= $elem1514;
+                        $_size1517 = 0;
+                        $_etype1520 = 0;
+                        $xfer += $input->readListBegin($_etype1520, $_size1517);
+                        for ($_i1521 = 0; $_i1521 < $_size1517; ++$_i1521) {
+                            $elem1522 = null;
+                            $xfer += $input->readString($elem1522);
+                            $this->group_names []= $elem1522;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -200,8 +200,8 @@ class ThriftHiveMetastore_get_partition_with_auth_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1515) {
-                $xfer += $output->writeString($iter1515);
+            foreach ($this->part_vals as $iter1523) {
+                $xfer += $output->writeString($iter1523);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -217,8 +217,8 @@ class ThriftHiveMetastore_get_partition_with_auth_args
             }
             $xfer += $output->writeFieldBegin('group_names', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->group_names));
-            foreach ($this->group_names as $iter1516) {
-                $xfer += $output->writeString($iter1516);
+            foreach ($this->group_names as $iter1524) {
+                $xfer += $output->writeString($iter1524);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_filter_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_filter_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_by_filter_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1608 = 0;
-                        $_etype1611 = 0;
-                        $xfer += $input->readListBegin($_etype1611, $_size1608);
-                        for ($_i1612 = 0; $_i1612 < $_size1608; ++$_i1612) {
-                            $elem1613 = null;
-                            $elem1613 = new \metastore\Partition();
-                            $xfer += $elem1613->read($input);
-                            $this->success []= $elem1613;
+                        $_size1616 = 0;
+                        $_etype1619 = 0;
+                        $xfer += $input->readListBegin($_etype1619, $_size1616);
+                        for ($_i1620 = 0; $_i1620 < $_size1616; ++$_i1620) {
+                            $elem1621 = null;
+                            $elem1621 = new \metastore\Partition();
+                            $xfer += $elem1621->read($input);
+                            $this->success []= $elem1621;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_by_filter_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1614) {
-                $xfer += $iter1614->write($output);
+            foreach ($this->success as $iter1622) {
+                $xfer += $iter1622->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_names_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_names_args.php
@@ -106,13 +106,13 @@ class ThriftHiveMetastore_get_partitions_by_names_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->names = array();
-                        $_size1622 = 0;
-                        $_etype1625 = 0;
-                        $xfer += $input->readListBegin($_etype1625, $_size1622);
-                        for ($_i1626 = 0; $_i1626 < $_size1622; ++$_i1626) {
-                            $elem1627 = null;
-                            $xfer += $input->readString($elem1627);
-                            $this->names []= $elem1627;
+                        $_size1630 = 0;
+                        $_etype1633 = 0;
+                        $xfer += $input->readListBegin($_etype1633, $_size1630);
+                        for ($_i1634 = 0; $_i1634 < $_size1630; ++$_i1634) {
+                            $elem1635 = null;
+                            $xfer += $input->readString($elem1635);
+                            $this->names []= $elem1635;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class ThriftHiveMetastore_get_partitions_by_names_args
             }
             $xfer += $output->writeFieldBegin('names', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->names));
-            foreach ($this->names as $iter1628) {
-                $xfer += $output->writeString($iter1628);
+            foreach ($this->names as $iter1636) {
+                $xfer += $output->writeString($iter1636);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_names_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_by_names_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_by_names_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1629 = 0;
-                        $_etype1632 = 0;
-                        $xfer += $input->readListBegin($_etype1632, $_size1629);
-                        for ($_i1633 = 0; $_i1633 < $_size1629; ++$_i1633) {
-                            $elem1634 = null;
-                            $elem1634 = new \metastore\Partition();
-                            $xfer += $elem1634->read($input);
-                            $this->success []= $elem1634;
+                        $_size1637 = 0;
+                        $_etype1640 = 0;
+                        $xfer += $input->readListBegin($_etype1640, $_size1637);
+                        for ($_i1641 = 0; $_i1641 < $_size1637; ++$_i1641) {
+                            $elem1642 = null;
+                            $elem1642 = new \metastore\Partition();
+                            $xfer += $elem1642->read($input);
+                            $this->success []= $elem1642;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_by_names_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1635) {
-                $xfer += $iter1635->write($output);
+            foreach ($this->success as $iter1643) {
+                $xfer += $iter1643->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_args.php
@@ -118,13 +118,13 @@ class ThriftHiveMetastore_get_partitions_ps_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1552 = 0;
-                        $_etype1555 = 0;
-                        $xfer += $input->readListBegin($_etype1555, $_size1552);
-                        for ($_i1556 = 0; $_i1556 < $_size1552; ++$_i1556) {
-                            $elem1557 = null;
-                            $xfer += $input->readString($elem1557);
-                            $this->part_vals []= $elem1557;
+                        $_size1560 = 0;
+                        $_etype1563 = 0;
+                        $xfer += $input->readListBegin($_etype1563, $_size1560);
+                        for ($_i1564 = 0; $_i1564 < $_size1560; ++$_i1564) {
+                            $elem1565 = null;
+                            $xfer += $input->readString($elem1565);
+                            $this->part_vals []= $elem1565;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -168,8 +168,8 @@ class ThriftHiveMetastore_get_partitions_ps_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1558) {
-                $xfer += $output->writeString($iter1558);
+            foreach ($this->part_vals as $iter1566) {
+                $xfer += $output->writeString($iter1566);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_ps_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1559 = 0;
-                        $_etype1562 = 0;
-                        $xfer += $input->readListBegin($_etype1562, $_size1559);
-                        for ($_i1563 = 0; $_i1563 < $_size1559; ++$_i1563) {
-                            $elem1564 = null;
-                            $elem1564 = new \metastore\Partition();
-                            $xfer += $elem1564->read($input);
-                            $this->success []= $elem1564;
+                        $_size1567 = 0;
+                        $_etype1570 = 0;
+                        $xfer += $input->readListBegin($_etype1570, $_size1567);
+                        for ($_i1571 = 0; $_i1571 < $_size1567; ++$_i1571) {
+                            $elem1572 = null;
+                            $elem1572 = new \metastore\Partition();
+                            $xfer += $elem1572->read($input);
+                            $this->success []= $elem1572;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_ps_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1565) {
-                $xfer += $iter1565->write($output);
+            foreach ($this->success as $iter1573) {
+                $xfer += $iter1573->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_with_auth_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_with_auth_args.php
@@ -146,13 +146,13 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1566 = 0;
-                        $_etype1569 = 0;
-                        $xfer += $input->readListBegin($_etype1569, $_size1566);
-                        for ($_i1570 = 0; $_i1570 < $_size1566; ++$_i1570) {
-                            $elem1571 = null;
-                            $xfer += $input->readString($elem1571);
-                            $this->part_vals []= $elem1571;
+                        $_size1574 = 0;
+                        $_etype1577 = 0;
+                        $xfer += $input->readListBegin($_etype1577, $_size1574);
+                        for ($_i1578 = 0; $_i1578 < $_size1574; ++$_i1578) {
+                            $elem1579 = null;
+                            $xfer += $input->readString($elem1579);
+                            $this->part_vals []= $elem1579;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -176,13 +176,13 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_args
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->group_names = array();
-                        $_size1572 = 0;
-                        $_etype1575 = 0;
-                        $xfer += $input->readListBegin($_etype1575, $_size1572);
-                        for ($_i1576 = 0; $_i1576 < $_size1572; ++$_i1576) {
-                            $elem1577 = null;
-                            $xfer += $input->readString($elem1577);
-                            $this->group_names []= $elem1577;
+                        $_size1580 = 0;
+                        $_etype1583 = 0;
+                        $xfer += $input->readListBegin($_etype1583, $_size1580);
+                        for ($_i1584 = 0; $_i1584 < $_size1580; ++$_i1584) {
+                            $elem1585 = null;
+                            $xfer += $input->readString($elem1585);
+                            $this->group_names []= $elem1585;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -219,8 +219,8 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1578) {
-                $xfer += $output->writeString($iter1578);
+            foreach ($this->part_vals as $iter1586) {
+                $xfer += $output->writeString($iter1586);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -241,8 +241,8 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_args
             }
             $xfer += $output->writeFieldBegin('group_names', TType::LST, 6);
             $output->writeListBegin(TType::STRING, count($this->group_names));
-            foreach ($this->group_names as $iter1579) {
-                $xfer += $output->writeString($iter1579);
+            foreach ($this->group_names as $iter1587) {
+                $xfer += $output->writeString($iter1587);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_with_auth_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_ps_with_auth_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1580 = 0;
-                        $_etype1583 = 0;
-                        $xfer += $input->readListBegin($_etype1583, $_size1580);
-                        for ($_i1584 = 0; $_i1584 < $_size1580; ++$_i1584) {
-                            $elem1585 = null;
-                            $elem1585 = new \metastore\Partition();
-                            $xfer += $elem1585->read($input);
-                            $this->success []= $elem1585;
+                        $_size1588 = 0;
+                        $_etype1591 = 0;
+                        $xfer += $input->readListBegin($_etype1591, $_size1588);
+                        for ($_i1592 = 0; $_i1592 < $_size1588; ++$_i1592) {
+                            $elem1593 = null;
+                            $elem1593 = new \metastore\Partition();
+                            $xfer += $elem1593->read($input);
+                            $this->success []= $elem1593;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_ps_with_auth_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1586) {
-                $xfer += $iter1586->write($output);
+            foreach ($this->success as $iter1594) {
+                $xfer += $iter1594->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_pspec_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_pspec_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_pspec_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1538 = 0;
-                        $_etype1541 = 0;
-                        $xfer += $input->readListBegin($_etype1541, $_size1538);
-                        for ($_i1542 = 0; $_i1542 < $_size1538; ++$_i1542) {
-                            $elem1543 = null;
-                            $elem1543 = new \metastore\PartitionSpec();
-                            $xfer += $elem1543->read($input);
-                            $this->success []= $elem1543;
+                        $_size1546 = 0;
+                        $_etype1549 = 0;
+                        $xfer += $input->readListBegin($_etype1549, $_size1546);
+                        for ($_i1550 = 0; $_i1550 < $_size1546; ++$_i1550) {
+                            $elem1551 = null;
+                            $elem1551 = new \metastore\PartitionSpec();
+                            $xfer += $elem1551->read($input);
+                            $this->success []= $elem1551;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_pspec_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1544) {
-                $xfer += $iter1544->write($output);
+            foreach ($this->success as $iter1552) {
+                $xfer += $iter1552->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1517 = 0;
-                        $_etype1520 = 0;
-                        $xfer += $input->readListBegin($_etype1520, $_size1517);
-                        for ($_i1521 = 0; $_i1521 < $_size1517; ++$_i1521) {
-                            $elem1522 = null;
-                            $elem1522 = new \metastore\Partition();
-                            $xfer += $elem1522->read($input);
-                            $this->success []= $elem1522;
+                        $_size1525 = 0;
+                        $_etype1528 = 0;
+                        $xfer += $input->readListBegin($_etype1528, $_size1525);
+                        for ($_i1529 = 0; $_i1529 < $_size1525; ++$_i1529) {
+                            $elem1530 = null;
+                            $elem1530 = new \metastore\Partition();
+                            $xfer += $elem1530->read($input);
+                            $this->success []= $elem1530;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1523) {
-                $xfer += $iter1523->write($output);
+            foreach ($this->success as $iter1531) {
+                $xfer += $iter1531->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_with_auth_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_with_auth_args.php
@@ -144,13 +144,13 @@ class ThriftHiveMetastore_get_partitions_with_auth_args
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->group_names = array();
-                        $_size1524 = 0;
-                        $_etype1527 = 0;
-                        $xfer += $input->readListBegin($_etype1527, $_size1524);
-                        for ($_i1528 = 0; $_i1528 < $_size1524; ++$_i1528) {
-                            $elem1529 = null;
-                            $xfer += $input->readString($elem1529);
-                            $this->group_names []= $elem1529;
+                        $_size1532 = 0;
+                        $_etype1535 = 0;
+                        $xfer += $input->readListBegin($_etype1535, $_size1532);
+                        for ($_i1536 = 0; $_i1536 < $_size1532; ++$_i1536) {
+                            $elem1537 = null;
+                            $xfer += $input->readString($elem1537);
+                            $this->group_names []= $elem1537;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -197,8 +197,8 @@ class ThriftHiveMetastore_get_partitions_with_auth_args
             }
             $xfer += $output->writeFieldBegin('group_names', TType::LST, 5);
             $output->writeListBegin(TType::STRING, count($this->group_names));
-            foreach ($this->group_names as $iter1530) {
-                $xfer += $output->writeString($iter1530);
+            foreach ($this->group_names as $iter1538) {
+                $xfer += $output->writeString($iter1538);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_with_auth_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_partitions_with_auth_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_partitions_with_auth_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1531 = 0;
-                        $_etype1534 = 0;
-                        $xfer += $input->readListBegin($_etype1534, $_size1531);
-                        for ($_i1535 = 0; $_i1535 < $_size1531; ++$_i1535) {
-                            $elem1536 = null;
-                            $elem1536 = new \metastore\Partition();
-                            $xfer += $elem1536->read($input);
-                            $this->success []= $elem1536;
+                        $_size1539 = 0;
+                        $_etype1542 = 0;
+                        $xfer += $input->readListBegin($_etype1542, $_size1539);
+                        for ($_i1543 = 0; $_i1543 < $_size1539; ++$_i1543) {
+                            $elem1544 = null;
+                            $elem1544 = new \metastore\Partition();
+                            $xfer += $elem1544->read($input);
+                            $this->success []= $elem1544;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_partitions_with_auth_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1537) {
-                $xfer += $iter1537->write($output);
+            foreach ($this->success as $iter1545) {
+                $xfer += $iter1545->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_privilege_set_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_privilege_set_args.php
@@ -108,13 +108,13 @@ class ThriftHiveMetastore_get_privilege_set_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->group_names = array();
-                        $_size1719 = 0;
-                        $_etype1722 = 0;
-                        $xfer += $input->readListBegin($_etype1722, $_size1719);
-                        for ($_i1723 = 0; $_i1723 < $_size1719; ++$_i1723) {
-                            $elem1724 = null;
-                            $xfer += $input->readString($elem1724);
-                            $this->group_names []= $elem1724;
+                        $_size1727 = 0;
+                        $_etype1730 = 0;
+                        $xfer += $input->readListBegin($_etype1730, $_size1727);
+                        for ($_i1731 = 0; $_i1731 < $_size1727; ++$_i1731) {
+                            $elem1732 = null;
+                            $xfer += $input->readString($elem1732);
+                            $this->group_names []= $elem1732;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -154,8 +154,8 @@ class ThriftHiveMetastore_get_privilege_set_args
             }
             $xfer += $output->writeFieldBegin('group_names', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->group_names));
-            foreach ($this->group_names as $iter1725) {
-                $xfer += $output->writeString($iter1725);
+            foreach ($this->group_names as $iter1733) {
+                $xfer += $output->writeString($iter1733);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_role_names_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_role_names_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_role_names_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1705 = 0;
-                        $_etype1708 = 0;
-                        $xfer += $input->readListBegin($_etype1708, $_size1705);
-                        for ($_i1709 = 0; $_i1709 < $_size1705; ++$_i1709) {
-                            $elem1710 = null;
-                            $xfer += $input->readString($elem1710);
-                            $this->success []= $elem1710;
+                        $_size1713 = 0;
+                        $_etype1716 = 0;
+                        $xfer += $input->readListBegin($_etype1716, $_size1713);
+                        for ($_i1717 = 0; $_i1717 < $_size1713; ++$_i1717) {
+                            $elem1718 = null;
+                            $xfer += $input->readString($elem1718);
+                            $this->success []= $elem1718;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_role_names_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1711) {
-                $xfer += $output->writeString($iter1711);
+            foreach ($this->success as $iter1719) {
+                $xfer += $output->writeString($iter1719);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_runtime_stats_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_runtime_stats_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_get_runtime_stats_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1775 = 0;
-                        $_etype1778 = 0;
-                        $xfer += $input->readListBegin($_etype1778, $_size1775);
-                        for ($_i1779 = 0; $_i1779 < $_size1775; ++$_i1779) {
-                            $elem1780 = null;
-                            $elem1780 = new \metastore\RuntimeStat();
-                            $xfer += $elem1780->read($input);
-                            $this->success []= $elem1780;
+                        $_size1783 = 0;
+                        $_etype1786 = 0;
+                        $xfer += $input->readListBegin($_etype1786, $_size1783);
+                        for ($_i1787 = 0; $_i1787 < $_size1783; ++$_i1787) {
+                            $elem1788 = null;
+                            $elem1788 = new \metastore\RuntimeStat();
+                            $xfer += $elem1788->read($input);
+                            $this->success []= $elem1788;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_get_runtime_stats_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1781) {
-                $xfer += $iter1781->write($output);
+            foreach ($this->success as $iter1789) {
+                $xfer += $iter1789->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_all_versions_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_all_versions_result.php
@@ -95,14 +95,14 @@ class ThriftHiveMetastore_get_schema_all_versions_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1768 = 0;
-                        $_etype1771 = 0;
-                        $xfer += $input->readListBegin($_etype1771, $_size1768);
-                        for ($_i1772 = 0; $_i1772 < $_size1768; ++$_i1772) {
-                            $elem1773 = null;
-                            $elem1773 = new \metastore\SchemaVersion();
-                            $xfer += $elem1773->read($input);
-                            $this->success []= $elem1773;
+                        $_size1776 = 0;
+                        $_etype1779 = 0;
+                        $xfer += $input->readListBegin($_etype1779, $_size1776);
+                        for ($_i1780 = 0; $_i1780 < $_size1776; ++$_i1780) {
+                            $elem1781 = null;
+                            $elem1781 = new \metastore\SchemaVersion();
+                            $xfer += $elem1781->read($input);
+                            $this->success []= $elem1781;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -145,8 +145,8 @@ class ThriftHiveMetastore_get_schema_all_versions_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1774) {
-                $xfer += $iter1774->write($output);
+            foreach ($this->success as $iter1782) {
+                $xfer += $iter1782->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_result.php
@@ -108,14 +108,14 @@ class ThriftHiveMetastore_get_schema_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1289 = 0;
-                        $_etype1292 = 0;
-                        $xfer += $input->readListBegin($_etype1292, $_size1289);
-                        for ($_i1293 = 0; $_i1293 < $_size1289; ++$_i1293) {
-                            $elem1294 = null;
-                            $elem1294 = new \metastore\FieldSchema();
-                            $xfer += $elem1294->read($input);
-                            $this->success []= $elem1294;
+                        $_size1297 = 0;
+                        $_etype1300 = 0;
+                        $xfer += $input->readListBegin($_etype1300, $_size1297);
+                        for ($_i1301 = 0; $_i1301 < $_size1297; ++$_i1301) {
+                            $elem1302 = null;
+                            $elem1302 = new \metastore\FieldSchema();
+                            $xfer += $elem1302->read($input);
+                            $this->success []= $elem1302;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -166,8 +166,8 @@ class ThriftHiveMetastore_get_schema_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1295) {
-                $xfer += $iter1295->write($output);
+            foreach ($this->success as $iter1303) {
+                $xfer += $iter1303->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_with_environment_context_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_schema_with_environment_context_result.php
@@ -108,14 +108,14 @@ class ThriftHiveMetastore_get_schema_with_environment_context_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1296 = 0;
-                        $_etype1299 = 0;
-                        $xfer += $input->readListBegin($_etype1299, $_size1296);
-                        for ($_i1300 = 0; $_i1300 < $_size1296; ++$_i1300) {
-                            $elem1301 = null;
-                            $elem1301 = new \metastore\FieldSchema();
-                            $xfer += $elem1301->read($input);
-                            $this->success []= $elem1301;
+                        $_size1304 = 0;
+                        $_etype1307 = 0;
+                        $xfer += $input->readListBegin($_etype1307, $_size1304);
+                        for ($_i1308 = 0; $_i1308 < $_size1304; ++$_i1308) {
+                            $elem1309 = null;
+                            $elem1309 = new \metastore\FieldSchema();
+                            $xfer += $elem1309->read($input);
+                            $this->success []= $elem1309;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -166,8 +166,8 @@ class ThriftHiveMetastore_get_schema_with_environment_context_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1302) {
-                $xfer += $iter1302->write($output);
+            foreach ($this->success as $iter1310) {
+                $xfer += $iter1310->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_meta_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_meta_args.php
@@ -106,13 +106,13 @@ class ThriftHiveMetastore_get_table_meta_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->tbl_types = array();
-                        $_size1380 = 0;
-                        $_etype1383 = 0;
-                        $xfer += $input->readListBegin($_etype1383, $_size1380);
-                        for ($_i1384 = 0; $_i1384 < $_size1380; ++$_i1384) {
-                            $elem1385 = null;
-                            $xfer += $input->readString($elem1385);
-                            $this->tbl_types []= $elem1385;
+                        $_size1388 = 0;
+                        $_etype1391 = 0;
+                        $xfer += $input->readListBegin($_etype1391, $_size1388);
+                        for ($_i1392 = 0; $_i1392 < $_size1388; ++$_i1392) {
+                            $elem1393 = null;
+                            $xfer += $input->readString($elem1393);
+                            $this->tbl_types []= $elem1393;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class ThriftHiveMetastore_get_table_meta_args
             }
             $xfer += $output->writeFieldBegin('tbl_types', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->tbl_types));
-            foreach ($this->tbl_types as $iter1386) {
-                $xfer += $output->writeString($iter1386);
+            foreach ($this->tbl_types as $iter1394) {
+                $xfer += $output->writeString($iter1394);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_meta_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_meta_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_get_table_meta_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1387 = 0;
-                        $_etype1390 = 0;
-                        $xfer += $input->readListBegin($_etype1390, $_size1387);
-                        for ($_i1391 = 0; $_i1391 < $_size1387; ++$_i1391) {
-                            $elem1392 = null;
-                            $elem1392 = new \metastore\TableMeta();
-                            $xfer += $elem1392->read($input);
-                            $this->success []= $elem1392;
+                        $_size1395 = 0;
+                        $_etype1398 = 0;
+                        $xfer += $input->readListBegin($_etype1398, $_size1395);
+                        for ($_i1399 = 0; $_i1399 < $_size1395; ++$_i1399) {
+                            $elem1400 = null;
+                            $elem1400 = new \metastore\TableMeta();
+                            $xfer += $elem1400->read($input);
+                            $this->success []= $elem1400;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_get_table_meta_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1393) {
-                $xfer += $iter1393->write($output);
+            foreach ($this->success as $iter1401) {
+                $xfer += $iter1401->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_names_by_filter_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_names_by_filter_result.php
@@ -107,13 +107,13 @@ class ThriftHiveMetastore_get_table_names_by_filter_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1422 = 0;
-                        $_etype1425 = 0;
-                        $xfer += $input->readListBegin($_etype1425, $_size1422);
-                        for ($_i1426 = 0; $_i1426 < $_size1422; ++$_i1426) {
-                            $elem1427 = null;
-                            $xfer += $input->readString($elem1427);
-                            $this->success []= $elem1427;
+                        $_size1430 = 0;
+                        $_etype1433 = 0;
+                        $xfer += $input->readListBegin($_etype1433, $_size1430);
+                        for ($_i1434 = 0; $_i1434 < $_size1430; ++$_i1434) {
+                            $elem1435 = null;
+                            $xfer += $input->readString($elem1435);
+                            $this->success []= $elem1435;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -164,8 +164,8 @@ class ThriftHiveMetastore_get_table_names_by_filter_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1428) {
-                $xfer += $output->writeString($iter1428);
+            foreach ($this->success as $iter1436) {
+                $xfer += $output->writeString($iter1436);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_objects_by_name_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_objects_by_name_args.php
@@ -87,13 +87,13 @@ class ThriftHiveMetastore_get_table_objects_by_name_args
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->tbl_names = array();
-                        $_size1401 = 0;
-                        $_etype1404 = 0;
-                        $xfer += $input->readListBegin($_etype1404, $_size1401);
-                        for ($_i1405 = 0; $_i1405 < $_size1401; ++$_i1405) {
-                            $elem1406 = null;
-                            $xfer += $input->readString($elem1406);
-                            $this->tbl_names []= $elem1406;
+                        $_size1409 = 0;
+                        $_etype1412 = 0;
+                        $xfer += $input->readListBegin($_etype1412, $_size1409);
+                        for ($_i1413 = 0; $_i1413 < $_size1409; ++$_i1413) {
+                            $elem1414 = null;
+                            $xfer += $input->readString($elem1414);
+                            $this->tbl_names []= $elem1414;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -125,8 +125,8 @@ class ThriftHiveMetastore_get_table_objects_by_name_args
             }
             $xfer += $output->writeFieldBegin('tbl_names', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->tbl_names));
-            foreach ($this->tbl_names as $iter1407) {
-                $xfer += $output->writeString($iter1407);
+            foreach ($this->tbl_names as $iter1415) {
+                $xfer += $output->writeString($iter1415);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_objects_by_name_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_table_objects_by_name_result.php
@@ -69,14 +69,14 @@ class ThriftHiveMetastore_get_table_objects_by_name_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1408 = 0;
-                        $_etype1411 = 0;
-                        $xfer += $input->readListBegin($_etype1411, $_size1408);
-                        for ($_i1412 = 0; $_i1412 < $_size1408; ++$_i1412) {
-                            $elem1413 = null;
-                            $elem1413 = new \metastore\Table();
-                            $xfer += $elem1413->read($input);
-                            $this->success []= $elem1413;
+                        $_size1416 = 0;
+                        $_etype1419 = 0;
+                        $xfer += $input->readListBegin($_etype1419, $_size1416);
+                        for ($_i1420 = 0; $_i1420 < $_size1416; ++$_i1420) {
+                            $elem1421 = null;
+                            $elem1421 = new \metastore\Table();
+                            $xfer += $elem1421->read($input);
+                            $this->success []= $elem1421;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class ThriftHiveMetastore_get_table_objects_by_name_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1414) {
-                $xfer += $iter1414->write($output);
+            foreach ($this->success as $iter1422) {
+                $xfer += $iter1422->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_by_type_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_by_type_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_tables_by_type_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1359 = 0;
-                        $_etype1362 = 0;
-                        $xfer += $input->readListBegin($_etype1362, $_size1359);
-                        for ($_i1363 = 0; $_i1363 < $_size1359; ++$_i1363) {
-                            $elem1364 = null;
-                            $xfer += $input->readString($elem1364);
-                            $this->success []= $elem1364;
+                        $_size1367 = 0;
+                        $_etype1370 = 0;
+                        $xfer += $input->readListBegin($_etype1370, $_size1367);
+                        for ($_i1371 = 0; $_i1371 < $_size1367; ++$_i1371) {
+                            $elem1372 = null;
+                            $xfer += $input->readString($elem1372);
+                            $this->success []= $elem1372;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_tables_by_type_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1365) {
-                $xfer += $output->writeString($iter1365);
+            foreach ($this->success as $iter1373) {
+                $xfer += $output->writeString($iter1373);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_ext_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_ext_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_get_tables_ext_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1415 = 0;
-                        $_etype1418 = 0;
-                        $xfer += $input->readListBegin($_etype1418, $_size1415);
-                        for ($_i1419 = 0; $_i1419 < $_size1415; ++$_i1419) {
-                            $elem1420 = null;
-                            $elem1420 = new \metastore\ExtendedTableInfo();
-                            $xfer += $elem1420->read($input);
-                            $this->success []= $elem1420;
+                        $_size1423 = 0;
+                        $_etype1426 = 0;
+                        $xfer += $input->readListBegin($_etype1426, $_size1423);
+                        for ($_i1427 = 0; $_i1427 < $_size1423; ++$_i1427) {
+                            $elem1428 = null;
+                            $elem1428 = new \metastore\ExtendedTableInfo();
+                            $xfer += $elem1428->read($input);
+                            $this->success []= $elem1428;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_get_tables_ext_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1421) {
-                $xfer += $iter1421->write($output);
+            foreach ($this->success as $iter1429) {
+                $xfer += $iter1429->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_tables_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_get_tables_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1352 = 0;
-                        $_etype1355 = 0;
-                        $xfer += $input->readListBegin($_etype1355, $_size1352);
-                        for ($_i1356 = 0; $_i1356 < $_size1352; ++$_i1356) {
-                            $elem1357 = null;
-                            $xfer += $input->readString($elem1357);
-                            $this->success []= $elem1357;
+                        $_size1360 = 0;
+                        $_etype1363 = 0;
+                        $xfer += $input->readListBegin($_etype1363, $_size1360);
+                        for ($_i1364 = 0; $_i1364 < $_size1360; ++$_i1364) {
+                            $elem1365 = null;
+                            $xfer += $input->readString($elem1365);
+                            $this->success []= $elem1365;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_get_tables_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1358) {
-                $xfer += $output->writeString($iter1358);
+            foreach ($this->success as $iter1366) {
+                $xfer += $output->writeString($iter1366);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_type_all_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_type_all_result.php
@@ -86,17 +86,17 @@ class ThriftHiveMetastore_get_type_all_result
                 case 0:
                     if ($ftype == TType::MAP) {
                         $this->success = array();
-                        $_size1266 = 0;
-                        $_ktype1267 = 0;
-                        $_vtype1268 = 0;
-                        $xfer += $input->readMapBegin($_ktype1267, $_vtype1268, $_size1266);
-                        for ($_i1270 = 0; $_i1270 < $_size1266; ++$_i1270) {
-                            $key1271 = '';
-                            $val1272 = new \metastore\Type();
-                            $xfer += $input->readString($key1271);
-                            $val1272 = new \metastore\Type();
-                            $xfer += $val1272->read($input);
-                            $this->success[$key1271] = $val1272;
+                        $_size1274 = 0;
+                        $_ktype1275 = 0;
+                        $_vtype1276 = 0;
+                        $xfer += $input->readMapBegin($_ktype1275, $_vtype1276, $_size1274);
+                        for ($_i1278 = 0; $_i1278 < $_size1274; ++$_i1278) {
+                            $key1279 = '';
+                            $val1280 = new \metastore\Type();
+                            $xfer += $input->readString($key1279);
+                            $val1280 = new \metastore\Type();
+                            $xfer += $val1280->read($input);
+                            $this->success[$key1279] = $val1280;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -131,9 +131,9 @@ class ThriftHiveMetastore_get_type_all_result
             }
             $xfer += $output->writeFieldBegin('success', TType::MAP, 0);
             $output->writeMapBegin(TType::STRING, TType::STRUCT, count($this->success));
-            foreach ($this->success as $kiter1273 => $viter1274) {
-                $xfer += $output->writeString($kiter1273);
-                $xfer += $viter1274->write($output);
+            foreach ($this->success as $kiter1281 => $viter1282) {
+                $xfer += $output->writeString($kiter1281);
+                $xfer += $viter1282->write($output);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_isPartitionMarkedForEvent_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_isPartitionMarkedForEvent_args.php
@@ -123,16 +123,16 @@ class ThriftHiveMetastore_isPartitionMarkedForEvent_args
                 case 3:
                     if ($ftype == TType::MAP) {
                         $this->part_vals = array();
-                        $_size1689 = 0;
-                        $_ktype1690 = 0;
-                        $_vtype1691 = 0;
-                        $xfer += $input->readMapBegin($_ktype1690, $_vtype1691, $_size1689);
-                        for ($_i1693 = 0; $_i1693 < $_size1689; ++$_i1693) {
-                            $key1694 = '';
-                            $val1695 = '';
-                            $xfer += $input->readString($key1694);
-                            $xfer += $input->readString($val1695);
-                            $this->part_vals[$key1694] = $val1695;
+                        $_size1697 = 0;
+                        $_ktype1698 = 0;
+                        $_vtype1699 = 0;
+                        $xfer += $input->readMapBegin($_ktype1698, $_vtype1699, $_size1697);
+                        for ($_i1701 = 0; $_i1701 < $_size1697; ++$_i1701) {
+                            $key1702 = '';
+                            $val1703 = '';
+                            $xfer += $input->readString($key1702);
+                            $xfer += $input->readString($val1703);
+                            $this->part_vals[$key1702] = $val1703;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -176,9 +176,9 @@ class ThriftHiveMetastore_isPartitionMarkedForEvent_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::MAP, 3);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $kiter1696 => $viter1697) {
-                $xfer += $output->writeString($kiter1696);
-                $xfer += $output->writeString($viter1697);
+            foreach ($this->part_vals as $kiter1704 => $viter1705) {
+                $xfer += $output->writeString($kiter1704);
+                $xfer += $output->writeString($viter1705);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_list_privileges_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_list_privileges_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_list_privileges_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1726 = 0;
-                        $_etype1729 = 0;
-                        $xfer += $input->readListBegin($_etype1729, $_size1726);
-                        for ($_i1730 = 0; $_i1730 < $_size1726; ++$_i1730) {
-                            $elem1731 = null;
-                            $elem1731 = new \metastore\HiveObjectPrivilege();
-                            $xfer += $elem1731->read($input);
-                            $this->success []= $elem1731;
+                        $_size1734 = 0;
+                        $_etype1737 = 0;
+                        $xfer += $input->readListBegin($_etype1737, $_size1734);
+                        for ($_i1738 = 0; $_i1738 < $_size1734; ++$_i1738) {
+                            $elem1739 = null;
+                            $elem1739 = new \metastore\HiveObjectPrivilege();
+                            $xfer += $elem1739->read($input);
+                            $this->success []= $elem1739;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_list_privileges_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1732) {
-                $xfer += $iter1732->write($output);
+            foreach ($this->success as $iter1740) {
+                $xfer += $iter1740->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_list_roles_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_list_roles_result.php
@@ -82,14 +82,14 @@ class ThriftHiveMetastore_list_roles_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1712 = 0;
-                        $_etype1715 = 0;
-                        $xfer += $input->readListBegin($_etype1715, $_size1712);
-                        for ($_i1716 = 0; $_i1716 < $_size1712; ++$_i1716) {
-                            $elem1717 = null;
-                            $elem1717 = new \metastore\Role();
-                            $xfer += $elem1717->read($input);
-                            $this->success []= $elem1717;
+                        $_size1720 = 0;
+                        $_etype1723 = 0;
+                        $xfer += $input->readListBegin($_etype1723, $_size1720);
+                        for ($_i1724 = 0; $_i1724 < $_size1720; ++$_i1724) {
+                            $elem1725 = null;
+                            $elem1725 = new \metastore\Role();
+                            $xfer += $elem1725->read($input);
+                            $this->success []= $elem1725;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -124,8 +124,8 @@ class ThriftHiveMetastore_list_roles_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRUCT, count($this->success));
-            foreach ($this->success as $iter1718) {
-                $xfer += $iter1718->write($output);
+            foreach ($this->success as $iter1726) {
+                $xfer += $iter1726->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_markPartitionForEvent_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_markPartitionForEvent_args.php
@@ -123,16 +123,16 @@ class ThriftHiveMetastore_markPartitionForEvent_args
                 case 3:
                     if ($ftype == TType::MAP) {
                         $this->part_vals = array();
-                        $_size1680 = 0;
-                        $_ktype1681 = 0;
-                        $_vtype1682 = 0;
-                        $xfer += $input->readMapBegin($_ktype1681, $_vtype1682, $_size1680);
-                        for ($_i1684 = 0; $_i1684 < $_size1680; ++$_i1684) {
-                            $key1685 = '';
-                            $val1686 = '';
-                            $xfer += $input->readString($key1685);
-                            $xfer += $input->readString($val1686);
-                            $this->part_vals[$key1685] = $val1686;
+                        $_size1688 = 0;
+                        $_ktype1689 = 0;
+                        $_vtype1690 = 0;
+                        $xfer += $input->readMapBegin($_ktype1689, $_vtype1690, $_size1688);
+                        for ($_i1692 = 0; $_i1692 < $_size1688; ++$_i1692) {
+                            $key1693 = '';
+                            $val1694 = '';
+                            $xfer += $input->readString($key1693);
+                            $xfer += $input->readString($val1694);
+                            $this->part_vals[$key1693] = $val1694;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -176,9 +176,9 @@ class ThriftHiveMetastore_markPartitionForEvent_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::MAP, 3);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $kiter1687 => $viter1688) {
-                $xfer += $output->writeString($kiter1687);
-                $xfer += $output->writeString($viter1688);
+            foreach ($this->part_vals as $kiter1695 => $viter1696) {
+                $xfer += $output->writeString($kiter1695);
+                $xfer += $output->writeString($viter1696);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_has_valid_characters_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_has_valid_characters_args.php
@@ -80,13 +80,13 @@ class ThriftHiveMetastore_partition_name_has_valid_characters_args
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1657 = 0;
-                        $_etype1660 = 0;
-                        $xfer += $input->readListBegin($_etype1660, $_size1657);
-                        for ($_i1661 = 0; $_i1661 < $_size1657; ++$_i1661) {
-                            $elem1662 = null;
-                            $xfer += $input->readString($elem1662);
-                            $this->part_vals []= $elem1662;
+                        $_size1665 = 0;
+                        $_etype1668 = 0;
+                        $xfer += $input->readListBegin($_etype1668, $_size1665);
+                        for ($_i1669 = 0; $_i1669 < $_size1665; ++$_i1669) {
+                            $elem1670 = null;
+                            $xfer += $input->readString($elem1670);
+                            $this->part_vals []= $elem1670;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -120,8 +120,8 @@ class ThriftHiveMetastore_partition_name_has_valid_characters_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1663) {
-                $xfer += $output->writeString($iter1663);
+            foreach ($this->part_vals as $iter1671) {
+                $xfer += $output->writeString($iter1671);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_to_spec_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_to_spec_result.php
@@ -85,16 +85,16 @@ class ThriftHiveMetastore_partition_name_to_spec_result
                 case 0:
                     if ($ftype == TType::MAP) {
                         $this->success = array();
-                        $_size1671 = 0;
-                        $_ktype1672 = 0;
-                        $_vtype1673 = 0;
-                        $xfer += $input->readMapBegin($_ktype1672, $_vtype1673, $_size1671);
-                        for ($_i1675 = 0; $_i1675 < $_size1671; ++$_i1675) {
-                            $key1676 = '';
-                            $val1677 = '';
-                            $xfer += $input->readString($key1676);
-                            $xfer += $input->readString($val1677);
-                            $this->success[$key1676] = $val1677;
+                        $_size1679 = 0;
+                        $_ktype1680 = 0;
+                        $_vtype1681 = 0;
+                        $xfer += $input->readMapBegin($_ktype1680, $_vtype1681, $_size1679);
+                        for ($_i1683 = 0; $_i1683 < $_size1679; ++$_i1683) {
+                            $key1684 = '';
+                            $val1685 = '';
+                            $xfer += $input->readString($key1684);
+                            $xfer += $input->readString($val1685);
+                            $this->success[$key1684] = $val1685;
                         }
                         $xfer += $input->readMapEnd();
                     } else {
@@ -129,9 +129,9 @@ class ThriftHiveMetastore_partition_name_to_spec_result
             }
             $xfer += $output->writeFieldBegin('success', TType::MAP, 0);
             $output->writeMapBegin(TType::STRING, TType::STRING, count($this->success));
-            foreach ($this->success as $kiter1678 => $viter1679) {
-                $xfer += $output->writeString($kiter1678);
-                $xfer += $output->writeString($viter1679);
+            foreach ($this->success as $kiter1686 => $viter1687) {
+                $xfer += $output->writeString($kiter1686);
+                $xfer += $output->writeString($viter1687);
             }
             $output->writeMapEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_to_vals_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_partition_name_to_vals_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_partition_name_to_vals_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1664 = 0;
-                        $_etype1667 = 0;
-                        $xfer += $input->readListBegin($_etype1667, $_size1664);
-                        for ($_i1668 = 0; $_i1668 < $_size1664; ++$_i1668) {
-                            $elem1669 = null;
-                            $xfer += $input->readString($elem1669);
-                            $this->success []= $elem1669;
+                        $_size1672 = 0;
+                        $_etype1675 = 0;
+                        $xfer += $input->readListBegin($_etype1675, $_size1672);
+                        for ($_i1676 = 0; $_i1676 < $_size1672; ++$_i1676) {
+                            $elem1677 = null;
+                            $xfer += $input->readString($elem1677);
+                            $this->success []= $elem1677;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_partition_name_to_vals_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1670) {
-                $xfer += $output->writeString($iter1670);
+            foreach ($this->success as $iter1678) {
+                $xfer += $output->writeString($iter1678);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_rename_partition_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_rename_partition_args.php
@@ -119,13 +119,13 @@ class ThriftHiveMetastore_rename_partition_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->part_vals = array();
-                        $_size1650 = 0;
-                        $_etype1653 = 0;
-                        $xfer += $input->readListBegin($_etype1653, $_size1650);
-                        for ($_i1654 = 0; $_i1654 < $_size1650; ++$_i1654) {
-                            $elem1655 = null;
-                            $xfer += $input->readString($elem1655);
-                            $this->part_vals []= $elem1655;
+                        $_size1658 = 0;
+                        $_etype1661 = 0;
+                        $xfer += $input->readListBegin($_etype1661, $_size1658);
+                        for ($_i1662 = 0; $_i1662 < $_size1658; ++$_i1662) {
+                            $elem1663 = null;
+                            $xfer += $input->readString($elem1663);
+                            $this->part_vals []= $elem1663;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -170,8 +170,8 @@ class ThriftHiveMetastore_rename_partition_args
             }
             $xfer += $output->writeFieldBegin('part_vals', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->part_vals));
-            foreach ($this->part_vals as $iter1656) {
-                $xfer += $output->writeString($iter1656);
+            foreach ($this->part_vals as $iter1664) {
+                $xfer += $output->writeString($iter1664);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_set_ugi_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_set_ugi_args.php
@@ -87,13 +87,13 @@ class ThriftHiveMetastore_set_ugi_args
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->group_names = array();
-                        $_size1733 = 0;
-                        $_etype1736 = 0;
-                        $xfer += $input->readListBegin($_etype1736, $_size1733);
-                        for ($_i1737 = 0; $_i1737 < $_size1733; ++$_i1737) {
-                            $elem1738 = null;
-                            $xfer += $input->readString($elem1738);
-                            $this->group_names []= $elem1738;
+                        $_size1741 = 0;
+                        $_etype1744 = 0;
+                        $xfer += $input->readListBegin($_etype1744, $_size1741);
+                        for ($_i1745 = 0; $_i1745 < $_size1741; ++$_i1745) {
+                            $elem1746 = null;
+                            $xfer += $input->readString($elem1746);
+                            $this->group_names []= $elem1746;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -125,8 +125,8 @@ class ThriftHiveMetastore_set_ugi_args
             }
             $xfer += $output->writeFieldBegin('group_names', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->group_names));
-            foreach ($this->group_names as $iter1739) {
-                $xfer += $output->writeString($iter1739);
+            foreach ($this->group_names as $iter1747) {
+                $xfer += $output->writeString($iter1747);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_set_ugi_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_set_ugi_result.php
@@ -81,13 +81,13 @@ class ThriftHiveMetastore_set_ugi_result
                 case 0:
                     if ($ftype == TType::LST) {
                         $this->success = array();
-                        $_size1740 = 0;
-                        $_etype1743 = 0;
-                        $xfer += $input->readListBegin($_etype1743, $_size1740);
-                        for ($_i1744 = 0; $_i1744 < $_size1740; ++$_i1744) {
-                            $elem1745 = null;
-                            $xfer += $input->readString($elem1745);
-                            $this->success []= $elem1745;
+                        $_size1748 = 0;
+                        $_etype1751 = 0;
+                        $xfer += $input->readListBegin($_etype1751, $_size1748);
+                        for ($_i1752 = 0; $_i1752 < $_size1748; ++$_i1752) {
+                            $elem1753 = null;
+                            $xfer += $input->readString($elem1753);
+                            $this->success []= $elem1753;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -122,8 +122,8 @@ class ThriftHiveMetastore_set_ugi_result
             }
             $xfer += $output->writeFieldBegin('success', TType::LST, 0);
             $output->writeListBegin(TType::STRING, count($this->success));
-            foreach ($this->success as $iter1746) {
-                $xfer += $output->writeString($iter1746);
+            foreach ($this->success as $iter1754) {
+                $xfer += $output->writeString($iter1754);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_truncate_table_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_truncate_table_args.php
@@ -106,13 +106,13 @@ class ThriftHiveMetastore_truncate_table_args
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->partNames = array();
-                        $_size1345 = 0;
-                        $_etype1348 = 0;
-                        $xfer += $input->readListBegin($_etype1348, $_size1345);
-                        for ($_i1349 = 0; $_i1349 < $_size1345; ++$_i1349) {
-                            $elem1350 = null;
-                            $xfer += $input->readString($elem1350);
-                            $this->partNames []= $elem1350;
+                        $_size1353 = 0;
+                        $_etype1356 = 0;
+                        $xfer += $input->readListBegin($_etype1356, $_size1353);
+                        for ($_i1357 = 0; $_i1357 < $_size1353; ++$_i1357) {
+                            $elem1358 = null;
+                            $xfer += $input->readString($elem1358);
+                            $this->partNames []= $elem1358;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -149,8 +149,8 @@ class ThriftHiveMetastore_truncate_table_args
             }
             $xfer += $output->writeFieldBegin('partNames', TType::LST, 3);
             $output->writeListBegin(TType::STRING, count($this->partNames));
-            foreach ($this->partNames as $iter1351) {
-                $xfer += $output->writeString($iter1351);
+            foreach ($this->partNames as $iter1359) {
+                $xfer += $output->writeString($iter1359);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/UniqueConstraintsResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/UniqueConstraintsResponse.php
@@ -69,14 +69,14 @@ class UniqueConstraintsResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->uniqueConstraints = array();
-                        $_size391 = 0;
-                        $_etype394 = 0;
-                        $xfer += $input->readListBegin($_etype394, $_size391);
-                        for ($_i395 = 0; $_i395 < $_size391; ++$_i395) {
-                            $elem396 = null;
-                            $elem396 = new \metastore\SQLUniqueConstraint();
-                            $xfer += $elem396->read($input);
-                            $this->uniqueConstraints []= $elem396;
+                        $_size399 = 0;
+                        $_etype402 = 0;
+                        $xfer += $input->readListBegin($_etype402, $_size399);
+                        for ($_i403 = 0; $_i403 < $_size399; ++$_i403) {
+                            $elem404 = null;
+                            $elem404 = new \metastore\SQLUniqueConstraint();
+                            $xfer += $elem404->read($input);
+                            $this->uniqueConstraints []= $elem404;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class UniqueConstraintsResponse
             }
             $xfer += $output->writeFieldBegin('uniqueConstraints', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->uniqueConstraints));
-            foreach ($this->uniqueConstraints as $iter397) {
-                $xfer += $iter397->write($output);
+            foreach ($this->uniqueConstraints as $iter405) {
+                $xfer += $iter405->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMFullResourcePlan.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMFullResourcePlan.php
@@ -141,14 +141,14 @@ class WMFullResourcePlan
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->pools = array();
-                        $_size991 = 0;
-                        $_etype994 = 0;
-                        $xfer += $input->readListBegin($_etype994, $_size991);
-                        for ($_i995 = 0; $_i995 < $_size991; ++$_i995) {
-                            $elem996 = null;
-                            $elem996 = new \metastore\WMPool();
-                            $xfer += $elem996->read($input);
-                            $this->pools []= $elem996;
+                        $_size999 = 0;
+                        $_etype1002 = 0;
+                        $xfer += $input->readListBegin($_etype1002, $_size999);
+                        for ($_i1003 = 0; $_i1003 < $_size999; ++$_i1003) {
+                            $elem1004 = null;
+                            $elem1004 = new \metastore\WMPool();
+                            $xfer += $elem1004->read($input);
+                            $this->pools []= $elem1004;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -158,14 +158,14 @@ class WMFullResourcePlan
                 case 3:
                     if ($ftype == TType::LST) {
                         $this->mappings = array();
-                        $_size997 = 0;
-                        $_etype1000 = 0;
-                        $xfer += $input->readListBegin($_etype1000, $_size997);
-                        for ($_i1001 = 0; $_i1001 < $_size997; ++$_i1001) {
-                            $elem1002 = null;
-                            $elem1002 = new \metastore\WMMapping();
-                            $xfer += $elem1002->read($input);
-                            $this->mappings []= $elem1002;
+                        $_size1005 = 0;
+                        $_etype1008 = 0;
+                        $xfer += $input->readListBegin($_etype1008, $_size1005);
+                        for ($_i1009 = 0; $_i1009 < $_size1005; ++$_i1009) {
+                            $elem1010 = null;
+                            $elem1010 = new \metastore\WMMapping();
+                            $xfer += $elem1010->read($input);
+                            $this->mappings []= $elem1010;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -175,14 +175,14 @@ class WMFullResourcePlan
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->triggers = array();
-                        $_size1003 = 0;
-                        $_etype1006 = 0;
-                        $xfer += $input->readListBegin($_etype1006, $_size1003);
-                        for ($_i1007 = 0; $_i1007 < $_size1003; ++$_i1007) {
-                            $elem1008 = null;
-                            $elem1008 = new \metastore\WMTrigger();
-                            $xfer += $elem1008->read($input);
-                            $this->triggers []= $elem1008;
+                        $_size1011 = 0;
+                        $_etype1014 = 0;
+                        $xfer += $input->readListBegin($_etype1014, $_size1011);
+                        for ($_i1015 = 0; $_i1015 < $_size1011; ++$_i1015) {
+                            $elem1016 = null;
+                            $elem1016 = new \metastore\WMTrigger();
+                            $xfer += $elem1016->read($input);
+                            $this->triggers []= $elem1016;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -192,14 +192,14 @@ class WMFullResourcePlan
                 case 5:
                     if ($ftype == TType::LST) {
                         $this->poolTriggers = array();
-                        $_size1009 = 0;
-                        $_etype1012 = 0;
-                        $xfer += $input->readListBegin($_etype1012, $_size1009);
-                        for ($_i1013 = 0; $_i1013 < $_size1009; ++$_i1013) {
-                            $elem1014 = null;
-                            $elem1014 = new \metastore\WMPoolTrigger();
-                            $xfer += $elem1014->read($input);
-                            $this->poolTriggers []= $elem1014;
+                        $_size1017 = 0;
+                        $_etype1020 = 0;
+                        $xfer += $input->readListBegin($_etype1020, $_size1017);
+                        for ($_i1021 = 0; $_i1021 < $_size1017; ++$_i1021) {
+                            $elem1022 = null;
+                            $elem1022 = new \metastore\WMPoolTrigger();
+                            $xfer += $elem1022->read($input);
+                            $this->poolTriggers []= $elem1022;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -234,8 +234,8 @@ class WMFullResourcePlan
             }
             $xfer += $output->writeFieldBegin('pools', TType::LST, 2);
             $output->writeListBegin(TType::STRUCT, count($this->pools));
-            foreach ($this->pools as $iter1015) {
-                $xfer += $iter1015->write($output);
+            foreach ($this->pools as $iter1023) {
+                $xfer += $iter1023->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -246,8 +246,8 @@ class WMFullResourcePlan
             }
             $xfer += $output->writeFieldBegin('mappings', TType::LST, 3);
             $output->writeListBegin(TType::STRUCT, count($this->mappings));
-            foreach ($this->mappings as $iter1016) {
-                $xfer += $iter1016->write($output);
+            foreach ($this->mappings as $iter1024) {
+                $xfer += $iter1024->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -258,8 +258,8 @@ class WMFullResourcePlan
             }
             $xfer += $output->writeFieldBegin('triggers', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->triggers));
-            foreach ($this->triggers as $iter1017) {
-                $xfer += $iter1017->write($output);
+            foreach ($this->triggers as $iter1025) {
+                $xfer += $iter1025->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -270,8 +270,8 @@ class WMFullResourcePlan
             }
             $xfer += $output->writeFieldBegin('poolTriggers', TType::LST, 5);
             $output->writeListBegin(TType::STRUCT, count($this->poolTriggers));
-            foreach ($this->poolTriggers as $iter1018) {
-                $xfer += $iter1018->write($output);
+            foreach ($this->poolTriggers as $iter1026) {
+                $xfer += $iter1026->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMGetAllResourcePlanResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMGetAllResourcePlanResponse.php
@@ -69,14 +69,14 @@ class WMGetAllResourcePlanResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->resourcePlans = array();
-                        $_size1019 = 0;
-                        $_etype1022 = 0;
-                        $xfer += $input->readListBegin($_etype1022, $_size1019);
-                        for ($_i1023 = 0; $_i1023 < $_size1019; ++$_i1023) {
-                            $elem1024 = null;
-                            $elem1024 = new \metastore\WMResourcePlan();
-                            $xfer += $elem1024->read($input);
-                            $this->resourcePlans []= $elem1024;
+                        $_size1027 = 0;
+                        $_etype1030 = 0;
+                        $xfer += $input->readListBegin($_etype1030, $_size1027);
+                        for ($_i1031 = 0; $_i1031 < $_size1027; ++$_i1031) {
+                            $elem1032 = null;
+                            $elem1032 = new \metastore\WMResourcePlan();
+                            $xfer += $elem1032->read($input);
+                            $this->resourcePlans []= $elem1032;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class WMGetAllResourcePlanResponse
             }
             $xfer += $output->writeFieldBegin('resourcePlans', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->resourcePlans));
-            foreach ($this->resourcePlans as $iter1025) {
-                $xfer += $iter1025->write($output);
+            foreach ($this->resourcePlans as $iter1033) {
+                $xfer += $iter1033->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMGetTriggersForResourePlanResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMGetTriggersForResourePlanResponse.php
@@ -69,14 +69,14 @@ class WMGetTriggersForResourePlanResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->triggers = array();
-                        $_size1040 = 0;
-                        $_etype1043 = 0;
-                        $xfer += $input->readListBegin($_etype1043, $_size1040);
-                        for ($_i1044 = 0; $_i1044 < $_size1040; ++$_i1044) {
-                            $elem1045 = null;
-                            $elem1045 = new \metastore\WMTrigger();
-                            $xfer += $elem1045->read($input);
-                            $this->triggers []= $elem1045;
+                        $_size1048 = 0;
+                        $_etype1051 = 0;
+                        $xfer += $input->readListBegin($_etype1051, $_size1048);
+                        for ($_i1052 = 0; $_i1052 < $_size1048; ++$_i1052) {
+                            $elem1053 = null;
+                            $elem1053 = new \metastore\WMTrigger();
+                            $xfer += $elem1053->read($input);
+                            $this->triggers []= $elem1053;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -103,8 +103,8 @@ class WMGetTriggersForResourePlanResponse
             }
             $xfer += $output->writeFieldBegin('triggers', TType::LST, 1);
             $output->writeListBegin(TType::STRUCT, count($this->triggers));
-            foreach ($this->triggers as $iter1046) {
-                $xfer += $iter1046->write($output);
+            foreach ($this->triggers as $iter1054) {
+                $xfer += $iter1054->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMValidateResourcePlanResponse.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WMValidateResourcePlanResponse.php
@@ -84,13 +84,13 @@ class WMValidateResourcePlanResponse
                 case 1:
                     if ($ftype == TType::LST) {
                         $this->errors = array();
-                        $_size1026 = 0;
-                        $_etype1029 = 0;
-                        $xfer += $input->readListBegin($_etype1029, $_size1026);
-                        for ($_i1030 = 0; $_i1030 < $_size1026; ++$_i1030) {
-                            $elem1031 = null;
-                            $xfer += $input->readString($elem1031);
-                            $this->errors []= $elem1031;
+                        $_size1034 = 0;
+                        $_etype1037 = 0;
+                        $xfer += $input->readListBegin($_etype1037, $_size1034);
+                        for ($_i1038 = 0; $_i1038 < $_size1034; ++$_i1038) {
+                            $elem1039 = null;
+                            $xfer += $input->readString($elem1039);
+                            $this->errors []= $elem1039;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -100,13 +100,13 @@ class WMValidateResourcePlanResponse
                 case 2:
                     if ($ftype == TType::LST) {
                         $this->warnings = array();
-                        $_size1032 = 0;
-                        $_etype1035 = 0;
-                        $xfer += $input->readListBegin($_etype1035, $_size1032);
-                        for ($_i1036 = 0; $_i1036 < $_size1032; ++$_i1036) {
-                            $elem1037 = null;
-                            $xfer += $input->readString($elem1037);
-                            $this->warnings []= $elem1037;
+                        $_size1040 = 0;
+                        $_etype1043 = 0;
+                        $xfer += $input->readListBegin($_etype1043, $_size1040);
+                        for ($_i1044 = 0; $_i1044 < $_size1040; ++$_i1044) {
+                            $elem1045 = null;
+                            $xfer += $input->readString($elem1045);
+                            $this->warnings []= $elem1045;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -133,8 +133,8 @@ class WMValidateResourcePlanResponse
             }
             $xfer += $output->writeFieldBegin('errors', TType::LST, 1);
             $output->writeListBegin(TType::STRING, count($this->errors));
-            foreach ($this->errors as $iter1038) {
-                $xfer += $output->writeString($iter1038);
+            foreach ($this->errors as $iter1046) {
+                $xfer += $output->writeString($iter1046);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();
@@ -145,8 +145,8 @@ class WMValidateResourcePlanResponse
             }
             $xfer += $output->writeFieldBegin('warnings', TType::LST, 2);
             $output->writeListBegin(TType::STRING, count($this->warnings));
-            foreach ($this->warnings as $iter1039) {
-                $xfer += $output->writeString($iter1039);
+            foreach ($this->warnings as $iter1047) {
+                $xfer += $output->writeString($iter1047);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WriteNotificationLogBatchRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WriteNotificationLogBatchRequest.php
@@ -126,14 +126,14 @@ class WriteNotificationLogBatchRequest
                 case 4:
                     if ($ftype == TType::LST) {
                         $this->requestList = array();
-                        $_size854 = 0;
-                        $_etype857 = 0;
-                        $xfer += $input->readListBegin($_etype857, $_size854);
-                        for ($_i858 = 0; $_i858 < $_size854; ++$_i858) {
-                            $elem859 = null;
-                            $elem859 = new \metastore\WriteNotificationLogRequest();
-                            $xfer += $elem859->read($input);
-                            $this->requestList []= $elem859;
+                        $_size862 = 0;
+                        $_etype865 = 0;
+                        $xfer += $input->readListBegin($_etype865, $_size862);
+                        for ($_i866 = 0; $_i866 < $_size862; ++$_i866) {
+                            $elem867 = null;
+                            $elem867 = new \metastore\WriteNotificationLogRequest();
+                            $xfer += $elem867->read($input);
+                            $this->requestList []= $elem867;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -175,8 +175,8 @@ class WriteNotificationLogBatchRequest
             }
             $xfer += $output->writeFieldBegin('requestList', TType::LST, 4);
             $output->writeListBegin(TType::STRUCT, count($this->requestList));
-            foreach ($this->requestList as $iter860) {
-                $xfer += $iter860->write($output);
+            foreach ($this->requestList as $iter868) {
+                $xfer += $iter868->write($output);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WriteNotificationLogRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/WriteNotificationLogRequest.php
@@ -165,13 +165,13 @@ class WriteNotificationLogRequest
                 case 6:
                     if ($ftype == TType::LST) {
                         $this->partitionVals = array();
-                        $_size847 = 0;
-                        $_etype850 = 0;
-                        $xfer += $input->readListBegin($_etype850, $_size847);
-                        for ($_i851 = 0; $_i851 < $_size847; ++$_i851) {
-                            $elem852 = null;
-                            $xfer += $input->readString($elem852);
-                            $this->partitionVals []= $elem852;
+                        $_size855 = 0;
+                        $_etype858 = 0;
+                        $xfer += $input->readListBegin($_etype858, $_size855);
+                        for ($_i859 = 0; $_i859 < $_size855; ++$_i859) {
+                            $elem860 = null;
+                            $xfer += $input->readString($elem860);
+                            $this->partitionVals []= $elem860;
                         }
                         $xfer += $input->readListEnd();
                     } else {
@@ -226,8 +226,8 @@ class WriteNotificationLogRequest
             }
             $xfer += $output->writeFieldBegin('partitionVals', TType::LST, 6);
             $output->writeListBegin(TType::STRING, count($this->partitionVals));
-            foreach ($this->partitionVals as $iter853) {
-                $xfer += $output->writeString($iter853);
+            foreach ($this->partitionVals as $iter861) {
+                $xfer += $output->writeString($iter861);
             }
             $output->writeListEnd();
             $xfer += $output->writeFieldEnd();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore-remote
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore-remote
@@ -80,7 +80,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('   get_tables_ext(GetTablesExtRequest req)')
     print('  GetTableResult get_table_req(GetTableRequest req)')
     print('  GetTablesResult get_table_objects_by_name_req(GetTablesRequest req)')
-    print('  Materialization get_materialization_invalidation_info(CreationMetadata creation_metadata)')
+    print('  Materialization get_materialization_invalidation_info(CreationMetadata creation_metadata, string validTxnList)')
     print('  void update_creation_metadata(string catName, string dbname, string tbl_name, CreationMetadata creation_metadata)')
     print('   get_table_names_by_filter(string dbname, string filter, i16 max_tables)')
     print('  void alter_table(string dbname, string tbl_name, Table new_tbl)')
@@ -719,10 +719,10 @@ elif cmd == 'get_table_objects_by_name_req':
     pp.pprint(client.get_table_objects_by_name_req(eval(args[0]),))
 
 elif cmd == 'get_materialization_invalidation_info':
-    if len(args) != 1:
-        print('get_materialization_invalidation_info requires 1 args')
+    if len(args) != 2:
+        print('get_materialization_invalidation_info requires 2 args')
         sys.exit(1)
-    pp.pprint(client.get_materialization_invalidation_info(eval(args[0]),))
+    pp.pprint(client.get_materialization_invalidation_info(eval(args[0]), args[1],))
 
 elif cmd == 'update_creation_metadata':
     if len(args) != 4:

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
@@ -486,10 +486,11 @@ class Iface(fb303.FacebookService.Iface):
         """
         pass
 
-    def get_materialization_invalidation_info(self, creation_metadata):
+    def get_materialization_invalidation_info(self, creation_metadata, validTxnList):
         """
         Parameters:
          - creation_metadata
+         - validTxnList
 
         """
         pass
@@ -4303,19 +4304,21 @@ class Client(fb303.FacebookService.Client, Iface):
             raise result.o3
         raise TApplicationException(TApplicationException.MISSING_RESULT, "get_table_objects_by_name_req failed: unknown result")
 
-    def get_materialization_invalidation_info(self, creation_metadata):
+    def get_materialization_invalidation_info(self, creation_metadata, validTxnList):
         """
         Parameters:
          - creation_metadata
+         - validTxnList
 
         """
-        self.send_get_materialization_invalidation_info(creation_metadata)
+        self.send_get_materialization_invalidation_info(creation_metadata, validTxnList)
         return self.recv_get_materialization_invalidation_info()
 
-    def send_get_materialization_invalidation_info(self, creation_metadata):
+    def send_get_materialization_invalidation_info(self, creation_metadata, validTxnList):
         self._oprot.writeMessageBegin('get_materialization_invalidation_info', TMessageType.CALL, self._seqid)
         args = get_materialization_invalidation_info_args()
         args.creation_metadata = creation_metadata
+        args.validTxnList = validTxnList
         args.write(self._oprot)
         self._oprot.writeMessageEnd()
         self._oprot.trans.flush()
@@ -13844,7 +13847,7 @@ class Processor(fb303.FacebookService.Processor, Iface, TProcessor):
         iprot.readMessageEnd()
         result = get_materialization_invalidation_info_result()
         try:
-            result.success = self._handler.get_materialization_invalidation_info(args.creation_metadata)
+            result.success = self._handler.get_materialization_invalidation_info(args.creation_metadata, args.validTxnList)
             msg_type = TMessageType.REPLY
         except TTransport.TTransportException:
             raise
@@ -21461,10 +21464,10 @@ class get_databases_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1245, _size1242) = iprot.readListBegin()
-                    for _i1246 in range(_size1242):
-                        _elem1247 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1247)
+                    (_etype1252, _size1249) = iprot.readListBegin()
+                    for _i1253 in range(_size1249):
+                        _elem1254 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1254)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -21486,8 +21489,8 @@ class get_databases_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1248 in self.success:
-                oprot.writeString(iter1248.encode('utf-8') if sys.version_info[0] == 2 else iter1248)
+            for iter1255 in self.success:
+                oprot.writeString(iter1255.encode('utf-8') if sys.version_info[0] == 2 else iter1255)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -21585,10 +21588,10 @@ class get_all_databases_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1252, _size1249) = iprot.readListBegin()
-                    for _i1253 in range(_size1249):
-                        _elem1254 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1254)
+                    (_etype1259, _size1256) = iprot.readListBegin()
+                    for _i1260 in range(_size1256):
+                        _elem1261 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1261)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -21610,8 +21613,8 @@ class get_all_databases_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1255 in self.success:
-                oprot.writeString(iter1255.encode('utf-8') if sys.version_info[0] == 2 else iter1255)
+            for iter1262 in self.success:
+                oprot.writeString(iter1262.encode('utf-8') if sys.version_info[0] == 2 else iter1262)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -22323,10 +22326,10 @@ class get_dataconnectors_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1259, _size1256) = iprot.readListBegin()
-                    for _i1260 in range(_size1256):
-                        _elem1261 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1261)
+                    (_etype1266, _size1263) = iprot.readListBegin()
+                    for _i1267 in range(_size1263):
+                        _elem1268 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1268)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -22348,8 +22351,8 @@ class get_dataconnectors_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1262 in self.success:
-                oprot.writeString(iter1262.encode('utf-8') if sys.version_info[0] == 2 else iter1262)
+            for iter1269 in self.success:
+                oprot.writeString(iter1269.encode('utf-8') if sys.version_info[0] == 2 else iter1269)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23070,12 +23073,12 @@ class get_type_all_result(object):
             if fid == 0:
                 if ftype == TType.MAP:
                     self.success = {}
-                    (_ktype1264, _vtype1265, _size1263) = iprot.readMapBegin()
-                    for _i1267 in range(_size1263):
-                        _key1268 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1269 = Type()
-                        _val1269.read(iprot)
-                        self.success[_key1268] = _val1269
+                    (_ktype1271, _vtype1272, _size1270) = iprot.readMapBegin()
+                    for _i1274 in range(_size1270):
+                        _key1275 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1276 = Type()
+                        _val1276.read(iprot)
+                        self.success[_key1275] = _val1276
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -23097,9 +23100,9 @@ class get_type_all_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.success))
-            for kiter1270, viter1271 in self.success.items():
-                oprot.writeString(kiter1270.encode('utf-8') if sys.version_info[0] == 2 else kiter1270)
-                viter1271.write(oprot)
+            for kiter1277, viter1278 in self.success.items():
+                oprot.writeString(kiter1277.encode('utf-8') if sys.version_info[0] == 2 else kiter1277)
+                viter1278.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.o2 is not None:
@@ -23232,11 +23235,11 @@ class get_fields_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1275, _size1272) = iprot.readListBegin()
-                    for _i1276 in range(_size1272):
-                        _elem1277 = FieldSchema()
-                        _elem1277.read(iprot)
-                        self.success.append(_elem1277)
+                    (_etype1282, _size1279) = iprot.readListBegin()
+                    for _i1283 in range(_size1279):
+                        _elem1284 = FieldSchema()
+                        _elem1284.read(iprot)
+                        self.success.append(_elem1284)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23268,8 +23271,8 @@ class get_fields_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1278 in self.success:
-                iter1278.write(oprot)
+            for iter1285 in self.success:
+                iter1285.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23425,11 +23428,11 @@ class get_fields_with_environment_context_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1282, _size1279) = iprot.readListBegin()
-                    for _i1283 in range(_size1279):
-                        _elem1284 = FieldSchema()
-                        _elem1284.read(iprot)
-                        self.success.append(_elem1284)
+                    (_etype1289, _size1286) = iprot.readListBegin()
+                    for _i1290 in range(_size1286):
+                        _elem1291 = FieldSchema()
+                        _elem1291.read(iprot)
+                        self.success.append(_elem1291)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23461,8 +23464,8 @@ class get_fields_with_environment_context_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1285 in self.success:
-                iter1285.write(oprot)
+            for iter1292 in self.success:
+                iter1292.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23766,11 +23769,11 @@ class get_schema_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1289, _size1286) = iprot.readListBegin()
-                    for _i1290 in range(_size1286):
-                        _elem1291 = FieldSchema()
-                        _elem1291.read(iprot)
-                        self.success.append(_elem1291)
+                    (_etype1296, _size1293) = iprot.readListBegin()
+                    for _i1297 in range(_size1293):
+                        _elem1298 = FieldSchema()
+                        _elem1298.read(iprot)
+                        self.success.append(_elem1298)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23802,8 +23805,8 @@ class get_schema_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1292 in self.success:
-                iter1292.write(oprot)
+            for iter1299 in self.success:
+                iter1299.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23959,11 +23962,11 @@ class get_schema_with_environment_context_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1296, _size1293) = iprot.readListBegin()
-                    for _i1297 in range(_size1293):
-                        _elem1298 = FieldSchema()
-                        _elem1298.read(iprot)
-                        self.success.append(_elem1298)
+                    (_etype1303, _size1300) = iprot.readListBegin()
+                    for _i1304 in range(_size1300):
+                        _elem1305 = FieldSchema()
+                        _elem1305.read(iprot)
+                        self.success.append(_elem1305)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23995,8 +23998,8 @@ class get_schema_with_environment_context_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1299 in self.success:
-                iter1299.write(oprot)
+            for iter1306 in self.success:
+                iter1306.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -24573,66 +24576,66 @@ class create_table_with_constraints_args(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.primaryKeys = []
-                    (_etype1303, _size1300) = iprot.readListBegin()
-                    for _i1304 in range(_size1300):
-                        _elem1305 = SQLPrimaryKey()
-                        _elem1305.read(iprot)
-                        self.primaryKeys.append(_elem1305)
+                    (_etype1310, _size1307) = iprot.readListBegin()
+                    for _i1311 in range(_size1307):
+                        _elem1312 = SQLPrimaryKey()
+                        _elem1312.read(iprot)
+                        self.primaryKeys.append(_elem1312)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.foreignKeys = []
-                    (_etype1309, _size1306) = iprot.readListBegin()
-                    for _i1310 in range(_size1306):
-                        _elem1311 = SQLForeignKey()
-                        _elem1311.read(iprot)
-                        self.foreignKeys.append(_elem1311)
+                    (_etype1316, _size1313) = iprot.readListBegin()
+                    for _i1317 in range(_size1313):
+                        _elem1318 = SQLForeignKey()
+                        _elem1318.read(iprot)
+                        self.foreignKeys.append(_elem1318)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.uniqueConstraints = []
-                    (_etype1315, _size1312) = iprot.readListBegin()
-                    for _i1316 in range(_size1312):
-                        _elem1317 = SQLUniqueConstraint()
-                        _elem1317.read(iprot)
-                        self.uniqueConstraints.append(_elem1317)
+                    (_etype1322, _size1319) = iprot.readListBegin()
+                    for _i1323 in range(_size1319):
+                        _elem1324 = SQLUniqueConstraint()
+                        _elem1324.read(iprot)
+                        self.uniqueConstraints.append(_elem1324)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.notNullConstraints = []
-                    (_etype1321, _size1318) = iprot.readListBegin()
-                    for _i1322 in range(_size1318):
-                        _elem1323 = SQLNotNullConstraint()
-                        _elem1323.read(iprot)
-                        self.notNullConstraints.append(_elem1323)
+                    (_etype1328, _size1325) = iprot.readListBegin()
+                    for _i1329 in range(_size1325):
+                        _elem1330 = SQLNotNullConstraint()
+                        _elem1330.read(iprot)
+                        self.notNullConstraints.append(_elem1330)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.defaultConstraints = []
-                    (_etype1327, _size1324) = iprot.readListBegin()
-                    for _i1328 in range(_size1324):
-                        _elem1329 = SQLDefaultConstraint()
-                        _elem1329.read(iprot)
-                        self.defaultConstraints.append(_elem1329)
+                    (_etype1334, _size1331) = iprot.readListBegin()
+                    for _i1335 in range(_size1331):
+                        _elem1336 = SQLDefaultConstraint()
+                        _elem1336.read(iprot)
+                        self.defaultConstraints.append(_elem1336)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.LIST:
                     self.checkConstraints = []
-                    (_etype1333, _size1330) = iprot.readListBegin()
-                    for _i1334 in range(_size1330):
-                        _elem1335 = SQLCheckConstraint()
-                        _elem1335.read(iprot)
-                        self.checkConstraints.append(_elem1335)
+                    (_etype1340, _size1337) = iprot.readListBegin()
+                    for _i1341 in range(_size1337):
+                        _elem1342 = SQLCheckConstraint()
+                        _elem1342.read(iprot)
+                        self.checkConstraints.append(_elem1342)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -24653,43 +24656,43 @@ class create_table_with_constraints_args(object):
         if self.primaryKeys is not None:
             oprot.writeFieldBegin('primaryKeys', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.primaryKeys))
-            for iter1336 in self.primaryKeys:
-                iter1336.write(oprot)
+            for iter1343 in self.primaryKeys:
+                iter1343.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.foreignKeys is not None:
             oprot.writeFieldBegin('foreignKeys', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.foreignKeys))
-            for iter1337 in self.foreignKeys:
-                iter1337.write(oprot)
+            for iter1344 in self.foreignKeys:
+                iter1344.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.uniqueConstraints is not None:
             oprot.writeFieldBegin('uniqueConstraints', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.uniqueConstraints))
-            for iter1338 in self.uniqueConstraints:
-                iter1338.write(oprot)
+            for iter1345 in self.uniqueConstraints:
+                iter1345.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.notNullConstraints is not None:
             oprot.writeFieldBegin('notNullConstraints', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.notNullConstraints))
-            for iter1339 in self.notNullConstraints:
-                iter1339.write(oprot)
+            for iter1346 in self.notNullConstraints:
+                iter1346.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.defaultConstraints is not None:
             oprot.writeFieldBegin('defaultConstraints', TType.LIST, 6)
             oprot.writeListBegin(TType.STRUCT, len(self.defaultConstraints))
-            for iter1340 in self.defaultConstraints:
-                iter1340.write(oprot)
+            for iter1347 in self.defaultConstraints:
+                iter1347.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.checkConstraints is not None:
             oprot.writeFieldBegin('checkConstraints', TType.LIST, 7)
             oprot.writeListBegin(TType.STRUCT, len(self.checkConstraints))
-            for iter1341 in self.checkConstraints:
-                iter1341.write(oprot)
+            for iter1348 in self.checkConstraints:
+                iter1348.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26482,10 +26485,10 @@ class truncate_table_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.partNames = []
-                    (_etype1345, _size1342) = iprot.readListBegin()
-                    for _i1346 in range(_size1342):
-                        _elem1347 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partNames.append(_elem1347)
+                    (_etype1352, _size1349) = iprot.readListBegin()
+                    for _i1353 in range(_size1349):
+                        _elem1354 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partNames.append(_elem1354)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26510,8 +26513,8 @@ class truncate_table_args(object):
         if self.partNames is not None:
             oprot.writeFieldBegin('partNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.partNames))
-            for iter1348 in self.partNames:
-                oprot.writeString(iter1348.encode('utf-8') if sys.version_info[0] == 2 else iter1348)
+            for iter1355 in self.partNames:
+                oprot.writeString(iter1355.encode('utf-8') if sys.version_info[0] == 2 else iter1355)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26837,10 +26840,10 @@ class get_tables_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1352, _size1349) = iprot.readListBegin()
-                    for _i1353 in range(_size1349):
-                        _elem1354 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1354)
+                    (_etype1359, _size1356) = iprot.readListBegin()
+                    for _i1360 in range(_size1356):
+                        _elem1361 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1361)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26862,8 +26865,8 @@ class get_tables_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1355 in self.success:
-                oprot.writeString(iter1355.encode('utf-8') if sys.version_info[0] == 2 else iter1355)
+            for iter1362 in self.success:
+                oprot.writeString(iter1362.encode('utf-8') if sys.version_info[0] == 2 else iter1362)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27004,10 +27007,10 @@ class get_tables_by_type_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1359, _size1356) = iprot.readListBegin()
-                    for _i1360 in range(_size1356):
-                        _elem1361 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1361)
+                    (_etype1366, _size1363) = iprot.readListBegin()
+                    for _i1367 in range(_size1363):
+                        _elem1368 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1368)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27029,8 +27032,8 @@ class get_tables_by_type_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1362 in self.success:
-                oprot.writeString(iter1362.encode('utf-8') if sys.version_info[0] == 2 else iter1362)
+            for iter1369 in self.success:
+                oprot.writeString(iter1369.encode('utf-8') if sys.version_info[0] == 2 else iter1369)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27128,11 +27131,11 @@ class get_all_materialized_view_objects_for_rewriting_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1366, _size1363) = iprot.readListBegin()
-                    for _i1367 in range(_size1363):
-                        _elem1368 = Table()
-                        _elem1368.read(iprot)
-                        self.success.append(_elem1368)
+                    (_etype1373, _size1370) = iprot.readListBegin()
+                    for _i1374 in range(_size1370):
+                        _elem1375 = Table()
+                        _elem1375.read(iprot)
+                        self.success.append(_elem1375)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27154,8 +27157,8 @@ class get_all_materialized_view_objects_for_rewriting_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1369 in self.success:
-                iter1369.write(oprot)
+            for iter1376 in self.success:
+                iter1376.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27272,10 +27275,10 @@ class get_materialized_views_for_rewriting_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1373, _size1370) = iprot.readListBegin()
-                    for _i1374 in range(_size1370):
-                        _elem1375 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1375)
+                    (_etype1380, _size1377) = iprot.readListBegin()
+                    for _i1381 in range(_size1377):
+                        _elem1382 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1382)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27297,8 +27300,8 @@ class get_materialized_views_for_rewriting_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1376 in self.success:
-                oprot.writeString(iter1376.encode('utf-8') if sys.version_info[0] == 2 else iter1376)
+            for iter1383 in self.success:
+                oprot.writeString(iter1383.encode('utf-8') if sys.version_info[0] == 2 else iter1383)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27365,10 +27368,10 @@ class get_table_meta_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.tbl_types = []
-                    (_etype1380, _size1377) = iprot.readListBegin()
-                    for _i1381 in range(_size1377):
-                        _elem1382 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tbl_types.append(_elem1382)
+                    (_etype1387, _size1384) = iprot.readListBegin()
+                    for _i1388 in range(_size1384):
+                        _elem1389 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.tbl_types.append(_elem1389)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27393,8 +27396,8 @@ class get_table_meta_args(object):
         if self.tbl_types is not None:
             oprot.writeFieldBegin('tbl_types', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.tbl_types))
-            for iter1383 in self.tbl_types:
-                oprot.writeString(iter1383.encode('utf-8') if sys.version_info[0] == 2 else iter1383)
+            for iter1390 in self.tbl_types:
+                oprot.writeString(iter1390.encode('utf-8') if sys.version_info[0] == 2 else iter1390)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -27447,11 +27450,11 @@ class get_table_meta_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1387, _size1384) = iprot.readListBegin()
-                    for _i1388 in range(_size1384):
-                        _elem1389 = TableMeta()
-                        _elem1389.read(iprot)
-                        self.success.append(_elem1389)
+                    (_etype1394, _size1391) = iprot.readListBegin()
+                    for _i1395 in range(_size1391):
+                        _elem1396 = TableMeta()
+                        _elem1396.read(iprot)
+                        self.success.append(_elem1396)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27473,8 +27476,8 @@ class get_table_meta_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1390 in self.success:
-                iter1390.write(oprot)
+            for iter1397 in self.success:
+                iter1397.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27591,10 +27594,10 @@ class get_all_tables_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1394, _size1391) = iprot.readListBegin()
-                    for _i1395 in range(_size1391):
-                        _elem1396 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1396)
+                    (_etype1401, _size1398) = iprot.readListBegin()
+                    for _i1402 in range(_size1398):
+                        _elem1403 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1403)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27616,8 +27619,8 @@ class get_all_tables_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1397 in self.success:
-                oprot.writeString(iter1397.encode('utf-8') if sys.version_info[0] == 2 else iter1397)
+            for iter1404 in self.success:
+                oprot.writeString(iter1404.encode('utf-8') if sys.version_info[0] == 2 else iter1404)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27837,10 +27840,10 @@ class get_table_objects_by_name_args(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.tbl_names = []
-                    (_etype1401, _size1398) = iprot.readListBegin()
-                    for _i1402 in range(_size1398):
-                        _elem1403 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tbl_names.append(_elem1403)
+                    (_etype1408, _size1405) = iprot.readListBegin()
+                    for _i1409 in range(_size1405):
+                        _elem1410 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.tbl_names.append(_elem1410)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27861,8 +27864,8 @@ class get_table_objects_by_name_args(object):
         if self.tbl_names is not None:
             oprot.writeFieldBegin('tbl_names', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.tbl_names))
-            for iter1404 in self.tbl_names:
-                oprot.writeString(iter1404.encode('utf-8') if sys.version_info[0] == 2 else iter1404)
+            for iter1411 in self.tbl_names:
+                oprot.writeString(iter1411.encode('utf-8') if sys.version_info[0] == 2 else iter1411)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -27912,11 +27915,11 @@ class get_table_objects_by_name_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1408, _size1405) = iprot.readListBegin()
-                    for _i1409 in range(_size1405):
-                        _elem1410 = Table()
-                        _elem1410.read(iprot)
-                        self.success.append(_elem1410)
+                    (_etype1415, _size1412) = iprot.readListBegin()
+                    for _i1416 in range(_size1412):
+                        _elem1417 = Table()
+                        _elem1417.read(iprot)
+                        self.success.append(_elem1417)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27933,8 +27936,8 @@ class get_table_objects_by_name_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1411 in self.success:
-                iter1411.write(oprot)
+            for iter1418 in self.success:
+                iter1418.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -28047,11 +28050,11 @@ class get_tables_ext_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1415, _size1412) = iprot.readListBegin()
-                    for _i1416 in range(_size1412):
-                        _elem1417 = ExtendedTableInfo()
-                        _elem1417.read(iprot)
-                        self.success.append(_elem1417)
+                    (_etype1422, _size1419) = iprot.readListBegin()
+                    for _i1423 in range(_size1419):
+                        _elem1424 = ExtendedTableInfo()
+                        _elem1424.read(iprot)
+                        self.success.append(_elem1424)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -28073,8 +28076,8 @@ class get_tables_ext_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1418 in self.success:
-                iter1418.write(oprot)
+            for iter1425 in self.success:
+                iter1425.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -28418,12 +28421,14 @@ class get_materialization_invalidation_info_args(object):
     """
     Attributes:
      - creation_metadata
+     - validTxnList
 
     """
 
 
-    def __init__(self, creation_metadata=None,):
+    def __init__(self, creation_metadata=None, validTxnList=None,):
         self.creation_metadata = creation_metadata
+        self.validTxnList = validTxnList
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -28440,6 +28445,11 @@ class get_materialization_invalidation_info_args(object):
                     self.creation_metadata.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.validTxnList = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -28453,6 +28463,10 @@ class get_materialization_invalidation_info_args(object):
         if self.creation_metadata is not None:
             oprot.writeFieldBegin('creation_metadata', TType.STRUCT, 1)
             self.creation_metadata.write(oprot)
+            oprot.writeFieldEnd()
+        if self.validTxnList is not None:
+            oprot.writeFieldBegin('validTxnList', TType.STRING, 2)
+            oprot.writeString(self.validTxnList.encode('utf-8') if sys.version_info[0] == 2 else self.validTxnList)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28474,6 +28488,7 @@ all_structs.append(get_materialization_invalidation_info_args)
 get_materialization_invalidation_info_args.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'creation_metadata', [CreationMetadata, None], None, ),  # 1
+    (2, TType.STRING, 'validTxnList', 'UTF8', None, ),  # 2
 )
 
 
@@ -28875,10 +28890,10 @@ class get_table_names_by_filter_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1422, _size1419) = iprot.readListBegin()
-                    for _i1423 in range(_size1419):
-                        _elem1424 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1424)
+                    (_etype1429, _size1426) = iprot.readListBegin()
+                    for _i1430 in range(_size1426):
+                        _elem1431 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1431)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -28910,8 +28925,8 @@ class get_table_names_by_filter_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1425 in self.success:
-                oprot.writeString(iter1425.encode('utf-8') if sys.version_info[0] == 2 else iter1425)
+            for iter1432 in self.success:
+                oprot.writeString(iter1432.encode('utf-8') if sys.version_info[0] == 2 else iter1432)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -29966,11 +29981,11 @@ class add_partitions_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.new_parts = []
-                    (_etype1429, _size1426) = iprot.readListBegin()
-                    for _i1430 in range(_size1426):
-                        _elem1431 = Partition()
-                        _elem1431.read(iprot)
-                        self.new_parts.append(_elem1431)
+                    (_etype1436, _size1433) = iprot.readListBegin()
+                    for _i1437 in range(_size1433):
+                        _elem1438 = Partition()
+                        _elem1438.read(iprot)
+                        self.new_parts.append(_elem1438)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -29987,8 +30002,8 @@ class add_partitions_args(object):
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.new_parts))
-            for iter1432 in self.new_parts:
-                iter1432.write(oprot)
+            for iter1439 in self.new_parts:
+                iter1439.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -30134,11 +30149,11 @@ class add_partitions_pspec_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.new_parts = []
-                    (_etype1436, _size1433) = iprot.readListBegin()
-                    for _i1437 in range(_size1433):
-                        _elem1438 = PartitionSpec()
-                        _elem1438.read(iprot)
-                        self.new_parts.append(_elem1438)
+                    (_etype1443, _size1440) = iprot.readListBegin()
+                    for _i1444 in range(_size1440):
+                        _elem1445 = PartitionSpec()
+                        _elem1445.read(iprot)
+                        self.new_parts.append(_elem1445)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -30155,8 +30170,8 @@ class add_partitions_pspec_args(object):
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.new_parts))
-            for iter1439 in self.new_parts:
-                iter1439.write(oprot)
+            for iter1446 in self.new_parts:
+                iter1446.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -30316,10 +30331,10 @@ class append_partition_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1443, _size1440) = iprot.readListBegin()
-                    for _i1444 in range(_size1440):
-                        _elem1445 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1445)
+                    (_etype1450, _size1447) = iprot.readListBegin()
+                    for _i1451 in range(_size1447):
+                        _elem1452 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1452)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -30344,8 +30359,8 @@ class append_partition_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1446 in self.part_vals:
-                oprot.writeString(iter1446.encode('utf-8') if sys.version_info[0] == 2 else iter1446)
+            for iter1453 in self.part_vals:
+                oprot.writeString(iter1453.encode('utf-8') if sys.version_info[0] == 2 else iter1453)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -30671,10 +30686,10 @@ class append_partition_with_environment_context_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1450, _size1447) = iprot.readListBegin()
-                    for _i1451 in range(_size1447):
-                        _elem1452 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1452)
+                    (_etype1457, _size1454) = iprot.readListBegin()
+                    for _i1458 in range(_size1454):
+                        _elem1459 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1459)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -30705,8 +30720,8 @@ class append_partition_with_environment_context_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1453 in self.part_vals:
-                oprot.writeString(iter1453.encode('utf-8') if sys.version_info[0] == 2 else iter1453)
+            for iter1460 in self.part_vals:
+                oprot.writeString(iter1460.encode('utf-8') if sys.version_info[0] == 2 else iter1460)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.environment_context is not None:
@@ -31257,10 +31272,10 @@ class drop_partition_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1457, _size1454) = iprot.readListBegin()
-                    for _i1458 in range(_size1454):
-                        _elem1459 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1459)
+                    (_etype1464, _size1461) = iprot.readListBegin()
+                    for _i1465 in range(_size1461):
+                        _elem1466 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1466)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -31290,8 +31305,8 @@ class drop_partition_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1460 in self.part_vals:
-                oprot.writeString(iter1460.encode('utf-8') if sys.version_info[0] == 2 else iter1460)
+            for iter1467 in self.part_vals:
+                oprot.writeString(iter1467.encode('utf-8') if sys.version_info[0] == 2 else iter1467)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.deleteData is not None:
@@ -31450,10 +31465,10 @@ class drop_partition_with_environment_context_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1464, _size1461) = iprot.readListBegin()
-                    for _i1465 in range(_size1461):
-                        _elem1466 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1466)
+                    (_etype1471, _size1468) = iprot.readListBegin()
+                    for _i1472 in range(_size1468):
+                        _elem1473 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1473)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -31489,8 +31504,8 @@ class drop_partition_with_environment_context_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1467 in self.part_vals:
-                oprot.writeString(iter1467.encode('utf-8') if sys.version_info[0] == 2 else iter1467)
+            for iter1474 in self.part_vals:
+                oprot.writeString(iter1474.encode('utf-8') if sys.version_info[0] == 2 else iter1474)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.deleteData is not None:
@@ -32178,10 +32193,10 @@ class get_partition_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1471, _size1468) = iprot.readListBegin()
-                    for _i1472 in range(_size1468):
-                        _elem1473 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1473)
+                    (_etype1478, _size1475) = iprot.readListBegin()
+                    for _i1479 in range(_size1475):
+                        _elem1480 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1480)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -32206,8 +32221,8 @@ class get_partition_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1474 in self.part_vals:
-                oprot.writeString(iter1474.encode('utf-8') if sys.version_info[0] == 2 else iter1474)
+            for iter1481 in self.part_vals:
+                oprot.writeString(iter1481.encode('utf-8') if sys.version_info[0] == 2 else iter1481)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -32501,11 +32516,11 @@ class exchange_partition_args(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.partitionSpecs = {}
-                    (_ktype1476, _vtype1477, _size1475) = iprot.readMapBegin()
-                    for _i1479 in range(_size1475):
-                        _key1480 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1481 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionSpecs[_key1480] = _val1481
+                    (_ktype1483, _vtype1484, _size1482) = iprot.readMapBegin()
+                    for _i1486 in range(_size1482):
+                        _key1487 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1488 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionSpecs[_key1487] = _val1488
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -32542,9 +32557,9 @@ class exchange_partition_args(object):
         if self.partitionSpecs is not None:
             oprot.writeFieldBegin('partitionSpecs', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.partitionSpecs))
-            for kiter1482, viter1483 in self.partitionSpecs.items():
-                oprot.writeString(kiter1482.encode('utf-8') if sys.version_info[0] == 2 else kiter1482)
-                oprot.writeString(viter1483.encode('utf-8') if sys.version_info[0] == 2 else viter1483)
+            for kiter1489, viter1490 in self.partitionSpecs.items():
+                oprot.writeString(kiter1489.encode('utf-8') if sys.version_info[0] == 2 else kiter1489)
+                oprot.writeString(viter1490.encode('utf-8') if sys.version_info[0] == 2 else viter1490)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.source_db is not None:
@@ -32731,11 +32746,11 @@ class exchange_partitions_args(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.partitionSpecs = {}
-                    (_ktype1485, _vtype1486, _size1484) = iprot.readMapBegin()
-                    for _i1488 in range(_size1484):
-                        _key1489 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1490 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionSpecs[_key1489] = _val1490
+                    (_ktype1492, _vtype1493, _size1491) = iprot.readMapBegin()
+                    for _i1495 in range(_size1491):
+                        _key1496 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1497 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionSpecs[_key1496] = _val1497
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -32772,9 +32787,9 @@ class exchange_partitions_args(object):
         if self.partitionSpecs is not None:
             oprot.writeFieldBegin('partitionSpecs', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.partitionSpecs))
-            for kiter1491, viter1492 in self.partitionSpecs.items():
-                oprot.writeString(kiter1491.encode('utf-8') if sys.version_info[0] == 2 else kiter1491)
-                oprot.writeString(viter1492.encode('utf-8') if sys.version_info[0] == 2 else viter1492)
+            for kiter1498, viter1499 in self.partitionSpecs.items():
+                oprot.writeString(kiter1498.encode('utf-8') if sys.version_info[0] == 2 else kiter1498)
+                oprot.writeString(viter1499.encode('utf-8') if sys.version_info[0] == 2 else viter1499)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.source_db is not None:
@@ -32851,11 +32866,11 @@ class exchange_partitions_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1496, _size1493) = iprot.readListBegin()
-                    for _i1497 in range(_size1493):
-                        _elem1498 = Partition()
-                        _elem1498.read(iprot)
-                        self.success.append(_elem1498)
+                    (_etype1503, _size1500) = iprot.readListBegin()
+                    for _i1504 in range(_size1500):
+                        _elem1505 = Partition()
+                        _elem1505.read(iprot)
+                        self.success.append(_elem1505)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -32892,8 +32907,8 @@ class exchange_partitions_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1499 in self.success:
-                iter1499.write(oprot)
+            for iter1506 in self.success:
+                iter1506.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -32979,10 +32994,10 @@ class get_partition_with_auth_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1503, _size1500) = iprot.readListBegin()
-                    for _i1504 in range(_size1500):
-                        _elem1505 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1505)
+                    (_etype1510, _size1507) = iprot.readListBegin()
+                    for _i1511 in range(_size1507):
+                        _elem1512 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1512)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -32994,10 +33009,10 @@ class get_partition_with_auth_args(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.group_names = []
-                    (_etype1509, _size1506) = iprot.readListBegin()
-                    for _i1510 in range(_size1506):
-                        _elem1511 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.group_names.append(_elem1511)
+                    (_etype1516, _size1513) = iprot.readListBegin()
+                    for _i1517 in range(_size1513):
+                        _elem1518 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.group_names.append(_elem1518)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -33022,8 +33037,8 @@ class get_partition_with_auth_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1512 in self.part_vals:
-                oprot.writeString(iter1512.encode('utf-8') if sys.version_info[0] == 2 else iter1512)
+            for iter1519 in self.part_vals:
+                oprot.writeString(iter1519.encode('utf-8') if sys.version_info[0] == 2 else iter1519)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.user_name is not None:
@@ -33033,8 +33048,8 @@ class get_partition_with_auth_args(object):
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
-            for iter1513 in self.group_names:
-                oprot.writeString(iter1513.encode('utf-8') if sys.version_info[0] == 2 else iter1513)
+            for iter1520 in self.group_names:
+                oprot.writeString(iter1520.encode('utf-8') if sys.version_info[0] == 2 else iter1520)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -33435,11 +33450,11 @@ class get_partitions_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1517, _size1514) = iprot.readListBegin()
-                    for _i1518 in range(_size1514):
-                        _elem1519 = Partition()
-                        _elem1519.read(iprot)
-                        self.success.append(_elem1519)
+                    (_etype1524, _size1521) = iprot.readListBegin()
+                    for _i1525 in range(_size1521):
+                        _elem1526 = Partition()
+                        _elem1526.read(iprot)
+                        self.success.append(_elem1526)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -33466,8 +33481,8 @@ class get_partitions_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1520 in self.success:
-                iter1520.write(oprot)
+            for iter1527 in self.success:
+                iter1527.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -33702,10 +33717,10 @@ class get_partitions_with_auth_args(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.group_names = []
-                    (_etype1524, _size1521) = iprot.readListBegin()
-                    for _i1525 in range(_size1521):
-                        _elem1526 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.group_names.append(_elem1526)
+                    (_etype1531, _size1528) = iprot.readListBegin()
+                    for _i1532 in range(_size1528):
+                        _elem1533 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.group_names.append(_elem1533)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -33738,8 +33753,8 @@ class get_partitions_with_auth_args(object):
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
-            for iter1527 in self.group_names:
-                oprot.writeString(iter1527.encode('utf-8') if sys.version_info[0] == 2 else iter1527)
+            for iter1534 in self.group_names:
+                oprot.writeString(iter1534.encode('utf-8') if sys.version_info[0] == 2 else iter1534)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -33796,11 +33811,11 @@ class get_partitions_with_auth_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1531, _size1528) = iprot.readListBegin()
-                    for _i1532 in range(_size1528):
-                        _elem1533 = Partition()
-                        _elem1533.read(iprot)
-                        self.success.append(_elem1533)
+                    (_etype1538, _size1535) = iprot.readListBegin()
+                    for _i1539 in range(_size1535):
+                        _elem1540 = Partition()
+                        _elem1540.read(iprot)
+                        self.success.append(_elem1540)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -33827,8 +33842,8 @@ class get_partitions_with_auth_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1534 in self.success:
-                iter1534.write(oprot)
+            for iter1541 in self.success:
+                iter1541.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -33976,11 +33991,11 @@ class get_partitions_pspec_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1538, _size1535) = iprot.readListBegin()
-                    for _i1539 in range(_size1535):
-                        _elem1540 = PartitionSpec()
-                        _elem1540.read(iprot)
-                        self.success.append(_elem1540)
+                    (_etype1545, _size1542) = iprot.readListBegin()
+                    for _i1546 in range(_size1542):
+                        _elem1547 = PartitionSpec()
+                        _elem1547.read(iprot)
+                        self.success.append(_elem1547)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34007,8 +34022,8 @@ class get_partitions_pspec_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1541 in self.success:
-                iter1541.write(oprot)
+            for iter1548 in self.success:
+                iter1548.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -34156,10 +34171,10 @@ class get_partition_names_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1545, _size1542) = iprot.readListBegin()
-                    for _i1546 in range(_size1542):
-                        _elem1547 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1547)
+                    (_etype1552, _size1549) = iprot.readListBegin()
+                    for _i1553 in range(_size1549):
+                        _elem1554 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1554)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34186,8 +34201,8 @@ class get_partition_names_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1548 in self.success:
-                oprot.writeString(iter1548.encode('utf-8') if sys.version_info[0] == 2 else iter1548)
+            for iter1555 in self.success:
+                oprot.writeString(iter1555.encode('utf-8') if sys.version_info[0] == 2 else iter1555)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -34410,10 +34425,10 @@ class get_partitions_ps_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1552, _size1549) = iprot.readListBegin()
-                    for _i1553 in range(_size1549):
-                        _elem1554 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1554)
+                    (_etype1559, _size1556) = iprot.readListBegin()
+                    for _i1560 in range(_size1556):
+                        _elem1561 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1561)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34443,8 +34458,8 @@ class get_partitions_ps_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1555 in self.part_vals:
-                oprot.writeString(iter1555.encode('utf-8') if sys.version_info[0] == 2 else iter1555)
+            for iter1562 in self.part_vals:
+                oprot.writeString(iter1562.encode('utf-8') if sys.version_info[0] == 2 else iter1562)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -34504,11 +34519,11 @@ class get_partitions_ps_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1559, _size1556) = iprot.readListBegin()
-                    for _i1560 in range(_size1556):
-                        _elem1561 = Partition()
-                        _elem1561.read(iprot)
-                        self.success.append(_elem1561)
+                    (_etype1566, _size1563) = iprot.readListBegin()
+                    for _i1567 in range(_size1563):
+                        _elem1568 = Partition()
+                        _elem1568.read(iprot)
+                        self.success.append(_elem1568)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34535,8 +34550,8 @@ class get_partitions_ps_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1562 in self.success:
-                iter1562.write(oprot)
+            for iter1569 in self.success:
+                iter1569.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -34614,10 +34629,10 @@ class get_partitions_ps_with_auth_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1566, _size1563) = iprot.readListBegin()
-                    for _i1567 in range(_size1563):
-                        _elem1568 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1568)
+                    (_etype1573, _size1570) = iprot.readListBegin()
+                    for _i1574 in range(_size1570):
+                        _elem1575 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1575)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34634,10 +34649,10 @@ class get_partitions_ps_with_auth_args(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.group_names = []
-                    (_etype1572, _size1569) = iprot.readListBegin()
-                    for _i1573 in range(_size1569):
-                        _elem1574 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.group_names.append(_elem1574)
+                    (_etype1579, _size1576) = iprot.readListBegin()
+                    for _i1580 in range(_size1576):
+                        _elem1581 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.group_names.append(_elem1581)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34662,8 +34677,8 @@ class get_partitions_ps_with_auth_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1575 in self.part_vals:
-                oprot.writeString(iter1575.encode('utf-8') if sys.version_info[0] == 2 else iter1575)
+            for iter1582 in self.part_vals:
+                oprot.writeString(iter1582.encode('utf-8') if sys.version_info[0] == 2 else iter1582)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -34677,8 +34692,8 @@ class get_partitions_ps_with_auth_args(object):
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
-            for iter1576 in self.group_names:
-                oprot.writeString(iter1576.encode('utf-8') if sys.version_info[0] == 2 else iter1576)
+            for iter1583 in self.group_names:
+                oprot.writeString(iter1583.encode('utf-8') if sys.version_info[0] == 2 else iter1583)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -34736,11 +34751,11 @@ class get_partitions_ps_with_auth_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1580, _size1577) = iprot.readListBegin()
-                    for _i1581 in range(_size1577):
-                        _elem1582 = Partition()
-                        _elem1582.read(iprot)
-                        self.success.append(_elem1582)
+                    (_etype1587, _size1584) = iprot.readListBegin()
+                    for _i1588 in range(_size1584):
+                        _elem1589 = Partition()
+                        _elem1589.read(iprot)
+                        self.success.append(_elem1589)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -34767,8 +34782,8 @@ class get_partitions_ps_with_auth_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1583 in self.success:
-                iter1583.write(oprot)
+            for iter1590 in self.success:
+                iter1590.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -34991,10 +35006,10 @@ class get_partition_names_ps_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1587, _size1584) = iprot.readListBegin()
-                    for _i1588 in range(_size1584):
-                        _elem1589 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1589)
+                    (_etype1594, _size1591) = iprot.readListBegin()
+                    for _i1595 in range(_size1591):
+                        _elem1596 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1596)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -35024,8 +35039,8 @@ class get_partition_names_ps_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1590 in self.part_vals:
-                oprot.writeString(iter1590.encode('utf-8') if sys.version_info[0] == 2 else iter1590)
+            for iter1597 in self.part_vals:
+                oprot.writeString(iter1597.encode('utf-8') if sys.version_info[0] == 2 else iter1597)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -35085,10 +35100,10 @@ class get_partition_names_ps_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1594, _size1591) = iprot.readListBegin()
-                    for _i1595 in range(_size1591):
-                        _elem1596 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1596)
+                    (_etype1601, _size1598) = iprot.readListBegin()
+                    for _i1602 in range(_size1598):
+                        _elem1603 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1603)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -35115,8 +35130,8 @@ class get_partition_names_ps_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1597 in self.success:
-                oprot.writeString(iter1597.encode('utf-8') if sys.version_info[0] == 2 else iter1597)
+            for iter1604 in self.success:
+                oprot.writeString(iter1604.encode('utf-8') if sys.version_info[0] == 2 else iter1604)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -35390,10 +35405,10 @@ class get_partition_names_req_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1601, _size1598) = iprot.readListBegin()
-                    for _i1602 in range(_size1598):
-                        _elem1603 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1603)
+                    (_etype1608, _size1605) = iprot.readListBegin()
+                    for _i1609 in range(_size1605):
+                        _elem1610 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1610)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -35420,8 +35435,8 @@ class get_partition_names_req_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1604 in self.success:
-                oprot.writeString(iter1604.encode('utf-8') if sys.version_info[0] == 2 else iter1604)
+            for iter1611 in self.success:
+                oprot.writeString(iter1611.encode('utf-8') if sys.version_info[0] == 2 else iter1611)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -35581,11 +35596,11 @@ class get_partitions_by_filter_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1608, _size1605) = iprot.readListBegin()
-                    for _i1609 in range(_size1605):
-                        _elem1610 = Partition()
-                        _elem1610.read(iprot)
-                        self.success.append(_elem1610)
+                    (_etype1615, _size1612) = iprot.readListBegin()
+                    for _i1616 in range(_size1612):
+                        _elem1617 = Partition()
+                        _elem1617.read(iprot)
+                        self.success.append(_elem1617)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -35612,8 +35627,8 @@ class get_partitions_by_filter_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1611 in self.success:
-                iter1611.write(oprot)
+            for iter1618 in self.success:
+                iter1618.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -35773,11 +35788,11 @@ class get_part_specs_by_filter_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1615, _size1612) = iprot.readListBegin()
-                    for _i1616 in range(_size1612):
-                        _elem1617 = PartitionSpec()
-                        _elem1617.read(iprot)
-                        self.success.append(_elem1617)
+                    (_etype1622, _size1619) = iprot.readListBegin()
+                    for _i1623 in range(_size1619):
+                        _elem1624 = PartitionSpec()
+                        _elem1624.read(iprot)
+                        self.success.append(_elem1624)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -35804,8 +35819,8 @@ class get_part_specs_by_filter_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1618 in self.success:
-                iter1618.write(oprot)
+            for iter1625 in self.success:
+                iter1625.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -36346,10 +36361,10 @@ class get_partitions_by_names_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.names = []
-                    (_etype1622, _size1619) = iprot.readListBegin()
-                    for _i1623 in range(_size1619):
-                        _elem1624 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.names.append(_elem1624)
+                    (_etype1629, _size1626) = iprot.readListBegin()
+                    for _i1630 in range(_size1626):
+                        _elem1631 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.names.append(_elem1631)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -36374,8 +36389,8 @@ class get_partitions_by_names_args(object):
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.names))
-            for iter1625 in self.names:
-                oprot.writeString(iter1625.encode('utf-8') if sys.version_info[0] == 2 else iter1625)
+            for iter1632 in self.names:
+                oprot.writeString(iter1632.encode('utf-8') if sys.version_info[0] == 2 else iter1632)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -36430,11 +36445,11 @@ class get_partitions_by_names_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1629, _size1626) = iprot.readListBegin()
-                    for _i1630 in range(_size1626):
-                        _elem1631 = Partition()
-                        _elem1631.read(iprot)
-                        self.success.append(_elem1631)
+                    (_etype1636, _size1633) = iprot.readListBegin()
+                    for _i1637 in range(_size1633):
+                        _elem1638 = Partition()
+                        _elem1638.read(iprot)
+                        self.success.append(_elem1638)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -36461,8 +36476,8 @@ class get_partitions_by_names_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1632 in self.success:
-                iter1632.write(oprot)
+            for iter1639 in self.success:
+                iter1639.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -36844,11 +36859,11 @@ class alter_partitions_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.new_parts = []
-                    (_etype1636, _size1633) = iprot.readListBegin()
-                    for _i1637 in range(_size1633):
-                        _elem1638 = Partition()
-                        _elem1638.read(iprot)
-                        self.new_parts.append(_elem1638)
+                    (_etype1643, _size1640) = iprot.readListBegin()
+                    for _i1644 in range(_size1640):
+                        _elem1645 = Partition()
+                        _elem1645.read(iprot)
+                        self.new_parts.append(_elem1645)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -36873,8 +36888,8 @@ class alter_partitions_args(object):
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.new_parts))
-            for iter1639 in self.new_parts:
-                iter1639.write(oprot)
+            for iter1646 in self.new_parts:
+                iter1646.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -37015,11 +37030,11 @@ class alter_partitions_with_environment_context_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.new_parts = []
-                    (_etype1643, _size1640) = iprot.readListBegin()
-                    for _i1644 in range(_size1640):
-                        _elem1645 = Partition()
-                        _elem1645.read(iprot)
-                        self.new_parts.append(_elem1645)
+                    (_etype1650, _size1647) = iprot.readListBegin()
+                    for _i1651 in range(_size1647):
+                        _elem1652 = Partition()
+                        _elem1652.read(iprot)
+                        self.new_parts.append(_elem1652)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -37050,8 +37065,8 @@ class alter_partitions_with_environment_context_args(object):
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.new_parts))
-            for iter1646 in self.new_parts:
-                iter1646.write(oprot)
+            for iter1653 in self.new_parts:
+                iter1653.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.environment_context is not None:
@@ -37520,10 +37535,10 @@ class rename_partition_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1650, _size1647) = iprot.readListBegin()
-                    for _i1651 in range(_size1647):
-                        _elem1652 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1652)
+                    (_etype1657, _size1654) = iprot.readListBegin()
+                    for _i1658 in range(_size1654):
+                        _elem1659 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1659)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -37554,8 +37569,8 @@ class rename_partition_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1653 in self.part_vals:
-                oprot.writeString(iter1653.encode('utf-8') if sys.version_info[0] == 2 else iter1653)
+            for iter1660 in self.part_vals:
+                oprot.writeString(iter1660.encode('utf-8') if sys.version_info[0] == 2 else iter1660)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.new_part is not None:
@@ -37836,10 +37851,10 @@ class partition_name_has_valid_characters_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.part_vals = []
-                    (_etype1657, _size1654) = iprot.readListBegin()
-                    for _i1658 in range(_size1654):
-                        _elem1659 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals.append(_elem1659)
+                    (_etype1664, _size1661) = iprot.readListBegin()
+                    for _i1665 in range(_size1661):
+                        _elem1666 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals.append(_elem1666)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -37861,8 +37876,8 @@ class partition_name_has_valid_characters_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
-            for iter1660 in self.part_vals:
-                oprot.writeString(iter1660.encode('utf-8') if sys.version_info[0] == 2 else iter1660)
+            for iter1667 in self.part_vals:
+                oprot.writeString(iter1667.encode('utf-8') if sys.version_info[0] == 2 else iter1667)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.throw_exception is not None:
@@ -38200,10 +38215,10 @@ class partition_name_to_vals_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1664, _size1661) = iprot.readListBegin()
-                    for _i1665 in range(_size1661):
-                        _elem1666 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1666)
+                    (_etype1671, _size1668) = iprot.readListBegin()
+                    for _i1672 in range(_size1668):
+                        _elem1673 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1673)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -38225,8 +38240,8 @@ class partition_name_to_vals_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1667 in self.success:
-                oprot.writeString(iter1667.encode('utf-8') if sys.version_info[0] == 2 else iter1667)
+            for iter1674 in self.success:
+                oprot.writeString(iter1674.encode('utf-8') if sys.version_info[0] == 2 else iter1674)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -38343,11 +38358,11 @@ class partition_name_to_spec_result(object):
             if fid == 0:
                 if ftype == TType.MAP:
                     self.success = {}
-                    (_ktype1669, _vtype1670, _size1668) = iprot.readMapBegin()
-                    for _i1672 in range(_size1668):
-                        _key1673 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1674 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success[_key1673] = _val1674
+                    (_ktype1676, _vtype1677, _size1675) = iprot.readMapBegin()
+                    for _i1679 in range(_size1675):
+                        _key1680 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1681 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success[_key1680] = _val1681
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -38369,9 +38384,9 @@ class partition_name_to_spec_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.success))
-            for kiter1675, viter1676 in self.success.items():
-                oprot.writeString(kiter1675.encode('utf-8') if sys.version_info[0] == 2 else kiter1675)
-                oprot.writeString(viter1676.encode('utf-8') if sys.version_info[0] == 2 else viter1676)
+            for kiter1682, viter1683 in self.success.items():
+                oprot.writeString(kiter1682.encode('utf-8') if sys.version_info[0] == 2 else kiter1682)
+                oprot.writeString(viter1683.encode('utf-8') if sys.version_info[0] == 2 else viter1683)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -38440,11 +38455,11 @@ class markPartitionForEvent_args(object):
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.part_vals = {}
-                    (_ktype1678, _vtype1679, _size1677) = iprot.readMapBegin()
-                    for _i1681 in range(_size1677):
-                        _key1682 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1683 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals[_key1682] = _val1683
+                    (_ktype1685, _vtype1686, _size1684) = iprot.readMapBegin()
+                    for _i1688 in range(_size1684):
+                        _key1689 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1690 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals[_key1689] = _val1690
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -38474,9 +38489,9 @@ class markPartitionForEvent_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.part_vals))
-            for kiter1684, viter1685 in self.part_vals.items():
-                oprot.writeString(kiter1684.encode('utf-8') if sys.version_info[0] == 2 else kiter1684)
-                oprot.writeString(viter1685.encode('utf-8') if sys.version_info[0] == 2 else viter1685)
+            for kiter1691, viter1692 in self.part_vals.items():
+                oprot.writeString(kiter1691.encode('utf-8') if sys.version_info[0] == 2 else kiter1691)
+                oprot.writeString(viter1692.encode('utf-8') if sys.version_info[0] == 2 else viter1692)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.eventType is not None:
@@ -38670,11 +38685,11 @@ class isPartitionMarkedForEvent_args(object):
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.part_vals = {}
-                    (_ktype1687, _vtype1688, _size1686) = iprot.readMapBegin()
-                    for _i1690 in range(_size1686):
-                        _key1691 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1692 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.part_vals[_key1691] = _val1692
+                    (_ktype1694, _vtype1695, _size1693) = iprot.readMapBegin()
+                    for _i1697 in range(_size1693):
+                        _key1698 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1699 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.part_vals[_key1698] = _val1699
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -38704,9 +38719,9 @@ class isPartitionMarkedForEvent_args(object):
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.part_vals))
-            for kiter1693, viter1694 in self.part_vals.items():
-                oprot.writeString(kiter1693.encode('utf-8') if sys.version_info[0] == 2 else kiter1693)
-                oprot.writeString(viter1694.encode('utf-8') if sys.version_info[0] == 2 else viter1694)
+            for kiter1700, viter1701 in self.part_vals.items():
+                oprot.writeString(kiter1700.encode('utf-8') if sys.version_info[0] == 2 else kiter1700)
+                oprot.writeString(viter1701.encode('utf-8') if sys.version_info[0] == 2 else viter1701)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.eventType is not None:
@@ -42748,10 +42763,10 @@ class get_functions_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1698, _size1695) = iprot.readListBegin()
-                    for _i1699 in range(_size1695):
-                        _elem1700 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1700)
+                    (_etype1705, _size1702) = iprot.readListBegin()
+                    for _i1706 in range(_size1702):
+                        _elem1707 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1707)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -42773,8 +42788,8 @@ class get_functions_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1701 in self.success:
-                oprot.writeString(iter1701.encode('utf-8') if sys.version_info[0] == 2 else iter1701)
+            for iter1708 in self.success:
+                oprot.writeString(iter1708.encode('utf-8') if sys.version_info[0] == 2 else iter1708)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -43420,10 +43435,10 @@ class get_role_names_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1705, _size1702) = iprot.readListBegin()
-                    for _i1706 in range(_size1702):
-                        _elem1707 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1707)
+                    (_etype1712, _size1709) = iprot.readListBegin()
+                    for _i1713 in range(_size1709):
+                        _elem1714 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1714)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -43445,8 +43460,8 @@ class get_role_names_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1708 in self.success:
-                oprot.writeString(iter1708.encode('utf-8') if sys.version_info[0] == 2 else iter1708)
+            for iter1715 in self.success:
+                oprot.writeString(iter1715.encode('utf-8') if sys.version_info[0] == 2 else iter1715)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -43929,11 +43944,11 @@ class list_roles_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1712, _size1709) = iprot.readListBegin()
-                    for _i1713 in range(_size1709):
-                        _elem1714 = Role()
-                        _elem1714.read(iprot)
-                        self.success.append(_elem1714)
+                    (_etype1719, _size1716) = iprot.readListBegin()
+                    for _i1720 in range(_size1716):
+                        _elem1721 = Role()
+                        _elem1721.read(iprot)
+                        self.success.append(_elem1721)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -43955,8 +43970,8 @@ class list_roles_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1715 in self.success:
-                iter1715.write(oprot)
+            for iter1722 in self.success:
+                iter1722.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -44435,10 +44450,10 @@ class get_privilege_set_args(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.group_names = []
-                    (_etype1719, _size1716) = iprot.readListBegin()
-                    for _i1720 in range(_size1716):
-                        _elem1721 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.group_names.append(_elem1721)
+                    (_etype1726, _size1723) = iprot.readListBegin()
+                    for _i1727 in range(_size1723):
+                        _elem1728 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.group_names.append(_elem1728)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -44463,8 +44478,8 @@ class get_privilege_set_args(object):
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
-            for iter1722 in self.group_names:
-                oprot.writeString(iter1722.encode('utf-8') if sys.version_info[0] == 2 else iter1722)
+            for iter1729 in self.group_names:
+                oprot.writeString(iter1729.encode('utf-8') if sys.version_info[0] == 2 else iter1729)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -44678,11 +44693,11 @@ class list_privileges_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1726, _size1723) = iprot.readListBegin()
-                    for _i1727 in range(_size1723):
-                        _elem1728 = HiveObjectPrivilege()
-                        _elem1728.read(iprot)
-                        self.success.append(_elem1728)
+                    (_etype1733, _size1730) = iprot.readListBegin()
+                    for _i1734 in range(_size1730):
+                        _elem1735 = HiveObjectPrivilege()
+                        _elem1735.read(iprot)
+                        self.success.append(_elem1735)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -44704,8 +44719,8 @@ class list_privileges_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1729 in self.success:
-                iter1729.write(oprot)
+            for iter1736 in self.success:
+                iter1736.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -45336,10 +45351,10 @@ class set_ugi_args(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.group_names = []
-                    (_etype1733, _size1730) = iprot.readListBegin()
-                    for _i1734 in range(_size1730):
-                        _elem1735 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.group_names.append(_elem1735)
+                    (_etype1740, _size1737) = iprot.readListBegin()
+                    for _i1741 in range(_size1737):
+                        _elem1742 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.group_names.append(_elem1742)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -45360,8 +45375,8 @@ class set_ugi_args(object):
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
-            for iter1736 in self.group_names:
-                oprot.writeString(iter1736.encode('utf-8') if sys.version_info[0] == 2 else iter1736)
+            for iter1743 in self.group_names:
+                oprot.writeString(iter1743.encode('utf-8') if sys.version_info[0] == 2 else iter1743)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -45413,10 +45428,10 @@ class set_ugi_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1740, _size1737) = iprot.readListBegin()
-                    for _i1741 in range(_size1737):
-                        _elem1742 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1742)
+                    (_etype1747, _size1744) = iprot.readListBegin()
+                    for _i1748 in range(_size1744):
+                        _elem1749 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1749)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -45438,8 +45453,8 @@ class set_ugi_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1743 in self.success:
-                oprot.writeString(iter1743.encode('utf-8') if sys.version_info[0] == 2 else iter1743)
+            for iter1750 in self.success:
+                oprot.writeString(iter1750.encode('utf-8') if sys.version_info[0] == 2 else iter1750)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -46322,10 +46337,10 @@ class get_all_token_identifiers_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1747, _size1744) = iprot.readListBegin()
-                    for _i1748 in range(_size1744):
-                        _elem1749 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1749)
+                    (_etype1754, _size1751) = iprot.readListBegin()
+                    for _i1755 in range(_size1751):
+                        _elem1756 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1756)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -46342,8 +46357,8 @@ class get_all_token_identifiers_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1750 in self.success:
-                oprot.writeString(iter1750.encode('utf-8') if sys.version_info[0] == 2 else iter1750)
+            for iter1757 in self.success:
+                oprot.writeString(iter1757.encode('utf-8') if sys.version_info[0] == 2 else iter1757)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -46840,10 +46855,10 @@ class get_master_keys_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1754, _size1751) = iprot.readListBegin()
-                    for _i1755 in range(_size1751):
-                        _elem1756 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1756)
+                    (_etype1761, _size1758) = iprot.readListBegin()
+                    for _i1762 in range(_size1758):
+                        _elem1763 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1763)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -46860,8 +46875,8 @@ class get_master_keys_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1757 in self.success:
-                oprot.writeString(iter1757.encode('utf-8') if sys.version_info[0] == 2 else iter1757)
+            for iter1764 in self.success:
+                oprot.writeString(iter1764.encode('utf-8') if sys.version_info[0] == 2 else iter1764)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -50362,10 +50377,10 @@ class find_columns_with_stats_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1761, _size1758) = iprot.readListBegin()
-                    for _i1762 in range(_size1758):
-                        _elem1763 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1763)
+                    (_etype1768, _size1765) = iprot.readListBegin()
+                    for _i1769 in range(_size1765):
+                        _elem1770 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1770)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -50382,8 +50397,8 @@ class find_columns_with_stats_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1764 in self.success:
-                oprot.writeString(iter1764.encode('utf-8') if sys.version_info[0] == 2 else iter1764)
+            for iter1771 in self.success:
+                oprot.writeString(iter1771.encode('utf-8') if sys.version_info[0] == 2 else iter1771)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -56553,11 +56568,11 @@ class get_schema_all_versions_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1768, _size1765) = iprot.readListBegin()
-                    for _i1769 in range(_size1765):
-                        _elem1770 = SchemaVersion()
-                        _elem1770.read(iprot)
-                        self.success.append(_elem1770)
+                    (_etype1775, _size1772) = iprot.readListBegin()
+                    for _i1776 in range(_size1772):
+                        _elem1777 = SchemaVersion()
+                        _elem1777.read(iprot)
+                        self.success.append(_elem1777)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -56584,8 +56599,8 @@ class get_schema_all_versions_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1771 in self.success:
-                iter1771.write(oprot)
+            for iter1778 in self.success:
+                iter1778.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -57974,11 +57989,11 @@ class get_runtime_stats_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1775, _size1772) = iprot.readListBegin()
-                    for _i1776 in range(_size1772):
-                        _elem1777 = RuntimeStat()
-                        _elem1777.read(iprot)
-                        self.success.append(_elem1777)
+                    (_etype1782, _size1779) = iprot.readListBegin()
+                    for _i1783 in range(_size1779):
+                        _elem1784 = RuntimeStat()
+                        _elem1784.read(iprot)
+                        self.success.append(_elem1784)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -58000,8 +58015,8 @@ class get_runtime_stats_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1778 in self.success:
-                iter1778.write(oprot)
+            for iter1785 in self.success:
+                iter1785.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -59638,10 +59653,10 @@ class get_all_stored_procedures_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1782, _size1779) = iprot.readListBegin()
-                    for _i1783 in range(_size1779):
-                        _elem1784 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1784)
+                    (_etype1789, _size1786) = iprot.readListBegin()
+                    for _i1790 in range(_size1786):
+                        _elem1791 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1791)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -59663,8 +59678,8 @@ class get_all_stored_procedures_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1785 in self.success:
-                oprot.writeString(iter1785.encode('utf-8') if sys.version_info[0] == 2 else iter1785)
+            for iter1792 in self.success:
+                oprot.writeString(iter1792.encode('utf-8') if sys.version_info[0] == 2 else iter1792)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -60056,10 +60071,10 @@ class get_all_packages_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1789, _size1786) = iprot.readListBegin()
-                    for _i1790 in range(_size1786):
-                        _elem1791 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.success.append(_elem1791)
+                    (_etype1796, _size1793) = iprot.readListBegin()
+                    for _i1797 in range(_size1793):
+                        _elem1798 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.success.append(_elem1798)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -60081,8 +60096,8 @@ class get_all_packages_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
-            for iter1792 in self.success:
-                oprot.writeString(iter1792.encode('utf-8') if sys.version_info[0] == 2 else iter1792)
+            for iter1799 in self.success:
+                oprot.writeString(iter1799.encode('utf-8') if sys.version_info[0] == 2 else iter1799)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -60325,11 +60340,11 @@ class get_all_write_event_info_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_etype1796, _size1793) = iprot.readListBegin()
-                    for _i1797 in range(_size1793):
-                        _elem1798 = WriteEventInfo()
-                        _elem1798.read(iprot)
-                        self.success.append(_elem1798)
+                    (_etype1803, _size1800) = iprot.readListBegin()
+                    for _i1804 in range(_size1800):
+                        _elem1805 = WriteEventInfo()
+                        _elem1805.read(iprot)
+                        self.success.append(_elem1805)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -60351,8 +60366,8 @@ class get_all_write_event_info_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRUCT, len(self.success))
-            for iter1799 in self.success:
-                iter1799.write(oprot)
+            for iter1806 in self.success:
+                iter1806.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -4717,17 +4717,19 @@ class CreationMetadata(object):
      - tablesUsed
      - validTxnList
      - materializationTime
+     - sourceTables
 
     """
 
 
-    def __init__(self, catName=None, dbName=None, tblName=None, tablesUsed=None, validTxnList=None, materializationTime=None,):
+    def __init__(self, catName=None, dbName=None, tblName=None, tablesUsed=None, validTxnList=None, materializationTime=None, sourceTables=None,):
         self.catName = catName
         self.dbName = dbName
         self.tblName = tblName
         self.tablesUsed = tablesUsed
         self.validTxnList = validTxnList
         self.materializationTime = materializationTime
+        self.sourceTables = sourceTables
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -4758,8 +4760,7 @@ class CreationMetadata(object):
                     self.tablesUsed = set()
                     (_etype236, _size233) = iprot.readSetBegin()
                     for _i237 in range(_size233):
-                        _elem238 = SourceTable()
-                        _elem238.read(iprot)
+                        _elem238 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                         self.tablesUsed.add(_elem238)
                     iprot.readSetEnd()
                 else:
@@ -4772,6 +4773,17 @@ class CreationMetadata(object):
             elif fid == 6:
                 if ftype == TType.I64:
                     self.materializationTime = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.SET:
+                    self.sourceTables = set()
+                    (_etype242, _size239) = iprot.readSetBegin()
+                    for _i243 in range(_size239):
+                        _elem244 = SourceTable()
+                        _elem244.read(iprot)
+                        self.sourceTables.add(_elem244)
+                    iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4798,9 +4810,9 @@ class CreationMetadata(object):
             oprot.writeFieldEnd()
         if self.tablesUsed is not None:
             oprot.writeFieldBegin('tablesUsed', TType.SET, 4)
-            oprot.writeSetBegin(TType.STRUCT, len(self.tablesUsed))
-            for iter239 in self.tablesUsed:
-                iter239.write(oprot)
+            oprot.writeSetBegin(TType.STRING, len(self.tablesUsed))
+            for iter245 in self.tablesUsed:
+                oprot.writeString(iter245.encode('utf-8') if sys.version_info[0] == 2 else iter245)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.validTxnList is not None:
@@ -4810,6 +4822,13 @@ class CreationMetadata(object):
         if self.materializationTime is not None:
             oprot.writeFieldBegin('materializationTime', TType.I64, 6)
             oprot.writeI64(self.materializationTime)
+            oprot.writeFieldEnd()
+        if self.sourceTables is not None:
+            oprot.writeFieldBegin('sourceTables', TType.SET, 7)
+            oprot.writeSetBegin(TType.STRUCT, len(self.sourceTables))
+            for iter246 in self.sourceTables:
+                iter246.write(oprot)
+            oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6240,11 +6259,11 @@ class ColumnStatistics(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.statsObj = []
-                    (_etype243, _size240) = iprot.readListBegin()
-                    for _i244 in range(_size240):
-                        _elem245 = ColumnStatisticsObj()
-                        _elem245.read(iprot)
-                        self.statsObj.append(_elem245)
+                    (_etype250, _size247) = iprot.readListBegin()
+                    for _i251 in range(_size247):
+                        _elem252 = ColumnStatisticsObj()
+                        _elem252.read(iprot)
+                        self.statsObj.append(_elem252)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6275,8 +6294,8 @@ class ColumnStatistics(object):
         if self.statsObj is not None:
             oprot.writeFieldBegin('statsObj', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.statsObj))
-            for iter246 in self.statsObj:
-                iter246.write(oprot)
+            for iter253 in self.statsObj:
+                iter253.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.isStatsCompliant is not None:
@@ -6346,10 +6365,10 @@ class FileMetadata(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.data = []
-                    (_etype250, _size247) = iprot.readListBegin()
-                    for _i251 in range(_size247):
-                        _elem252 = iprot.readBinary()
-                        self.data.append(_elem252)
+                    (_etype257, _size254) = iprot.readListBegin()
+                    for _i258 in range(_size254):
+                        _elem259 = iprot.readBinary()
+                        self.data.append(_elem259)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6374,8 +6393,8 @@ class FileMetadata(object):
         if self.data is not None:
             oprot.writeFieldBegin('data', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.data))
-            for iter253 in self.data:
-                oprot.writeBinary(iter253)
+            for iter260 in self.data:
+                oprot.writeBinary(iter260)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -6419,16 +6438,16 @@ class ObjectDictionary(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.values = {}
-                    (_ktype255, _vtype256, _size254) = iprot.readMapBegin()
-                    for _i258 in range(_size254):
-                        _key259 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val260 = []
-                        (_etype264, _size261) = iprot.readListBegin()
-                        for _i265 in range(_size261):
-                            _elem266 = iprot.readBinary()
-                            _val260.append(_elem266)
+                    (_ktype262, _vtype263, _size261) = iprot.readMapBegin()
+                    for _i265 in range(_size261):
+                        _key266 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val267 = []
+                        (_etype271, _size268) = iprot.readListBegin()
+                        for _i272 in range(_size268):
+                            _elem273 = iprot.readBinary()
+                            _val267.append(_elem273)
                         iprot.readListEnd()
-                        self.values[_key259] = _val260
+                        self.values[_key266] = _val267
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6445,11 +6464,11 @@ class ObjectDictionary(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.values))
-            for kiter267, viter268 in self.values.items():
-                oprot.writeString(kiter267.encode('utf-8') if sys.version_info[0] == 2 else kiter267)
-                oprot.writeListBegin(TType.STRING, len(viter268))
-                for iter269 in viter268:
-                    oprot.writeBinary(iter269)
+            for kiter274, viter275 in self.values.items():
+                oprot.writeString(kiter274.encode('utf-8') if sys.version_info[0] == 2 else kiter274)
+                oprot.writeListBegin(TType.STRING, len(viter275))
+                for iter276 in viter275:
+                    oprot.writeBinary(iter276)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -6584,22 +6603,22 @@ class Table(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.partitionKeys = []
-                    (_etype273, _size270) = iprot.readListBegin()
-                    for _i274 in range(_size270):
-                        _elem275 = FieldSchema()
-                        _elem275.read(iprot)
-                        self.partitionKeys.append(_elem275)
+                    (_etype280, _size277) = iprot.readListBegin()
+                    for _i281 in range(_size277):
+                        _elem282 = FieldSchema()
+                        _elem282.read(iprot)
+                        self.partitionKeys.append(_elem282)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype277, _vtype278, _size276) = iprot.readMapBegin()
-                    for _i280 in range(_size276):
-                        _key281 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val282 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key281] = _val282
+                    (_ktype284, _vtype285, _size283) = iprot.readMapBegin()
+                    for _i287 in range(_size283):
+                        _key288 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val289 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key288] = _val289
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6674,20 +6693,20 @@ class Table(object):
             elif fid == 23:
                 if ftype == TType.LIST:
                     self.requiredReadCapabilities = []
-                    (_etype286, _size283) = iprot.readListBegin()
-                    for _i287 in range(_size283):
-                        _elem288 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredReadCapabilities.append(_elem288)
+                    (_etype293, _size290) = iprot.readListBegin()
+                    for _i294 in range(_size290):
+                        _elem295 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredReadCapabilities.append(_elem295)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 24:
                 if ftype == TType.LIST:
                     self.requiredWriteCapabilities = []
-                    (_etype292, _size289) = iprot.readListBegin()
-                    for _i293 in range(_size289):
-                        _elem294 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredWriteCapabilities.append(_elem294)
+                    (_etype299, _size296) = iprot.readListBegin()
+                    for _i300 in range(_size296):
+                        _elem301 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredWriteCapabilities.append(_elem301)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6749,16 +6768,16 @@ class Table(object):
         if self.partitionKeys is not None:
             oprot.writeFieldBegin('partitionKeys', TType.LIST, 8)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionKeys))
-            for iter295 in self.partitionKeys:
-                iter295.write(oprot)
+            for iter302 in self.partitionKeys:
+                iter302.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 9)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter296, viter297 in self.parameters.items():
-                oprot.writeString(kiter296.encode('utf-8') if sys.version_info[0] == 2 else kiter296)
-                oprot.writeString(viter297.encode('utf-8') if sys.version_info[0] == 2 else viter297)
+            for kiter303, viter304 in self.parameters.items():
+                oprot.writeString(kiter303.encode('utf-8') if sys.version_info[0] == 2 else kiter303)
+                oprot.writeString(viter304.encode('utf-8') if sys.version_info[0] == 2 else viter304)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.viewOriginalText is not None:
@@ -6816,15 +6835,15 @@ class Table(object):
         if self.requiredReadCapabilities is not None:
             oprot.writeFieldBegin('requiredReadCapabilities', TType.LIST, 23)
             oprot.writeListBegin(TType.STRING, len(self.requiredReadCapabilities))
-            for iter298 in self.requiredReadCapabilities:
-                oprot.writeString(iter298.encode('utf-8') if sys.version_info[0] == 2 else iter298)
+            for iter305 in self.requiredReadCapabilities:
+                oprot.writeString(iter305.encode('utf-8') if sys.version_info[0] == 2 else iter305)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.requiredWriteCapabilities is not None:
             oprot.writeFieldBegin('requiredWriteCapabilities', TType.LIST, 24)
             oprot.writeListBegin(TType.STRING, len(self.requiredWriteCapabilities))
-            for iter299 in self.requiredWriteCapabilities:
-                oprot.writeString(iter299.encode('utf-8') if sys.version_info[0] == 2 else iter299)
+            for iter306 in self.requiredWriteCapabilities:
+                oprot.writeString(iter306.encode('utf-8') if sys.version_info[0] == 2 else iter306)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.id is not None:
@@ -6904,10 +6923,10 @@ class Partition(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.values = []
-                    (_etype303, _size300) = iprot.readListBegin()
-                    for _i304 in range(_size300):
-                        _elem305 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.values.append(_elem305)
+                    (_etype310, _size307) = iprot.readListBegin()
+                    for _i311 in range(_size307):
+                        _elem312 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.values.append(_elem312)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6940,11 +6959,11 @@ class Partition(object):
             elif fid == 7:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype307, _vtype308, _size306) = iprot.readMapBegin()
-                    for _i310 in range(_size306):
-                        _key311 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val312 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key311] = _val312
+                    (_ktype314, _vtype315, _size313) = iprot.readMapBegin()
+                    for _i317 in range(_size313):
+                        _key318 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val319 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key318] = _val319
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -6994,8 +7013,8 @@ class Partition(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter313 in self.values:
-                oprot.writeString(iter313.encode('utf-8') if sys.version_info[0] == 2 else iter313)
+            for iter320 in self.values:
+                oprot.writeString(iter320.encode('utf-8') if sys.version_info[0] == 2 else iter320)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.dbName is not None:
@@ -7021,9 +7040,9 @@ class Partition(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 7)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter314, viter315 in self.parameters.items():
-                oprot.writeString(kiter314.encode('utf-8') if sys.version_info[0] == 2 else kiter314)
-                oprot.writeString(viter315.encode('utf-8') if sys.version_info[0] == 2 else viter315)
+            for kiter321, viter322 in self.parameters.items():
+                oprot.writeString(kiter321.encode('utf-8') if sys.version_info[0] == 2 else kiter321)
+                oprot.writeString(viter322.encode('utf-8') if sys.version_info[0] == 2 else viter322)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -7101,10 +7120,10 @@ class PartitionWithoutSD(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.values = []
-                    (_etype319, _size316) = iprot.readListBegin()
-                    for _i320 in range(_size316):
-                        _elem321 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.values.append(_elem321)
+                    (_etype326, _size323) = iprot.readListBegin()
+                    for _i327 in range(_size323):
+                        _elem328 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.values.append(_elem328)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7126,11 +7145,11 @@ class PartitionWithoutSD(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype323, _vtype324, _size322) = iprot.readMapBegin()
-                    for _i326 in range(_size322):
-                        _key327 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val328 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key327] = _val328
+                    (_ktype330, _vtype331, _size329) = iprot.readMapBegin()
+                    for _i333 in range(_size329):
+                        _key334 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val335 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key334] = _val335
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -7153,8 +7172,8 @@ class PartitionWithoutSD(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
-            for iter329 in self.values:
-                oprot.writeString(iter329.encode('utf-8') if sys.version_info[0] == 2 else iter329)
+            for iter336 in self.values:
+                oprot.writeString(iter336.encode('utf-8') if sys.version_info[0] == 2 else iter336)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.createTime is not None:
@@ -7172,9 +7191,9 @@ class PartitionWithoutSD(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 5)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter330, viter331 in self.parameters.items():
-                oprot.writeString(kiter330.encode('utf-8') if sys.version_info[0] == 2 else kiter330)
-                oprot.writeString(viter331.encode('utf-8') if sys.version_info[0] == 2 else viter331)
+            for kiter337, viter338 in self.parameters.items():
+                oprot.writeString(kiter337.encode('utf-8') if sys.version_info[0] == 2 else kiter337)
+                oprot.writeString(viter338.encode('utf-8') if sys.version_info[0] == 2 else viter338)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -7224,11 +7243,11 @@ class PartitionSpecWithSharedSD(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype335, _size332) = iprot.readListBegin()
-                    for _i336 in range(_size332):
-                        _elem337 = PartitionWithoutSD()
-                        _elem337.read(iprot)
-                        self.partitions.append(_elem337)
+                    (_etype342, _size339) = iprot.readListBegin()
+                    for _i343 in range(_size339):
+                        _elem344 = PartitionWithoutSD()
+                        _elem344.read(iprot)
+                        self.partitions.append(_elem344)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7251,8 +7270,8 @@ class PartitionSpecWithSharedSD(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter338 in self.partitions:
-                iter338.write(oprot)
+            for iter345 in self.partitions:
+                iter345.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sd is not None:
@@ -7300,11 +7319,11 @@ class PartitionListComposingSpec(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype342, _size339) = iprot.readListBegin()
-                    for _i343 in range(_size339):
-                        _elem344 = Partition()
-                        _elem344.read(iprot)
-                        self.partitions.append(_elem344)
+                    (_etype349, _size346) = iprot.readListBegin()
+                    for _i350 in range(_size346):
+                        _elem351 = Partition()
+                        _elem351.read(iprot)
+                        self.partitions.append(_elem351)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7321,8 +7340,8 @@ class PartitionListComposingSpec(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter345 in self.partitions:
-                iter345.write(oprot)
+            for iter352 in self.partitions:
+                iter352.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -7506,11 +7525,11 @@ class AggrStats(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.colStats = []
-                    (_etype349, _size346) = iprot.readListBegin()
-                    for _i350 in range(_size346):
-                        _elem351 = ColumnStatisticsObj()
-                        _elem351.read(iprot)
-                        self.colStats.append(_elem351)
+                    (_etype356, _size353) = iprot.readListBegin()
+                    for _i357 in range(_size353):
+                        _elem358 = ColumnStatisticsObj()
+                        _elem358.read(iprot)
+                        self.colStats.append(_elem358)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7537,8 +7556,8 @@ class AggrStats(object):
         if self.colStats is not None:
             oprot.writeFieldBegin('colStats', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.colStats))
-            for iter352 in self.colStats:
-                iter352.write(oprot)
+            for iter359 in self.colStats:
+                iter359.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.partsFound is not None:
@@ -7602,11 +7621,11 @@ class SetPartitionsStatsRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.colStats = []
-                    (_etype356, _size353) = iprot.readListBegin()
-                    for _i357 in range(_size353):
-                        _elem358 = ColumnStatistics()
-                        _elem358.read(iprot)
-                        self.colStats.append(_elem358)
+                    (_etype363, _size360) = iprot.readListBegin()
+                    for _i364 in range(_size360):
+                        _elem365 = ColumnStatistics()
+                        _elem365.read(iprot)
+                        self.colStats.append(_elem365)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7643,8 +7662,8 @@ class SetPartitionsStatsRequest(object):
         if self.colStats is not None:
             oprot.writeFieldBegin('colStats', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.colStats))
-            for iter359 in self.colStats:
-                iter359.write(oprot)
+            for iter366 in self.colStats:
+                iter366.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.needMerge is not None:
@@ -7769,22 +7788,22 @@ class Schema(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fieldSchemas = []
-                    (_etype363, _size360) = iprot.readListBegin()
-                    for _i364 in range(_size360):
-                        _elem365 = FieldSchema()
-                        _elem365.read(iprot)
-                        self.fieldSchemas.append(_elem365)
+                    (_etype370, _size367) = iprot.readListBegin()
+                    for _i371 in range(_size367):
+                        _elem372 = FieldSchema()
+                        _elem372.read(iprot)
+                        self.fieldSchemas.append(_elem372)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.properties = {}
-                    (_ktype367, _vtype368, _size366) = iprot.readMapBegin()
-                    for _i370 in range(_size366):
-                        _key371 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val372 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.properties[_key371] = _val372
+                    (_ktype374, _vtype375, _size373) = iprot.readMapBegin()
+                    for _i377 in range(_size373):
+                        _key378 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val379 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.properties[_key378] = _val379
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -7801,16 +7820,16 @@ class Schema(object):
         if self.fieldSchemas is not None:
             oprot.writeFieldBegin('fieldSchemas', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.fieldSchemas))
-            for iter373 in self.fieldSchemas:
-                iter373.write(oprot)
+            for iter380 in self.fieldSchemas:
+                iter380.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.properties is not None:
             oprot.writeFieldBegin('properties', TType.MAP, 2)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
-            for kiter374, viter375 in self.properties.items():
-                oprot.writeString(kiter374.encode('utf-8') if sys.version_info[0] == 2 else kiter374)
-                oprot.writeString(viter375.encode('utf-8') if sys.version_info[0] == 2 else viter375)
+            for kiter381, viter382 in self.properties.items():
+                oprot.writeString(kiter381.encode('utf-8') if sys.version_info[0] == 2 else kiter381)
+                oprot.writeString(viter382.encode('utf-8') if sys.version_info[0] == 2 else viter382)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -7959,11 +7978,11 @@ class PrimaryKeysResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.primaryKeys = []
-                    (_etype379, _size376) = iprot.readListBegin()
-                    for _i380 in range(_size376):
-                        _elem381 = SQLPrimaryKey()
-                        _elem381.read(iprot)
-                        self.primaryKeys.append(_elem381)
+                    (_etype386, _size383) = iprot.readListBegin()
+                    for _i387 in range(_size383):
+                        _elem388 = SQLPrimaryKey()
+                        _elem388.read(iprot)
+                        self.primaryKeys.append(_elem388)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7980,8 +7999,8 @@ class PrimaryKeysResponse(object):
         if self.primaryKeys is not None:
             oprot.writeFieldBegin('primaryKeys', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.primaryKeys))
-            for iter382 in self.primaryKeys:
-                iter382.write(oprot)
+            for iter389 in self.primaryKeys:
+                iter389.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8150,11 +8169,11 @@ class ForeignKeysResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.foreignKeys = []
-                    (_etype386, _size383) = iprot.readListBegin()
-                    for _i387 in range(_size383):
-                        _elem388 = SQLForeignKey()
-                        _elem388.read(iprot)
-                        self.foreignKeys.append(_elem388)
+                    (_etype393, _size390) = iprot.readListBegin()
+                    for _i394 in range(_size390):
+                        _elem395 = SQLForeignKey()
+                        _elem395.read(iprot)
+                        self.foreignKeys.append(_elem395)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -8171,8 +8190,8 @@ class ForeignKeysResponse(object):
         if self.foreignKeys is not None:
             oprot.writeFieldBegin('foreignKeys', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.foreignKeys))
-            for iter389 in self.foreignKeys:
-                iter389.write(oprot)
+            for iter396 in self.foreignKeys:
+                iter396.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8325,11 +8344,11 @@ class UniqueConstraintsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.uniqueConstraints = []
-                    (_etype393, _size390) = iprot.readListBegin()
-                    for _i394 in range(_size390):
-                        _elem395 = SQLUniqueConstraint()
-                        _elem395.read(iprot)
-                        self.uniqueConstraints.append(_elem395)
+                    (_etype400, _size397) = iprot.readListBegin()
+                    for _i401 in range(_size397):
+                        _elem402 = SQLUniqueConstraint()
+                        _elem402.read(iprot)
+                        self.uniqueConstraints.append(_elem402)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -8346,8 +8365,8 @@ class UniqueConstraintsResponse(object):
         if self.uniqueConstraints is not None:
             oprot.writeFieldBegin('uniqueConstraints', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.uniqueConstraints))
-            for iter396 in self.uniqueConstraints:
-                iter396.write(oprot)
+            for iter403 in self.uniqueConstraints:
+                iter403.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8500,11 +8519,11 @@ class NotNullConstraintsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.notNullConstraints = []
-                    (_etype400, _size397) = iprot.readListBegin()
-                    for _i401 in range(_size397):
-                        _elem402 = SQLNotNullConstraint()
-                        _elem402.read(iprot)
-                        self.notNullConstraints.append(_elem402)
+                    (_etype407, _size404) = iprot.readListBegin()
+                    for _i408 in range(_size404):
+                        _elem409 = SQLNotNullConstraint()
+                        _elem409.read(iprot)
+                        self.notNullConstraints.append(_elem409)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -8521,8 +8540,8 @@ class NotNullConstraintsResponse(object):
         if self.notNullConstraints is not None:
             oprot.writeFieldBegin('notNullConstraints', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.notNullConstraints))
-            for iter403 in self.notNullConstraints:
-                iter403.write(oprot)
+            for iter410 in self.notNullConstraints:
+                iter410.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8675,11 +8694,11 @@ class DefaultConstraintsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.defaultConstraints = []
-                    (_etype407, _size404) = iprot.readListBegin()
-                    for _i408 in range(_size404):
-                        _elem409 = SQLDefaultConstraint()
-                        _elem409.read(iprot)
-                        self.defaultConstraints.append(_elem409)
+                    (_etype414, _size411) = iprot.readListBegin()
+                    for _i415 in range(_size411):
+                        _elem416 = SQLDefaultConstraint()
+                        _elem416.read(iprot)
+                        self.defaultConstraints.append(_elem416)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -8696,8 +8715,8 @@ class DefaultConstraintsResponse(object):
         if self.defaultConstraints is not None:
             oprot.writeFieldBegin('defaultConstraints', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.defaultConstraints))
-            for iter410 in self.defaultConstraints:
-                iter410.write(oprot)
+            for iter417 in self.defaultConstraints:
+                iter417.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8850,11 +8869,11 @@ class CheckConstraintsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.checkConstraints = []
-                    (_etype414, _size411) = iprot.readListBegin()
-                    for _i415 in range(_size411):
-                        _elem416 = SQLCheckConstraint()
-                        _elem416.read(iprot)
-                        self.checkConstraints.append(_elem416)
+                    (_etype421, _size418) = iprot.readListBegin()
+                    for _i422 in range(_size418):
+                        _elem423 = SQLCheckConstraint()
+                        _elem423.read(iprot)
+                        self.checkConstraints.append(_elem423)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -8871,8 +8890,8 @@ class CheckConstraintsResponse(object):
         if self.checkConstraints is not None:
             oprot.writeFieldBegin('checkConstraints', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.checkConstraints))
-            for iter417 in self.checkConstraints:
-                iter417.write(oprot)
+            for iter424 in self.checkConstraints:
+                iter424.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9181,11 +9200,11 @@ class AddPrimaryKeyRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.primaryKeyCols = []
-                    (_etype421, _size418) = iprot.readListBegin()
-                    for _i422 in range(_size418):
-                        _elem423 = SQLPrimaryKey()
-                        _elem423.read(iprot)
-                        self.primaryKeyCols.append(_elem423)
+                    (_etype428, _size425) = iprot.readListBegin()
+                    for _i429 in range(_size425):
+                        _elem430 = SQLPrimaryKey()
+                        _elem430.read(iprot)
+                        self.primaryKeyCols.append(_elem430)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9202,8 +9221,8 @@ class AddPrimaryKeyRequest(object):
         if self.primaryKeyCols is not None:
             oprot.writeFieldBegin('primaryKeyCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.primaryKeyCols))
-            for iter424 in self.primaryKeyCols:
-                iter424.write(oprot)
+            for iter431 in self.primaryKeyCols:
+                iter431.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9249,11 +9268,11 @@ class AddForeignKeyRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.foreignKeyCols = []
-                    (_etype428, _size425) = iprot.readListBegin()
-                    for _i429 in range(_size425):
-                        _elem430 = SQLForeignKey()
-                        _elem430.read(iprot)
-                        self.foreignKeyCols.append(_elem430)
+                    (_etype435, _size432) = iprot.readListBegin()
+                    for _i436 in range(_size432):
+                        _elem437 = SQLForeignKey()
+                        _elem437.read(iprot)
+                        self.foreignKeyCols.append(_elem437)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9270,8 +9289,8 @@ class AddForeignKeyRequest(object):
         if self.foreignKeyCols is not None:
             oprot.writeFieldBegin('foreignKeyCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.foreignKeyCols))
-            for iter431 in self.foreignKeyCols:
-                iter431.write(oprot)
+            for iter438 in self.foreignKeyCols:
+                iter438.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9317,11 +9336,11 @@ class AddUniqueConstraintRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.uniqueConstraintCols = []
-                    (_etype435, _size432) = iprot.readListBegin()
-                    for _i436 in range(_size432):
-                        _elem437 = SQLUniqueConstraint()
-                        _elem437.read(iprot)
-                        self.uniqueConstraintCols.append(_elem437)
+                    (_etype442, _size439) = iprot.readListBegin()
+                    for _i443 in range(_size439):
+                        _elem444 = SQLUniqueConstraint()
+                        _elem444.read(iprot)
+                        self.uniqueConstraintCols.append(_elem444)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9338,8 +9357,8 @@ class AddUniqueConstraintRequest(object):
         if self.uniqueConstraintCols is not None:
             oprot.writeFieldBegin('uniqueConstraintCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.uniqueConstraintCols))
-            for iter438 in self.uniqueConstraintCols:
-                iter438.write(oprot)
+            for iter445 in self.uniqueConstraintCols:
+                iter445.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9385,11 +9404,11 @@ class AddNotNullConstraintRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.notNullConstraintCols = []
-                    (_etype442, _size439) = iprot.readListBegin()
-                    for _i443 in range(_size439):
-                        _elem444 = SQLNotNullConstraint()
-                        _elem444.read(iprot)
-                        self.notNullConstraintCols.append(_elem444)
+                    (_etype449, _size446) = iprot.readListBegin()
+                    for _i450 in range(_size446):
+                        _elem451 = SQLNotNullConstraint()
+                        _elem451.read(iprot)
+                        self.notNullConstraintCols.append(_elem451)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9406,8 +9425,8 @@ class AddNotNullConstraintRequest(object):
         if self.notNullConstraintCols is not None:
             oprot.writeFieldBegin('notNullConstraintCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.notNullConstraintCols))
-            for iter445 in self.notNullConstraintCols:
-                iter445.write(oprot)
+            for iter452 in self.notNullConstraintCols:
+                iter452.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9453,11 +9472,11 @@ class AddDefaultConstraintRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.defaultConstraintCols = []
-                    (_etype449, _size446) = iprot.readListBegin()
-                    for _i450 in range(_size446):
-                        _elem451 = SQLDefaultConstraint()
-                        _elem451.read(iprot)
-                        self.defaultConstraintCols.append(_elem451)
+                    (_etype456, _size453) = iprot.readListBegin()
+                    for _i457 in range(_size453):
+                        _elem458 = SQLDefaultConstraint()
+                        _elem458.read(iprot)
+                        self.defaultConstraintCols.append(_elem458)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9474,8 +9493,8 @@ class AddDefaultConstraintRequest(object):
         if self.defaultConstraintCols is not None:
             oprot.writeFieldBegin('defaultConstraintCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.defaultConstraintCols))
-            for iter452 in self.defaultConstraintCols:
-                iter452.write(oprot)
+            for iter459 in self.defaultConstraintCols:
+                iter459.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9521,11 +9540,11 @@ class AddCheckConstraintRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.checkConstraintCols = []
-                    (_etype456, _size453) = iprot.readListBegin()
-                    for _i457 in range(_size453):
-                        _elem458 = SQLCheckConstraint()
-                        _elem458.read(iprot)
-                        self.checkConstraintCols.append(_elem458)
+                    (_etype463, _size460) = iprot.readListBegin()
+                    for _i464 in range(_size460):
+                        _elem465 = SQLCheckConstraint()
+                        _elem465.read(iprot)
+                        self.checkConstraintCols.append(_elem465)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9542,8 +9561,8 @@ class AddCheckConstraintRequest(object):
         if self.checkConstraintCols is not None:
             oprot.writeFieldBegin('checkConstraintCols', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.checkConstraintCols))
-            for iter459 in self.checkConstraintCols:
-                iter459.write(oprot)
+            for iter466 in self.checkConstraintCols:
+                iter466.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -9591,11 +9610,11 @@ class PartitionsByExprResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype463, _size460) = iprot.readListBegin()
-                    for _i464 in range(_size460):
-                        _elem465 = Partition()
-                        _elem465.read(iprot)
-                        self.partitions.append(_elem465)
+                    (_etype470, _size467) = iprot.readListBegin()
+                    for _i471 in range(_size467):
+                        _elem472 = Partition()
+                        _elem472.read(iprot)
+                        self.partitions.append(_elem472)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9617,8 +9636,8 @@ class PartitionsByExprResult(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter466 in self.partitions:
-                iter466.write(oprot)
+            for iter473 in self.partitions:
+                iter473.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.hasUnknownPartitions is not None:
@@ -9672,11 +9691,11 @@ class PartitionsSpecByExprResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitionsSpec = []
-                    (_etype470, _size467) = iprot.readListBegin()
-                    for _i471 in range(_size467):
-                        _elem472 = PartitionSpec()
-                        _elem472.read(iprot)
-                        self.partitionsSpec.append(_elem472)
+                    (_etype477, _size474) = iprot.readListBegin()
+                    for _i478 in range(_size474):
+                        _elem479 = PartitionSpec()
+                        _elem479.read(iprot)
+                        self.partitionsSpec.append(_elem479)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9698,8 +9717,8 @@ class PartitionsSpecByExprResult(object):
         if self.partitionsSpec is not None:
             oprot.writeFieldBegin('partitionsSpec', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionsSpec))
-            for iter473 in self.partitionsSpec:
-                iter473.write(oprot)
+            for iter480 in self.partitionsSpec:
+                iter480.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.hasUnknownPartitions is not None:
@@ -9904,11 +9923,11 @@ class TableStatsResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.tableStats = []
-                    (_etype477, _size474) = iprot.readListBegin()
-                    for _i478 in range(_size474):
-                        _elem479 = ColumnStatisticsObj()
-                        _elem479.read(iprot)
-                        self.tableStats.append(_elem479)
+                    (_etype484, _size481) = iprot.readListBegin()
+                    for _i485 in range(_size481):
+                        _elem486 = ColumnStatisticsObj()
+                        _elem486.read(iprot)
+                        self.tableStats.append(_elem486)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9930,8 +9949,8 @@ class TableStatsResult(object):
         if self.tableStats is not None:
             oprot.writeFieldBegin('tableStats', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.tableStats))
-            for iter480 in self.tableStats:
-                iter480.write(oprot)
+            for iter487 in self.tableStats:
+                iter487.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.isStatsCompliant is not None:
@@ -9983,17 +10002,17 @@ class PartitionsStatsResult(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.partStats = {}
-                    (_ktype482, _vtype483, _size481) = iprot.readMapBegin()
-                    for _i485 in range(_size481):
-                        _key486 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val487 = []
-                        (_etype491, _size488) = iprot.readListBegin()
-                        for _i492 in range(_size488):
-                            _elem493 = ColumnStatisticsObj()
-                            _elem493.read(iprot)
-                            _val487.append(_elem493)
+                    (_ktype489, _vtype490, _size488) = iprot.readMapBegin()
+                    for _i492 in range(_size488):
+                        _key493 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val494 = []
+                        (_etype498, _size495) = iprot.readListBegin()
+                        for _i499 in range(_size495):
+                            _elem500 = ColumnStatisticsObj()
+                            _elem500.read(iprot)
+                            _val494.append(_elem500)
                         iprot.readListEnd()
-                        self.partStats[_key486] = _val487
+                        self.partStats[_key493] = _val494
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -10015,11 +10034,11 @@ class PartitionsStatsResult(object):
         if self.partStats is not None:
             oprot.writeFieldBegin('partStats', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.partStats))
-            for kiter494, viter495 in self.partStats.items():
-                oprot.writeString(kiter494.encode('utf-8') if sys.version_info[0] == 2 else kiter494)
-                oprot.writeListBegin(TType.STRUCT, len(viter495))
-                for iter496 in viter495:
-                    iter496.write(oprot)
+            for kiter501, viter502 in self.partStats.items():
+                oprot.writeString(kiter501.encode('utf-8') if sys.version_info[0] == 2 else kiter501)
+                oprot.writeListBegin(TType.STRUCT, len(viter502))
+                for iter503 in viter502:
+                    iter503.write(oprot)
                 oprot.writeListEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -10092,10 +10111,10 @@ class TableStatsRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.colNames = []
-                    (_etype500, _size497) = iprot.readListBegin()
-                    for _i501 in range(_size497):
-                        _elem502 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.colNames.append(_elem502)
+                    (_etype507, _size504) = iprot.readListBegin()
+                    for _i508 in range(_size504):
+                        _elem509 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.colNames.append(_elem509)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10140,8 +10159,8 @@ class TableStatsRequest(object):
         if self.colNames is not None:
             oprot.writeFieldBegin('colNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.colNames))
-            for iter503 in self.colNames:
-                oprot.writeString(iter503.encode('utf-8') if sys.version_info[0] == 2 else iter503)
+            for iter510 in self.colNames:
+                oprot.writeString(iter510.encode('utf-8') if sys.version_info[0] == 2 else iter510)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.catName is not None:
@@ -10231,20 +10250,20 @@ class PartitionsStatsRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.colNames = []
-                    (_etype507, _size504) = iprot.readListBegin()
-                    for _i508 in range(_size504):
-                        _elem509 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.colNames.append(_elem509)
+                    (_etype514, _size511) = iprot.readListBegin()
+                    for _i515 in range(_size511):
+                        _elem516 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.colNames.append(_elem516)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partNames = []
-                    (_etype513, _size510) = iprot.readListBegin()
-                    for _i514 in range(_size510):
-                        _elem515 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partNames.append(_elem515)
+                    (_etype520, _size517) = iprot.readListBegin()
+                    for _i521 in range(_size517):
+                        _elem522 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partNames.append(_elem522)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10284,15 +10303,15 @@ class PartitionsStatsRequest(object):
         if self.colNames is not None:
             oprot.writeFieldBegin('colNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.colNames))
-            for iter516 in self.colNames:
-                oprot.writeString(iter516.encode('utf-8') if sys.version_info[0] == 2 else iter516)
+            for iter523 in self.colNames:
+                oprot.writeString(iter523.encode('utf-8') if sys.version_info[0] == 2 else iter523)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.partNames is not None:
             oprot.writeFieldBegin('partNames', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partNames))
-            for iter517 in self.partNames:
-                oprot.writeString(iter517.encode('utf-8') if sys.version_info[0] == 2 else iter517)
+            for iter524 in self.partNames:
+                oprot.writeString(iter524.encode('utf-8') if sys.version_info[0] == 2 else iter524)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.catName is not None:
@@ -10360,11 +10379,11 @@ class AddPartitionsResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype521, _size518) = iprot.readListBegin()
-                    for _i522 in range(_size518):
-                        _elem523 = Partition()
-                        _elem523.read(iprot)
-                        self.partitions.append(_elem523)
+                    (_etype528, _size525) = iprot.readListBegin()
+                    for _i529 in range(_size525):
+                        _elem530 = Partition()
+                        _elem530.read(iprot)
+                        self.partitions.append(_elem530)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10386,8 +10405,8 @@ class AddPartitionsResult(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter524 in self.partitions:
-                iter524.write(oprot)
+            for iter531 in self.partitions:
+                iter531.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.isStatsCompliant is not None:
@@ -10457,11 +10476,11 @@ class AddPartitionsRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.parts = []
-                    (_etype528, _size525) = iprot.readListBegin()
-                    for _i529 in range(_size525):
-                        _elem530 = Partition()
-                        _elem530.read(iprot)
-                        self.parts.append(_elem530)
+                    (_etype535, _size532) = iprot.readListBegin()
+                    for _i536 in range(_size532):
+                        _elem537 = Partition()
+                        _elem537.read(iprot)
+                        self.parts.append(_elem537)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10506,8 +10525,8 @@ class AddPartitionsRequest(object):
         if self.parts is not None:
             oprot.writeFieldBegin('parts', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.parts))
-            for iter531 in self.parts:
-                iter531.write(oprot)
+            for iter538 in self.parts:
+                iter538.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.ifNotExists is not None:
@@ -10575,11 +10594,11 @@ class DropPartitionsResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype535, _size532) = iprot.readListBegin()
-                    for _i536 in range(_size532):
-                        _elem537 = Partition()
-                        _elem537.read(iprot)
-                        self.partitions.append(_elem537)
+                    (_etype542, _size539) = iprot.readListBegin()
+                    for _i543 in range(_size539):
+                        _elem544 = Partition()
+                        _elem544.read(iprot)
+                        self.partitions.append(_elem544)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10596,8 +10615,8 @@ class DropPartitionsResult(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter538 in self.partitions:
-                iter538.write(oprot)
+            for iter545 in self.partitions:
+                iter545.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -10713,21 +10732,21 @@ class RequestPartsSpec(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.names = []
-                    (_etype542, _size539) = iprot.readListBegin()
-                    for _i543 in range(_size539):
-                        _elem544 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.names.append(_elem544)
+                    (_etype549, _size546) = iprot.readListBegin()
+                    for _i550 in range(_size546):
+                        _elem551 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.names.append(_elem551)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.exprs = []
-                    (_etype548, _size545) = iprot.readListBegin()
-                    for _i549 in range(_size545):
-                        _elem550 = DropPartitionsExpr()
-                        _elem550.read(iprot)
-                        self.exprs.append(_elem550)
+                    (_etype555, _size552) = iprot.readListBegin()
+                    for _i556 in range(_size552):
+                        _elem557 = DropPartitionsExpr()
+                        _elem557.read(iprot)
+                        self.exprs.append(_elem557)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10744,15 +10763,15 @@ class RequestPartsSpec(object):
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.names))
-            for iter551 in self.names:
-                oprot.writeString(iter551.encode('utf-8') if sys.version_info[0] == 2 else iter551)
+            for iter558 in self.names:
+                oprot.writeString(iter558.encode('utf-8') if sys.version_info[0] == 2 else iter558)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.exprs is not None:
             oprot.writeFieldBegin('exprs', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.exprs))
-            for iter552 in self.exprs:
-                iter552.write(oprot)
+            for iter559 in self.exprs:
+                iter559.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -10977,11 +10996,11 @@ class PartitionValuesRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.partitionKeys = []
-                    (_etype556, _size553) = iprot.readListBegin()
-                    for _i557 in range(_size553):
-                        _elem558 = FieldSchema()
-                        _elem558.read(iprot)
-                        self.partitionKeys.append(_elem558)
+                    (_etype563, _size560) = iprot.readListBegin()
+                    for _i564 in range(_size560):
+                        _elem565 = FieldSchema()
+                        _elem565.read(iprot)
+                        self.partitionKeys.append(_elem565)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10998,11 +11017,11 @@ class PartitionValuesRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.partitionOrder = []
-                    (_etype562, _size559) = iprot.readListBegin()
-                    for _i563 in range(_size559):
-                        _elem564 = FieldSchema()
-                        _elem564.read(iprot)
-                        self.partitionOrder.append(_elem564)
+                    (_etype569, _size566) = iprot.readListBegin()
+                    for _i570 in range(_size566):
+                        _elem571 = FieldSchema()
+                        _elem571.read(iprot)
+                        self.partitionOrder.append(_elem571)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11047,8 +11066,8 @@ class PartitionValuesRequest(object):
         if self.partitionKeys is not None:
             oprot.writeFieldBegin('partitionKeys', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionKeys))
-            for iter565 in self.partitionKeys:
-                iter565.write(oprot)
+            for iter572 in self.partitionKeys:
+                iter572.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.applyDistinct is not None:
@@ -11062,8 +11081,8 @@ class PartitionValuesRequest(object):
         if self.partitionOrder is not None:
             oprot.writeFieldBegin('partitionOrder', TType.LIST, 6)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionOrder))
-            for iter566 in self.partitionOrder:
-                iter566.write(oprot)
+            for iter573 in self.partitionOrder:
+                iter573.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.ascending is not None:
@@ -11129,10 +11148,10 @@ class PartitionValuesRow(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.row = []
-                    (_etype570, _size567) = iprot.readListBegin()
-                    for _i571 in range(_size567):
-                        _elem572 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.row.append(_elem572)
+                    (_etype577, _size574) = iprot.readListBegin()
+                    for _i578 in range(_size574):
+                        _elem579 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.row.append(_elem579)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11149,8 +11168,8 @@ class PartitionValuesRow(object):
         if self.row is not None:
             oprot.writeFieldBegin('row', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.row))
-            for iter573 in self.row:
-                oprot.writeString(iter573.encode('utf-8') if sys.version_info[0] == 2 else iter573)
+            for iter580 in self.row:
+                oprot.writeString(iter580.encode('utf-8') if sys.version_info[0] == 2 else iter580)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -11196,11 +11215,11 @@ class PartitionValuesResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitionValues = []
-                    (_etype577, _size574) = iprot.readListBegin()
-                    for _i578 in range(_size574):
-                        _elem579 = PartitionValuesRow()
-                        _elem579.read(iprot)
-                        self.partitionValues.append(_elem579)
+                    (_etype584, _size581) = iprot.readListBegin()
+                    for _i585 in range(_size581):
+                        _elem586 = PartitionValuesRow()
+                        _elem586.read(iprot)
+                        self.partitionValues.append(_elem586)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11217,8 +11236,8 @@ class PartitionValuesResponse(object):
         if self.partitionValues is not None:
             oprot.writeFieldBegin('partitionValues', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionValues))
-            for iter580 in self.partitionValues:
-                iter580.write(oprot)
+            for iter587 in self.partitionValues:
+                iter587.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -11292,10 +11311,10 @@ class GetPartitionsByNamesRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.names = []
-                    (_etype584, _size581) = iprot.readListBegin()
-                    for _i585 in range(_size581):
-                        _elem586 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.names.append(_elem586)
+                    (_etype591, _size588) = iprot.readListBegin()
+                    for _i592 in range(_size588):
+                        _elem593 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.names.append(_elem593)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11307,10 +11326,10 @@ class GetPartitionsByNamesRequest(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype590, _size587) = iprot.readListBegin()
-                    for _i591 in range(_size587):
-                        _elem592 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem592)
+                    (_etype597, _size594) = iprot.readListBegin()
+                    for _i598 in range(_size594):
+                        _elem599 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem599)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11360,8 +11379,8 @@ class GetPartitionsByNamesRequest(object):
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.names))
-            for iter593 in self.names:
-                oprot.writeString(iter593.encode('utf-8') if sys.version_info[0] == 2 else iter593)
+            for iter600 in self.names:
+                oprot.writeString(iter600.encode('utf-8') if sys.version_info[0] == 2 else iter600)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.get_col_stats is not None:
@@ -11371,8 +11390,8 @@ class GetPartitionsByNamesRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter594 in self.processorCapabilities:
-                oprot.writeString(iter594.encode('utf-8') if sys.version_info[0] == 2 else iter594)
+            for iter601 in self.processorCapabilities:
+                oprot.writeString(iter601.encode('utf-8') if sys.version_info[0] == 2 else iter601)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -11442,11 +11461,11 @@ class GetPartitionsByNamesResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype598, _size595) = iprot.readListBegin()
-                    for _i599 in range(_size595):
-                        _elem600 = Partition()
-                        _elem600.read(iprot)
-                        self.partitions.append(_elem600)
+                    (_etype605, _size602) = iprot.readListBegin()
+                    for _i606 in range(_size602):
+                        _elem607 = Partition()
+                        _elem607.read(iprot)
+                        self.partitions.append(_elem607)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11469,8 +11488,8 @@ class GetPartitionsByNamesResult(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter601 in self.partitions:
-                iter601.write(oprot)
+            for iter608 in self.partitions:
+                iter608.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.dictionary is not None:
@@ -11554,11 +11573,11 @@ class DataConnector(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype603, _vtype604, _size602) = iprot.readMapBegin()
-                    for _i606 in range(_size602):
-                        _key607 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val608 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key607] = _val608
+                    (_ktype610, _vtype611, _size609) = iprot.readMapBegin()
+                    for _i613 in range(_size609):
+                        _key614 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val615 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key614] = _val615
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -11606,9 +11625,9 @@ class DataConnector(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 5)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter609, viter610 in self.parameters.items():
-                oprot.writeString(kiter609.encode('utf-8') if sys.version_info[0] == 2 else kiter609)
-                oprot.writeString(viter610.encode('utf-8') if sys.version_info[0] == 2 else viter610)
+            for kiter616, viter617 in self.parameters.items():
+                oprot.writeString(kiter616.encode('utf-8') if sys.version_info[0] == 2 else kiter616)
+                oprot.writeString(viter617.encode('utf-8') if sys.version_info[0] == 2 else viter617)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.ownerName is not None:
@@ -11783,11 +11802,11 @@ class Function(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.resourceUris = []
-                    (_etype614, _size611) = iprot.readListBegin()
-                    for _i615 in range(_size611):
-                        _elem616 = ResourceUri()
-                        _elem616.read(iprot)
-                        self.resourceUris.append(_elem616)
+                    (_etype621, _size618) = iprot.readListBegin()
+                    for _i622 in range(_size618):
+                        _elem623 = ResourceUri()
+                        _elem623.read(iprot)
+                        self.resourceUris.append(_elem623)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -11837,8 +11856,8 @@ class Function(object):
         if self.resourceUris is not None:
             oprot.writeFieldBegin('resourceUris', TType.LIST, 8)
             oprot.writeListBegin(TType.STRUCT, len(self.resourceUris))
-            for iter617 in self.resourceUris:
-                iter617.write(oprot)
+            for iter624 in self.resourceUris:
+                iter624.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.catName is not None:
@@ -12046,11 +12065,11 @@ class GetOpenTxnsInfoResponse(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.open_txns = []
-                    (_etype621, _size618) = iprot.readListBegin()
-                    for _i622 in range(_size618):
-                        _elem623 = TxnInfo()
-                        _elem623.read(iprot)
-                        self.open_txns.append(_elem623)
+                    (_etype628, _size625) = iprot.readListBegin()
+                    for _i629 in range(_size625):
+                        _elem630 = TxnInfo()
+                        _elem630.read(iprot)
+                        self.open_txns.append(_elem630)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12071,8 +12090,8 @@ class GetOpenTxnsInfoResponse(object):
         if self.open_txns is not None:
             oprot.writeFieldBegin('open_txns', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.open_txns))
-            for iter624 in self.open_txns:
-                iter624.write(oprot)
+            for iter631 in self.open_txns:
+                iter631.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -12131,10 +12150,10 @@ class GetOpenTxnsResponse(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.open_txns = []
-                    (_etype628, _size625) = iprot.readListBegin()
-                    for _i629 in range(_size625):
-                        _elem630 = iprot.readI64()
-                        self.open_txns.append(_elem630)
+                    (_etype635, _size632) = iprot.readListBegin()
+                    for _i636 in range(_size632):
+                        _elem637 = iprot.readI64()
+                        self.open_txns.append(_elem637)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12165,8 +12184,8 @@ class GetOpenTxnsResponse(object):
         if self.open_txns is not None:
             oprot.writeFieldBegin('open_txns', TType.LIST, 2)
             oprot.writeListBegin(TType.I64, len(self.open_txns))
-            for iter631 in self.open_txns:
-                oprot.writeI64(iter631)
+            for iter638 in self.open_txns:
+                oprot.writeI64(iter638)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.min_open_txn is not None:
@@ -12261,10 +12280,10 @@ class OpenTxnRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.replSrcTxnIds = []
-                    (_etype635, _size632) = iprot.readListBegin()
-                    for _i636 in range(_size632):
-                        _elem637 = iprot.readI64()
-                        self.replSrcTxnIds.append(_elem637)
+                    (_etype642, _size639) = iprot.readListBegin()
+                    for _i643 in range(_size639):
+                        _elem644 = iprot.readI64()
+                        self.replSrcTxnIds.append(_elem644)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12306,8 +12325,8 @@ class OpenTxnRequest(object):
         if self.replSrcTxnIds is not None:
             oprot.writeFieldBegin('replSrcTxnIds', TType.LIST, 6)
             oprot.writeListBegin(TType.I64, len(self.replSrcTxnIds))
-            for iter638 in self.replSrcTxnIds:
-                oprot.writeI64(iter638)
+            for iter645 in self.replSrcTxnIds:
+                oprot.writeI64(iter645)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.txn_type is not None:
@@ -12361,10 +12380,10 @@ class OpenTxnsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.txn_ids = []
-                    (_etype642, _size639) = iprot.readListBegin()
-                    for _i643 in range(_size639):
-                        _elem644 = iprot.readI64()
-                        self.txn_ids.append(_elem644)
+                    (_etype649, _size646) = iprot.readListBegin()
+                    for _i650 in range(_size646):
+                        _elem651 = iprot.readI64()
+                        self.txn_ids.append(_elem651)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12381,8 +12400,8 @@ class OpenTxnsResponse(object):
         if self.txn_ids is not None:
             oprot.writeFieldBegin('txn_ids', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.txn_ids))
-            for iter645 in self.txn_ids:
-                oprot.writeI64(iter645)
+            for iter652 in self.txn_ids:
+                oprot.writeI64(iter652)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -12509,10 +12528,10 @@ class AbortTxnsRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.txn_ids = []
-                    (_etype649, _size646) = iprot.readListBegin()
-                    for _i650 in range(_size646):
-                        _elem651 = iprot.readI64()
-                        self.txn_ids.append(_elem651)
+                    (_etype656, _size653) = iprot.readListBegin()
+                    for _i657 in range(_size653):
+                        _elem658 = iprot.readI64()
+                        self.txn_ids.append(_elem658)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12529,8 +12548,8 @@ class AbortTxnsRequest(object):
         if self.txn_ids is not None:
             oprot.writeFieldBegin('txn_ids', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.txn_ids))
-            for iter652 in self.txn_ids:
-                oprot.writeI64(iter652)
+            for iter659 in self.txn_ids:
+                oprot.writeI64(iter659)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -12820,10 +12839,10 @@ class ReplLastIdInfo(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.partitionList = []
-                    (_etype656, _size653) = iprot.readListBegin()
-                    for _i657 in range(_size653):
-                        _elem658 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionList.append(_elem658)
+                    (_etype663, _size660) = iprot.readListBegin()
+                    for _i664 in range(_size660):
+                        _elem665 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionList.append(_elem665)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -12856,8 +12875,8 @@ class ReplLastIdInfo(object):
         if self.partitionList is not None:
             oprot.writeFieldBegin('partitionList', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.partitionList))
-            for iter659 in self.partitionList:
-                oprot.writeString(iter659.encode('utf-8') if sys.version_info[0] == 2 else iter659)
+            for iter666 in self.partitionList:
+                oprot.writeString(iter666.encode('utf-8') if sys.version_info[0] == 2 else iter666)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -13025,11 +13044,11 @@ class CommitTxnRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.writeEventInfos = []
-                    (_etype663, _size660) = iprot.readListBegin()
-                    for _i664 in range(_size660):
-                        _elem665 = WriteEventInfo()
-                        _elem665.read(iprot)
-                        self.writeEventInfos.append(_elem665)
+                    (_etype670, _size667) = iprot.readListBegin()
+                    for _i671 in range(_size667):
+                        _elem672 = WriteEventInfo()
+                        _elem672.read(iprot)
+                        self.writeEventInfos.append(_elem672)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13076,8 +13095,8 @@ class CommitTxnRequest(object):
         if self.writeEventInfos is not None:
             oprot.writeFieldBegin('writeEventInfos', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.writeEventInfos))
-            for iter666 in self.writeEventInfos:
-                iter666.write(oprot)
+            for iter673 in self.writeEventInfos:
+                iter673.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.replLastIdInfo is not None:
@@ -13174,10 +13193,10 @@ class ReplTblWriteIdStateRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.partNames = []
-                    (_etype670, _size667) = iprot.readListBegin()
-                    for _i671 in range(_size667):
-                        _elem672 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partNames.append(_elem672)
+                    (_etype677, _size674) = iprot.readListBegin()
+                    for _i678 in range(_size674):
+                        _elem679 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partNames.append(_elem679)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13214,8 +13233,8 @@ class ReplTblWriteIdStateRequest(object):
         if self.partNames is not None:
             oprot.writeFieldBegin('partNames', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.partNames))
-            for iter673 in self.partNames:
-                oprot.writeString(iter673.encode('utf-8') if sys.version_info[0] == 2 else iter673)
+            for iter680 in self.partNames:
+                oprot.writeString(iter680.encode('utf-8') if sys.version_info[0] == 2 else iter680)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -13273,10 +13292,10 @@ class GetValidWriteIdsRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fullTableNames = []
-                    (_etype677, _size674) = iprot.readListBegin()
-                    for _i678 in range(_size674):
-                        _elem679 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.fullTableNames.append(_elem679)
+                    (_etype684, _size681) = iprot.readListBegin()
+                    for _i685 in range(_size681):
+                        _elem686 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.fullTableNames.append(_elem686)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13303,8 +13322,8 @@ class GetValidWriteIdsRequest(object):
         if self.fullTableNames is not None:
             oprot.writeFieldBegin('fullTableNames', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.fullTableNames))
-            for iter680 in self.fullTableNames:
-                oprot.writeString(iter680.encode('utf-8') if sys.version_info[0] == 2 else iter680)
+            for iter687 in self.fullTableNames:
+                oprot.writeString(iter687.encode('utf-8') if sys.version_info[0] == 2 else iter687)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.validTxnList is not None:
@@ -13376,10 +13395,10 @@ class TableValidWriteIds(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.invalidWriteIds = []
-                    (_etype684, _size681) = iprot.readListBegin()
-                    for _i685 in range(_size681):
-                        _elem686 = iprot.readI64()
-                        self.invalidWriteIds.append(_elem686)
+                    (_etype691, _size688) = iprot.readListBegin()
+                    for _i692 in range(_size688):
+                        _elem693 = iprot.readI64()
+                        self.invalidWriteIds.append(_elem693)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13414,8 +13433,8 @@ class TableValidWriteIds(object):
         if self.invalidWriteIds is not None:
             oprot.writeFieldBegin('invalidWriteIds', TType.LIST, 3)
             oprot.writeListBegin(TType.I64, len(self.invalidWriteIds))
-            for iter687 in self.invalidWriteIds:
-                oprot.writeI64(iter687)
+            for iter694 in self.invalidWriteIds:
+                oprot.writeI64(iter694)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.minOpenWriteId is not None:
@@ -13475,11 +13494,11 @@ class GetValidWriteIdsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.tblValidWriteIds = []
-                    (_etype691, _size688) = iprot.readListBegin()
-                    for _i692 in range(_size688):
-                        _elem693 = TableValidWriteIds()
-                        _elem693.read(iprot)
-                        self.tblValidWriteIds.append(_elem693)
+                    (_etype698, _size695) = iprot.readListBegin()
+                    for _i699 in range(_size695):
+                        _elem700 = TableValidWriteIds()
+                        _elem700.read(iprot)
+                        self.tblValidWriteIds.append(_elem700)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13496,8 +13515,8 @@ class GetValidWriteIdsResponse(object):
         if self.tblValidWriteIds is not None:
             oprot.writeFieldBegin('tblValidWriteIds', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.tblValidWriteIds))
-            for iter694 in self.tblValidWriteIds:
-                iter694.write(oprot)
+            for iter701 in self.tblValidWriteIds:
+                iter701.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -13633,10 +13652,10 @@ class AllocateTableWriteIdsRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.txnIds = []
-                    (_etype698, _size695) = iprot.readListBegin()
-                    for _i699 in range(_size695):
-                        _elem700 = iprot.readI64()
-                        self.txnIds.append(_elem700)
+                    (_etype705, _size702) = iprot.readListBegin()
+                    for _i706 in range(_size702):
+                        _elem707 = iprot.readI64()
+                        self.txnIds.append(_elem707)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13648,11 +13667,11 @@ class AllocateTableWriteIdsRequest(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.srcTxnToWriteIdList = []
-                    (_etype704, _size701) = iprot.readListBegin()
-                    for _i705 in range(_size701):
-                        _elem706 = TxnToWriteId()
-                        _elem706.read(iprot)
-                        self.srcTxnToWriteIdList.append(_elem706)
+                    (_etype711, _size708) = iprot.readListBegin()
+                    for _i712 in range(_size708):
+                        _elem713 = TxnToWriteId()
+                        _elem713.read(iprot)
+                        self.srcTxnToWriteIdList.append(_elem713)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13677,8 +13696,8 @@ class AllocateTableWriteIdsRequest(object):
         if self.txnIds is not None:
             oprot.writeFieldBegin('txnIds', TType.LIST, 3)
             oprot.writeListBegin(TType.I64, len(self.txnIds))
-            for iter707 in self.txnIds:
-                oprot.writeI64(iter707)
+            for iter714 in self.txnIds:
+                oprot.writeI64(iter714)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.replPolicy is not None:
@@ -13688,8 +13707,8 @@ class AllocateTableWriteIdsRequest(object):
         if self.srcTxnToWriteIdList is not None:
             oprot.writeFieldBegin('srcTxnToWriteIdList', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.srcTxnToWriteIdList))
-            for iter708 in self.srcTxnToWriteIdList:
-                iter708.write(oprot)
+            for iter715 in self.srcTxnToWriteIdList:
+                iter715.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -13737,11 +13756,11 @@ class AllocateTableWriteIdsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.txnToWriteIds = []
-                    (_etype712, _size709) = iprot.readListBegin()
-                    for _i713 in range(_size709):
-                        _elem714 = TxnToWriteId()
-                        _elem714.read(iprot)
-                        self.txnToWriteIds.append(_elem714)
+                    (_etype719, _size716) = iprot.readListBegin()
+                    for _i720 in range(_size716):
+                        _elem721 = TxnToWriteId()
+                        _elem721.read(iprot)
+                        self.txnToWriteIds.append(_elem721)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -13758,8 +13777,8 @@ class AllocateTableWriteIdsResponse(object):
         if self.txnToWriteIds is not None:
             oprot.writeFieldBegin('txnToWriteIds', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.txnToWriteIds))
-            for iter715 in self.txnToWriteIds:
-                iter715.write(oprot)
+            for iter722 in self.txnToWriteIds:
+                iter722.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -14230,11 +14249,11 @@ class LockRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.component = []
-                    (_etype719, _size716) = iprot.readListBegin()
-                    for _i720 in range(_size716):
-                        _elem721 = LockComponent()
-                        _elem721.read(iprot)
-                        self.component.append(_elem721)
+                    (_etype726, _size723) = iprot.readListBegin()
+                    for _i727 in range(_size723):
+                        _elem728 = LockComponent()
+                        _elem728.read(iprot)
+                        self.component.append(_elem728)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -14276,8 +14295,8 @@ class LockRequest(object):
         if self.component is not None:
             oprot.writeFieldBegin('component', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.component))
-            for iter722 in self.component:
-                iter722.write(oprot)
+            for iter729 in self.component:
+                iter729.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.txnid is not None:
@@ -14907,11 +14926,11 @@ class ShowLocksResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.locks = []
-                    (_etype726, _size723) = iprot.readListBegin()
-                    for _i727 in range(_size723):
-                        _elem728 = ShowLocksResponseElement()
-                        _elem728.read(iprot)
-                        self.locks.append(_elem728)
+                    (_etype733, _size730) = iprot.readListBegin()
+                    for _i734 in range(_size730):
+                        _elem735 = ShowLocksResponseElement()
+                        _elem735.read(iprot)
+                        self.locks.append(_elem735)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -14928,8 +14947,8 @@ class ShowLocksResponse(object):
         if self.locks is not None:
             oprot.writeFieldBegin('locks', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.locks))
-            for iter729 in self.locks:
-                iter729.write(oprot)
+            for iter736 in self.locks:
+                iter736.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -15115,20 +15134,20 @@ class HeartbeatTxnRangeResponse(object):
             if fid == 1:
                 if ftype == TType.SET:
                     self.aborted = set()
-                    (_etype733, _size730) = iprot.readSetBegin()
-                    for _i734 in range(_size730):
-                        _elem735 = iprot.readI64()
-                        self.aborted.add(_elem735)
+                    (_etype740, _size737) = iprot.readSetBegin()
+                    for _i741 in range(_size737):
+                        _elem742 = iprot.readI64()
+                        self.aborted.add(_elem742)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.nosuch = set()
-                    (_etype739, _size736) = iprot.readSetBegin()
-                    for _i740 in range(_size736):
-                        _elem741 = iprot.readI64()
-                        self.nosuch.add(_elem741)
+                    (_etype746, _size743) = iprot.readSetBegin()
+                    for _i747 in range(_size743):
+                        _elem748 = iprot.readI64()
+                        self.nosuch.add(_elem748)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -15145,15 +15164,15 @@ class HeartbeatTxnRangeResponse(object):
         if self.aborted is not None:
             oprot.writeFieldBegin('aborted', TType.SET, 1)
             oprot.writeSetBegin(TType.I64, len(self.aborted))
-            for iter742 in self.aborted:
-                oprot.writeI64(iter742)
+            for iter749 in self.aborted:
+                oprot.writeI64(iter749)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.nosuch is not None:
             oprot.writeFieldBegin('nosuch', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.nosuch))
-            for iter743 in self.nosuch:
-                oprot.writeI64(iter743)
+            for iter750 in self.nosuch:
+                oprot.writeI64(iter750)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -15240,11 +15259,11 @@ class CompactionRequest(object):
             elif fid == 6:
                 if ftype == TType.MAP:
                     self.properties = {}
-                    (_ktype745, _vtype746, _size744) = iprot.readMapBegin()
-                    for _i748 in range(_size744):
-                        _key749 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val750 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.properties[_key749] = _val750
+                    (_ktype752, _vtype753, _size751) = iprot.readMapBegin()
+                    for _i755 in range(_size751):
+                        _key756 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val757 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.properties[_key756] = _val757
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -15291,9 +15310,9 @@ class CompactionRequest(object):
         if self.properties is not None:
             oprot.writeFieldBegin('properties', TType.MAP, 6)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
-            for kiter751, viter752 in self.properties.items():
-                oprot.writeString(kiter751.encode('utf-8') if sys.version_info[0] == 2 else kiter751)
-                oprot.writeString(viter752.encode('utf-8') if sys.version_info[0] == 2 else viter752)
+            for kiter758, viter759 in self.properties.items():
+                oprot.writeString(kiter758.encode('utf-8') if sys.version_info[0] == 2 else kiter758)
+                oprot.writeString(viter759.encode('utf-8') if sys.version_info[0] == 2 else viter759)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.initiatorId is not None:
@@ -16016,11 +16035,11 @@ class ShowCompactResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.compacts = []
-                    (_etype756, _size753) = iprot.readListBegin()
-                    for _i757 in range(_size753):
-                        _elem758 = ShowCompactResponseElement()
-                        _elem758.read(iprot)
-                        self.compacts.append(_elem758)
+                    (_etype763, _size760) = iprot.readListBegin()
+                    for _i764 in range(_size760):
+                        _elem765 = ShowCompactResponseElement()
+                        _elem765.read(iprot)
+                        self.compacts.append(_elem765)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16037,8 +16056,8 @@ class ShowCompactResponse(object):
         if self.compacts is not None:
             oprot.writeFieldBegin('compacts', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.compacts))
-            for iter759 in self.compacts:
-                iter759.write(oprot)
+            for iter766 in self.compacts:
+                iter766.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -16098,10 +16117,10 @@ class GetLatestCommittedCompactionInfoRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.partitionnames = []
-                    (_etype763, _size760) = iprot.readListBegin()
-                    for _i764 in range(_size760):
-                        _elem765 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionnames.append(_elem765)
+                    (_etype770, _size767) = iprot.readListBegin()
+                    for _i771 in range(_size767):
+                        _elem772 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionnames.append(_elem772)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16126,8 +16145,8 @@ class GetLatestCommittedCompactionInfoRequest(object):
         if self.partitionnames is not None:
             oprot.writeFieldBegin('partitionnames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.partitionnames))
-            for iter766 in self.partitionnames:
-                oprot.writeString(iter766.encode('utf-8') if sys.version_info[0] == 2 else iter766)
+            for iter773 in self.partitionnames:
+                oprot.writeString(iter773.encode('utf-8') if sys.version_info[0] == 2 else iter773)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -16175,11 +16194,11 @@ class GetLatestCommittedCompactionInfoResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.compactions = []
-                    (_etype770, _size767) = iprot.readListBegin()
-                    for _i771 in range(_size767):
-                        _elem772 = CompactionInfoStruct()
-                        _elem772.read(iprot)
-                        self.compactions.append(_elem772)
+                    (_etype777, _size774) = iprot.readListBegin()
+                    for _i778 in range(_size774):
+                        _elem779 = CompactionInfoStruct()
+                        _elem779.read(iprot)
+                        self.compactions.append(_elem779)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16196,8 +16215,8 @@ class GetLatestCommittedCompactionInfoResponse(object):
         if self.compactions is not None:
             oprot.writeFieldBegin('compactions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.compactions))
-            for iter773 in self.compactions:
-                iter773.write(oprot)
+            for iter780 in self.compactions:
+                iter780.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -16341,10 +16360,10 @@ class AddDynamicPartitions(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.partitionnames = []
-                    (_etype777, _size774) = iprot.readListBegin()
-                    for _i778 in range(_size774):
-                        _elem779 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionnames.append(_elem779)
+                    (_etype784, _size781) = iprot.readListBegin()
+                    for _i785 in range(_size781):
+                        _elem786 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionnames.append(_elem786)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16382,8 +16401,8 @@ class AddDynamicPartitions(object):
         if self.partitionnames is not None:
             oprot.writeFieldBegin('partitionnames', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.partitionnames))
-            for iter780 in self.partitionnames:
-                oprot.writeString(iter780.encode('utf-8') if sys.version_info[0] == 2 else iter780)
+            for iter787 in self.partitionnames:
+                oprot.writeString(iter787.encode('utf-8') if sys.version_info[0] == 2 else iter787)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.operationType is not None:
@@ -16569,10 +16588,10 @@ class NotificationEventRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.eventTypeSkipList = []
-                    (_etype784, _size781) = iprot.readListBegin()
-                    for _i785 in range(_size781):
-                        _elem786 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.eventTypeSkipList.append(_elem786)
+                    (_etype791, _size788) = iprot.readListBegin()
+                    for _i792 in range(_size788):
+                        _elem793 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.eventTypeSkipList.append(_elem793)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16597,8 +16616,8 @@ class NotificationEventRequest(object):
         if self.eventTypeSkipList is not None:
             oprot.writeFieldBegin('eventTypeSkipList', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.eventTypeSkipList))
-            for iter787 in self.eventTypeSkipList:
-                oprot.writeString(iter787.encode('utf-8') if sys.version_info[0] == 2 else iter787)
+            for iter794 in self.eventTypeSkipList:
+                oprot.writeString(iter794.encode('utf-8') if sys.version_info[0] == 2 else iter794)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -16786,11 +16805,11 @@ class NotificationEventResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.events = []
-                    (_etype791, _size788) = iprot.readListBegin()
-                    for _i792 in range(_size788):
-                        _elem793 = NotificationEvent()
-                        _elem793.read(iprot)
-                        self.events.append(_elem793)
+                    (_etype798, _size795) = iprot.readListBegin()
+                    for _i799 in range(_size795):
+                        _elem800 = NotificationEvent()
+                        _elem800.read(iprot)
+                        self.events.append(_elem800)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -16807,8 +16826,8 @@ class NotificationEventResponse(object):
         if self.events is not None:
             oprot.writeFieldBegin('events', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.events))
-            for iter794 in self.events:
-                iter794.write(oprot)
+            for iter801 in self.events:
+                iter801.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17090,40 +17109,40 @@ class InsertEventRequestData(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.filesAdded = []
-                    (_etype798, _size795) = iprot.readListBegin()
-                    for _i799 in range(_size795):
-                        _elem800 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.filesAdded.append(_elem800)
+                    (_etype805, _size802) = iprot.readListBegin()
+                    for _i806 in range(_size802):
+                        _elem807 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.filesAdded.append(_elem807)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.filesAddedChecksum = []
-                    (_etype804, _size801) = iprot.readListBegin()
-                    for _i805 in range(_size801):
-                        _elem806 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.filesAddedChecksum.append(_elem806)
+                    (_etype811, _size808) = iprot.readListBegin()
+                    for _i812 in range(_size808):
+                        _elem813 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.filesAddedChecksum.append(_elem813)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.subDirectoryList = []
-                    (_etype810, _size807) = iprot.readListBegin()
-                    for _i811 in range(_size807):
-                        _elem812 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.subDirectoryList.append(_elem812)
+                    (_etype817, _size814) = iprot.readListBegin()
+                    for _i818 in range(_size814):
+                        _elem819 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.subDirectoryList.append(_elem819)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.partitionVal = []
-                    (_etype816, _size813) = iprot.readListBegin()
-                    for _i817 in range(_size813):
-                        _elem818 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionVal.append(_elem818)
+                    (_etype823, _size820) = iprot.readListBegin()
+                    for _i824 in range(_size820):
+                        _elem825 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionVal.append(_elem825)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17144,29 +17163,29 @@ class InsertEventRequestData(object):
         if self.filesAdded is not None:
             oprot.writeFieldBegin('filesAdded', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.filesAdded))
-            for iter819 in self.filesAdded:
-                oprot.writeString(iter819.encode('utf-8') if sys.version_info[0] == 2 else iter819)
+            for iter826 in self.filesAdded:
+                oprot.writeString(iter826.encode('utf-8') if sys.version_info[0] == 2 else iter826)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.filesAddedChecksum is not None:
             oprot.writeFieldBegin('filesAddedChecksum', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.filesAddedChecksum))
-            for iter820 in self.filesAddedChecksum:
-                oprot.writeString(iter820.encode('utf-8') if sys.version_info[0] == 2 else iter820)
+            for iter827 in self.filesAddedChecksum:
+                oprot.writeString(iter827.encode('utf-8') if sys.version_info[0] == 2 else iter827)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.subDirectoryList is not None:
             oprot.writeFieldBegin('subDirectoryList', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.subDirectoryList))
-            for iter821 in self.subDirectoryList:
-                oprot.writeString(iter821.encode('utf-8') if sys.version_info[0] == 2 else iter821)
+            for iter828 in self.subDirectoryList:
+                oprot.writeString(iter828.encode('utf-8') if sys.version_info[0] == 2 else iter828)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.partitionVal is not None:
             oprot.writeFieldBegin('partitionVal', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.partitionVal))
-            for iter822 in self.partitionVal:
-                oprot.writeString(iter822.encode('utf-8') if sys.version_info[0] == 2 else iter822)
+            for iter829 in self.partitionVal:
+                oprot.writeString(iter829.encode('utf-8') if sys.version_info[0] == 2 else iter829)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17220,11 +17239,11 @@ class FireEventRequestData(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.insertDatas = []
-                    (_etype826, _size823) = iprot.readListBegin()
-                    for _i827 in range(_size823):
-                        _elem828 = InsertEventRequestData()
-                        _elem828.read(iprot)
-                        self.insertDatas.append(_elem828)
+                    (_etype833, _size830) = iprot.readListBegin()
+                    for _i834 in range(_size830):
+                        _elem835 = InsertEventRequestData()
+                        _elem835.read(iprot)
+                        self.insertDatas.append(_elem835)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17245,8 +17264,8 @@ class FireEventRequestData(object):
         if self.insertDatas is not None:
             oprot.writeFieldBegin('insertDatas', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.insertDatas))
-            for iter829 in self.insertDatas:
-                iter829.write(oprot)
+            for iter836 in self.insertDatas:
+                iter836.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17321,10 +17340,10 @@ class FireEventRequest(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.partitionVals = []
-                    (_etype833, _size830) = iprot.readListBegin()
-                    for _i834 in range(_size830):
-                        _elem835 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionVals.append(_elem835)
+                    (_etype840, _size837) = iprot.readListBegin()
+                    for _i841 in range(_size837):
+                        _elem842 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionVals.append(_elem842)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17362,8 +17381,8 @@ class FireEventRequest(object):
         if self.partitionVals is not None:
             oprot.writeFieldBegin('partitionVals', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.partitionVals))
-            for iter836 in self.partitionVals:
-                oprot.writeString(iter836.encode('utf-8') if sys.version_info[0] == 2 else iter836)
+            for iter843 in self.partitionVals:
+                oprot.writeString(iter843.encode('utf-8') if sys.version_info[0] == 2 else iter843)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.catName is not None:
@@ -17415,10 +17434,10 @@ class FireEventResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.eventIds = []
-                    (_etype840, _size837) = iprot.readListBegin()
-                    for _i841 in range(_size837):
-                        _elem842 = iprot.readI64()
-                        self.eventIds.append(_elem842)
+                    (_etype847, _size844) = iprot.readListBegin()
+                    for _i848 in range(_size844):
+                        _elem849 = iprot.readI64()
+                        self.eventIds.append(_elem849)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17435,8 +17454,8 @@ class FireEventResponse(object):
         if self.eventIds is not None:
             oprot.writeFieldBegin('eventIds', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.eventIds))
-            for iter843 in self.eventIds:
-                oprot.writeI64(iter843)
+            for iter850 in self.eventIds:
+                oprot.writeI64(iter850)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17516,10 +17535,10 @@ class WriteNotificationLogRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.partitionVals = []
-                    (_etype847, _size844) = iprot.readListBegin()
-                    for _i848 in range(_size844):
-                        _elem849 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partitionVals.append(_elem849)
+                    (_etype854, _size851) = iprot.readListBegin()
+                    for _i855 in range(_size851):
+                        _elem856 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partitionVals.append(_elem856)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17556,8 +17575,8 @@ class WriteNotificationLogRequest(object):
         if self.partitionVals is not None:
             oprot.writeFieldBegin('partitionVals', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.partitionVals))
-            for iter850 in self.partitionVals:
-                oprot.writeString(iter850.encode('utf-8') if sys.version_info[0] == 2 else iter850)
+            for iter857 in self.partitionVals:
+                oprot.writeString(iter857.encode('utf-8') if sys.version_info[0] == 2 else iter857)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17672,11 +17691,11 @@ class WriteNotificationLogBatchRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.requestList = []
-                    (_etype854, _size851) = iprot.readListBegin()
-                    for _i855 in range(_size851):
-                        _elem856 = WriteNotificationLogRequest()
-                        _elem856.read(iprot)
-                        self.requestList.append(_elem856)
+                    (_etype861, _size858) = iprot.readListBegin()
+                    for _i862 in range(_size858):
+                        _elem863 = WriteNotificationLogRequest()
+                        _elem863.read(iprot)
+                        self.requestList.append(_elem863)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17705,8 +17724,8 @@ class WriteNotificationLogBatchRequest(object):
         if self.requestList is not None:
             oprot.writeFieldBegin('requestList', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.requestList))
-            for iter857 in self.requestList:
-                iter857.write(oprot)
+            for iter864 in self.requestList:
+                iter864.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17868,12 +17887,12 @@ class GetFileMetadataByExprResult(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.metadata = {}
-                    (_ktype859, _vtype860, _size858) = iprot.readMapBegin()
-                    for _i862 in range(_size858):
-                        _key863 = iprot.readI64()
-                        _val864 = MetadataPpdResult()
-                        _val864.read(iprot)
-                        self.metadata[_key863] = _val864
+                    (_ktype866, _vtype867, _size865) = iprot.readMapBegin()
+                    for _i869 in range(_size865):
+                        _key870 = iprot.readI64()
+                        _val871 = MetadataPpdResult()
+                        _val871.read(iprot)
+                        self.metadata[_key870] = _val871
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -17895,9 +17914,9 @@ class GetFileMetadataByExprResult(object):
         if self.metadata is not None:
             oprot.writeFieldBegin('metadata', TType.MAP, 1)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.metadata))
-            for kiter865, viter866 in self.metadata.items():
-                oprot.writeI64(kiter865)
-                viter866.write(oprot)
+            for kiter872, viter873 in self.metadata.items():
+                oprot.writeI64(kiter872)
+                viter873.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.isSupported is not None:
@@ -17955,10 +17974,10 @@ class GetFileMetadataByExprRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fileIds = []
-                    (_etype870, _size867) = iprot.readListBegin()
-                    for _i871 in range(_size867):
-                        _elem872 = iprot.readI64()
-                        self.fileIds.append(_elem872)
+                    (_etype877, _size874) = iprot.readListBegin()
+                    for _i878 in range(_size874):
+                        _elem879 = iprot.readI64()
+                        self.fileIds.append(_elem879)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -17990,8 +18009,8 @@ class GetFileMetadataByExprRequest(object):
         if self.fileIds is not None:
             oprot.writeFieldBegin('fileIds', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.fileIds))
-            for iter873 in self.fileIds:
-                oprot.writeI64(iter873)
+            for iter880 in self.fileIds:
+                oprot.writeI64(iter880)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.expr is not None:
@@ -18053,11 +18072,11 @@ class GetFileMetadataResult(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.metadata = {}
-                    (_ktype875, _vtype876, _size874) = iprot.readMapBegin()
-                    for _i878 in range(_size874):
-                        _key879 = iprot.readI64()
-                        _val880 = iprot.readBinary()
-                        self.metadata[_key879] = _val880
+                    (_ktype882, _vtype883, _size881) = iprot.readMapBegin()
+                    for _i885 in range(_size881):
+                        _key886 = iprot.readI64()
+                        _val887 = iprot.readBinary()
+                        self.metadata[_key886] = _val887
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -18079,9 +18098,9 @@ class GetFileMetadataResult(object):
         if self.metadata is not None:
             oprot.writeFieldBegin('metadata', TType.MAP, 1)
             oprot.writeMapBegin(TType.I64, TType.STRING, len(self.metadata))
-            for kiter881, viter882 in self.metadata.items():
-                oprot.writeI64(kiter881)
-                oprot.writeBinary(viter882)
+            for kiter888, viter889 in self.metadata.items():
+                oprot.writeI64(kiter888)
+                oprot.writeBinary(viter889)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.isSupported is not None:
@@ -18133,10 +18152,10 @@ class GetFileMetadataRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fileIds = []
-                    (_etype886, _size883) = iprot.readListBegin()
-                    for _i887 in range(_size883):
-                        _elem888 = iprot.readI64()
-                        self.fileIds.append(_elem888)
+                    (_etype893, _size890) = iprot.readListBegin()
+                    for _i894 in range(_size890):
+                        _elem895 = iprot.readI64()
+                        self.fileIds.append(_elem895)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18153,8 +18172,8 @@ class GetFileMetadataRequest(object):
         if self.fileIds is not None:
             oprot.writeFieldBegin('fileIds', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.fileIds))
-            for iter889 in self.fileIds:
-                oprot.writeI64(iter889)
+            for iter896 in self.fileIds:
+                oprot.writeI64(iter896)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -18244,20 +18263,20 @@ class PutFileMetadataRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fileIds = []
-                    (_etype893, _size890) = iprot.readListBegin()
-                    for _i894 in range(_size890):
-                        _elem895 = iprot.readI64()
-                        self.fileIds.append(_elem895)
+                    (_etype900, _size897) = iprot.readListBegin()
+                    for _i901 in range(_size897):
+                        _elem902 = iprot.readI64()
+                        self.fileIds.append(_elem902)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.metadata = []
-                    (_etype899, _size896) = iprot.readListBegin()
-                    for _i900 in range(_size896):
-                        _elem901 = iprot.readBinary()
-                        self.metadata.append(_elem901)
+                    (_etype906, _size903) = iprot.readListBegin()
+                    for _i907 in range(_size903):
+                        _elem908 = iprot.readBinary()
+                        self.metadata.append(_elem908)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18279,15 +18298,15 @@ class PutFileMetadataRequest(object):
         if self.fileIds is not None:
             oprot.writeFieldBegin('fileIds', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.fileIds))
-            for iter902 in self.fileIds:
-                oprot.writeI64(iter902)
+            for iter909 in self.fileIds:
+                oprot.writeI64(iter909)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.metadata is not None:
             oprot.writeFieldBegin('metadata', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.metadata))
-            for iter903 in self.metadata:
-                oprot.writeBinary(iter903)
+            for iter910 in self.metadata:
+                oprot.writeBinary(iter910)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.type is not None:
@@ -18379,10 +18398,10 @@ class ClearFileMetadataRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fileIds = []
-                    (_etype907, _size904) = iprot.readListBegin()
-                    for _i908 in range(_size904):
-                        _elem909 = iprot.readI64()
-                        self.fileIds.append(_elem909)
+                    (_etype914, _size911) = iprot.readListBegin()
+                    for _i915 in range(_size911):
+                        _elem916 = iprot.readI64()
+                        self.fileIds.append(_elem916)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18399,8 +18418,8 @@ class ClearFileMetadataRequest(object):
         if self.fileIds is not None:
             oprot.writeFieldBegin('fileIds', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.fileIds))
-            for iter910 in self.fileIds:
-                oprot.writeI64(iter910)
+            for iter917 in self.fileIds:
+                oprot.writeI64(iter917)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -18599,11 +18618,11 @@ class GetAllFunctionsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.functions = []
-                    (_etype914, _size911) = iprot.readListBegin()
-                    for _i915 in range(_size911):
-                        _elem916 = Function()
-                        _elem916.read(iprot)
-                        self.functions.append(_elem916)
+                    (_etype921, _size918) = iprot.readListBegin()
+                    for _i922 in range(_size918):
+                        _elem923 = Function()
+                        _elem923.read(iprot)
+                        self.functions.append(_elem923)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18620,8 +18639,8 @@ class GetAllFunctionsResponse(object):
         if self.functions is not None:
             oprot.writeFieldBegin('functions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.functions))
-            for iter917 in self.functions:
-                iter917.write(oprot)
+            for iter924 in self.functions:
+                iter924.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -18665,10 +18684,10 @@ class ClientCapabilities(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.values = []
-                    (_etype921, _size918) = iprot.readListBegin()
-                    for _i922 in range(_size918):
-                        _elem923 = iprot.readI32()
-                        self.values.append(_elem923)
+                    (_etype928, _size925) = iprot.readListBegin()
+                    for _i929 in range(_size925):
+                        _elem930 = iprot.readI32()
+                        self.values.append(_elem930)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18685,8 +18704,8 @@ class ClientCapabilities(object):
         if self.values is not None:
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.I32, len(self.values))
-            for iter924 in self.values:
-                oprot.writeI32(iter924)
+            for iter931 in self.values:
+                oprot.writeI32(iter931)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -18736,10 +18755,10 @@ class GetProjectionsSpec(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fieldList = []
-                    (_etype928, _size925) = iprot.readListBegin()
-                    for _i929 in range(_size925):
-                        _elem930 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.fieldList.append(_elem930)
+                    (_etype935, _size932) = iprot.readListBegin()
+                    for _i936 in range(_size932):
+                        _elem937 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.fieldList.append(_elem937)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18766,8 +18785,8 @@ class GetProjectionsSpec(object):
         if self.fieldList is not None:
             oprot.writeFieldBegin('fieldList', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.fieldList))
-            for iter931 in self.fieldList:
-                oprot.writeString(iter931.encode('utf-8') if sys.version_info[0] == 2 else iter931)
+            for iter938 in self.fieldList:
+                oprot.writeString(iter938.encode('utf-8') if sys.version_info[0] == 2 else iter938)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.includeParamKeyPattern is not None:
@@ -18868,10 +18887,10 @@ class GetTableRequest(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype935, _size932) = iprot.readListBegin()
-                    for _i936 in range(_size932):
-                        _elem937 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem937)
+                    (_etype942, _size939) = iprot.readListBegin()
+                    for _i943 in range(_size939):
+                        _elem944 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem944)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -18927,8 +18946,8 @@ class GetTableRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter938 in self.processorCapabilities:
-                oprot.writeString(iter938.encode('utf-8') if sys.version_info[0] == 2 else iter938)
+            for iter945 in self.processorCapabilities:
+                oprot.writeString(iter945.encode('utf-8') if sys.version_info[0] == 2 else iter945)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -19078,10 +19097,10 @@ class GetTablesRequest(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.tblNames = []
-                    (_etype942, _size939) = iprot.readListBegin()
-                    for _i943 in range(_size939):
-                        _elem944 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tblNames.append(_elem944)
+                    (_etype949, _size946) = iprot.readListBegin()
+                    for _i950 in range(_size946):
+                        _elem951 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.tblNames.append(_elem951)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19099,10 +19118,10 @@ class GetTablesRequest(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype948, _size945) = iprot.readListBegin()
-                    for _i949 in range(_size945):
-                        _elem950 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem950)
+                    (_etype955, _size952) = iprot.readListBegin()
+                    for _i956 in range(_size952):
+                        _elem957 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem957)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19139,8 +19158,8 @@ class GetTablesRequest(object):
         if self.tblNames is not None:
             oprot.writeFieldBegin('tblNames', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.tblNames))
-            for iter951 in self.tblNames:
-                oprot.writeString(iter951.encode('utf-8') if sys.version_info[0] == 2 else iter951)
+            for iter958 in self.tblNames:
+                oprot.writeString(iter958.encode('utf-8') if sys.version_info[0] == 2 else iter958)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.capabilities is not None:
@@ -19154,8 +19173,8 @@ class GetTablesRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter952 in self.processorCapabilities:
-                oprot.writeString(iter952.encode('utf-8') if sys.version_info[0] == 2 else iter952)
+            for iter959 in self.processorCapabilities:
+                oprot.writeString(iter959.encode('utf-8') if sys.version_info[0] == 2 else iter959)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -19213,11 +19232,11 @@ class GetTablesResult(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.tables = []
-                    (_etype956, _size953) = iprot.readListBegin()
-                    for _i957 in range(_size953):
-                        _elem958 = Table()
-                        _elem958.read(iprot)
-                        self.tables.append(_elem958)
+                    (_etype963, _size960) = iprot.readListBegin()
+                    for _i964 in range(_size960):
+                        _elem965 = Table()
+                        _elem965.read(iprot)
+                        self.tables.append(_elem965)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19234,8 +19253,8 @@ class GetTablesResult(object):
         if self.tables is not None:
             oprot.writeFieldBegin('tables', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.tables))
-            for iter959 in self.tables:
-                iter959.write(oprot)
+            for iter966 in self.tables:
+                iter966.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -19318,10 +19337,10 @@ class GetTablesExtRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype963, _size960) = iprot.readListBegin()
-                    for _i964 in range(_size960):
-                        _elem965 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem965)
+                    (_etype970, _size967) = iprot.readListBegin()
+                    for _i971 in range(_size967):
+                        _elem972 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem972)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19363,8 +19382,8 @@ class GetTablesExtRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter966 in self.processorCapabilities:
-                oprot.writeString(iter966.encode('utf-8') if sys.version_info[0] == 2 else iter966)
+            for iter973 in self.processorCapabilities:
+                oprot.writeString(iter973.encode('utf-8') if sys.version_info[0] == 2 else iter973)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -19436,20 +19455,20 @@ class ExtendedTableInfo(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.requiredReadCapabilities = []
-                    (_etype970, _size967) = iprot.readListBegin()
-                    for _i971 in range(_size967):
-                        _elem972 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredReadCapabilities.append(_elem972)
+                    (_etype977, _size974) = iprot.readListBegin()
+                    for _i978 in range(_size974):
+                        _elem979 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredReadCapabilities.append(_elem979)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.requiredWriteCapabilities = []
-                    (_etype976, _size973) = iprot.readListBegin()
-                    for _i977 in range(_size973):
-                        _elem978 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.requiredWriteCapabilities.append(_elem978)
+                    (_etype983, _size980) = iprot.readListBegin()
+                    for _i984 in range(_size980):
+                        _elem985 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.requiredWriteCapabilities.append(_elem985)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19474,15 +19493,15 @@ class ExtendedTableInfo(object):
         if self.requiredReadCapabilities is not None:
             oprot.writeFieldBegin('requiredReadCapabilities', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.requiredReadCapabilities))
-            for iter979 in self.requiredReadCapabilities:
-                oprot.writeString(iter979.encode('utf-8') if sys.version_info[0] == 2 else iter979)
+            for iter986 in self.requiredReadCapabilities:
+                oprot.writeString(iter986.encode('utf-8') if sys.version_info[0] == 2 else iter986)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.requiredWriteCapabilities is not None:
             oprot.writeFieldBegin('requiredWriteCapabilities', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.requiredWriteCapabilities))
-            for iter980 in self.requiredWriteCapabilities:
-                oprot.writeString(iter980.encode('utf-8') if sys.version_info[0] == 2 else iter980)
+            for iter987 in self.requiredWriteCapabilities:
+                oprot.writeString(iter987.encode('utf-8') if sys.version_info[0] == 2 else iter987)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -19544,10 +19563,10 @@ class GetDatabaseRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype984, _size981) = iprot.readListBegin()
-                    for _i985 in range(_size981):
-                        _elem986 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem986)
+                    (_etype991, _size988) = iprot.readListBegin()
+                    for _i992 in range(_size988):
+                        _elem993 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem993)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -19577,8 +19596,8 @@ class GetDatabaseRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter987 in self.processorCapabilities:
-                oprot.writeString(iter987.encode('utf-8') if sys.version_info[0] == 2 else iter987)
+            for iter994 in self.processorCapabilities:
+                oprot.writeString(iter994.encode('utf-8') if sys.version_info[0] == 2 else iter994)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -20717,44 +20736,44 @@ class WMFullResourcePlan(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.pools = []
-                    (_etype991, _size988) = iprot.readListBegin()
-                    for _i992 in range(_size988):
-                        _elem993 = WMPool()
-                        _elem993.read(iprot)
-                        self.pools.append(_elem993)
+                    (_etype998, _size995) = iprot.readListBegin()
+                    for _i999 in range(_size995):
+                        _elem1000 = WMPool()
+                        _elem1000.read(iprot)
+                        self.pools.append(_elem1000)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.mappings = []
-                    (_etype997, _size994) = iprot.readListBegin()
-                    for _i998 in range(_size994):
-                        _elem999 = WMMapping()
-                        _elem999.read(iprot)
-                        self.mappings.append(_elem999)
+                    (_etype1004, _size1001) = iprot.readListBegin()
+                    for _i1005 in range(_size1001):
+                        _elem1006 = WMMapping()
+                        _elem1006.read(iprot)
+                        self.mappings.append(_elem1006)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.triggers = []
-                    (_etype1003, _size1000) = iprot.readListBegin()
-                    for _i1004 in range(_size1000):
-                        _elem1005 = WMTrigger()
-                        _elem1005.read(iprot)
-                        self.triggers.append(_elem1005)
+                    (_etype1010, _size1007) = iprot.readListBegin()
+                    for _i1011 in range(_size1007):
+                        _elem1012 = WMTrigger()
+                        _elem1012.read(iprot)
+                        self.triggers.append(_elem1012)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.poolTriggers = []
-                    (_etype1009, _size1006) = iprot.readListBegin()
-                    for _i1010 in range(_size1006):
-                        _elem1011 = WMPoolTrigger()
-                        _elem1011.read(iprot)
-                        self.poolTriggers.append(_elem1011)
+                    (_etype1016, _size1013) = iprot.readListBegin()
+                    for _i1017 in range(_size1013):
+                        _elem1018 = WMPoolTrigger()
+                        _elem1018.read(iprot)
+                        self.poolTriggers.append(_elem1018)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -20775,29 +20794,29 @@ class WMFullResourcePlan(object):
         if self.pools is not None:
             oprot.writeFieldBegin('pools', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.pools))
-            for iter1012 in self.pools:
-                iter1012.write(oprot)
+            for iter1019 in self.pools:
+                iter1019.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.mappings is not None:
             oprot.writeFieldBegin('mappings', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.mappings))
-            for iter1013 in self.mappings:
-                iter1013.write(oprot)
+            for iter1020 in self.mappings:
+                iter1020.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.triggers is not None:
             oprot.writeFieldBegin('triggers', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.triggers))
-            for iter1014 in self.triggers:
-                iter1014.write(oprot)
+            for iter1021 in self.triggers:
+                iter1021.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.poolTriggers is not None:
             oprot.writeFieldBegin('poolTriggers', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.poolTriggers))
-            for iter1015 in self.poolTriggers:
-                iter1015.write(oprot)
+            for iter1022 in self.poolTriggers:
+                iter1022.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -21252,11 +21271,11 @@ class WMGetAllResourcePlanResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.resourcePlans = []
-                    (_etype1019, _size1016) = iprot.readListBegin()
-                    for _i1020 in range(_size1016):
-                        _elem1021 = WMResourcePlan()
-                        _elem1021.read(iprot)
-                        self.resourcePlans.append(_elem1021)
+                    (_etype1026, _size1023) = iprot.readListBegin()
+                    for _i1027 in range(_size1023):
+                        _elem1028 = WMResourcePlan()
+                        _elem1028.read(iprot)
+                        self.resourcePlans.append(_elem1028)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -21273,8 +21292,8 @@ class WMGetAllResourcePlanResponse(object):
         if self.resourcePlans is not None:
             oprot.writeFieldBegin('resourcePlans', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.resourcePlans))
-            for iter1022 in self.resourcePlans:
-                iter1022.write(oprot)
+            for iter1029 in self.resourcePlans:
+                iter1029.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -21559,20 +21578,20 @@ class WMValidateResourcePlanResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.errors = []
-                    (_etype1026, _size1023) = iprot.readListBegin()
-                    for _i1027 in range(_size1023):
-                        _elem1028 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.errors.append(_elem1028)
+                    (_etype1033, _size1030) = iprot.readListBegin()
+                    for _i1034 in range(_size1030):
+                        _elem1035 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.errors.append(_elem1035)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.warnings = []
-                    (_etype1032, _size1029) = iprot.readListBegin()
-                    for _i1033 in range(_size1029):
-                        _elem1034 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.warnings.append(_elem1034)
+                    (_etype1039, _size1036) = iprot.readListBegin()
+                    for _i1040 in range(_size1036):
+                        _elem1041 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.warnings.append(_elem1041)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -21589,15 +21608,15 @@ class WMValidateResourcePlanResponse(object):
         if self.errors is not None:
             oprot.writeFieldBegin('errors', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.errors))
-            for iter1035 in self.errors:
-                oprot.writeString(iter1035.encode('utf-8') if sys.version_info[0] == 2 else iter1035)
+            for iter1042 in self.errors:
+                oprot.writeString(iter1042.encode('utf-8') if sys.version_info[0] == 2 else iter1042)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.warnings is not None:
             oprot.writeFieldBegin('warnings', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.warnings))
-            for iter1036 in self.warnings:
-                oprot.writeString(iter1036.encode('utf-8') if sys.version_info[0] == 2 else iter1036)
+            for iter1043 in self.warnings:
+                oprot.writeString(iter1043.encode('utf-8') if sys.version_info[0] == 2 else iter1043)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -22132,11 +22151,11 @@ class WMGetTriggersForResourePlanResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.triggers = []
-                    (_etype1040, _size1037) = iprot.readListBegin()
-                    for _i1041 in range(_size1037):
-                        _elem1042 = WMTrigger()
-                        _elem1042.read(iprot)
-                        self.triggers.append(_elem1042)
+                    (_etype1047, _size1044) = iprot.readListBegin()
+                    for _i1048 in range(_size1044):
+                        _elem1049 = WMTrigger()
+                        _elem1049.read(iprot)
+                        self.triggers.append(_elem1049)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -22153,8 +22172,8 @@ class WMGetTriggersForResourePlanResponse(object):
         if self.triggers is not None:
             oprot.writeFieldBegin('triggers', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.triggers))
-            for iter1043 in self.triggers:
-                iter1043.write(oprot)
+            for iter1050 in self.triggers:
+                iter1050.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -23200,11 +23219,11 @@ class SchemaVersion(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.cols = []
-                    (_etype1047, _size1044) = iprot.readListBegin()
-                    for _i1048 in range(_size1044):
-                        _elem1049 = FieldSchema()
-                        _elem1049.read(iprot)
-                        self.cols.append(_elem1049)
+                    (_etype1054, _size1051) = iprot.readListBegin()
+                    for _i1055 in range(_size1051):
+                        _elem1056 = FieldSchema()
+                        _elem1056.read(iprot)
+                        self.cols.append(_elem1056)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23264,8 +23283,8 @@ class SchemaVersion(object):
         if self.cols is not None:
             oprot.writeFieldBegin('cols', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.cols))
-            for iter1050 in self.cols:
-                iter1050.write(oprot)
+            for iter1057 in self.cols:
+                iter1057.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.state is not None:
@@ -23481,11 +23500,11 @@ class FindSchemasByColsResp(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.schemaVersions = []
-                    (_etype1054, _size1051) = iprot.readListBegin()
-                    for _i1055 in range(_size1051):
-                        _elem1056 = SchemaVersionDescriptor()
-                        _elem1056.read(iprot)
-                        self.schemaVersions.append(_elem1056)
+                    (_etype1061, _size1058) = iprot.readListBegin()
+                    for _i1062 in range(_size1058):
+                        _elem1063 = SchemaVersionDescriptor()
+                        _elem1063.read(iprot)
+                        self.schemaVersions.append(_elem1063)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -23502,8 +23521,8 @@ class FindSchemasByColsResp(object):
         if self.schemaVersions is not None:
             oprot.writeFieldBegin('schemaVersions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.schemaVersions))
-            for iter1057 in self.schemaVersions:
-                iter1057.write(oprot)
+            for iter1064 in self.schemaVersions:
+                iter1064.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -23927,76 +23946,76 @@ class CreateTableRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.primaryKeys = []
-                    (_etype1061, _size1058) = iprot.readListBegin()
-                    for _i1062 in range(_size1058):
-                        _elem1063 = SQLPrimaryKey()
-                        _elem1063.read(iprot)
-                        self.primaryKeys.append(_elem1063)
+                    (_etype1068, _size1065) = iprot.readListBegin()
+                    for _i1069 in range(_size1065):
+                        _elem1070 = SQLPrimaryKey()
+                        _elem1070.read(iprot)
+                        self.primaryKeys.append(_elem1070)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.foreignKeys = []
-                    (_etype1067, _size1064) = iprot.readListBegin()
-                    for _i1068 in range(_size1064):
-                        _elem1069 = SQLForeignKey()
-                        _elem1069.read(iprot)
-                        self.foreignKeys.append(_elem1069)
+                    (_etype1074, _size1071) = iprot.readListBegin()
+                    for _i1075 in range(_size1071):
+                        _elem1076 = SQLForeignKey()
+                        _elem1076.read(iprot)
+                        self.foreignKeys.append(_elem1076)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.uniqueConstraints = []
-                    (_etype1073, _size1070) = iprot.readListBegin()
-                    for _i1074 in range(_size1070):
-                        _elem1075 = SQLUniqueConstraint()
-                        _elem1075.read(iprot)
-                        self.uniqueConstraints.append(_elem1075)
+                    (_etype1080, _size1077) = iprot.readListBegin()
+                    for _i1081 in range(_size1077):
+                        _elem1082 = SQLUniqueConstraint()
+                        _elem1082.read(iprot)
+                        self.uniqueConstraints.append(_elem1082)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.notNullConstraints = []
-                    (_etype1079, _size1076) = iprot.readListBegin()
-                    for _i1080 in range(_size1076):
-                        _elem1081 = SQLNotNullConstraint()
-                        _elem1081.read(iprot)
-                        self.notNullConstraints.append(_elem1081)
+                    (_etype1086, _size1083) = iprot.readListBegin()
+                    for _i1087 in range(_size1083):
+                        _elem1088 = SQLNotNullConstraint()
+                        _elem1088.read(iprot)
+                        self.notNullConstraints.append(_elem1088)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.LIST:
                     self.defaultConstraints = []
-                    (_etype1085, _size1082) = iprot.readListBegin()
-                    for _i1086 in range(_size1082):
-                        _elem1087 = SQLDefaultConstraint()
-                        _elem1087.read(iprot)
-                        self.defaultConstraints.append(_elem1087)
+                    (_etype1092, _size1089) = iprot.readListBegin()
+                    for _i1093 in range(_size1089):
+                        _elem1094 = SQLDefaultConstraint()
+                        _elem1094.read(iprot)
+                        self.defaultConstraints.append(_elem1094)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.checkConstraints = []
-                    (_etype1091, _size1088) = iprot.readListBegin()
-                    for _i1092 in range(_size1088):
-                        _elem1093 = SQLCheckConstraint()
-                        _elem1093.read(iprot)
-                        self.checkConstraints.append(_elem1093)
+                    (_etype1098, _size1095) = iprot.readListBegin()
+                    for _i1099 in range(_size1095):
+                        _elem1100 = SQLCheckConstraint()
+                        _elem1100.read(iprot)
+                        self.checkConstraints.append(_elem1100)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype1097, _size1094) = iprot.readListBegin()
-                    for _i1098 in range(_size1094):
-                        _elem1099 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem1099)
+                    (_etype1104, _size1101) = iprot.readListBegin()
+                    for _i1105 in range(_size1101):
+                        _elem1106 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem1106)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -24026,50 +24045,50 @@ class CreateTableRequest(object):
         if self.primaryKeys is not None:
             oprot.writeFieldBegin('primaryKeys', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.primaryKeys))
-            for iter1100 in self.primaryKeys:
-                iter1100.write(oprot)
+            for iter1107 in self.primaryKeys:
+                iter1107.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.foreignKeys is not None:
             oprot.writeFieldBegin('foreignKeys', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.foreignKeys))
-            for iter1101 in self.foreignKeys:
-                iter1101.write(oprot)
+            for iter1108 in self.foreignKeys:
+                iter1108.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.uniqueConstraints is not None:
             oprot.writeFieldBegin('uniqueConstraints', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.uniqueConstraints))
-            for iter1102 in self.uniqueConstraints:
-                iter1102.write(oprot)
+            for iter1109 in self.uniqueConstraints:
+                iter1109.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.notNullConstraints is not None:
             oprot.writeFieldBegin('notNullConstraints', TType.LIST, 6)
             oprot.writeListBegin(TType.STRUCT, len(self.notNullConstraints))
-            for iter1103 in self.notNullConstraints:
-                iter1103.write(oprot)
+            for iter1110 in self.notNullConstraints:
+                iter1110.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.defaultConstraints is not None:
             oprot.writeFieldBegin('defaultConstraints', TType.LIST, 7)
             oprot.writeListBegin(TType.STRUCT, len(self.defaultConstraints))
-            for iter1104 in self.defaultConstraints:
-                iter1104.write(oprot)
+            for iter1111 in self.defaultConstraints:
+                iter1111.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.checkConstraints is not None:
             oprot.writeFieldBegin('checkConstraints', TType.LIST, 8)
             oprot.writeListBegin(TType.STRUCT, len(self.checkConstraints))
-            for iter1105 in self.checkConstraints:
-                iter1105.write(oprot)
+            for iter1112 in self.checkConstraints:
+                iter1112.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 9)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter1106 in self.processorCapabilities:
-                oprot.writeString(iter1106.encode('utf-8') if sys.version_info[0] == 2 else iter1106)
+            for iter1113 in self.processorCapabilities:
+                oprot.writeString(iter1113.encode('utf-8') if sys.version_info[0] == 2 else iter1113)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -24156,11 +24175,11 @@ class CreateDatabaseRequest(object):
             elif fid == 4:
                 if ftype == TType.MAP:
                     self.parameters = {}
-                    (_ktype1108, _vtype1109, _size1107) = iprot.readMapBegin()
-                    for _i1111 in range(_size1107):
-                        _key1112 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val1113 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.parameters[_key1112] = _val1113
+                    (_ktype1115, _vtype1116, _size1114) = iprot.readMapBegin()
+                    for _i1118 in range(_size1114):
+                        _key1119 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val1120 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.parameters[_key1119] = _val1120
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -24230,9 +24249,9 @@ class CreateDatabaseRequest(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
-            for kiter1114, viter1115 in self.parameters.items():
-                oprot.writeString(kiter1114.encode('utf-8') if sys.version_info[0] == 2 else kiter1114)
-                oprot.writeString(viter1115.encode('utf-8') if sys.version_info[0] == 2 else viter1115)
+            for kiter1121, viter1122 in self.parameters.items():
+                oprot.writeString(kiter1121.encode('utf-8') if sys.version_info[0] == 2 else kiter1121)
+                oprot.writeString(viter1122.encode('utf-8') if sys.version_info[0] == 2 else viter1122)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -24960,11 +24979,11 @@ class AlterPartitionsRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype1119, _size1116) = iprot.readListBegin()
-                    for _i1120 in range(_size1116):
-                        _elem1121 = Partition()
-                        _elem1121.read(iprot)
-                        self.partitions.append(_elem1121)
+                    (_etype1126, _size1123) = iprot.readListBegin()
+                    for _i1127 in range(_size1123):
+                        _elem1128 = Partition()
+                        _elem1128.read(iprot)
+                        self.partitions.append(_elem1128)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25009,8 +25028,8 @@ class AlterPartitionsRequest(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter1122 in self.partitions:
-                iter1122.write(oprot)
+            for iter1129 in self.partitions:
+                iter1129.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.environmentContext is not None:
@@ -25137,10 +25156,10 @@ class RenamePartitionRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partVals = []
-                    (_etype1126, _size1123) = iprot.readListBegin()
-                    for _i1127 in range(_size1123):
-                        _elem1128 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partVals.append(_elem1128)
+                    (_etype1133, _size1130) = iprot.readListBegin()
+                    for _i1134 in range(_size1130):
+                        _elem1135 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partVals.append(_elem1135)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25180,8 +25199,8 @@ class RenamePartitionRequest(object):
         if self.partVals is not None:
             oprot.writeFieldBegin('partVals', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partVals))
-            for iter1129 in self.partVals:
-                oprot.writeString(iter1129.encode('utf-8') if sys.version_info[0] == 2 else iter1129)
+            for iter1136 in self.partVals:
+                oprot.writeString(iter1136.encode('utf-8') if sys.version_info[0] == 2 else iter1136)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.newPart is not None:
@@ -25334,10 +25353,10 @@ class AlterTableRequest(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype1133, _size1130) = iprot.readListBegin()
-                    for _i1134 in range(_size1130):
-                        _elem1135 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem1135)
+                    (_etype1140, _size1137) = iprot.readListBegin()
+                    for _i1141 in range(_size1137):
+                        _elem1142 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem1142)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25387,8 +25406,8 @@ class AlterTableRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter1136 in self.processorCapabilities:
-                oprot.writeString(iter1136.encode('utf-8') if sys.version_info[0] == 2 else iter1136)
+            for iter1143 in self.processorCapabilities:
+                oprot.writeString(iter1143.encode('utf-8') if sys.version_info[0] == 2 else iter1143)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -25489,10 +25508,10 @@ class GetPartitionsFilterSpec(object):
             elif fid == 8:
                 if ftype == TType.LIST:
                     self.filters = []
-                    (_etype1140, _size1137) = iprot.readListBegin()
-                    for _i1141 in range(_size1137):
-                        _elem1142 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.filters.append(_elem1142)
+                    (_etype1147, _size1144) = iprot.readListBegin()
+                    for _i1148 in range(_size1144):
+                        _elem1149 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.filters.append(_elem1149)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25513,8 +25532,8 @@ class GetPartitionsFilterSpec(object):
         if self.filters is not None:
             oprot.writeFieldBegin('filters', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.filters))
-            for iter1143 in self.filters:
-                oprot.writeString(iter1143.encode('utf-8') if sys.version_info[0] == 2 else iter1143)
+            for iter1150 in self.filters:
+                oprot.writeString(iter1150.encode('utf-8') if sys.version_info[0] == 2 else iter1150)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -25558,11 +25577,11 @@ class GetPartitionsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitionSpec = []
-                    (_etype1147, _size1144) = iprot.readListBegin()
-                    for _i1148 in range(_size1144):
-                        _elem1149 = PartitionSpec()
-                        _elem1149.read(iprot)
-                        self.partitionSpec.append(_elem1149)
+                    (_etype1154, _size1151) = iprot.readListBegin()
+                    for _i1155 in range(_size1151):
+                        _elem1156 = PartitionSpec()
+                        _elem1156.read(iprot)
+                        self.partitionSpec.append(_elem1156)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25579,8 +25598,8 @@ class GetPartitionsResponse(object):
         if self.partitionSpec is not None:
             oprot.writeFieldBegin('partitionSpec', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitionSpec))
-            for iter1150 in self.partitionSpec:
-                iter1150.write(oprot)
+            for iter1157 in self.partitionSpec:
+                iter1157.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -25669,10 +25688,10 @@ class GetPartitionsRequest(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.groupNames = []
-                    (_etype1154, _size1151) = iprot.readListBegin()
-                    for _i1155 in range(_size1151):
-                        _elem1156 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.groupNames.append(_elem1156)
+                    (_etype1161, _size1158) = iprot.readListBegin()
+                    for _i1162 in range(_size1158):
+                        _elem1163 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.groupNames.append(_elem1163)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25691,10 +25710,10 @@ class GetPartitionsRequest(object):
             elif fid == 9:
                 if ftype == TType.LIST:
                     self.processorCapabilities = []
-                    (_etype1160, _size1157) = iprot.readListBegin()
-                    for _i1161 in range(_size1157):
-                        _elem1162 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.processorCapabilities.append(_elem1162)
+                    (_etype1167, _size1164) = iprot.readListBegin()
+                    for _i1168 in range(_size1164):
+                        _elem1169 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.processorCapabilities.append(_elem1169)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25741,8 +25760,8 @@ class GetPartitionsRequest(object):
         if self.groupNames is not None:
             oprot.writeFieldBegin('groupNames', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.groupNames))
-            for iter1163 in self.groupNames:
-                oprot.writeString(iter1163.encode('utf-8') if sys.version_info[0] == 2 else iter1163)
+            for iter1170 in self.groupNames:
+                oprot.writeString(iter1170.encode('utf-8') if sys.version_info[0] == 2 else iter1170)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.projectionSpec is not None:
@@ -25756,8 +25775,8 @@ class GetPartitionsRequest(object):
         if self.processorCapabilities is not None:
             oprot.writeFieldBegin('processorCapabilities', TType.LIST, 9)
             oprot.writeListBegin(TType.STRING, len(self.processorCapabilities))
-            for iter1164 in self.processorCapabilities:
-                oprot.writeString(iter1164.encode('utf-8') if sys.version_info[0] == 2 else iter1164)
+            for iter1171 in self.processorCapabilities:
+                oprot.writeString(iter1171.encode('utf-8') if sys.version_info[0] == 2 else iter1171)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.processorIdentifier is not None:
@@ -25926,11 +25945,11 @@ class GetFieldsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fields = []
-                    (_etype1168, _size1165) = iprot.readListBegin()
-                    for _i1169 in range(_size1165):
-                        _elem1170 = FieldSchema()
-                        _elem1170.read(iprot)
-                        self.fields.append(_elem1170)
+                    (_etype1175, _size1172) = iprot.readListBegin()
+                    for _i1176 in range(_size1172):
+                        _elem1177 = FieldSchema()
+                        _elem1177.read(iprot)
+                        self.fields.append(_elem1177)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -25947,8 +25966,8 @@ class GetFieldsResponse(object):
         if self.fields is not None:
             oprot.writeFieldBegin('fields', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.fields))
-            for iter1171 in self.fields:
-                iter1171.write(oprot)
+            for iter1178 in self.fields:
+                iter1178.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26111,11 +26130,11 @@ class GetSchemaResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.fields = []
-                    (_etype1175, _size1172) = iprot.readListBegin()
-                    for _i1176 in range(_size1172):
-                        _elem1177 = FieldSchema()
-                        _elem1177.read(iprot)
-                        self.fields.append(_elem1177)
+                    (_etype1182, _size1179) = iprot.readListBegin()
+                    for _i1183 in range(_size1179):
+                        _elem1184 = FieldSchema()
+                        _elem1184.read(iprot)
+                        self.fields.append(_elem1184)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26132,8 +26151,8 @@ class GetSchemaResponse(object):
         if self.fields is not None:
             oprot.writeFieldBegin('fields', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.fields))
-            for iter1178 in self.fields:
-                iter1178.write(oprot)
+            for iter1185 in self.fields:
+                iter1185.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26204,10 +26223,10 @@ class GetPartitionRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partVals = []
-                    (_etype1182, _size1179) = iprot.readListBegin()
-                    for _i1183 in range(_size1179):
-                        _elem1184 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partVals.append(_elem1184)
+                    (_etype1189, _size1186) = iprot.readListBegin()
+                    for _i1190 in range(_size1186):
+                        _elem1191 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partVals.append(_elem1191)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26246,8 +26265,8 @@ class GetPartitionRequest(object):
         if self.partVals is not None:
             oprot.writeFieldBegin('partVals', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partVals))
-            for iter1185 in self.partVals:
-                oprot.writeString(iter1185.encode('utf-8') if sys.version_info[0] == 2 else iter1185)
+            for iter1192 in self.partVals:
+                oprot.writeString(iter1192.encode('utf-8') if sys.version_info[0] == 2 else iter1192)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.validWriteIdList is not None:
@@ -26481,11 +26500,11 @@ class PartitionsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype1189, _size1186) = iprot.readListBegin()
-                    for _i1190 in range(_size1186):
-                        _elem1191 = Partition()
-                        _elem1191.read(iprot)
-                        self.partitions.append(_elem1191)
+                    (_etype1196, _size1193) = iprot.readListBegin()
+                    for _i1197 in range(_size1193):
+                        _elem1198 = Partition()
+                        _elem1198.read(iprot)
+                        self.partitions.append(_elem1198)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26502,8 +26521,8 @@ class PartitionsResponse(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter1192 in self.partitions:
-                iter1192.write(oprot)
+            for iter1199 in self.partitions:
+                iter1199.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26576,10 +26595,10 @@ class GetPartitionNamesPsRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partValues = []
-                    (_etype1196, _size1193) = iprot.readListBegin()
-                    for _i1197 in range(_size1193):
-                        _elem1198 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partValues.append(_elem1198)
+                    (_etype1203, _size1200) = iprot.readListBegin()
+                    for _i1204 in range(_size1200):
+                        _elem1205 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partValues.append(_elem1205)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26623,8 +26642,8 @@ class GetPartitionNamesPsRequest(object):
         if self.partValues is not None:
             oprot.writeFieldBegin('partValues', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partValues))
-            for iter1199 in self.partValues:
-                oprot.writeString(iter1199.encode('utf-8') if sys.version_info[0] == 2 else iter1199)
+            for iter1206 in self.partValues:
+                oprot.writeString(iter1206.encode('utf-8') if sys.version_info[0] == 2 else iter1206)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.maxParts is not None:
@@ -26684,10 +26703,10 @@ class GetPartitionNamesPsResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.names = []
-                    (_etype1203, _size1200) = iprot.readListBegin()
-                    for _i1204 in range(_size1200):
-                        _elem1205 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.names.append(_elem1205)
+                    (_etype1210, _size1207) = iprot.readListBegin()
+                    for _i1211 in range(_size1207):
+                        _elem1212 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.names.append(_elem1212)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26704,8 +26723,8 @@ class GetPartitionNamesPsResponse(object):
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.names))
-            for iter1206 in self.names:
-                oprot.writeString(iter1206.encode('utf-8') if sys.version_info[0] == 2 else iter1206)
+            for iter1213 in self.names:
+                oprot.writeString(iter1213.encode('utf-8') if sys.version_info[0] == 2 else iter1213)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -26782,10 +26801,10 @@ class GetPartitionsPsWithAuthRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.partVals = []
-                    (_etype1210, _size1207) = iprot.readListBegin()
-                    for _i1211 in range(_size1207):
-                        _elem1212 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.partVals.append(_elem1212)
+                    (_etype1217, _size1214) = iprot.readListBegin()
+                    for _i1218 in range(_size1214):
+                        _elem1219 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.partVals.append(_elem1219)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26802,10 +26821,10 @@ class GetPartitionsPsWithAuthRequest(object):
             elif fid == 7:
                 if ftype == TType.LIST:
                     self.groupNames = []
-                    (_etype1216, _size1213) = iprot.readListBegin()
-                    for _i1217 in range(_size1213):
-                        _elem1218 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.groupNames.append(_elem1218)
+                    (_etype1223, _size1220) = iprot.readListBegin()
+                    for _i1224 in range(_size1220):
+                        _elem1225 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.groupNames.append(_elem1225)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26844,8 +26863,8 @@ class GetPartitionsPsWithAuthRequest(object):
         if self.partVals is not None:
             oprot.writeFieldBegin('partVals', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partVals))
-            for iter1219 in self.partVals:
-                oprot.writeString(iter1219.encode('utf-8') if sys.version_info[0] == 2 else iter1219)
+            for iter1226 in self.partVals:
+                oprot.writeString(iter1226.encode('utf-8') if sys.version_info[0] == 2 else iter1226)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.maxParts is not None:
@@ -26859,8 +26878,8 @@ class GetPartitionsPsWithAuthRequest(object):
         if self.groupNames is not None:
             oprot.writeFieldBegin('groupNames', TType.LIST, 7)
             oprot.writeListBegin(TType.STRING, len(self.groupNames))
-            for iter1220 in self.groupNames:
-                oprot.writeString(iter1220.encode('utf-8') if sys.version_info[0] == 2 else iter1220)
+            for iter1227 in self.groupNames:
+                oprot.writeString(iter1227.encode('utf-8') if sys.version_info[0] == 2 else iter1227)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.validWriteIdList is not None:
@@ -26916,11 +26935,11 @@ class GetPartitionsPsWithAuthResponse(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.partitions = []
-                    (_etype1224, _size1221) = iprot.readListBegin()
-                    for _i1225 in range(_size1221):
-                        _elem1226 = Partition()
-                        _elem1226.read(iprot)
-                        self.partitions.append(_elem1226)
+                    (_etype1231, _size1228) = iprot.readListBegin()
+                    for _i1232 in range(_size1228):
+                        _elem1233 = Partition()
+                        _elem1233.read(iprot)
+                        self.partitions.append(_elem1233)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -26937,8 +26956,8 @@ class GetPartitionsPsWithAuthResponse(object):
         if self.partitions is not None:
             oprot.writeFieldBegin('partitions', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.partitions))
-            for iter1227 in self.partitions:
-                iter1227.write(oprot)
+            for iter1234 in self.partitions:
+                iter1234.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -27102,11 +27121,11 @@ class ReplicationMetricList(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.replicationMetricList = []
-                    (_etype1231, _size1228) = iprot.readListBegin()
-                    for _i1232 in range(_size1228):
-                        _elem1233 = ReplicationMetrics()
-                        _elem1233.read(iprot)
-                        self.replicationMetricList.append(_elem1233)
+                    (_etype1238, _size1235) = iprot.readListBegin()
+                    for _i1239 in range(_size1235):
+                        _elem1240 = ReplicationMetrics()
+                        _elem1240.read(iprot)
+                        self.replicationMetricList.append(_elem1240)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27123,8 +27142,8 @@ class ReplicationMetricList(object):
         if self.replicationMetricList is not None:
             oprot.writeFieldBegin('replicationMetricList', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.replicationMetricList))
-            for iter1234 in self.replicationMetricList:
-                iter1234.write(oprot)
+            for iter1241 in self.replicationMetricList:
+                iter1241.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -27249,10 +27268,10 @@ class GetOpenTxnsRequest(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.excludeTxnTypes = []
-                    (_etype1238, _size1235) = iprot.readListBegin()
-                    for _i1239 in range(_size1235):
-                        _elem1240 = iprot.readI32()
-                        self.excludeTxnTypes.append(_elem1240)
+                    (_etype1245, _size1242) = iprot.readListBegin()
+                    for _i1246 in range(_size1242):
+                        _elem1247 = iprot.readI32()
+                        self.excludeTxnTypes.append(_elem1247)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -27269,8 +27288,8 @@ class GetOpenTxnsRequest(object):
         if self.excludeTxnTypes is not None:
             oprot.writeFieldBegin('excludeTxnTypes', TType.LIST, 1)
             oprot.writeListBegin(TType.I32, len(self.excludeTxnTypes))
-            for iter1241 in self.excludeTxnTypes:
-                oprot.writeI32(iter1241)
+            for iter1248 in self.excludeTxnTypes:
+                oprot.writeI32(iter1248)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -29534,9 +29553,10 @@ CreationMetadata.thrift_spec = (
     (1, TType.STRING, 'catName', 'UTF8', None, ),  # 1
     (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
     (3, TType.STRING, 'tblName', 'UTF8', None, ),  # 3
-    (4, TType.SET, 'tablesUsed', (TType.STRUCT, [SourceTable, None], False), None, ),  # 4
+    (4, TType.SET, 'tablesUsed', (TType.STRING, 'UTF8', False), None, ),  # 4
     (5, TType.STRING, 'validTxnList', 'UTF8', None, ),  # 5
     (6, TType.I64, 'materializationTime', None, None, ),  # 6
+    (7, TType.SET, 'sourceTables', (TType.STRUCT, [SourceTable, None], False), None, ),  # 7
 )
 all_structs.append(BooleanColumnStatsData)
 BooleanColumnStatsData.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -1848,14 +1848,16 @@ class CreationMetadata
   TABLESUSED = 4
   VALIDTXNLIST = 5
   MATERIALIZATIONTIME = 6
+  SOURCETABLES = 7
 
   FIELDS = {
     CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName'},
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TBLNAME => {:type => ::Thrift::Types::STRING, :name => 'tblName'},
-    TABLESUSED => {:type => ::Thrift::Types::SET, :name => 'tablesUsed', :element => {:type => ::Thrift::Types::STRUCT, :class => ::SourceTable}},
+    TABLESUSED => {:type => ::Thrift::Types::SET, :name => 'tablesUsed', :element => {:type => ::Thrift::Types::STRING}},
     VALIDTXNLIST => {:type => ::Thrift::Types::STRING, :name => 'validTxnList', :optional => true},
-    MATERIALIZATIONTIME => {:type => ::Thrift::Types::I64, :name => 'materializationTime', :optional => true}
+    MATERIALIZATIONTIME => {:type => ::Thrift::Types::I64, :name => 'materializationTime', :optional => true},
+    SOURCETABLES => {:type => ::Thrift::Types::SET, :name => 'sourceTables', :element => {:type => ::Thrift::Types::STRUCT, :class => ::SourceTable}, :optional => true}
   }
 
   def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
@@ -947,13 +947,13 @@ module ThriftHiveMetastore
       raise ::Thrift::ApplicationException.new(::Thrift::ApplicationException::MISSING_RESULT, 'get_table_objects_by_name_req failed: unknown result')
     end
 
-    def get_materialization_invalidation_info(creation_metadata)
-      send_get_materialization_invalidation_info(creation_metadata)
+    def get_materialization_invalidation_info(creation_metadata, validTxnList)
+      send_get_materialization_invalidation_info(creation_metadata, validTxnList)
       return recv_get_materialization_invalidation_info()
     end
 
-    def send_get_materialization_invalidation_info(creation_metadata)
-      send_message('get_materialization_invalidation_info', Get_materialization_invalidation_info_args, :creation_metadata => creation_metadata)
+    def send_get_materialization_invalidation_info(creation_metadata, validTxnList)
+      send_message('get_materialization_invalidation_info', Get_materialization_invalidation_info_args, :creation_metadata => creation_metadata, :validTxnList => validTxnList)
     end
 
     def recv_get_materialization_invalidation_info()
@@ -5165,7 +5165,7 @@ module ThriftHiveMetastore
       args = read_args(iprot, Get_materialization_invalidation_info_args)
       result = Get_materialization_invalidation_info_result.new()
       begin
-        result.success = @handler.get_materialization_invalidation_info(args.creation_metadata)
+        result.success = @handler.get_materialization_invalidation_info(args.creation_metadata, args.validTxnList)
       rescue ::MetaException => o1
         result.o1 = o1
       rescue ::InvalidOperationException => o2
@@ -9770,9 +9770,11 @@ module ThriftHiveMetastore
   class Get_materialization_invalidation_info_args
     include ::Thrift::Struct, ::Thrift::Struct_Union
     CREATION_METADATA = 1
+    VALIDTXNLIST = 2
 
     FIELDS = {
-      CREATION_METADATA => {:type => ::Thrift::Types::STRUCT, :name => 'creation_metadata', :class => ::CreationMetadata}
+      CREATION_METADATA => {:type => ::Thrift::Types::STRUCT, :name => 'creation_metadata', :class => ::CreationMetadata},
+      VALIDTXNLIST => {:type => ::Thrift::Types::STRING, :name => 'validTxnList'}
     }
 
     def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/AbstractThriftHiveMetastore.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/AbstractThriftHiveMetastore.java
@@ -353,7 +353,7 @@ public abstract class AbstractThriftHiveMetastore implements Iface {
     }
 
     @Override
-    public Materialization get_materialization_invalidation_info(CreationMetadata creation_metadata)
+    public Materialization get_materialization_invalidation_info(CreationMetadata creation_metadata, String validTxnList)
             throws MetaException, InvalidOperationException, UnknownDBException, TException {
         throw new UnsupportedOperationException("this method is not supported");
     }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2642,10 +2642,14 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return deepCopyTables(FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs));
   }
 
-  @Override
   public Materialization getMaterializationInvalidationInfo(CreationMetadata cm)
       throws MetaException, InvalidOperationException, UnknownDBException, TException {
-    return client.get_materialization_invalidation_info(cm);
+    return client.get_materialization_invalidation_info(cm, null);
+  }
+
+  public Materialization getMaterializationInvalidationInfo(CreationMetadata cm, String validTxnList)
+      throws MetaException, InvalidOperationException, UnknownDBException, TException {
+    return client.get_materialization_invalidation_info(cm, validTxnList);
   }
 
   @Override

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -811,6 +811,13 @@ public interface IMetaStoreClient {
   Materialization getMaterializationInvalidationInfo(CreationMetadata cm)
       throws MetaException, InvalidOperationException, UnknownDBException, TException;
 
+  @Deprecated
+  /**
+   * Use {@link IMetaStoreClient#getMaterializationInvalidationInfo(CreationMetadata)} instead.
+   */
+  Materialization getMaterializationInvalidationInfo(CreationMetadata cm, String validTxnList)
+      throws MetaException, InvalidOperationException, UnknownDBException, TException;
+
   /**
    * Updates the creation metadata for the materialized view.
    */

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -465,12 +465,13 @@ struct SourceTable {
 }
 
 struct CreationMetadata {
-    1: required string catName
+    1: required string catName,
     2: required string dbName,
     3: required string tblName,
-    4: required set<SourceTable> tablesUsed,
+    4: required set<string> tablesUsed,
     5: optional string validTxnList,
-    6: optional i64 materializationTime
+    6: optional i64 materializationTime,
+    7: optional set<SourceTable> sourceTables
 }
 
 // column statistics
@@ -2469,7 +2470,7 @@ service ThriftHiveMetastore extends fb303.FacebookService
   GetTableResult get_table_req(1:GetTableRequest req) throws (1:MetaException o1, 2:NoSuchObjectException o2)
   GetTablesResult get_table_objects_by_name_req(1:GetTablesRequest req)
 				   throws (1:MetaException o1, 2:InvalidOperationException o2, 3:UnknownDBException o3)
-  Materialization get_materialization_invalidation_info(1:CreationMetadata creation_metadata)
+  Materialization get_materialization_invalidation_info(1:CreationMetadata creation_metadata, 2:string validTxnList)
 				   throws (1:MetaException o1, 2:InvalidOperationException o2, 3:UnknownDBException o3)
   void update_creation_metadata(1: string catName, 2:string dbname, 3:string tbl_name, 4:CreationMetadata creation_metadata)
                    throws (1:MetaException o1, 2:InvalidOperationException o2, 3:UnknownDBException o3)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3870,8 +3870,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   }
 
   @Override
-  public Materialization get_materialization_invalidation_info(final CreationMetadata cm) throws MetaException {
-    return getTxnHandler().getMaterializationInvalidationInfo(cm);
+  public Materialization get_materialization_invalidation_info(final CreationMetadata cm, String validTxnList) throws MetaException {
+    if (validTxnList == null) {
+      return getTxnHandler().getMaterializationInvalidationInfo(cm);
+    }
+    return getTxnHandler().getMaterializationInvalidationInfo(cm, validTxnList);
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2513,7 +2513,7 @@ public class ObjectStore implements RawStore, Configurable {
     }
     assert !m.isSetMaterializationTime();
     Set<MMVSource> tablesUsed = new HashSet<>();
-    for (SourceTable sourceTable : m.getTablesUsed()) {
+    for (SourceTable sourceTable : m.getSourceTables()) {
       Table table = sourceTable.getTable();
       MTable mtbl = getMTable(m.getCatName(), table.getDbName(), table.getTableName(), false).mtbl;
       MMVSource source = new MMVSource();
@@ -2532,9 +2532,11 @@ public class ObjectStore implements RawStore, Configurable {
     if (s == null) {
       return null;
     }
-    Set<SourceTable> tablesUsed = new HashSet<>();
+    Set<String> tablesUsed = new HashSet<>();
+    Set<SourceTable> sourceTables = new HashSet<>();
     for (MMVSource mtbl : s.getTables()) {
-      tablesUsed.add(convertToSourceTable(mtbl, s.getCatalogName()));
+      tablesUsed.add(Warehouse.getQualifiedName(mtbl.getTable().getDatabase().getName(), mtbl.getTable().getTableName()));
+      sourceTables.add(convertToSourceTable(mtbl, s.getCatalogName()));
     }
     CreationMetadata r = new CreationMetadata(s.getCatalogName(),
         s.getDbName(), s.getTblName(), tablesUsed);
@@ -2542,6 +2544,7 @@ public class ObjectStore implements RawStore, Configurable {
     if (s.getTxnList() != null) {
       r.setValidTxnList(s.getTxnList());
     }
+    r.setSourceTables(sourceTables);
     return r;
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.metastore.client.builder;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Build a {@link Table}.  The database name and table name must be provided, plus whatever is
@@ -211,7 +213,12 @@ public class TableBuilder extends StorageDescriptorBuilder<TableBuilder> {
     if (temporary) t.setTemporary(temporary);
     t.setCatName(catName);
     if (!mvReferencedTables.isEmpty()) {
-      CreationMetadata cm = new CreationMetadata(catName, dbName, tableName, mvReferencedTables);
+      Set<String> tablesUsed = mvReferencedTables.stream()
+              .map(sourceTable -> TableName.getDbTable(
+                      sourceTable.getTable().getDbName(), sourceTable.getTable().getTableName()))
+              .collect(Collectors.toSet());
+      CreationMetadata cm = new CreationMetadata(catName, dbName, tableName, tablesUsed);
+      cm.setSourceTables(mvReferencedTables);
       if (mvValidTxnList != null) cm.setValidTxnList(mvValidTxnList);
       t.setCreationMetadata(cm);
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -75,6 +76,7 @@ import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.common.classification.RetrySemantics;
 import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.MetaStoreListenerNotifier;
 import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
@@ -2509,16 +2511,15 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
    */
   @Override
   @RetrySemantics.ReadOnly
-  public Materialization getMaterializationInvalidationInfo(
-      CreationMetadata creationMetadata) throws MetaException {
-    if (creationMetadata.getTablesUsed().isEmpty()) {
+  public Materialization getMaterializationInvalidationInfo(CreationMetadata creationMetadata) throws MetaException {
+    if (creationMetadata.getSourceTables().isEmpty()) {
       // Bail out
       LOG.warn("Materialization creation metadata does not contain any table");
       return null;
     }
 
     boolean sourceTablesUpdateDeleteModified = false;
-    for (SourceTable sourceTable : creationMetadata.getTablesUsed()) {
+    for (SourceTable sourceTable : creationMetadata.getSourceTables()) {
       if (sourceTable.getDeletedCount() > 0 || sourceTable.getUpdatedCount() > 0) {
         sourceTablesUpdateDeleteModified = true;
         break;
@@ -2534,7 +2535,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
 
   private Boolean wasCompacted(CreationMetadata creationMetadata) throws MetaException {
     Set<String> insertOnlyTables = new HashSet<>();
-    for (SourceTable sourceTable : creationMetadata.getTablesUsed()) {
+    for (SourceTable sourceTable : creationMetadata.getSourceTables()) {
       Table table = sourceTable.getTable();
       String transactionalProp = table.getParameters().get(hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES);
       if (!"insert_only".equalsIgnoreCase(transactionalProp)) {
@@ -2554,7 +2555,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
 
     // Parse validReaderWriteIdList from creation metadata
     final ValidTxnWriteIdList validReaderWriteIdList =
-        new ValidTxnWriteIdList(creationMetadata.getValidTxnList());
+            new ValidTxnWriteIdList(creationMetadata.getValidTxnList());
 
 
     List<String> params = new ArrayList<>();
@@ -2566,7 +2567,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     int i = 0;
     for (String fullyQualifiedName : insertOnlyTables) {
       ValidWriteIdList tblValidWriteIdList =
-          validReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
+              validReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
       if (tblValidWriteIdList == null) {
         LOG.warn("ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
         return null;
@@ -2587,8 +2588,8 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
       queryCompletedCompactions.append(" AND (\"CC_HIGHEST_WRITE_ID\" > ");
       queryCompletedCompactions.append(tblValidWriteIdList.getHighWatermark());
       queryCompletedCompactions.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
-          " OR \"CC_HIGHEST_WRITE_ID\" IN(" + StringUtils.join(",",
-              Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ) ");
+              " OR \"CC_HIGHEST_WRITE_ID\" IN(" + StringUtils.join(",",
+                      Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ) ");
       queryCompletedCompactions.append(") ");
       queryCompactionQueue.append(") ");
       i++;
@@ -2604,7 +2605,129 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     List<String> paramsTwice = new ArrayList<>(params);
     paramsTwice.addAll(params);
     return executeBoolean(queryCompletedCompactions.toString(), paramsTwice,
-        "Unable to retrieve materialization invalidation information: compactions");
+            "Unable to retrieve materialization invalidation information: compactions");
+  }
+
+  /**
+   * Use {@link TxnHandler#getMaterializationInvalidationInfo(CreationMetadata)} instead.
+   */
+  @Override
+  @Deprecated
+  @RetrySemantics.ReadOnly
+  public Materialization getMaterializationInvalidationInfo(
+          CreationMetadata creationMetadata, String validTxnListStr) throws MetaException {
+    if (creationMetadata.getTablesUsed().isEmpty()) {
+      // Bail out
+      LOG.warn("Materialization creation metadata does not contain any table");
+      return null;
+    }
+
+    // We are composing a query that returns a single row if an update happened after
+    // the materialization was created. Otherwise, query returns 0 rows.
+
+    // Parse validReaderWriteIdList from creation metadata
+    final ValidTxnWriteIdList validReaderWriteIdList =
+            new ValidTxnWriteIdList(creationMetadata.getValidTxnList());
+
+    // Parse validTxnList
+    final ValidReadTxnList currentValidTxnList = new ValidReadTxnList(validTxnListStr);
+    // Get the valid write id list for the tables in current state
+    final List<TableValidWriteIds> currentTblValidWriteIdsList = new ArrayList<>();
+    Connection dbConn = null;
+    for (String fullTableName : creationMetadata.getTablesUsed()) {
+      try {
+        dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
+        currentTblValidWriteIdsList.add(getValidWriteIdsForTable(dbConn, fullTableName, currentValidTxnList));
+      } catch (SQLException ex) {
+        String errorMsg = "Unable to query Valid writeIds of table " + fullTableName;
+        LOG.warn(errorMsg, ex);
+        throw new MetaException(errorMsg + " " + StringUtils.stringifyException(ex));
+      } finally {
+        closeDbConn(dbConn);
+      }
+    }
+    final ValidTxnWriteIdList currentValidReaderWriteIdList = TxnCommonUtils.createValidTxnWriteIdList(
+            currentValidTxnList.getHighWatermark(), currentTblValidWriteIdsList);
+
+    List<String> params = new ArrayList<>();
+    StringBuilder queryUpdateDelete = new StringBuilder();
+    StringBuilder queryCompletedCompactions = new StringBuilder();
+    StringBuilder queryCompactionQueue = new StringBuilder();
+    // compose a query that select transactions containing an update...
+    queryUpdateDelete.append("SELECT \"CTC_UPDATE_DELETE\" FROM \"COMPLETED_TXN_COMPONENTS\" WHERE \"CTC_UPDATE_DELETE\" ='Y' AND (");
+    queryCompletedCompactions.append("SELECT 1 FROM \"COMPLETED_COMPACTIONS\" WHERE (");
+    queryCompactionQueue.append("SELECT 1 FROM \"COMPACTION_QUEUE\" WHERE (");
+    int i = 0;
+    for (String fullyQualifiedName : creationMetadata.getTablesUsed()) {
+      ValidWriteIdList tblValidWriteIdList =
+              validReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
+      if (tblValidWriteIdList == null) {
+        LOG.warn("ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
+        return null;
+      }
+
+      // First, we check whether the low watermark has moved for any of the tables.
+      // If it has, we return true, since it is not incrementally refreshable, e.g.,
+      // one of the commits that are not available may be an update/delete.
+      ValidWriteIdList currentTblValidWriteIdList =
+              currentValidReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
+      if (currentTblValidWriteIdList == null) {
+        LOG.warn("Current ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
+        return null;
+      }
+      if (!Objects.equals(currentTblValidWriteIdList.getMinOpenWriteId(), tblValidWriteIdList.getMinOpenWriteId())) {
+        LOG.debug("Minimum open write id do not match for table {}", fullyQualifiedName);
+        return null;
+      }
+
+      // ...for each of the tables that are part of the materialized view,
+      // where the transaction had to be committed after the materialization was created...
+      if (i != 0) {
+        queryUpdateDelete.append("OR");
+        queryCompletedCompactions.append("OR");
+        queryCompactionQueue.append("OR");
+      }
+      String[] names = TxnUtils.getDbTableName(fullyQualifiedName);
+      assert (names.length == 2);
+      queryUpdateDelete.append(" (\"CTC_DATABASE\"=? AND \"CTC_TABLE\"=?");
+      queryCompletedCompactions.append(" (\"CC_DATABASE\"=? AND \"CC_TABLE\"=?");
+      queryCompactionQueue.append(" (\"CQ_DATABASE\"=? AND \"CQ_TABLE\"=?");
+      params.add(names[0]);
+      params.add(names[1]);
+      queryUpdateDelete.append(" AND (\"CTC_WRITEID\" > " + tblValidWriteIdList.getHighWatermark());
+      queryCompletedCompactions.append(" AND (\"CC_HIGHEST_WRITE_ID\" > " + tblValidWriteIdList.getHighWatermark());
+      queryUpdateDelete.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
+              " OR \"CTC_WRITEID\" IN(" + StringUtils.join(",",
+                      Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ) ");
+      queryCompletedCompactions.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
+              " OR \"CC_HIGHEST_WRITE_ID\" IN(" + StringUtils.join(",",
+                      Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ) ");
+      queryUpdateDelete.append(") ");
+      queryCompletedCompactions.append(") ");
+      queryCompactionQueue.append(") ");
+      i++;
+    }
+    // ... and where the transaction has already been committed as per snapshot taken
+    // when we are running current query
+    queryUpdateDelete.append(") AND \"CTC_TXNID\" <= " + currentValidTxnList.getHighWatermark());
+    queryUpdateDelete.append(currentValidTxnList.getInvalidTransactions().length == 0 ? " " :
+            " AND \"CTC_TXNID\" NOT IN(" + StringUtils.join(",",
+                    Arrays.asList(ArrayUtils.toObject(currentValidTxnList.getInvalidTransactions()))) + ") ");
+    queryCompletedCompactions.append(")");
+    queryCompactionQueue.append(") ");
+
+    boolean hasUpdateDelete = executeBoolean(queryUpdateDelete.toString(), params,
+            "Unable to retrieve materialization invalidation information: completed transaction components.");
+
+    // Execute query
+    queryCompletedCompactions.append(" UNION ");
+    queryCompletedCompactions.append(queryCompactionQueue.toString());
+    List<String> paramsTwice = new ArrayList<>(params);
+    paramsTwice.addAll(params);
+    boolean hasCompaction = executeBoolean(queryCompletedCompactions.toString(), paramsTwice,
+            "Unable to retrieve materialization invalidation information: compactions");
+
+    return new Materialization(hasUpdateDelete, hasCompaction);
   }
 
   private boolean executeBoolean(String queryText, List<String> params, String errorMessage) throws MetaException {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
@@ -202,8 +202,11 @@ public interface TxnStore extends Configurable {
    * @throws MetaException
    */
   @RetrySemantics.Idempotent
-  Materialization getMaterializationInvalidationInfo(
-      final CreationMetadata cm)
+  Materialization getMaterializationInvalidationInfo(final CreationMetadata cm)
+          throws MetaException;
+
+  @RetrySemantics.Idempotent
+  Materialization getMaterializationInvalidationInfo(final CreationMetadata cm, String validTxnList)
           throws MetaException;
 
   @RetrySemantics.ReadOnly

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -1601,7 +1601,17 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   @Override
   public Materialization getMaterializationInvalidationInfo(CreationMetadata cm)
       throws MetaException, InvalidOperationException, UnknownDBException, TException {
-    return client.get_materialization_invalidation_info(cm);
+    return client.get_materialization_invalidation_info(cm, null);
+  }
+
+  @Deprecated
+  /**
+   * Use {@link HiveMetaStoreClientPreCatalog#getMaterializationInvalidationInfo(CreationMetadata)} instead.
+   */
+  @Override
+  public Materialization getMaterializationInvalidationInfo(CreationMetadata cm, String validTxnList)
+      throws MetaException, InvalidOperationException, UnknownDBException, TException {
+    return client.get_materialization_invalidation_info(cm, validTxnList);
   }
 
   /** {@inheritDoc} */

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -1345,12 +1345,14 @@ public class TestObjectStore {
     creationMetadata.setCatName(db1.getCatalogName());
     creationMetadata.setDbName(matView1.getDbName());
     creationMetadata.setTblName(matView1.getTableName());
-    creationMetadata.setSourceTables(new HashSet<SourceTable>() {{ add(createSourceTable(tbl1)); }});
+    creationMetadata.setTablesUsed(Collections.singleton(tbl1.getDbName() + "." + tbl1.getTableName()));
+    creationMetadata.setSourceTables(Collections.singleton(createSourceTable(tbl1)));
     matView1.setCreationMetadata(creationMetadata);
     objectStore.createTable(matView1);
 
     CreationMetadata newCreationMetadata = new CreationMetadata(matView1.getCatName(), matView1.getDbName(),
             matView1.getTableName(), ImmutableSet.copyOf(creationMetadata.getTablesUsed()));
+    newCreationMetadata.setSourceTables(Collections.unmodifiableSet(creationMetadata.getSourceTables()));
     objectStore.updateCreationMetadata(matView1.getCatName(), matView1.getDbName(), matView1.getTableName(), newCreationMetadata);
 
     assertThat(creationMetadata.getMaterializationTime(), is(not(0)));

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -1345,7 +1345,7 @@ public class TestObjectStore {
     creationMetadata.setCatName(db1.getCatalogName());
     creationMetadata.setDbName(matView1.getDbName());
     creationMetadata.setTblName(matView1.getTableName());
-    creationMetadata.setTablesUsed(new HashSet<SourceTable>() {{ add(createSourceTable(tbl1)); }});
+    creationMetadata.setSourceTables(new HashSet<SourceTable>() {{ add(createSourceTable(tbl1)); }});
     matView1.setCreationMetadata(creationMetadata);
     objectStore.createTable(matView1);
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetTableMeta.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetTableMeta.java
@@ -147,6 +147,7 @@ public class TestGetTableMeta extends MetaStoreClientTest {
     if (type == TableType.MATERIALIZED_VIEW) {
       CreationMetadata cm = new CreationMetadata(
           MetaStoreUtils.getDefaultCatalog(metaStore.getConf()), dbName, tableName, ImmutableSet.of());
+      cm.setSourceTables(Collections.emptySet());
       table.setCreationMetadata(cm);
     }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.client;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
@@ -1301,7 +1302,9 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
         .addCol("col2_2", ColumnType.INT_TYPE_NAME).build(metaStore.getConf());
     client.createTable(table1);
     sourceTable = createSourceTable(table1);
-    cm.addToTablesUsed(sourceTable);
+    cm.addToTablesUsed(
+            TableName.getDbTable(sourceTable.getTable().getDbName(), sourceTable.getTable().getTableName()));
+    cm.addToSourceTables(sourceTable);
     cm.unsetMaterializationTime();
     client.updateCreationMetadata(catName, dbName, tableNames[3], cm);
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. Restore the original type of `CreationMetadata.tablesUsed`
2. Add new optional field `CreationMetadata.soruceTables`
3. Wrap the generated `CreationMetadata` object into `MaterializedViewMetadata` and extract `CreationMetadata` operations.

### Why are the changes needed?
See HIVE-25656 description

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestDbTxnManagerIsolationProperties#testRebuildMVWhenOpenTxnPresents -pl ql
```