### PR TITLE
HIVE-25821: Update log4j2 version to 2.17.0 to incorporate further CVE-2021-45105…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.14.1</libthrift.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.27</mysql.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -91,7 +91,7 @@
     <junit.vintage.version>5.6.2</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.14.1</libthrift.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <mockito-core.version>3.3.3</mockito-core.version>
     <orc.version>1.6.9</orc.version>
     <!-- com.google repo will be used except on Aarch64 platform. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update log4j version to 2.17.0




### Why are the changes needed?
To incorporate further changes related to [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105).



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
