### PR TITLE
HIVE-25799: Add java rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1479,6 +1479,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
         <dependencies>
           <dependency>
             <groupId>de.skuzzle.enforcer</groupId>
@@ -1539,6 +1540,19 @@
                 </bannedDependencies>
               </rules>
               <fail>true</fail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8.0,1.9.0)</version>
+                </requireJavaVersion>
+              </rules>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
HIVE only supports Java 8

### What changes were proposed in this pull request?

Fail build early if using a Java version that's new or older than Java 8.

### Why are the changes needed?

Hive apparently doesn't support other versions

### Does this PR introduce _any_ user-facing change?

Developers who try to build hive with a newer version of Java get an easy to understand error message instead of some hard to understand error message.

### How was this patch tested?
I tried building w/:
OpenJDK Runtime Environment AdoptOpenJDK-11.0.11+9 (build 11.0.11+9)
OpenJDK Runtime Environment Corretto-17.0.1.12.1 (build 17.0.1+12-LTS)
and they both failed quickly

Building with:
OpenJDK Runtime Environment Corretto-8.312.07.1 (build 1.8.0_312-b07)
doesn't fail quickly.