### PR TITLE
HIVE-25758: OOM due to recursive application of CBO rules

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveFilterProjectTransposeRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveFilterProjectTransposeRule.java
@@ -323,7 +323,7 @@ public class HiveFilterProjectTransposeRule extends FilterProjectTransposeRule {
 
       final RexSimplify simplify = new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY,
           Util.first(cluster.getPlanner().getExecutor(), RexUtil.EXECUTOR));
-      final RexNode newCondition = simplify.simplify(filter2newConditionMap.get(filter));
+      final RexNode newCondition = simplify.simplifyUnknownAsFalse(filter2newConditionMap.get(filter));
 
       // if the condition simplifies to a literal, bail out
       if (RexUtil.isLiteral(newCondition, true)) {
@@ -336,7 +336,7 @@ public class HiveFilterProjectTransposeRule extends FilterProjectTransposeRule {
         return;
       }
 
-      final RexNode filterCondition = simplify.simplify(filter.getCondition());
+      final RexNode filterCondition = simplify.simplifyUnknownAsFalse(filter.getCondition());
 
       final Set<Integer> inputRefs = HiveCalciteUtil.getInputRefs(newCondition);
       final RexInputRef rexInputRef =

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveInBetweenExpandRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveInBetweenExpandRule.java
@@ -133,14 +133,18 @@ public class HiveInBetweenExpandRule {
    * If any call is modified, the modified flag will be set to
    * true after its execution.
    */
-  private static final class RexInBetweenExpander extends RexShuttle {
+  static final class RexInBetweenExpander extends RexShuttle {
 
     private final RexBuilder rexBuilder;
     private boolean modified;
 
-    private RexInBetweenExpander(RexBuilder rexBuilder) {
+    RexInBetweenExpander(RexBuilder rexBuilder) {
       this.rexBuilder = rexBuilder;
       this.modified = false;
+    }
+
+    public boolean isModified() {
+      return modified;
     }
 
     @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinPushTransitivePredicatesRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinPushTransitivePredicatesRule.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinPushTransitivePredicatesRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinPushTransitivePredicatesRule.java
@@ -108,12 +108,12 @@ public class HiveJoinPushTransitivePredicatesRule extends RelOptRule {
       return;
     }
 
-    final RelOptCluster cluster = join.getCluster();
-    final RexSimplify rexSimplify = new RexSimplify(cluster.getRexBuilder(),
-        RelOptPredicateList.EMPTY, join.getCluster().getPlanner().getExecutor());
+    final RexSimplify rexSimplify = new RexSimplify(
+        join.getCluster().getRexBuilder(), RelOptPredicateList.EMPTY,
+        Util.first(join.getCluster().getPlanner().getExecutor(), RexUtil.EXECUTOR));
 
-    newLeftPredicate = rexSimplify.simplify(newLeftPredicate);
-    newRightPredicate = rexSimplify.simplify(newRightPredicate);
+    newLeftPredicate = rexSimplify.simplifyUnknownAsFalse(newLeftPredicate);
+    newRightPredicate = rexSimplify.simplifyUnknownAsFalse(newRightPredicate);
 
     if (!newLeftPredicate.isAlwaysTrue()) {
       RelNode curr = lChild;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsRule.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.rules;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptRuleCall;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsWithStatsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsWithStatsRule.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rex.RexSimplify;
 import org.apache.calcite.rex.RexUnknownAs;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.Pair;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveIn;
@@ -191,6 +192,10 @@ public class HiveReduceExpressionsWithStatsRule extends RelOptRule {
             }
             if (newOperands.size() == 1) {
               return rexBuilder.makeLiteral(false);
+            }
+            else if (newOperands.size() == 2) {
+              return rexBuilder.makeCall(
+                  SqlStdOperatorTable.EQUALS, newOperands.get(0), newOperands.get(1));
             }
             return rexBuilder.makeCall(HiveIn.INSTANCE, newOperands);
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveUnionPullUpConstantsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveUnionPullUpConstantsRule.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilder;
@@ -88,7 +89,9 @@ public class HiveUnionPullUpConstantsRule extends RelOptRule {
     for (int i = 0; i < count ; i++) {
       RexNode expr = rexBuilder.makeInputRef(union, i);
       if (conditionsExtracted.containsKey(expr)) {
-        constants.put(expr, conditionsExtracted.get(expr));
+        RexNode literal = rexBuilder.makeLiteral(
+            ((RexLiteral) conditionsExtracted.get(expr)).getValue(), expr.getType(), true);
+        constants.put(expr, literal);
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveRelMdPredicates.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveRelMdPredicates.java
@@ -165,7 +165,8 @@ public class HiveRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
         final RexLiteral literal = (RexLiteral) expr.e;
         RexNode r = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS,
             rexBuilder.makeInputRef(project, expr.i), literal);
-        r = rexSimplify.simplifyPreservingType(r);
+        // do not simplify here, it can intefere with AggregateProjectPullUpConstantRule
+        // which needs '=($i, literal)', but '=($i, true)' gets simplified to 'true'
         projectPullUpPredicates.add(r);
       } else if (expr.e instanceof RexCall && HiveCalciteUtil.isDeterministicFuncOnLiterals(expr.e)) {
       //TODO: Move this to calcite

--- a/ql/src/test/queries/clientpositive/cbo_join_push_transitive_pred_oom.q
+++ b/ql/src/test/queries/clientpositive/cbo_join_push_transitive_pred_oom.q
@@ -1,0 +1,13 @@
+create table test1 (a string);
+create table test2 (m string);
+create table test3 (m string);
+
+EXPLAIN CBO SELECT c.m
+FROM
+ (SELECT substr(from_unixtime(unix_timestamp(), 'yyyy-MM-dd'), 1, 1) AS m
+  FROM test1
+  UNION ALL
+  SELECT m
+  FROM test2
+  WHERE m = '2') c
+JOIN test3 d ON c.m = d.m;

--- a/ql/src/test/queries/clientpositive/pcs.q
+++ b/ql/src/test/queries/clientpositive/pcs.q
@@ -44,7 +44,7 @@ SELECT * FROM (
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds;
 
 SELECT * FROM (
@@ -52,7 +52,7 @@ SELECT * FROM (
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds;
 
 explain extended select ds from pcs_t1 where struct(case when ds='2000-04-08' then 10 else 20 end) in (struct(10),struct(11));

--- a/ql/src/test/results/clientpositive/llap/cbo_join_push_transitive_pred_oom.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_join_push_transitive_pred_oom.q.out
@@ -30,23 +30,6 @@ unix_timestamp(void) is deprecated. Use current_timestamp instead.
 unix_timestamp(void) is deprecated. Use current_timestamp instead.
 unix_timestamp(void) is deprecated. Use current_timestamp instead.
 unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
-unix_timestamp(void) is deprecated. Use current_timestamp instead.
 PREHOOK: query: EXPLAIN CBO SELECT c.m
 FROM
  (SELECT substr(from_unixtime(unix_timestamp(), 'yyyy-MM-dd'), 1, 1) AS m
@@ -81,13 +64,13 @@ HiveProject(m=[$0])
     HiveProject(m=[$0])
       HiveUnion(all=[true])
         HiveProject(m=[substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)])
-          HiveFilter(condition=[AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IN(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+          HiveFilter(condition=[OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2'))])
             HiveProject(DUMMY=[0])
               HiveTableScan(table=[[default, test1]], table:alias=[test1])
         HiveProject($f0=[CAST(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
-          HiveFilter(condition=[AND(=($0, _UTF-16LE'2'), IN(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+          HiveFilter(condition=[=($0, _UTF-16LE'2')])
             HiveTableScan(table=[[default, test2]], table:alias=[test2])
     HiveProject(m=[$0])
-      HiveFilter(condition=[AND(OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), =($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =($0, _UTF-16LE'2')), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IN(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2'))), AND(IN(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($0, _UTF-16LE'2'))), IN($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+      HiveFilter(condition=[AND(OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), =($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =($0, _UTF-16LE'2')), IN($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
         HiveTableScan(table=[[default, test3]], table:alias=[d])
 

--- a/ql/src/test/results/clientpositive/llap/cbo_join_push_transitive_pred_oom.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_join_push_transitive_pred_oom.q.out
@@ -1,0 +1,93 @@
+PREHOOK: query: create table test1 (a string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test1
+POSTHOOK: query: create table test1 (a string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test1
+PREHOOK: query: create table test2 (m string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test2
+POSTHOOK: query: create table test2 (m string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test2
+PREHOOK: query: create table test3 (m string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test3
+POSTHOOK: query: create table test3 (m string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test3
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+unix_timestamp(void) is deprecated. Use current_timestamp instead.
+PREHOOK: query: EXPLAIN CBO SELECT c.m
+FROM
+ (SELECT substr(from_unixtime(unix_timestamp(), 'yyyy-MM-dd'), 1, 1) AS m
+  FROM test1
+  UNION ALL
+  SELECT m
+  FROM test2
+  WHERE m = '2') c
+JOIN test3 d ON c.m = d.m
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test1
+PREHOOK: Input: default@test2
+PREHOOK: Input: default@test3
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT c.m
+FROM
+ (SELECT substr(from_unixtime(unix_timestamp(), 'yyyy-MM-dd'), 1, 1) AS m
+  FROM test1
+  UNION ALL
+  SELECT m
+  FROM test2
+  WHERE m = '2') c
+JOIN test3 d ON c.m = d.m
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test1
+POSTHOOK: Input: default@test2
+POSTHOOK: Input: default@test3
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(m=[$0])
+  HiveJoin(condition=[=($0, $1)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(m=[$0])
+      HiveUnion(all=[true])
+        HiveProject(m=[substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)])
+          HiveFilter(condition=[AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IN(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+            HiveProject(DUMMY=[0])
+              HiveTableScan(table=[[default, test1]], table:alias=[test1])
+        HiveProject($f0=[CAST(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+          HiveFilter(condition=[AND(=($0, _UTF-16LE'2'), IN(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+            HiveTableScan(table=[[default, test2]], table:alias=[test2])
+    HiveProject(m=[$0])
+      HiveFilter(condition=[AND(OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), =($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =($0, _UTF-16LE'2')), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IN(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), OR(AND(OR(IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1)), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2')), IS NOT NULL(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1))), =(substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2'))), AND(IN(_UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($0, _UTF-16LE'2'))), IN($0, substr(FROM_UNIXTIME(UNIX_TIMESTAMP, _UTF-16LE'yyyy-MM-dd':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), 1, 1), _UTF-16LE'2':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+        HiveTableScan(table=[[default, test3]], table:alias=[d])
+

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
@@ -40,24 +40,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -65,24 +65,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -116,13 +116,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 4 
             Execution mode: llap
@@ -154,13 +154,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Union 3 
             Vertex: Union 3
@@ -248,24 +248,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -273,24 +273,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -324,13 +324,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 4 
             Execution mode: llap
@@ -362,13 +362,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Union 3 
             Vertex: Union 3
@@ -896,24 +896,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -921,24 +921,24 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 26344 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string), value (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 148 Data size: 27528 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 30876 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                        Statistics: Num rows: 148 Data size: 27528 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 30876 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -972,13 +972,13 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: string)
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint)
         Reducer 4 
             Execution mode: llap
@@ -1010,17 +1010,17 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string), KEY._col1 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 148 Data size: 27528 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 30876 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), _col2 (type: bigint)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: string)
                     null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: string)
-                    Statistics: Num rows: 296 Data size: 28120 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
         Union 3 
             Vertex: Union 3

--- a/ql/src/test/results/clientpositive/llap/in_typecheck_char.q.out
+++ b/ql/src/test/results/clientpositive/llap/in_typecheck_char.q.out
@@ -305,7 +305,7 @@ POSTHOOK: Input: default@ax
 #### A masked pattern was here ####
 CBO PLAN:
 HiveAggregate(group=[{}], agg#0=[count()])
-  HiveFilter(condition=[IN($1, _UTF-16LE'a         ', _UTF-16LE'bb        ', _UTF-16LE'aa        ', _UTF-16LE'bbb       ', _UTF-16LE'ab        ', _UTF-16LE'ba        ', _UTF-16LE'aaa       ', _UTF-16LE'bbb       ', _UTF-16LE'abc       ', _UTF-16LE'bc        ', _UTF-16LE'ac        ', _UTF-16LE'bca       ', _UTF-16LE'cab       ', _UTF-16LE'cb        ', _UTF-16LE'ca        ', _UTF-16LE'cbc       ', _UTF-16LE'z         ')])
+  HiveFilter(condition=[IN($1, _UTF-16LE'a         ', _UTF-16LE'bb        ', _UTF-16LE'aa        ', _UTF-16LE'bbb       ', _UTF-16LE'ab        ', _UTF-16LE'ba        ', _UTF-16LE'aaa       ', _UTF-16LE'abc       ', _UTF-16LE'bc        ', _UTF-16LE'ac        ', _UTF-16LE'bca       ', _UTF-16LE'cab       ', _UTF-16LE'cb        ', _UTF-16LE'ca        ', _UTF-16LE'cbc       ', _UTF-16LE'z         ')])
     HiveTableScan(table=[[default, ax]], table:alias=[ax])
 
 PREHOOK: query: explain select count(*) from ax where t in
@@ -334,10 +334,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: ax
-                  filterExpr: (t) IN ('a         ', 'bb        ', 'aa        ', 'bbb       ', 'ab        ', 'ba        ', 'aaa       ', 'bbb       ', 'abc       ', 'bc        ', 'ac        ', 'bca       ', 'cab       ', 'cb        ', 'ca        ', 'cbc       ', 'z         ') (type: boolean)
+                  filterExpr: (t) IN ('a         ', 'bb        ', 'aa        ', 'bbb       ', 'ab        ', 'ba        ', 'aaa       ', 'abc       ', 'bc        ', 'ac        ', 'bca       ', 'cab       ', 'cb        ', 'ca        ', 'cbc       ', 'z         ') (type: boolean)
                   Statistics: Num rows: 3 Data size: 255 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (t) IN ('a         ', 'bb        ', 'aa        ', 'bbb       ', 'ab        ', 'ba        ', 'aaa       ', 'bbb       ', 'abc       ', 'bc        ', 'ac        ', 'bca       ', 'cab       ', 'cb        ', 'ca        ', 'cbc       ', 'z         ') (type: boolean)
+                    predicate: (t) IN ('a         ', 'bb        ', 'aa        ', 'bbb       ', 'ab        ', 'ba        ', 'aaa       ', 'abc       ', 'bc        ', 'ac        ', 'bca       ', 'cab       ', 'cb        ', 'ca        ', 'cbc       ', 'z         ') (type: boolean)
                     Statistics: Num rows: 3 Data size: 255 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       Statistics: Num rows: 3 Data size: 255 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/infer_join_preds.q.out
+++ b/ql/src/test/results/clientpositive/llap/infer_join_preds.q.out
@@ -805,10 +805,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src1
-                  filterExpr: (4.0D BETWEEN UDFToDouble(key) AND UDFToDouble(value) and key is not null and value is not null) (type: boolean)
+                  filterExpr: 4.0D BETWEEN UDFToDouble(key) AND UDFToDouble(value) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (4.0D BETWEEN UDFToDouble(key) AND UDFToDouble(value) and key is not null and value is not null) (type: boolean)
+                    predicate: 4.0D BETWEEN UDFToDouble(key) AND UDFToDouble(value) (type: boolean)
                     Statistics: Num rows: 2 Data size: 350 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)

--- a/ql/src/test/results/clientpositive/llap/join34.q.out
+++ b/ql/src/test/results/clientpositive/llap/join34.q.out
@@ -36,11 +36,11 @@ OPTIMIZED SQL: SELECT `t6`.`key`, `t6`.`value`, `t4`.`value` AS `value1`
 FROM (SELECT *
 FROM (SELECT `key`, `value`
 FROM `default`.`src`
-WHERE CAST(`key` AS DOUBLE) BETWEEN 20 AND 100 AND `key` < 20
+WHERE `key` < 20
 UNION ALL
 SELECT `key`, `value`
 FROM `default`.`src`
-WHERE CAST(`key` AS DOUBLE) BETWEEN 20 AND 100 AND `key` > 100) AS `t3`) AS `t4`
+WHERE `key` > 100) AS `t3`) AS `t4`
 INNER JOIN (SELECT `key`, `value`
 FROM `default`.`src1`
 WHERE CAST(`key` AS DOUBLE) BETWEEN 20 AND 100 AND `key` IS NOT NULL) AS `t6` ON `t4`.`key` = `t6`.`key`
@@ -64,18 +64,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
                   probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_40_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.092
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
                     isSamplingPred: false
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 26344 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 26344 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -180,17 +180,17 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
                     isSamplingPred: false
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 26344 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 26344 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1

--- a/ql/src/test/results/clientpositive/llap/join35.q.out
+++ b/ql/src/test/results/clientpositive/llap/join35.q.out
@@ -36,12 +36,12 @@ OPTIMIZED SQL: SELECT `t8`.`key`, `t8`.`value`, `t6`.`$f1` AS `cnt`
 FROM (SELECT *
 FROM (SELECT `key`, COUNT(*) AS `$f1`
 FROM `default`.`src`
-WHERE CAST(`key` AS DOUBLE) BETWEEN 20 AND 100 AND `key` < 20
+WHERE `key` < 20
 GROUP BY `key`
 UNION ALL
 SELECT `key`, COUNT(*) AS `$f1`
 FROM `default`.`src`
-WHERE CAST(`key` AS DOUBLE) BETWEEN 20 AND 100 AND `key` > 100
+WHERE `key` > 100
 GROUP BY `key`) AS `t5`) AS `t6`
 INNER JOIN (SELECT `key`, `value`
 FROM `default`.`src1`
@@ -66,20 +66,20 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
                     isSamplingPred: false
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         bucketingVersion: 2
                         key expressions: _col0 (type: string)
@@ -87,7 +87,7 @@ STAGE PLANS:
                         numBuckets: -1
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: -1
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
@@ -134,20 +134,20 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
+                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
                     isSamplingPred: false
-                    predicate: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) > 100.0D)) (type: boolean)
-                    Statistics: Num rows: 148 Data size: 12876 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string)
                       minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         bucketingVersion: 2
                         key expressions: _col0 (type: string)
@@ -155,7 +155,7 @@ STAGE PLANS:
                         numBuckets: -1
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: -1
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
@@ -283,7 +283,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Map Join Operator
                   condition map:
                        Inner Join 0 to 1
@@ -391,7 +391,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 148 Data size: 14060 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Map Join Operator
                   condition map:
                        Inner Join 0 to 1

--- a/ql/src/test/results/clientpositive/llap/pcs.q.out
+++ b/ql/src/test/results/clientpositive/llap/pcs.q.out
@@ -1043,6 +1043,9 @@ WHERE A.ds = '2008-04-08'
 SORT BY A.key, A.value, A.ds
 PREHOOK: type: QUERY
 PREHOOK: Input: default@pcs_t1
+PREHOOK: Input: default@pcs_t1@ds=2000-04-08
+PREHOOK: Input: default@pcs_t1@ds=2000-04-09
+PREHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN EXTENDED
 SELECT * FROM (
@@ -1054,6 +1057,9 @@ WHERE A.ds = '2008-04-08'
 SORT BY A.key, A.value, A.ds
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@pcs_t1
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-08
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-09
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1073,69 +1079,295 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: ((struct(key,ds)) IN (const struct(1,'2000-04-08'), const struct(2,'2000-04-09')) and (ds = '2008-04-08')) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 268 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 60 Data size: 16680 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: ((struct(key,ds)) IN (const struct(1,'2000-04-08'), const struct(2,'2000-04-09')) and (ds = '2008-04-08')) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 268 Basic stats: COMPLETE Column stats: COMPLETE
+                  Limit
+                    Number of rows: 0
+                    Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: key (type: int), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: key (type: int), value (type: string), ds (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         bucketingVersion: 2
-                        key expressions: _col0 (type: int), _col1 (type: string)
-                        null sort order: zz
+                        key expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
+                        null sort order: zzz
                         numBuckets: -1
-                        sort order: ++
-                        Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        sort order: +++
+                        Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: -1
                         auto parallelism: true
             Execution mode: vectorized, llap
-            LLAP IO: unknown
+            LLAP IO: all inputs
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-08
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-08
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-09
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-09
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-10
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-10
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+            Truncated Path -> Alias:
+              /pcs_t1/ds=2000-04-08 [x]
+              /pcs_t1/ds=2000-04-09 [x]
+              /pcs_t1/ds=2000-04-10 [x]
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: y
-                  filterExpr: ((struct(key,ds)) IN (const struct(1,'2000-04-08'), const struct(2,'2000-04-09')) and (ds = '2008-04-08')) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 268 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 60 Data size: 16680 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: ((struct(key,ds)) IN (const struct(1,'2000-04-08'), const struct(2,'2000-04-09')) and (ds = '2008-04-08')) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 268 Basic stats: COMPLETE Column stats: COMPLETE
+                  Limit
+                    Number of rows: 0
+                    Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: key (type: int), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: key (type: int), value (type: string), ds (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         bucketingVersion: 2
-                        key expressions: _col0 (type: int), _col1 (type: string)
-                        null sort order: zz
+                        key expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
+                        null sort order: zzz
                         numBuckets: -1
-                        sort order: ++
-                        Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        sort order: +++
+                        Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: -1
                         auto parallelism: true
             Execution mode: vectorized, llap
-            LLAP IO: unknown
+            LLAP IO: all inputs
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-08
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-08
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-09
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-09
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+#### A masked pattern was here ####
+                Partition
+                  base file name: ds=2000-04-10
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  partition values:
+                    ds 2000-04-10
+                  properties:
+                    column.name.delimiter ,
+                    columns key,value
+                    columns.types int:string
+#### A masked pattern was here ####
+                    name default.pcs_t1
+                    partition_columns ds
+                    partition_columns.types string
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns key,value
+                      columns.comments 
+                      columns.types int:string
+#### A masked pattern was here ####
+                      name default.pcs_t1
+                      partition_columns ds
+                      partition_columns.types string
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.pcs_t1
+                  name: default.pcs_t1
+            Truncated Path -> Alias:
+              /pcs_t1/ds=2000-04-08 [y]
+              /pcs_t1/ds=2000-04-09 [y]
+              /pcs_t1/ds=2000-04-10 [y]
         Reducer 3 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string), '2008-04-08' (type: string)
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey2 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   bucketingVersion: 2
                   compressed: false
                   GlobalTableId: 0
 #### A masked pattern was here ####
                   NumFilesPerFileSink: 1
-                  Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
 #### A masked pattern was here ####
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1171,6 +1403,9 @@ WHERE A.ds = '2008-04-08'
 SORT BY A.key, A.value, A.ds
 PREHOOK: type: QUERY
 PREHOOK: Input: default@pcs_t1
+PREHOOK: Input: default@pcs_t1@ds=2000-04-08
+PREHOOK: Input: default@pcs_t1@ds=2000-04-09
+PREHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT * FROM (
   SELECT X.* FROM pcs_t1 X WHERE struct(X.ds, X.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
@@ -1181,6 +1416,9 @@ WHERE A.ds = '2008-04-08'
 SORT BY A.key, A.value, A.ds
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@pcs_t1
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-08
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-09
+POSTHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 PREHOOK: query: explain extended select ds from pcs_t1 where struct(case when ds='2000-04-08' then 10 else 20 end) in (struct(10),struct(11))
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/pcs.q.out
+++ b/ql/src/test/results/clientpositive/llap/pcs.q.out
@@ -1039,13 +1039,11 @@ SELECT * FROM (
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds
 PREHOOK: type: QUERY
 PREHOOK: Input: default@pcs_t1
 PREHOOK: Input: default@pcs_t1@ds=2000-04-08
-PREHOOK: Input: default@pcs_t1@ds=2000-04-09
-PREHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN EXTENDED
 SELECT * FROM (
@@ -1053,13 +1051,11 @@ SELECT * FROM (
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@pcs_t1
 POSTHOOK: Input: default@pcs_t1@ds=2000-04-08
-POSTHOOK: Input: default@pcs_t1@ds=2000-04-09
-POSTHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1079,24 +1075,30 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  Statistics: Num rows: 60 Data size: 16680 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: ((key = 1) and (ds = '2000-04-08')) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1880 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
-                  Limit
-                    Number of rows: 0
-                    Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    isSamplingPred: false
+                    predicate: (key = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: key (type: int), value (type: string), ds (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        bucketingVersion: 2
-                        key expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
-                        null sort order: zzz
-                        numBuckets: -1
-                        sort order: +++
-                        Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
-                        tag: -1
-                        auto parallelism: true
+                      expressions: value (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        expressions: _col0 (type: string)
+                        outputColumnNames: _col1
+                        Statistics: Num rows: 4 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          bucketingVersion: 2
+                          key expressions: _col1 (type: string)
+                          null sort order: z
+                          numBuckets: -1
+                          sort order: +
+                          Statistics: Num rows: 4 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                          tag: -1
+                          auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Path -> Alias:
@@ -1109,78 +1111,6 @@ STAGE PLANS:
                   output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                   partition values:
                     ds 2000-04-08
-                  properties:
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types int:string
-#### A masked pattern was here ####
-                    name default.pcs_t1
-                    partition_columns ds
-                    partition_columns.types string
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 
-                      columns.types int:string
-#### A masked pattern was here ####
-                      name default.pcs_t1
-                      partition_columns ds
-                      partition_columns.types string
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.pcs_t1
-                  name: default.pcs_t1
-#### A masked pattern was here ####
-                Partition
-                  base file name: ds=2000-04-09
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  partition values:
-                    ds 2000-04-09
-                  properties:
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types int:string
-#### A masked pattern was here ####
-                    name default.pcs_t1
-                    partition_columns ds
-                    partition_columns.types string
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 
-                      columns.types int:string
-#### A masked pattern was here ####
-                      name default.pcs_t1
-                      partition_columns ds
-                      partition_columns.types string
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.pcs_t1
-                  name: default.pcs_t1
-#### A masked pattern was here ####
-                Partition
-                  base file name: ds=2000-04-10
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  partition values:
-                    ds 2000-04-10
                   properties:
                     column.name.delimiter ,
                     columns key,value
@@ -1212,30 +1142,34 @@ STAGE PLANS:
                   name: default.pcs_t1
             Truncated Path -> Alias:
               /pcs_t1/ds=2000-04-08 [x]
-              /pcs_t1/ds=2000-04-09 [x]
-              /pcs_t1/ds=2000-04-10 [x]
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: y
-                  Statistics: Num rows: 60 Data size: 16680 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: ((key = 1) and (ds = '2000-04-08')) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1880 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
-                  Limit
-                    Number of rows: 0
-                    Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    isSamplingPred: false
+                    predicate: (key = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: key (type: int), value (type: string), ds (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 278 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        bucketingVersion: 2
-                        key expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
-                        null sort order: zzz
-                        numBuckets: -1
-                        sort order: +++
-                        Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
-                        tag: -1
-                        auto parallelism: true
+                      expressions: value (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        expressions: _col0 (type: string)
+                        outputColumnNames: _col1
+                        Statistics: Num rows: 4 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          bucketingVersion: 2
+                          key expressions: _col1 (type: string)
+                          null sort order: z
+                          numBuckets: -1
+                          sort order: +
+                          Statistics: Num rows: 4 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                          tag: -1
+                          auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Path -> Alias:
@@ -1277,97 +1211,23 @@ STAGE PLANS:
                     serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                     name: default.pcs_t1
                   name: default.pcs_t1
-#### A masked pattern was here ####
-                Partition
-                  base file name: ds=2000-04-09
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  partition values:
-                    ds 2000-04-09
-                  properties:
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types int:string
-#### A masked pattern was here ####
-                    name default.pcs_t1
-                    partition_columns ds
-                    partition_columns.types string
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 
-                      columns.types int:string
-#### A masked pattern was here ####
-                      name default.pcs_t1
-                      partition_columns ds
-                      partition_columns.types string
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.pcs_t1
-                  name: default.pcs_t1
-#### A masked pattern was here ####
-                Partition
-                  base file name: ds=2000-04-10
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  partition values:
-                    ds 2000-04-10
-                  properties:
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types int:string
-#### A masked pattern was here ####
-                    name default.pcs_t1
-                    partition_columns ds
-                    partition_columns.types string
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 
-                      columns.types int:string
-#### A masked pattern was here ####
-                      name default.pcs_t1
-                      partition_columns ds
-                      partition_columns.types string
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.pcs_t1
-                  name: default.pcs_t1
             Truncated Path -> Alias:
               /pcs_t1/ds=2000-04-08 [y]
-              /pcs_t1/ds=2000-04-09 [y]
-              /pcs_t1/ds=2000-04-10 [y]
         Reducer 3 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey2 (type: string)
+                expressions: 1 (type: int), KEY.reducesinkkey0 (type: string), '2000-04-08' (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   bucketingVersion: 2
                   compressed: false
                   GlobalTableId: 0
 #### A masked pattern was here ####
                   NumFilesPerFileSink: 1
-                  Statistics: Num rows: 2 Data size: 556 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 4 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
 #### A masked pattern was here ####
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1399,26 +1259,22 @@ PREHOOK: query: SELECT * FROM (
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds
 PREHOOK: type: QUERY
 PREHOOK: Input: default@pcs_t1
 PREHOOK: Input: default@pcs_t1@ds=2000-04-08
-PREHOOK: Input: default@pcs_t1@ds=2000-04-09
-PREHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT * FROM (
   SELECT X.* FROM pcs_t1 X WHERE struct(X.ds, X.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
   UNION ALL
   SELECT Y.* FROM pcs_t1 Y WHERE struct(Y.ds, Y.key) in (struct('2000-04-08',1), struct('2000-04-09',2))
 ) A
-WHERE A.ds = '2008-04-08'
+WHERE A.ds = '2000-04-08'
 SORT BY A.key, A.value, A.ds
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@pcs_t1
 POSTHOOK: Input: default@pcs_t1@ds=2000-04-08
-POSTHOOK: Input: default@pcs_t1@ds=2000-04-09
-POSTHOOK: Input: default@pcs_t1@ds=2000-04-10
 #### A masked pattern was here ####
 PREHOOK: query: explain extended select ds from pcs_t1 where struct(case when ds='2000-04-08' then 10 else 20 end) in (struct(10),struct(11))
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/subquery_select.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_select.q.out
@@ -852,15 +852,11 @@ STAGE PLANS:
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: true (type: boolean)
-                  outputColumnNames: _col0
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: boolean)
+                  value expressions: _col0 (type: boolean)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1129,15 +1125,11 @@ STAGE PLANS:
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: true (type: boolean)
-                  outputColumnNames: _col0
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: boolean)
+                  value expressions: _col0 (type: boolean)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Removes OOM in query planning by adding simplification of new predicates created by `HiveJoinPushTransitivePredicatesRule`. In addition, the following side improvements have been made:

- `HiveReduceExpressionsWithStatsRule` now produces `a=b` instead of `a IN (b)` for single-element `IN` clauses
- the pulled-up constant in `HiveUnionPullUpConstantsRule` now respects the nullability of the expression it is "replacing" to avoid type mismatches
- additional simplifications in `HiveRelMdPredicates`, `HiveJoinPushTransitivePredicatesRule` and `HiveFilterProjectTransposeRule` to prevent loops in predicates inference
- conversion of `IN`/`BETWEEN` expressions into `OR`/`AND` (respectively), re-conversion into `IN`/`BETWEEN` after reduction/simplifications in `HiveReduceExpressionsRule`, since `RexSimplify` can't handle `IN`/`BETWEEN` and it was therefore missing some opportunities

Per-file description of the changes:

```
ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveInBetweenExpandRule.java
ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HivePointLookupOptimizerRule.java
```
- change visibility and modifier of few methods to be reused in HiveReduceExpressionsRule

`ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsRule.java`
- now converts in/between to or/and before simplification, and back to in/between after since RexSimplify does not handle them and we were missing simplification opportunities. Tried to introduce

`ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveReduceExpressionsWithStatsRule.java`
- fixed to avoid the creation of IN($i, a), producing =($i, a) instead

`ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveUnionPullUpConstantsRule.java`
- when pulling up a constant we need to make sure the nullability is preserved (by default literals are non nullable, this was causing problems with type mismatch across union operands)

```
ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveRelMdPredicates.java
ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveFilterProjectTransposeRule.java
ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveJoinPushTransitivePredicatesRule.java
```
- simplification applied consistently

```
ql/src/test/queries/clientpositive/cbo_join_push_transitive_pred_oom.q
ql/src/test/results/clientpositive/llap/cbo_join_push_transitive_pred_oom.q.out
```
- added qtest reproducing the problem

```
ql/src/test/queries/clientpositive/pcs.q
ql/src/test/results/clientpositive/llap/pcs.q.out
```
- wrong query most probably, updated as well as result

`ql/src/test/results/clientpositive/llap/in_typecheck_char.q.out`
- remove redundant costants in IN clause, plan improved

```
ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
ql/src/test/results/clientpositive/llap/infer_join_preds.q.out
ql/src/test/results/clientpositive/llap/join34.q.out
ql/src/test/results/clientpositive/llap/join35.q.out
ql/src/test/results/clientpositive/llap/subquery_select.q.out
```
- simplified predicates

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Query in the JIRA ticket was failing with OOM.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Affected queries are now succeeding, in some cases there are additional predicates simplifications.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

`mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile="cbo_join_push_transitive_pred_oom.q" -pl itests/qtest -Pitests`