### PR TITLE
HIVE-25843: Add flag to disable Iceberg FileIO config serialization

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -79,6 +79,8 @@ public class InputFormatConfig {
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";
 
+  public static final String CONFIG_SERIALIZATION_DISABLED = "iceberg.mr.config.serialization.disabled";
+  public static final boolean CONFIG_SERIALIZATION_DISABLED_DEFAULT = true;
   public static final String OUTPUT_TABLES = "iceberg.mr.output.tables";
   public static final String COMMIT_TABLE_THREAD_POOL_SIZE = "iceberg.mr.commit.table.thread.pool.size";
   public static final int COMMIT_TABLE_THREAD_POOL_SIZE_DEFAULT = 10;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -72,9 +72,11 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -410,12 +412,47 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   /**
    * Returns the Table serialized to the configuration based on the table name.
+   * If configuration is missing from the FileIO of the table, it will be populated with the input config.
+   *
    * @param config The configuration used to get the data from
    * @param name The name of the table we need as returned by TableDesc.getTableName()
    * @return The Table
    */
   public static Table table(Configuration config, String name) {
-    return SerializationUtil.deserializeFromBase64(config.get(InputFormatConfig.SERIALIZED_TABLE_PREFIX + name));
+    Table table = SerializationUtil.deserializeFromBase64(config.get(InputFormatConfig.SERIALIZED_TABLE_PREFIX + name));
+    checkAndSetIoConfig(config, table);
+    return table;
+  }
+
+  /**
+   * If enabled, it populates the FileIO's hadoop configuration with the input config object.
+   * This might be necessary when the table object was serialized without the FileIO config.
+   *
+   * @param config Configuration to set for FileIO, if enabled
+   * @param table The Iceberg table object
+   */
+  public static void checkAndSetIoConfig(Configuration config, Table table) {
+    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+        InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
+      ((HadoopConfigurable) table.io()).setConf(config);
+    }
+  }
+
+  /**
+   * If enabled, it ensures that the FileIO's hadoop configuration will not be serialized.
+   * This might be desirable for decreasing the overall size of serialized table objects.
+   *
+   * Note: Skipping FileIO config serialization in this fashion might in turn necessitate calling
+   * {@link #checkAndSetIoConfig(Configuration, Table)} on the deserializer-side to enable subsequent use of the FileIO.
+   *
+   * @param config Configuration to set for FileIO in a transient manner, if enabled
+   * @param table The Iceberg table object
+   */
+  public static void checkAndSkipIoConfigSerialization(Configuration config, Table table) {
+    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+        InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
+      ((HadoopConfigurable) table.io()).serializeConfWith(conf -> new NonSerializingConfig(config)::get);
+    }
   }
 
   /**
@@ -477,10 +514,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     map.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
     props.put(InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(table.spec()));
 
-    if (table instanceof Serializable) {
-      map.put(InputFormatConfig.SERIALIZED_TABLE_PREFIX + tableDesc.getTableName(),
-          SerializationUtil.serializeToBase64(table));
-    }
+    // serialize table object into config
+    Table serializableTable = SerializableTable.copyOf(table);
+    checkAndSkipIoConfigSerialization(configuration, serializableTable);
+    map.put(InputFormatConfig.SERIALIZED_TABLE_PREFIX + tableDesc.getTableName(),
+        SerializationUtil.serializeToBase64(serializableTable));
 
     // We need to remove this otherwise the job.xml will be invalid as column comments are separated with '\0' and
     // the serialization utils fail to serialize this character
@@ -589,6 +627,23 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       // most likely empty write scenario
       LOG.debug("Unable to find commit information in query state for table: {}", tableName);
       return Optional.empty();
+    }
+  }
+
+  private static class NonSerializingConfig implements Serializable {
+
+    private final transient Configuration conf;
+
+    NonSerializingConfig(Configuration conf) {
+      this.conf = conf;
+    }
+
+    public Configuration get() {
+      if (conf == null) {
+        throw new IllegalStateException("Configuration was not serialized on purpose but was not set manually either");
+      }
+
+      return conf;
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -432,7 +432,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param table The Iceberg table object
    */
   public static void checkAndSetIoConfig(Configuration config, Table table) {
-    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+    if (table != null && config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
         InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
       ((HadoopConfigurable) table.io()).setConf(config);
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -449,7 +449,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param table The Iceberg table object
    */
   public static void checkAndSkipIoConfigSerialization(Configuration config, Table table) {
-    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+    if (table != null && config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
         InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
       ((HadoopConfigurable) table.io()).serializeConfWith(conf -> new NonSerializingConfig(config)::get);
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -175,6 +175,9 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
     }
 
+    // if enabled, do not serialize FileIO hadoop config to decrease split size
+    HiveIcebergStorageHandler.checkAndSkipIoConfigSerialization(conf, table);
+
     return splits;
   }
 
@@ -234,6 +237,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       CombinedScanTask task = ((IcebergSplit) split).task();
       this.context = newContext;
       Table table = ((IcebergSplit) split).table();
+      HiveIcebergStorageHandler.checkAndSetIoConfig(conf, table);
       this.io = table.io();
       this.encryptionManager = table.encryption();
       this.tasks = task.files().iterator();

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.DataTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
@@ -175,8 +176,12 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       throw new UncheckedIOException(String.format("Failed to close table scan: %s", scan), e);
     }
 
-    // if enabled, do not serialize FileIO hadoop config to decrease split size
-    HiveIcebergStorageHandler.checkAndSkipIoConfigSerialization(conf, table);
+    // If enabled, do not serialize FileIO hadoop config to decrease split size
+    // However, skip serialization for metatable queries, because some metadata tasks cache the IO object and we
+    // wouldn't be able to inject the config into these tasks on the deser-side, unlike for standard data file queries
+    if (scan instanceof DataTableScan) {
+      HiveIcebergStorageHandler.checkAndSkipIoConfigSerialization(conf, table);
+    }
 
     return splits;
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -177,8 +177,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     }
 
     // If enabled, do not serialize FileIO hadoop config to decrease split size
-    // However, skip serialization for metatable queries, because some metadata tasks cache the IO object and we
-    // wouldn't be able to inject the config into these tasks on the deser-side, unlike for standard data file queries
+    // However, do not skip serialization for metatable queries, because some metadata tasks cache the IO object and we
+    // wouldn't be able to inject the config into these tasks on the deserializer-side, unlike for standard queries
     if (scan instanceof DataTableScan) {
       HiveIcebergStorageHandler.checkAndSkipIoConfigSerialization(conf, table);
     }


### PR DESCRIPTION
Cross-porting https://github.com/apache/iceberg/pull/3752 from Iceberg (commit da712eaf60744c933c08fe1cab7a00cdcb2f4829)

Note: unlike in Iceberg, the default in Hive is `iceberg.mr.config.serialization.disabled=true`.