### PR TITLE
HIVE-25832:Exclude Category-X JDBC drivers from binary distribution

### DIFF
--- a/packaging/src/main/assembly/bin.xml
+++ b/packaging/src/main/assembly/bin.xml
@@ -48,6 +48,9 @@
         <exclude>commons-configuration:commons-configuration</exclude>
         <exclude>org.apache.hive:hive-jdbc:*:standalone</exclude>
         <exclude>org.apache.hive:hive-contrib</exclude>
+        <exclude>com.oracle.database.jdbc:*</exclude>
+        <exclude>mysql:mysql-connector-java:*</exclude>
+        <exclude>org.mariadb.jdbc:*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -99,10 +99,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <optional>true</optional>
@@ -264,6 +260,10 @@
     </dependency>
     <!-- JDBC drivers -->
     <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc8</artifactId>
     </dependency>
@@ -271,11 +271,19 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
-    <!-- test scope dependencies -->
     <dependency>
-      <groupId>com.microsoft.sqlserver</groupId>
-      <artifactId>mssql-jdbc</artifactId>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <!-- test scope dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -304,10 +312,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/standalone-metastore/metastore-server/src/assembly/bin.xml
+++ b/standalone-metastore/metastore-server/src/assembly/bin.xml
@@ -42,6 +42,9 @@
         <exclude>org.apache.hadoop:*</exclude>
         <exclude>org.slf4j:*</exclude>
         <exclude>log4j:*</exclude>
+        <exclude>com.oracle.database.jdbc:*</exclude>
+        <exclude>mysql:mysql-connector-java:*</exclude>
+        <exclude>org.mariadb.jdbc:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
Exclude drivers for Oracle, MySQL, and MariaDB to avoid licensing violations.

Misc:
1. Group all JDBC drivers in metastore-server pom.xml together for readability.
2. Add MariaDB driver in metastore-server pom.xml for keeping things uniform.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Build binary distribution and manually inspect lib directory.

```
mvn clean package -DskipTests -Pdist
ls packaging/target/apache-hive-4.0.0-SNAPSHOT-bin/apache-hive-4.0.0-SNAPSHOT-bin/lib/ | grep -e "postgres" -e "ojdbc" -e "mssql" -e "mariadb" -e "derby" -e "mysql"
```
Do the same for metastore:
```
ls -l apache-hive-metastore-4.0.0-SNAPSHOT-bin/lib/ | grep -e "postgres" -e "ojdbc" -e "mssql" -e "mariadb" -e "derby" -e "mysql"
-rw-r--r-- 1 stamatis stamatis  3232158 Jan 22  2020 derby-10.14.1.0.jar
-rw-r--r-- 1 stamatis stamatis   792491 Jan 22  2020 mssql-jdbc-6.2.1.jre8.jar
-rw-r--r-- 1 stamatis stamatis   932808 Jan 22  2020 postgresql-42.2.14.jar
```