### PR TITLE
HIVE-25646: Thrift metastore URI reverse resolution could fail in some environments

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -240,15 +240,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         if (uriResolverHook != null) {
           metastoreURIArray.addAll(uriResolverHook.resolveURI(tmpUri));
         } else {
-          metastoreURIArray.add(new URI(
-                  tmpUri.getScheme(),
-                  tmpUri.getUserInfo(),
-                  HadoopThriftAuthBridge.getBridge().getCanonicalHostName(tmpUri.getHost()),
-                  tmpUri.getPort(),
-                  tmpUri.getPath(),
-                  tmpUri.getQuery(),
-                  tmpUri.getFragment()
-          ));
+          metastoreURIArray.add(tmpUri);
         }
       }
       metastoreUris = new URI[metastoreURIArray.size()];


### PR DESCRIPTION
When custom URI resolver is not specified, the default thrift metastore URI goes through DNS reverse resolution (getCanonicalHostname) which is unlikely to resolve correctly when the HMS is sitting behind LBs and proxies. This is a change in behaviour from hive 2.x branch which isn't required. If reverse resolution is required, custom URI resolver can be implemented.

