### PR TITLE
HIVE-25793 Isolate metastore metrics related to a retrying handler

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreMetrics.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreMetrics.java
@@ -61,8 +61,7 @@ public class TestMetaStoreMetrics {
   public void testMethodCounts() throws Exception {
     driver.run("show databases");
 
-    //one call by init, one called here.
-    Assert.assertEquals(2, Metrics.getRegistry().getTimers().get("api_get_databases").getCount());
+    Assert.assertEquals(1, Metrics.getRegistry().getTimers().get("api_get_databases").getCount());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetryingHMSHandlerMetrics.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetryingHMSHandlerMetrics.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.metrics.Metrics;
+import org.apache.hadoop.hive.metastore.metrics.MetricsTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.apache.hadoop.hive.metastore.metrics.MetricsTestUtils.verifyMetrics;
+
+@Category(MetastoreUnitTest.class)
+public class TestRetryingHMSHandlerMetrics {
+  private MetricRegistry metrics;
+  protected Configuration conf;
+  private IHMSHandler hmsHandler;
+
+  @Before
+  public void setup() throws Exception {
+    Configuration conf = MetastoreConf.newMetastoreConf();
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_METADATA_TRANSFORMER_CLASS, " ");
+    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.METRICS_ENABLED, true);
+
+    MetaStoreTestUtils.setConfForStandloneMode(conf);
+
+    hmsHandler = RetryingHMSHandler.getProxy(conf, new HMSHandler("test-hms-handler", conf), true);
+    metrics = Metrics.getRegistry();
+  }
+
+  @Test
+  public void testGetDatabasesCount() throws Exception {
+    hmsHandler.get_databases("test_db");
+
+    verifyMetrics(metrics, MetricsTestUtils.TIMER, "api_get_databases", 1);
+    verifyMetrics(metrics, MetricsTestUtils.TIMER, "api_RetryingHMSHandler.get_databases", 1);
+  }
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/MetricsTestUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/MetricsTestUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+// Stolen from Hive's MetricsTestUtils.
+public class MetricsTestUtils {
+  public static final MetricsCategory COUNTER = new MetricsCategory("counters", "count");
+  public static final MetricsCategory TIMER = new MetricsCategory("timers", "count");
+  public static final MetricsCategory GAUGE = new MetricsCategory("gauges", "value");
+  public static final MetricsCategory METER = new MetricsCategory("meters", "count");
+
+  static class MetricsCategory {
+    String category;
+    String metricsHandle;
+
+    MetricsCategory(String category, String metricsHandle) {
+      this.category = category;
+      this.metricsHandle = metricsHandle;
+    }
+  }
+
+  public static void verifyMetrics(MetricRegistry metricRegistry, MetricsCategory category, String metricsName,
+      Object expectedValue) throws Exception {
+    verifyMetricsJson(dumpJson(metricRegistry), category, metricsName, expectedValue);
+  }
+
+  public static void verifyMetricsJson(String json, MetricsCategory category, String metricsName, Object expectedValue)
+      throws Exception {
+    JsonNode jsonNode = getJsonNode(json, category, metricsName);
+    Assert.assertTrue(
+        String.format("%s.%s.%s should not be empty", category.category, metricsName, category.metricsHandle),
+        !jsonNode.asText().isEmpty());
+
+    if (expectedValue != null) {
+      Assert.assertEquals(expectedValue.toString(), jsonNode.asText());
+    }
+  }
+
+  static void verifyMetricsJson(String json, MetricsCategory category, String metricsName) throws Exception {
+    verifyMetricsJson(json, category, metricsName, null);
+  }
+
+  static JsonNode getJsonNode(String json, MetricsCategory category, String metricsName) throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode rootNode = objectMapper.readTree(json);
+    JsonNode categoryNode = rootNode.path(category.category);
+    JsonNode metricsNode = categoryNode.path(metricsName);
+    return metricsNode.path(category.metricsHandle);
+  }
+
+  static byte[] getFileData(String path, int timeoutInterval, int tries) throws Exception {
+    File file = new File(path);
+    do {
+      Thread.sleep(timeoutInterval);
+      tries--;
+    } while (tries > 0 && !file.exists());
+    return Files.readAllBytes(Paths.get(path));
+  }
+
+  static String dumpJson(MetricRegistry metricRegistry) throws Exception {
+    ObjectMapper jsonMapper =
+        new ObjectMapper().registerModule(new MetricsModule(TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS, false));
+    return jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(metricRegistry);
+  }
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMetrics.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMetrics.java
@@ -20,14 +20,10 @@ package org.apache.hadoop.hive.metastore.metrics;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
@@ -188,56 +184,7 @@ public class TestMetrics {
     Assert.assertEquals(2, Metrics.getReporters().size());
   }
 
-  // Stolen from Hive's MetricsTestUtils.  Probably should break it out into it's own class.
-  private static class MetricsTestUtils {
 
-    static final MetricsCategory COUNTER = new MetricsCategory("counters", "count");
-    static final MetricsCategory TIMER = new MetricsCategory("timers", "count");
-    static final MetricsCategory GAUGE = new MetricsCategory("gauges", "value");
-    static final MetricsCategory METER = new MetricsCategory("meters", "count");
-
-    static class MetricsCategory {
-      String category;
-      String metricsHandle;
-      MetricsCategory(String category, String metricsHandle) {
-        this.category = category;
-        this.metricsHandle = metricsHandle;
-      }
-    }
-
-    static void verifyMetricsJson(String json, MetricsCategory category, String metricsName,
-        Object expectedValue) throws Exception {
-      JsonNode jsonNode = getJsonNode(json, category, metricsName);
-      Assert.assertTrue(String.format("%s.%s.%s should not be empty", category.category,
-          metricsName, category.metricsHandle), !jsonNode.asText().isEmpty());
-
-      if (expectedValue != null) {
-        Assert.assertEquals(expectedValue.toString(), jsonNode.asText());
-      }
-    }
-
-    static void verifyMetricsJson(String json, MetricsCategory category, String metricsName)
-        throws Exception {
-      verifyMetricsJson(json, category, metricsName, null);
-    }
-
-    static JsonNode getJsonNode(String json, MetricsCategory category, String metricsName) throws Exception {
-      ObjectMapper objectMapper = new ObjectMapper();
-      JsonNode rootNode = objectMapper.readTree(json);
-      JsonNode categoryNode = rootNode.path(category.category);
-      JsonNode metricsNode = categoryNode.path(metricsName);
-      return metricsNode.path(category.metricsHandle);
-    }
-
-    static byte[] getFileData(String path, int timeoutInterval, int tries) throws Exception {
-      File file = new File(path);
-      do {
-        Thread.sleep(timeoutInterval);
-        tries--;
-      } while (tries > 0 && !file.exists());
-      return Files.readAllBytes(Paths.get(path));
-    }
-  }
 
   private void initializeMetrics(Configuration conf) throws Exception {
     Field field = Metrics.class.getDeclaredField("self");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change will make new metrics for a metastore retrying proxy handler.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We can see that metastore api count increments twice for one RPC. A metastore server makes two timers with same name for one RPC. one for retrying proxy handler and another for hms handler.  It will make api metrics more inaccurate, Especially during retrying.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
This change will make new metrics for a metastore retrying proxy handler.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
A test was added
