### PR TITLE
HIVE-25778 : Hive DB creation is failing when MANAGEDLOCATION is specified with existing location

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1362,8 +1362,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
             if (madeManagedDir) {
               LOG.info("Created database path in managed directory " + dbMgdPath);
             } else if (!isInTest || !isDbReplicationTarget(db)) { // Hive replication tests doesn't drop the db after each test
-              throw new MetaException(
-                  "Unable to create database managed directory " + dbMgdPath + ", failed to create database " + db.getName());
+              LOG.warn("Creating database with existing managed directory " + dbMgdPath);
             }
           } catch (IOException | InterruptedException e) {
             throw new MetaException(

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -338,6 +338,33 @@ public class TestDatabases extends MetaStoreClientTest {
     Assert.assertFalse("The data file should not exist", metaStore.isPathExists(dataFile));
   }
 
+  @Test
+  public void testDropDatabaseExistingManagedLocation() throws Exception {
+    String databaseName = "test_managed_location";
+    Database database =
+            new DatabaseBuilder().setName(databaseName).create(client, metaStore.getConf());
+    Database createdDatabase = client.getDatabase(database.getName());
+
+    String managedLocationUri = createdDatabase.getLocationUri() + "/managed";
+    Path managedPath = new Path(managedLocationUri);
+    Database database1 = new DatabaseBuilder().setName("test_managed_location1").
+            setManagedLocation(managedLocationUri).create(client, metaStore.getConf());
+
+    Assert.assertTrue("The managed path should still exist", metaStore.isPathExists(managedPath));
+
+    // Create database with same managed location
+    Database database2 = new DatabaseBuilder().setName("test_managed_location2").
+            setManagedLocation(managedLocationUri).create(client, metaStore.getConf());
+
+    // Delete the data
+    client.dropDatabase(database.getName(), true, false);
+    client.dropDatabase(database1.getName(), true, false);
+    client.dropDatabase(database2.getName(), true, false);
+
+    // Check that the data is removed
+    Assert.assertFalse("The managed path should not exist", metaStore.isPathExists(managedPath));
+  }
+
   @Test(expected = NoSuchObjectException.class)
   public void testDropDatabaseIgnoreUnknownFalse() throws Exception {
     // No such database


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes the check to prevent user from creating a database with existing managed location.Now with this fix, user will nbe able to create a database even if the managed location specified is already exist.



### Why are the changes needed?

TO maintain the backward compatibility.



### Does this PR introduce _any_ user-facing change?

Yes, now user will be bale to create the database even if the managed location specified is already exist.



### How was this patch tested?

Unit test is added to confirm the behaviour.

