### PR TITLE
HIVE-25818: Values query with order by position clause fails

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4025,7 +4025,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
         // replace each of the position alias in ORDERBY with the actual column
         if (ref != null && ref.getToken().getType() == HiveParser.Number) {
           if (isObyByPos) {
-            fieldIndex = getFieldIndexFromColumnNumber(selectOutputRR, ref);
+            int columnCount =
+                    selectOutputRR != null ? selectOutputRR.getColumnInfos().size() : inputRR.getColumnInfos().size();
+            fieldIndex = getFieldIndexFromColumnNumber(columnCount, ref);
           } else { // if not using position alias and it is a number.
             LOG.warn("Using constant number "
                     + ref.getText()
@@ -4140,10 +4142,10 @@ public class CalcitePlanner extends SemanticAnalyzer {
     }
 
     // SELECT a, b FROM t ORDER BY 1
-    private int getFieldIndexFromColumnNumber(RowResolver selectOutputRR, ASTNode ref) throws SemanticException {
+    private int getFieldIndexFromColumnNumber(int columnCount, ASTNode ref) throws SemanticException {
       int fieldIndex;
       int pos = Integer.parseInt(ref.getText());
-      if (pos > 0 && pos <= selectOutputRR.getColumnInfos().size()) {
+      if (pos > 0 && pos <= columnCount) {
         // fieldIndex becomes so simple
         // Note that pos starts from 1 while fieldIndex starts from 0;
         fieldIndex = pos - 1;
@@ -4151,7 +4153,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
         throw new SemanticException(
                 ErrorMsg.INVALID_POSITION_ALIAS_IN_ORDERBY.getMsg("Position alias: " + pos
                         + " does not exist\n" + "The Select List is indexed from 1 to "
-                        + selectOutputRR.getColumnInfos().size()));
+                        + columnCount));
       }
       return fieldIndex;
     }

--- a/ql/src/test/queries/clientpositive/order_by_pos.q
+++ b/ql/src/test/queries/clientpositive/order_by_pos.q
@@ -17,4 +17,5 @@ select * from t_n3 union select * from t_n3 order by 1, 2;
 select * from (select a, count(a) from t_n3 group by a)subq order by 2, 1;
 
 select * from (select a,b, count(*) from t_n3 group by a, b)subq order by 3, 2 desc, 1;
- 
+
+values(1+1, 2, 5.0, 'a'), (-12, 2, 5.0, 'a'), (100, 2, 5.0, 'a') order by 1 limit 2;

--- a/ql/src/test/results/clientpositive/llap/order_by_pos.q.out
+++ b/ql/src/test/results/clientpositive/llap/order_by_pos.q.out
@@ -129,3 +129,13 @@ POSTHOOK: Input: default@t_n3
 1	3	1
 20	-100	1
 1	2	2
+PREHOOK: query: values(1+1, 2, 5.0, 'a'), (-12, 2, 5.0, 'a'), (100, 2, 5.0, 'a') order by 1 limit 2
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: values(1+1, 2, 5.0, 'a'), (-12, 2, 5.0, 'a'), (100, 2, 5.0, 'a') order by 1 limit 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+-12	2	5	a
+2	2	5	a


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When verifying the column index defined in the order by clause use the column count stored in the project's input row resolver if the ouput RR is null

### Why are the changes needed?
`NullPointerException` was thrown because in case of `values` queries there is no output row resolver of the project.

### Does this PR introduce _any_ user-facing change?
Such queries don't fail with exception but provides a result.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=order_by_pos.q -pl itests/qtest -Pitests
```
