### PR TITLE
Add flag to skip validate phase for Iceberg module

### DIFF
--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -40,6 +40,7 @@
         <google.errorprone.version>2.5.1</google.errorprone.version>
         <assertj.version>3.19.0</assertj.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
+        <validate.skip>false</validate.skip>
     </properties>
 
     <modules>
@@ -236,6 +237,7 @@
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>${spotless.maven.plugin.version}</version>
                 <configuration>
+                    <skip>${validate.skip}</skip>
                     <java>
                         <removeUnusedImports />
                         <importOrder>
@@ -266,6 +268,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${iceberg.checkstyle.plugin.version}</version>
                 <configuration>
+                    <skip>${validate.skip}</skip>
                     <propertyExpansion>config_loc=${basedir}/${path.to.iceberg.root}/checkstyle/</propertyExpansion>
                     <configLocation>${basedir}/${path.to.iceberg.root}/checkstyle/checkstyle.xml</configLocation>
                     <suppressionsLocation>${basedir}/${path.to.iceberg.root}/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>


### PR DESCRIPTION
Introduce maven `validate.skip` flag to be able to skip checkstyle and spotless checks, which can speed up local development/quick iterations.
Example:
`mvn clean install -Dvalidate.skip`