### PR TITLE
HIVE-25794: CombineHiveRecordReader: log statements in a loop leads to memory pressure

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
@@ -113,7 +113,7 @@ public class CombineHiveRecordReader<K extends WritableComparable, V extends Wri
     for (Path path : hsplit.getPaths()) {
       PartitionDesc otherPart = HiveFileFormatUtils.getFromPathRecursively(
           pathToPartInfo, path, cache);
-      LOG.debug("Found spec for " + path + " " + otherPart + " from " + pathToPartInfo);
+      LOG.debug("Found spec for {} {} from {}", path, otherPart, pathToPartInfo);
       if (part == null) {
         part = otherPart;
       } else if (otherPart != part) { // Assume we should have the exact same object.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable lazy evaluation for a LOG.debug message in CombineHiveRecordReader.

### Why are the changes needed?
It became a perf bottleneck, even in case of INFO level logging, because string concatenation was evaluated regardless of logging level.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested on customer side on a cluster which hit the perf issue. 