### PR TITLE
HIVE-25623: Create a parametrized test to check against the disabled MIN_HISTORY config

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.TestTxnCommands2;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
@@ -1203,6 +1204,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
    */
   @Test
   public void testWriteSetTracking5() throws Exception {
+    Assume.assumeTrue(minHistoryLevel);   //skip execution for disabled TXN_USE_MIN_HISTORY_LEVEL
     dropTable(new String[] {"TAB_PART"});
     Assert.assertEquals(0, TestTxnDbUtil.countQueryAgent(conf, "select count(*) from \"WRITE_SET\""));
     driver.run("create table if not exists TAB_PART (a int, b int) " +
@@ -2061,6 +2063,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
 
   @Test
   public void testMergeUnpartitioned() throws Exception {
+    Assume.assumeTrue(minHistoryLevel);     //skip execution for disabled TXN_USE_MIN_HISTORY_LEVEL
     testMergeUnpartitioned(false, false);
   }
   @Test
@@ -2606,10 +2609,12 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
 
   @Test
   public void testMergePartitioned() throws Exception {
+    Assume.assumeTrue(minHistoryLevel);     //skip execution for disabled TXN_USE_MIN_HISTORY_LEVEL
     testMergePartitioned(false, false);
   }
   @Test
   public void testMergePartitionedConflict() throws Exception {
+    Assume.assumeTrue(minHistoryLevel);     //skip execution for disabled TXN_USE_MIN_HISTORY_LEVEL
     testMergePartitioned(true, false);
   }
   @Test
@@ -3300,12 +3305,6 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
   }
 
   @Test
-  public void testInsertSnapshotIsolationMinHistoryDisabled() throws Exception {
-    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.TXN_USE_MIN_HISTORY_LEVEL, false);
-    testInsertSnapshotIsolation();
-  }
-
-  @Test
   public void testInsertSnapshotIsolation() throws Exception {
     dropTable(new String[] {"tab_acid"});
 
@@ -3326,12 +3325,6 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     List<String> res = new ArrayList<>();
     driver2.getFetchTask().fetch(res);
     Assert.assertEquals(0, res.size());
-  }
-
-  @Test
-  public void testUpdateSnapshotIsolationMinHistoryDisabled() throws Exception {
-    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.TXN_USE_MIN_HISTORY_LEVEL, false);
-    testUpdateSnapshotIsolation();
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManagerIsolationProperties.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManagerIsolationProperties.java
@@ -200,6 +200,7 @@ public class TestDbTxnManagerIsolationProperties extends DbTxnManagerEndToEndTes
 
   @Test
   public void testRebuildMVWhenOpenTxnPresents() throws Exception {
+    driver.run(("drop materialized view if exists mat1"));
     driver.run(("drop table if exists t1"));
     driver.run("create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true')");
     driver.run("insert into t1 values(1,2),(2,2)");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make the `DbTxnManager` based tests parameterized and running them both with enabled and disabled **TXN_USE_MIN_HISTORY_LEVEL**.
I also modified the `setup` function to set back the `HiveConf` to default value before every test run since there were some tests e.g. `testFullTableReadLock` that made changes in the configuration and didn't reset them so it affected other tests.


### Why are the changes needed?
Cover the disabled **TXN_USE_MIN_HISTORY_LEVEL** functionality with tests.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Locally run the tests.
