### PR TITLE
HIVE-25824: Upgrade log4j dependencies to 2.17.0

### DIFF
--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -68,3 +68,7 @@ export HIVE_AUX_JARS_PATH=$HIVE_AUX_JARS_PATH
 
 # Default to use 256MB 
 export HADOOP_HEAPSIZE=${HADOOP_HEAPSIZE:-256}
+
+# Disable the JNDI. This feature has critical RCE vulnerability.
+# when 2.x <= log4j.version <= 2.14.1
+export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dlog4j2.formatMsgNoLookups=true"

--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -223,6 +223,11 @@
       <artifactId>calcite-druid</artifactId>
       <version>${calcite.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>junit</groupId>

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>hbase-hadoop-compat</artifactId>
       <version>${hbase.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
 
     <!-- test inter-project -->
     <dependency>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -109,6 +109,11 @@
       <version>${hadoop.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>junit</groupId>

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -230,6 +230,11 @@
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
 
     <!-- test inter-project -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <maven.install.plugin.version>2.4</maven.install.plugin.version>
     <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>2.4</maven.javadoc.plugin.version>
-    <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
+    <maven.shade.plugin.version>3.2.0</maven.shade.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <maven.war.plugin.version>2.4</maven.war.plugin.version>
     <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
@@ -143,7 +143,7 @@
     <hamcrest.version>1.1</hamcrest.version>
     <hbase.version>1.1.1</hbase.version>
     <!-- required for logging test to avoid including hbase which pulls disruptor transitively -->
-    <disruptor.version>3.3.0</disruptor.version>
+    <disruptor.version>3.3.7</disruptor.version>
     <hikaricp.version>2.5.1</hikaricp.version>
     <!-- httpcomponents are not always in version sync -->
     <httpcomponents.client.version>4.4</httpcomponents.client.version>
@@ -174,7 +174,7 @@
     <kryo.version>3.0.3</kryo.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.6.2</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.3.4</orc.version>
     <mockito-all.version>1.9.5</mockito-all.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -141,6 +141,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
     </dependency>

--- a/ql/src/java/org/apache/hadoop/hive/ql/log/NoDeleteRollingFileAppender.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/NoDeleteRollingFileAppender.java
@@ -27,7 +27,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Layout;
 import org.apache.log4j.helpers.CountingQuietWriter;
 import org.apache.log4j.helpers.LogLog;
-import org.apache.log4j.helpers.OptionConverter;
+import org.apache.logging.log4j.core.util.OptionConverter;
 import org.apache.log4j.spi.LoggingEvent;
 
 public class NoDeleteRollingFileAppender extends FileAppender {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -81,7 +81,12 @@
           </exclusion>
         </exclusions>
    </dependency>
-    <!-- used by thrift generated code -->
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
+   <!-- used by thrift generated code -->
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>

--- a/testutils/ptest2/pom.xml
+++ b/testutils/ptest2/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <name>hive-ptest</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j2.version>2.6.2</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <spring.framework.version>3.2.16.RELEASE</spring.framework.version>
     <jclouds.version>2.0.0</jclouds.version>
   </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change should mimic what done in the 3.x and master branches to fix the various CVEs related to log4j.

### How was this patch tested?

The Apache Bigtop project used the same patch on top of 2.3.6 (released with Bigtop 1.5) and all our build/smoke-tests passed.
More info https://github.com/apache/bigtop/pull/844