### PR TITLE
HIVE-25858: DISTINCT with ORDER BY on ordinals fails with NPE

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4856,7 +4856,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       }
 
       inputRR.setCheckForAmbiguity(false);
-      return new Pair<RelNode, RowResolver>(outputRel, null);
+      return new Pair<>(outputRel, outputRR);
     }
 
     Integer genRexNodeRegex(String colRegex, String tabAlias, ASTNode sel,

--- a/ql/src/test/queries/clientpositive/order_by_pos.q
+++ b/ql/src/test/queries/clientpositive/order_by_pos.q
@@ -19,3 +19,5 @@ select * from (select a, count(a) from t_n3 group by a)subq order by 2, 1;
 select * from (select a,b, count(*) from t_n3 group by a, b)subq order by 3, 2 desc, 1;
 
 values(1+1, 2, 5.0, 'a'), (-12, 2, 5.0, 'a'), (100, 2, 5.0, 'a') order by 1 limit 2;
+
+select distinct a, b from t_n3 order by 2, 1;

--- a/ql/src/test/results/clientpositive/llap/order_by_pos.q.out
+++ b/ql/src/test/results/clientpositive/llap/order_by_pos.q.out
@@ -139,3 +139,19 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 -12	2	5	a
 2	2	5	a
+PREHOOK: query: select distinct a, b from t_n3 order by 2, 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t_n3
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct a, b from t_n3 order by 2, 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t_n3
+#### A masked pattern was here ####
+20	-100
+1	2
+1	3
+2	4
+4	5
+3	7
+8	9
+-1000	100


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Return the output `RowResolver` object when generating Select logical plan instead of null.

### Why are the changes needed?
the select row resolver is required for generating Order by logical plan when the columns are referenced by indexes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=order_by_pos.q -pl itests/qtest -Pitests
```