### PR TITLE
HIVE-25765: skip.header.line.count property should skip rows of only files in FetchOperator

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -568,11 +568,13 @@ public class FetchOperator implements Serializable {
            * If file contains footer, used FooterBuffer to cache and remove footer
            * records at the end of the file.
            */
-          headerCount = Utilities.getHeaderCount(currDesc.getTableDesc());
-          footerCount = Utilities.getFooterCount(currDesc.getTableDesc(), job);
+	  if (currRecReader.getPos() == 0) {
+            headerCount = Utilities.getHeaderCount(currDesc.getTableDesc());
+            // Skip header lines.
+            opNotEOF = Utilities.skipHeader(currRecReader, headerCount, key, value);
+	  }
 
-          // Skip header lines.
-          opNotEOF = Utilities.skipHeader(currRecReader, headerCount, key, value);
+	  footerCount = Utilities.getFooterCount(currDesc.getTableDesc(), job);
 
           // Initialize footer buffer.
           if (opNotEOF && footerCount > 0) {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When skip.header.line.count property is set in table properties, simple select queries that gets converted into FetchTask skip rows of each block instead of skipping header lines of each file. This happens when the file size is larger and file is read in blocks. This issue doesn't exist when select query is converted into map only job by setting hive.fetch.task.conversion to none because the header lines are skipped only for the first block because of [this check](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/HiveContextAwareRecordReader.java#L330). We should have similar check in FetchOperator to avoid this issue. 

Ref: https://issues.apache.org/jira/browse/HIVE-25765 for more details.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change is required to avoid getting incorrect result when simple select query is converted into FetchTask and the data file size is larger. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Patch was tested by running simple select queries on a table created on top of larger data set. Couldn't add qtest since the dataset is larger. Verified that the numbers rows returned by running aggregation [ count(*) ] and selecting all columns without limit (select *) are same. Please refer [HIVE-25765](https://issues.apache.org/jira/browse/HIVE-25765) for the dataset and queries to test this patch. 