### PR TITLE
Fix projection for union all queries with multiple aliases

### DIFF
--- a/ql/src/test/queries/clientpositive/udf_explode.q
+++ b/ql/src/test/queries/clientpositive/udf_explode.q
@@ -23,3 +23,9 @@ INSERT OVERWRITE TABLE lazy_array_map select map(1, 'one', 2, 'two', 3, 'three')
 
 SELECT array_col, myCol FROM lazy_array_map lateral view explode(array_col) X AS myCol ORDER BY array_col, myCol;
 SELECT map_col, myKey, myValue FROM lazy_array_map lateral view explode(map_col) X AS myKey, myValue ORDER BY map_col, myKey, myValue;
+
+create table source1 (dt string, d1 int, d2 int) stored as orc;
+create table source2 (dt string, d1 int, d2 int) stored as orc;
+insert into source1 values ('20211107', 1, 2);
+insert into source2 values ('20211108', 11, 22);
+select explode(map('D219', d1,'D220', d2)) as (keyx, valuex) from source1 union all select explode(map('D221', d1,'D222', d2)) as (keyy, valuey) from source2;

--- a/ql/src/test/results/clientpositive/llap/udf_explode.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_explode.q.out
@@ -653,3 +653,55 @@ POSTHOOK: Input: default@lazy_array_map
 {1:"one",2:"two",3:"three"}	1	one
 {1:"one",2:"two",3:"three"}	2	two
 {1:"one",2:"two",3:"three"}	3	three
+PREHOOK: query: create table source1 (dt string, d1 int, d2 int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source1
+POSTHOOK: query: create table source1 (dt string, d1 int, d2 int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source1
+PREHOOK: query: create table source2 (dt string, d1 int, d2 int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source2
+POSTHOOK: query: create table source2 (dt string, d1 int, d2 int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source2
+PREHOOK: query: insert into source1 values ('20211107', 1, 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source1
+POSTHOOK: query: insert into source1 values ('20211107', 1, 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source1
+POSTHOOK: Lineage: source1.d1 SCRIPT []
+POSTHOOK: Lineage: source1.d2 SCRIPT []
+POSTHOOK: Lineage: source1.dt SCRIPT []
+PREHOOK: query: insert into source2 values ('20211108', 11, 22)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source2
+POSTHOOK: query: insert into source2 values ('20211108', 11, 22)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source2
+POSTHOOK: Lineage: source2.d1 SCRIPT []
+POSTHOOK: Lineage: source2.d2 SCRIPT []
+POSTHOOK: Lineage: source2.dt SCRIPT []
+PREHOOK: query: select explode(map('D219', d1,'D220', d2)) as (keyx, valuex) from source1 union all select explode(map('D221', d1,'D222', d2)) as (keyy, valuey) from source2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source1
+PREHOOK: Input: default@source2
+#### A masked pattern was here ####
+POSTHOOK: query: select explode(map('D219', d1,'D220', d2)) as (keyx, valuex) from source1 union all select explode(map('D221', d1,'D222', d2)) as (keyy, valuey) from source2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source1
+POSTHOOK: Input: default@source2
+#### A masked pattern was here ####
+D219	1
+D220	2
+D221	11
+D222	22


### PR DESCRIPTION
Given two tables:
```
create table source1 (dt string, d1 int, d2 int) stored as orc;
create table source2 (dt string, d1 int, d2 int) stored as orc;
insert into source1 values ('20211107', 1, 2);
insert into source2 values ('20211108', 11, 22);
```

If you run this query with UNION ALL, the `key` column will be missing from the output:
```
select explode(map('D219', D219
,'D220', D220)) as (key, value)
from (
select '20211107' as date_key
,1 as D219
,2 as D220
) t
union all
select explode(map('D221', D221
,'D222', D222)) as (key, value)
from (
select '20211107' as date_key
,1 as D221
,2 as D222
) t

```
Result:
```
1
2
11
22
```
Correct result should be:
```
D219	1
D220	2
D221	11
D222	22
```
(Note: If you run the two subqueries individually, it works fine. The problem occurs with the UNION).

The problem seems to be related to parsing. Currently we assume that only the last column can be an alias column:
```
// Examine the last child. It could be an alias.
Tree child = selExpr.getChild(selExpr.getChildCount() - 1);
```
which ignores the fact that we could have multiple aliases defined, such as in this case (e.g. `... as (keyx, valuex)`)