### PR TITLE
HIVE-25861: When ConstantPropagate optimizer optimizes case when equals case when…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
@@ -589,7 +589,7 @@ public final class ConstantPropagateProcFactory {
        if(children.size() % 2 == 1) {
          i = children.size()-1;
          children.set(i, ExprNodeGenericFuncDesc.newInstance(new GenericUDFOPEqual(),
-             Lists.newArrayList(children.get(i),newExprs.get(foundUDFInFirst ? 1 : 0))));
+             Lists.newArrayList(children.get(i),newExprs.get(foundUDFInFirst ? 1 : 0).clone())));
        }
        // after constant folding of child expression the return type of UDFWhen might have changed,
        // so recreate the expression
@@ -604,7 +604,7 @@ public final class ConstantPropagateProcFactory {
         if(children.size() % 2 == 0) {
           i = children.size()-1;
           children.set(i, ExprNodeGenericFuncDesc.newInstance(new GenericUDFOPEqual(),
-              Lists.newArrayList(children.get(i),newExprs.get(foundUDFInFirst ? 1 : 0))));
+              Lists.newArrayList(children.get(i),newExprs.get(foundUDFInFirst ? 1 : 0).clone())));
         }
        // after constant folding of child expression the return type of UDFCase might have changed,
        // so recreate the expression


### PR DESCRIPTION
### What changes were proposed in this pull request?
As described in jira, when ConstantPropagate optimizer optimizes case when equals case when twice, got wrong logical execution plan.


### Why are the changes needed?
In some cases case when equals case when will get wrong results.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Customer side, on cluster.
