### PR TITLE
HIVE-25854: Port Iceberg Hive fix - ORC vectorization fails after spl…

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.data;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -39,14 +40,18 @@ import org.junit.rules.TemporaryFolder;
  */
 public class GenericAppenderHelper {
 
+  private static final String ORC_CONFIG_PREFIX = "^orc.*";
+
   private final Table table;
   private final FileFormat fileFormat;
   private final TemporaryFolder tmp;
+  private final Configuration conf;
 
-  public GenericAppenderHelper(Table table, FileFormat fileFormat, TemporaryFolder tmp) {
+  public GenericAppenderHelper(Table table, FileFormat fileFormat, TemporaryFolder tmp, Configuration conf) {
     this.table = table;
     this.fileFormat = fileFormat;
     this.tmp = tmp;
+    this.conf = conf;
   }
 
   public void appendToTable(DataFile... dataFiles) {
@@ -73,13 +78,20 @@ public class GenericAppenderHelper {
     Preconditions.checkNotNull(table, "table not set");
     File file = tmp.newFile();
     Assert.assertTrue(file.delete());
-    return appendToLocalFile(table, file, fileFormat, partition, records);
+    return appendToLocalFile(table, file, fileFormat, partition, records, conf);
   }
 
-  private static DataFile appendToLocalFile(
-      Table table, File file, FileFormat format, StructLike partition, List<Record> records)
+  private static DataFile appendToLocalFile(Table table, File file, FileFormat format, StructLike partition,
+      List<Record> records, Configuration conf)
       throws IOException {
-    FileAppender<Record> appender = new GenericAppenderFactory(table.schema()).newAppender(
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(table.schema());
+
+    // Push down ORC related settings to appender
+    if (FileFormat.ORC.equals(format)) {
+      appenderFactory.setAll(conf.getValByRegex(ORC_CONFIG_PREFIX));
+    }
+
+    FileAppender<Record> appender = appenderFactory.newAppender(
         Files.localOutput(file), format);
     try (FileAppender<Record> fileAppender = appender) {
       fileAppender.addAll(records);
@@ -92,6 +104,7 @@ public class GenericAppenderHelper {
         .withMetrics(appender.metrics())
         .withFormat(format)
         .withPartition(partition)
+        .withSplitOffsets(appender.splitOffsets())
         .build();
   }
 }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestHelper.java
@@ -125,7 +125,7 @@ public class TestHelper {
   }
 
   private GenericAppenderHelper appender() {
-    return new GenericAppenderHelper(table, fileFormat, tmp);
+    return new GenericAppenderHelper(table, fileFormat, tmp, conf);
   }
 
   public static class RecordsBuilder {

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
@@ -35,6 +36,7 @@ import org.junit.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Runs miscellaneous select statements on Iceberg tables, and verifies the result. Tests meant to verify simple
@@ -228,5 +230,36 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
     List<Object[]> result = shell.executeStatement(query);
     Assert.assertEquals(1, result.size());
     Assert.assertArrayEquals(new Object[]{"val"}, result.get(0));
+  }
+
+  /**
+   * Tests that vectorized ORC reading code path correctly handles when the same ORC file is split into multiple parts.
+   * Although the split offsets and length will not always include the file tail that contains the metadata, the
+   * vectorized reader needs to make sure to handle the tail reading regardless of the offsets. If this is not done
+   * correctly, the last SELECT query will fail.
+   * @throws Exception - any test error
+   */
+  @Test
+  public void testVectorizedOrcMultipleSplits() throws Exception {
+    assumeTrue(isVectorized && FileFormat.ORC.equals(fileFormat));
+
+    // This data will be held by a ~870kB ORC file
+    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        20000, 0L);
+
+    // To support splitting the ORC file, we need to specify the stripe size to a small value. It looks like the min
+    // value is about 220kB, no smaller stripes are written by ORC. Anyway, this setting will produce 4 stripes.
+    shell.setHiveSessionValue("orc.stripe.size", "210000");
+
+    testTables.createTable(shell, "targettab", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, records);
+
+    // Will request 4 splits, separated on the exact stripe boundaries within the ORC file.
+    // (Would request 5 if ORC split generation wouldn't be split (aka stripe) offset aware).
+    shell.setHiveSessionValue(InputFormatConfig.SPLIT_SIZE, "210000");
+    List<Object[]> result = shell.executeStatement("SELECT * FROM targettab ORDER BY last_name");
+
+    Assert.assertEquals(20000, result.size());
+
   }
 }


### PR DESCRIPTION
Porting Iceberg commit: https://github.com/apache/iceberg/commit/339866d72784a3e90625037d3a9de4fdafc5fcef
Hive: ORC vectorization fails when split offsets are considered during split generation (#3748 

.. to fix issue with reading non-first splits of ORC files in vectorized mode