### PR TITLE
HIVE-25860: Optimize the synchronized scope of the renewToken method to improve concurrency

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
@@ -157,18 +157,20 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
         id.getMasterKeyId());
       reloadKeys();
     }
+    long res;
+    DelegationTokenInformation newTokenInfo;
     // reuse super renewal logic
     synchronized (this) {
-      super.currentTokens.put(id,  tokenInfo);
+      super.currentTokens.put(id, tokenInfo);
       try {
-        long res = super.renewToken(token, renewer);
-        this.tokenStore.removeToken(id);
-        this.tokenStore.addToken(id, super.currentTokens.get(id));
-        return res;
+        res = super.renewToken(token, renewer);
       } finally {
-        super.currentTokens.remove(id);
+        newTokenInfo = super.currentTokens.remove(id);
       }
     }
+    this.tokenStore.removeToken(id);
+    this.tokenStore.addToken(id, newTokenInfo);
+    return res;
   }
 
   public static String encodeWritable(Writable key) throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Optimize the synchronized scope of the renewToken method to improve concurrency.

### Why are the changes needed?
HIVE-22033 Using `tokenStore` in `renewToken` method does not need to be in synchronized scope.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
exist UT