### PR TITLE
HIVE-25750: Creating a standalone tarball by isolating dependencies

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -233,6 +233,53 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>jar-with-dependencies</finalName>
+              <transformers>
+                <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                  Shading signed JARs will fail without this.
+                  http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+
     </plugins>
   </build>
 

--- a/packaging/src/main/assembly/beeline.xml
+++ b/packaging/src/main/assembly/beeline.xml
@@ -73,6 +73,15 @@
             </includes>
             <outputDirectory>/</outputDirectory>
         </fileSet>
+
+        <fileSet>
+            <fileMode>755</fileMode>
+            <directory>${project.parent.basedir}/beeline/target</directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>original-jar-with-dependencies.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
 
 </assembly>


### PR DESCRIPTION
The code to create a standalone beeline tarball was created as part of this ticket https://issues.apache.org/jira/browse/HIVE-24348. However, a bug was reported in the case when the beeline is tried to install without the hadoop installed. 
The beeline script complains of missing dependencies when it is run. 


### What changes were proposed in this pull request?
The beeline script can be run with/without hadoop installed. All the required dependencies are bundled into a single downloadable tar file. 
`mvn clean package install -Pdist -Pitests -DskipTests -Denforcer.skip=true` generates something along the lines of 
**apache-hive-beeline-4.0.0-SNAPSHOT.tar.gz** in the **packaging/target** folder.



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

Created a docker container using the command
`sudo docker run  --rm -it -v /Users/achennagiri/Downloads:/container --user root docker-private.infra.cloudera.com/cloudera_base/ubi8/python-38:1-68 /bin/bash`

Need to install `yum install -y java-11-openjdk` java in the container. 


