### PR TITLE
HIVE-25872: Skip tracking of alterDatabase events for replication specific properties

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestReplChangeManager.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestReplChangeManager.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ReplChangeManager.RecycleType;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -36,7 +36,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 public class BaseReplicationAcrossInstances {
   @Rule

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationScenariosAcidTables.java
@@ -59,7 +59,7 @@ import java.util.List;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 /**
  * TestReplicationScenariosAcidTablesBase - base class for replication for ACID tables tests

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestCopyUtils.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestCopyUtils.java
@@ -43,7 +43,7 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.shims.HadoopShims.MiniMrShim;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 public class TestCopyUtils {
   @Rule

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
@@ -122,9 +122,6 @@ public class TestMetaStoreEventListenerInRepl {
     // Add expected events with associated tables, if any.
     Map<String, Set<String>> eventsMap = new HashMap<>();
     eventsMap.put(CreateDatabaseEvent.class.getName(), null);
-    // Replication causes many implicit alter database operations, so metastore will see some
-    // alter table events as well.
-    eventsMap.put(AlterDatabaseEvent.class.getName(), null);
     eventsMap.put(CreateTableEvent.class.getName(), new HashSet<>(Arrays.asList("t1", "t2", "t4")));
     eventsMap.put(AlterTableEvent.class.getName(), new HashSet<>(Arrays.asList("t1", "t2", "t4")));
     return eventsMap;
@@ -142,9 +139,6 @@ public class TestMetaStoreEventListenerInRepl {
 
     // Add expected events with associated tables, if any.
     Map<String, Set<String>> eventsMap = new HashMap<>();
-    // Replication causes many implicit alter database operations, so metastore will see some
-    // alter table events as well.
-    eventsMap.put(AlterDatabaseEvent.class.getName(), null);
     eventsMap.put(CreateTableEvent.class.getName(), new HashSet<>(Arrays.asList("t6")));
     eventsMap.put(AlterTableEvent.class.getName(), new HashSet<>(Arrays.asList("t1", "t2", "t6")));
     eventsMap.put(DropTableEvent.class.getName(), new HashSet<>(Arrays.asList("t2")));

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
@@ -160,9 +160,6 @@ public class TestMetaStoreEventListenerInRepl {
             .run("drop table t1");
     // Add expected events with associated tables, if any.
     Map<String, Set<String>> eventsMap = new HashMap<>();
-    // Replication causes many implicit alter database operations, so metastore will see some
-    // alter table events as well.
-    eventsMap.put(AlterDatabaseEvent.class.getName(), null);
     eventsMap.put(CreateTableEvent.class.getName(), new HashSet<>(Arrays.asList("t7")));
     eventsMap.put(AlterTableEvent.class.getName(), new HashSet<>(Arrays.asList("t4", "t7")));
     eventsMap.put(DropTableEvent.class.getName(), new HashSet<>(Arrays.asList("t1")));

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestMetaStoreEventListenerInRepl.java
@@ -44,7 +44,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 /**
  * TestMetaStoreEventListenerInRepl - Test metastore events created by replication.

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOfHiveStreaming.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOfHiveStreaming.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 /**
  * TestReplicationOfHiveStreaming - test replication for streaming ingest on ACID tables.

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOnHDFSEncryptedZones.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOnHDFSEncryptedZones.java
@@ -43,7 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_ENABLED;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 public class TestReplicationOnHDFSEncryptedZones {
   private static String jksFile = System.getProperty("java.io.tmpdir") + "/test.jks";

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOptimisedBootstrap.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOptimisedBootstrap.java
@@ -538,9 +538,8 @@ public class TestReplicationOptimisedBootstrap extends BaseReplicationAcrossInst
         .getNextNotification(Long.parseLong(getEventIdFromFile(new Path(tuple.dumpLocation), conf)[1]), -1,
             new DatabaseAndTableFilter(replicatedDbName, null));
 
-    // There should be 4 events, one for alter db, second to remove first incremental pending and then two custom
-    // alter operations.
-    assertEquals(4, nl.getEvents().size());
+    // There should be 2 events, two custom alter operations.
+    assertEquals(2, nl.getEvents().size());
   }
 
   @Test
@@ -648,7 +647,7 @@ public class TestReplicationOptimisedBootstrap extends BaseReplicationAcrossInst
         .getNextNotification(Long.parseLong(getEventIdFromFile(new Path(tuple.dumpLocation), conf)[1]), 10,
             new DatabaseAndTableFilter(replicatedDbName, null));
 
-    assertEquals(1, nl.getEvents().size());
+    assertEquals(0, nl.getEventsSize());
   }
 
   @Test

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -131,7 +131,7 @@ import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -77,7 +77,7 @@ import java.util.List;
 import java.util.Map;
 
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.DUMP_ACKNOWLEDGEMENT;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_ACKNOWLEDGEMENT;
 import static org.junit.Assert.assertEquals;
@@ -172,7 +172,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
       replica.run("REPL LOAD " + srcDbName + " INTO " + replicaDb);
       latestEventId = replica.getCurrentNotificationEventId().getEventId();
       //Assert that repl.target.id, hive.repl.ckpt.key and hive.repl.first.inc.pending is not captured in notificationLog.
-      assertEquals(latestEventId, lastEventId + 2); //This load will generate only 2 event i.e. CREATE_DATABASE, AlterDatabaseSetOwnerDesc
+      assertEquals(latestEventId, lastEventId + 1); //This load will generate only 1 event i.e. CREATE_DATABASE
 
       WarehouseInstance.Tuple incDump = primary.run("use " + srcDbName)
               .run("create table t1 (id int) clustered by(id) into 3 buckets stored as orc " +

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.QUOTA_DONT_SET;
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.QUOTA_RESET;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_ACKNOWLEDGEMENT;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.NON_RECOVERABLE_MARKER;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -967,13 +967,13 @@ public class TestReplicationScenariosAcrossInstances extends BaseReplicationAcro
   }
 
   private void verifyIfCkptSet(Map<String, String> props, String dumpDir) {
-    assertTrue(props.containsKey(ReplUtils.REPL_CHECKPOINT_KEY));
+    assertTrue(props.containsKey(ReplConst.REPL_TARGET_DB_PROPERTY));
     String hiveDumpDir = dumpDir + File.separator + ReplUtils.REPL_HIVE_BASE_DIR;
-    assertTrue(props.get(ReplUtils.REPL_CHECKPOINT_KEY).equals(hiveDumpDir));
+    assertTrue(props.get(ReplConst.REPL_TARGET_DB_PROPERTY).equals(hiveDumpDir));
   }
 
   private void verifyIfCkptPropMissing(Map<String, String> props) {
-    assertFalse(props.containsKey(ReplUtils.REPL_CHECKPOINT_KEY));
+    assertFalse(props.containsKey(ReplConst.REPL_TARGET_DB_PROPERTY));
   }
 
   private void verifyIfSrcOfReplPropMissing(Map<String, String> props) {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExclusiveReplica.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExclusiveReplica.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 /**
  * Test replication scenarios with staging on replica.

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExternalTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExternalTables.java
@@ -83,7 +83,7 @@ import javax.annotation.Nullable;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_EXTERNAL_WAREHOUSE_SINGLE_COPY_TASK;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_EXTERNAL_WAREHOUSE_SINGLE_COPY_TASK_PATHS;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.INC_BOOTSTRAP_ROOT_DIR_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExternalTablesMetaDataOnly.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosExternalTablesMetaDataOnly.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.INC_BOOTSTRAP_ROOT_DIR_NAME;
 import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.REPL_HIVE_BASE_DIR;
 import static org.junit.Assert.assertFalse;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosIncrementalLoadAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosIncrementalLoadAcidTables.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClientWithLocalCache;
 import org.apache.hadoop.hive.metastore.messaging.json.gzip.GzipJSONMessageEncoder;
 import org.apache.hadoop.hive.ql.parse.repl.CopyUtils;
 import org.apache.hadoop.hive.shims.Utils;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import org.junit.rules.TestName;
 
 import org.slf4j.Logger;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
@@ -57,7 +57,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestStatsReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestStatsReplicationScenarios.java
@@ -58,7 +58,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 /**
  * Tests for statistics replication.

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -432,8 +432,8 @@ public class WarehouseInstance implements Closeable {
   }
 
   private void verifyIfCkptSet(Map<String, String> props, String dumpDir) {
-    assertTrue(props.containsKey(ReplUtils.REPL_CHECKPOINT_KEY));
-    assertTrue(props.get(ReplUtils.REPL_CHECKPOINT_KEY).equals(dumpDir));
+    assertTrue(props.containsKey(ReplConst.REPL_TARGET_DB_PROPERTY));
+    assertTrue(props.get(ReplConst.REPL_TARGET_DB_PROPERTY).equals(dumpDir));
   }
 
   public void verifyIfCkptSet(String dbName, String dumpDir) throws Exception {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.security.authorization.plugin;
 
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCleanerWithReplication.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCleanerWithReplication.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.ShowCompactRequest;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
 import org.apache.hadoop.hive.metastore.api.Table;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniHS2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniHS2.java
@@ -87,7 +87,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 
 public class TestJdbcWithMiniHS2 {
   private static MiniHS2 miniHS2 = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/flags/ReplRemoveFirstIncLoadPendFlagOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/flags/ReplRemoveFirstIncLoadPendFlagOperation.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.ql.ddl.misc.flags;
 
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
-import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 
 import java.util.Map;
 
@@ -43,9 +43,9 @@ public class ReplRemoveFirstIncLoadPendFlagOperation extends DDLOperation<ReplRe
     for (String dbName : Utils.matchesDb(context.getDb(), dbNameOrPattern)) {
       Database database = context.getDb().getMSC().getDatabase(dbName);
       Map<String, String> parameters = database.getParameters();
-      String incPendPara = parameters != null ? parameters.get(ReplUtils.REPL_FIRST_INC_PENDING_FLAG) : null;
+      String incPendPara = parameters != null ? parameters.get(ReplConst.REPL_FIRST_INC_PENDING_FLAG) : null;
       if (incPendPara != null) {
-        parameters.remove(ReplUtils.REPL_FIRST_INC_PENDING_FLAG);
+        parameters.remove(ReplConst.REPL_FIRST_INC_PENDING_FLAG);
         context.getDb().getMSC().alterDatabase(dbName, database);
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -123,7 +123,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_METADATA_O
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_EXTERNAL_WAREHOUSE_SINGLE_COPY_TASK;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_EXTERNAL_WAREHOUSE_SINGLE_COPY_TASK_PATHS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_SNAPSHOT_DIFF_FOR_EXTERNAL_TABLE_COPY;
-import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
+import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.metastore.ReplChangeManager.getReplPolicyIdString;
 import static org.apache.hadoop.hive.ql.exec.repl.OptimisedBootstrapUtils.EVENT_ACK_FILE;
 import static org.apache.hadoop.hive.ql.exec.repl.OptimisedBootstrapUtils.TABLE_DIFF_COMPLETE_DIRECTORY;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/LoadDatabase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/LoadDatabase.java
@@ -100,7 +100,7 @@ public class LoadDatabase {
 
   String getDbLocation(Database dbInMetadata) {
     if (context.hiveConf.getBoolVar(HiveConf.ConfVars.REPL_RETAIN_CUSTOM_LOCATIONS_FOR_DB_ON_TARGET)
-            && Boolean.parseBoolean(dbInMetadata.getParameters().get(ReplUtils.REPL_IS_CUSTOM_DB_LOC))) {
+            && Boolean.parseBoolean(dbInMetadata.getParameters().get(ReplConst.REPL_IS_CUSTOM_DB_LOC))) {
       String locOnTarget = new Path(dbInMetadata.getLocationUri()).toUri().getPath().toString();
       LOG.info("Using the custom location {} on the target", locOnTarget);
       return locOnTarget;
@@ -110,7 +110,7 @@ public class LoadDatabase {
 
   String getDbManagedLocation(Database dbInMetadata) {
     if (context.hiveConf.getBoolVar(HiveConf.ConfVars.REPL_RETAIN_CUSTOM_LOCATIONS_FOR_DB_ON_TARGET)
-            && Boolean.parseBoolean(dbInMetadata.getParameters().get(ReplUtils.REPL_IS_CUSTOM_DB_MANAGEDLOC))) {
+            && Boolean.parseBoolean(dbInMetadata.getParameters().get(ReplConst.REPL_IS_CUSTOM_DB_MANAGEDLOC))) {
       String locOnTarget = new Path(dbInMetadata.getManagedLocationUri()).toUri().getPath().toString();
       LOG.info("Using the custom managed location {} on the target", locOnTarget);
       return locOnTarget;
@@ -184,19 +184,19 @@ public class LoadDatabase {
 
     parameters.remove(ReplicationSpec.KEY.CURR_STATE_ID_TARGET.toString());
 
-    parameters.remove(ReplUtils.REPL_IS_CUSTOM_DB_LOC);
+    parameters.remove(ReplConst.REPL_IS_CUSTOM_DB_LOC);
 
-    parameters.remove(ReplUtils.REPL_IS_CUSTOM_DB_MANAGEDLOC);
+    parameters.remove(ReplConst.REPL_IS_CUSTOM_DB_MANAGEDLOC);
 
     // Add the checkpoint key to the Database binding it to current dump directory.
     // So, if retry using same dump, we shall skip Database object update.
-    parameters.put(ReplUtils.REPL_CHECKPOINT_KEY, dumpDirectory);
+    parameters.put(ReplConst.REPL_TARGET_DB_PROPERTY, dumpDirectory);
 
     // This flag will be set to false after first incremental load is done. This flag is used by repl copy task to
     // check if duplicate file check is required or not. This flag is used by compaction to check if compaction can be
     // done for this database or not. If compaction is done before first incremental then duplicate check will fail as
     // compaction may change the directory structure.
-    parameters.put(ReplUtils.REPL_FIRST_INC_PENDING_FLAG, "true");
+    parameters.put(ReplConst.REPL_FIRST_INC_PENDING_FLAG, "true");
     //This flag will be set to identify its a target of replication. Repl dump won't be allowed on a database
     //which is a target of replication.
     parameters.put(ReplConst.TARGET_OF_REPLICATION, "true");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.table;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -62,7 +63,6 @@ import java.util.Map;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_METADATA_ONLY;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_SKIP_IMMUTABLE_DATA_COPY;
 import static org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.ReplicationState.PartitionState;
-import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.REPL_CHECKPOINT_KEY;
 import static org.apache.hadoop.hive.ql.parse.ImportSemanticAnalyzer.isPartitioned;
 import static org.apache.hadoop.hive.ql.parse.ImportSemanticAnalyzer.partSpecToString;
 
@@ -210,7 +210,7 @@ public class LoadPartitions {
         if (partParams == null) {
           partParams = new HashMap<>();
         }
-        partParams.put(REPL_CHECKPOINT_KEY, context.dumpDirectory);
+        partParams.put(ReplConst.REPL_TARGET_DB_PROPERTY, context.dumpDirectory);
         Path replicaWarehousePartitionLocation = locationOnReplicaWarehouse(table, src);
         partitions.add(new AlterTableAddPartitionDesc.PartitionDesc(
           src.getPartSpec(), replicaWarehousePartitionLocation.toString(), partParams, src.getInputFormat(),
@@ -376,7 +376,7 @@ public class LoadPartitions {
       AlterTableAddPartitionDesc.PartitionDesc src = addPartitionDesc.getPartitions().get(0);
       //Add check point task as part of add partition
       Map<String, String> partParams = new HashMap<>();
-      partParams.put(REPL_CHECKPOINT_KEY, context.dumpDirectory);
+      partParams.put(ReplConst.REPL_TARGET_DB_PROPERTY, context.dumpDirectory);
       Path replicaWarehousePartitionLocation = locationOnReplicaWarehouse(table, src);
       src.setLocation(replicaWarehousePartitionLocation.toString());
       src.addPartParams(partParams);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
@@ -87,15 +87,14 @@ public class ReplUtils {
 
   public static final String LAST_REPL_ID_KEY = "hive.repl.last.repl.id";
   public static final String REPL_CHECKPOINT_KEY = ReplConst.REPL_TARGET_DB_PROPERTY;
-  public static final String REPL_FIRST_INC_PENDING_FLAG = "hive.repl.first.inc.pending";
+  public static final String REPL_FIRST_INC_PENDING_FLAG = ReplConst.REPL_FIRST_INC_PENDING_FLAG;
 
   // write id allocated in the current execution context which will be passed through config to be used by different
   // tasks.
   public static final String REPL_CURRENT_TBL_WRITE_ID = "hive.repl.current.table.write.id";
 
-  public static final String REPL_IS_CUSTOM_DB_LOC = "hive.repl.is.custom.db.loc";
-
-  public static final String REPL_IS_CUSTOM_DB_MANAGEDLOC = "hive.repl.is.custom.db.managedloc";
+  public static final String REPL_IS_CUSTOM_DB_LOC = ReplConst.REPL_IS_CUSTOM_DB_LOC;
+  public static final String REPL_IS_CUSTOM_DB_MANAGEDLOC = ReplConst.REPL_IS_CUSTOM_DB_MANAGEDLOC;
 
   public static final String FUNCTIONS_ROOT_DIR_NAME = "_functions";
   public static final String CONSTRAINTS_ROOT_DIR_NAME = "_constraints";

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
@@ -86,15 +86,6 @@ import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.NON_RECOVERABLE_MARKER
 public class ReplUtils {
 
   public static final String LAST_REPL_ID_KEY = "hive.repl.last.repl.id";
-  public static final String REPL_CHECKPOINT_KEY = ReplConst.REPL_TARGET_DB_PROPERTY;
-  public static final String REPL_FIRST_INC_PENDING_FLAG = ReplConst.REPL_FIRST_INC_PENDING_FLAG;
-
-  // write id allocated in the current execution context which will be passed through config to be used by different
-  // tasks.
-  public static final String REPL_CURRENT_TBL_WRITE_ID = "hive.repl.current.table.write.id";
-
-  public static final String REPL_IS_CUSTOM_DB_LOC = ReplConst.REPL_IS_CUSTOM_DB_LOC;
-  public static final String REPL_IS_CUSTOM_DB_MANAGEDLOC = ReplConst.REPL_IS_CUSTOM_DB_MANAGEDLOC;
 
   public static final String FUNCTIONS_ROOT_DIR_NAME = "_functions";
   public static final String CONSTRAINTS_ROOT_DIR_NAME = "_constraints";
@@ -229,7 +220,7 @@ public class ReplUtils {
                                                String dumpRoot, ReplicationMetricCollector metricCollector,
                                                HiveConf conf) throws SemanticException {
     HashMap<String, String> mapProp = new HashMap<>();
-    mapProp.put(REPL_CHECKPOINT_KEY, dumpRoot);
+    mapProp.put(ReplConst.REPL_TARGET_DB_PROPERTY, dumpRoot);
 
     final TableName tName = TableName.fromString(tableDesc.getTableName(), null, tableDesc.getDatabaseName());
     AlterTableSetPropertiesDesc alterTblDesc =  new AlterTableSetPropertiesDesc(tName, partSpec, null, false,
@@ -241,12 +232,13 @@ public class ReplUtils {
   public static boolean replCkptStatus(String dbName, Map<String, String> props, String dumpRoot)
           throws InvalidOperationException {
     // If ckpt property not set or empty means, bootstrap is not run on this object.
-    if ((props != null) && props.containsKey(REPL_CHECKPOINT_KEY) && !props.get(REPL_CHECKPOINT_KEY).isEmpty()) {
-      if (props.get(REPL_CHECKPOINT_KEY).equals(dumpRoot)) {
+    if ((props != null) && props.containsKey(ReplConst.REPL_TARGET_DB_PROPERTY)
+            && !props.get(ReplConst.REPL_TARGET_DB_PROPERTY).isEmpty()) {
+      if (props.get(ReplConst.REPL_TARGET_DB_PROPERTY).equals(dumpRoot)) {
         return true;
       }
       throw new InvalidOperationException(ErrorMsg.REPL_BOOTSTRAP_LOAD_PATH_NOT_VALID.format(dumpRoot,
-              props.get(REPL_CHECKPOINT_KEY)));
+              props.get(ReplConst.REPL_TARGET_DB_PROPERTY)));
     }
     return false;
   }
@@ -363,7 +355,7 @@ public class ReplUtils {
   public static boolean isFirstIncPending(Map<String, String> parameters) {
     // If flag is not set, then we assume first incremental load is done as the database/table may be created by user
     // and not through replication.
-    return parameters != null && ReplConst.TRUE.equalsIgnoreCase(parameters.get(ReplUtils.REPL_FIRST_INC_PENDING_FLAG));
+    return parameters != null && ReplConst.TRUE.equalsIgnoreCase(parameters.get(ReplConst.REPL_FIRST_INC_PENDING_FLAG));
   }
 
   public static EnvironmentContext setReplDataLocationChangedFlag(EnvironmentContext envContext) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.ReplChangeManager;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
@@ -35,7 +34,6 @@ import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.Utilities;
-import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.exec.repl.util.StringConvertibleObject;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
@@ -44,7 +42,6 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.repl.DumpType;
-import org.apache.hadoop.hive.ql.parse.repl.dump.Utils;
 import org.apache.hadoop.hive.ql.parse.repl.dump.io.DBSerializer;
 import org.apache.hadoop.hive.ql.parse.repl.dump.io.JsonWriter;
 import org.apache.hadoop.hive.ql.parse.repl.dump.io.ReplicationSpecSerializer;
@@ -370,10 +367,10 @@ public class EximUtil {
     if (parameters != null) {
       Map<String, String> tmpParameters = new HashMap<>(parameters);
       tmpParameters.entrySet()
-                .removeIf(e -> e.getKey().startsWith(Utils.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
-                            || e.getKey().equals(ReplUtils.REPL_CHECKPOINT_KEY)
-                            || e.getKey().equals(ReplChangeManager.SOURCE_OF_REPLICATION)
-                            || e.getKey().equals(ReplUtils.REPL_FIRST_INC_PENDING_FLAG)
+                .removeIf(e -> e.getKey().startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
+                            || e.getKey().equals(ReplConst.REPL_TARGET_DB_PROPERTY)
+                            || e.getKey().equals(ReplConst.SOURCE_OF_REPLICATION)
+                            || e.getKey().equals(ReplConst.REPL_FIRST_INC_PENDING_FLAG)
                             || e.getKey().equals(ReplConst.REPL_FAILOVER_ENDPOINT));
       dbObj.setParameters(tmpParameters);
     }
@@ -391,13 +388,13 @@ public class EximUtil {
               MetastoreConf.getVar(conf, MetastoreConf.ConfVars.WAREHOUSE));
       Path dbDerivedLoc = new Path(whLocatoion, database.getName().toLowerCase() + DATABASE_PATH_SUFFIX);
       String defaultDbLoc = Utilities.getQualifiedPath((HiveConf) conf, dbDerivedLoc);
-      database.putToParameters(ReplUtils.REPL_IS_CUSTOM_DB_LOC,
+      database.putToParameters(ReplConst.REPL_IS_CUSTOM_DB_LOC,
               Boolean.toString(!defaultDbLoc.equals(database.getLocationUri())));
       String whManagedLocatoion = MetastoreConf.getVar(conf, MetastoreConf.ConfVars.WAREHOUSE);
       Path dbDerivedManagedLoc = new Path(whManagedLocatoion, database.getName().toLowerCase()
               + DATABASE_PATH_SUFFIX);
       String defaultDbManagedLoc = Utilities.getQualifiedPath((HiveConf) conf, dbDerivedManagedLoc);
-      database.getParameters().put(ReplUtils.REPL_IS_CUSTOM_DB_MANAGEDLOC, Boolean.toString(
+      database.getParameters().put(ReplConst.REPL_IS_CUSTOM_DB_MANAGEDLOC, Boolean.toString(
               !(database.getManagedLocationUri() == null
                       ||defaultDbManagedLoc.equals(database.getManagedLocationUri()))));
     } catch (HiveException ex) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ValidTxnList;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.common.repl.ReplScope;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ReplChangeManager;
@@ -64,7 +65,7 @@ import java.util.concurrent.Callable;
 
 public class Utils {
   private static Logger LOG = LoggerFactory.getLogger(Utils.class);
-  public static final String BOOTSTRAP_DUMP_STATE_KEY_PREFIX = "bootstrap.dump.state.";
+  public static final String BOOTSTRAP_DUMP_STATE_KEY_PREFIX = ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX;
   private static final int DEF_BUF_SIZE = 8 * 1024;
 
   public enum ReplDumpState {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
@@ -65,7 +65,6 @@ import java.util.concurrent.Callable;
 
 public class Utils {
   private static Logger LOG = LoggerFactory.getLogger(Utils.class);
-  public static final String BOOTSTRAP_DUMP_STATE_KEY_PREFIX = ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX;
   private static final int DEF_BUF_SIZE = 8 * 1024;
 
   public enum ReplDumpState {
@@ -275,7 +274,7 @@ public class Utils {
     }
 
     Map<String, String> newParams = new HashMap<>();
-    String uniqueKey = BOOTSTRAP_DUMP_STATE_KEY_PREFIX + UUID.randomUUID().toString();
+    String uniqueKey = ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX + UUID.randomUUID().toString();
     newParams.put(uniqueKey, ReplDumpState.ACTIVE.name());
     Map<String, String> params = database.getParameters();
 
@@ -320,7 +319,7 @@ public class Utils {
     }
 
     for (String key : params.keySet()) {
-      if (key.startsWith(BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
+      if (key.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
               && params.get(key).equals(ReplDumpState.ACTIVE.name())) {
         return true;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/PartitionSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/PartitionSerializer.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.parse.repl.dump.io;
 
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.ql.ErrorMsg;
-import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.thrift.TException;
@@ -48,7 +48,7 @@ public class PartitionSerializer implements JsonWriter.Serializer {
       Map<String, String> parameters = partition.getParameters();
       if (parameters != null) {
         parameters.entrySet()
-                .removeIf(e -> e.getKey().equals(ReplUtils.REPL_CHECKPOINT_KEY));
+                .removeIf(e -> e.getKey().equals(ReplConst.REPL_TARGET_DB_PROPERTY));
       }
 
       if (additionalPropertiesProvider.isInReplicationScope()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hive.ql.parse.repl.dump.io;
 
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.ErrorMsg;
-import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -76,8 +76,8 @@ public class TableSerializer implements JsonWriter.Serializer {
     Map<String, String> parameters = table.getParameters();
     if (parameters != null) {
       parameters.entrySet()
-              .removeIf(e -> (e.getKey().equals(ReplUtils.REPL_CHECKPOINT_KEY) ||
-                      e.getKey().equals(ReplUtils.REPL_FIRST_INC_PENDING_FLAG)));
+              .removeIf(e -> (e.getKey().equals(ReplConst.REPL_TARGET_DB_PROPERTY) ||
+                      e.getKey().equals(ReplConst.REPL_FIRST_INC_PENDING_FLAG)));
     }
 
     if (additionalPropertiesProvider.isInReplicationScope()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/load/message/AlterDatabaseHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/load/message/AlterDatabaseHandler.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.parse.repl.load.message;
 
-import org.apache.hadoop.hive.common.repl.ReplConst;
-import org.apache.hadoop.hive.metastore.ReplChangeManager;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.messaging.AlterDatabaseMessage;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
@@ -28,10 +26,7 @@ import org.apache.hadoop.hive.ql.ddl.database.alter.poperties.AlterDatabaseSetPr
 import org.apache.hadoop.hive.ql.ddl.privilege.PrincipalDesc;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
-import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
-import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
-import org.apache.hadoop.hive.ql.parse.repl.dump.Utils;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,18 +56,7 @@ public class AlterDatabaseHandler extends AbstractMessageHandler {
         Map<String, String> dbProps = newDb.getParameters();
 
         for (Map.Entry<String, String> entry : dbProps.entrySet()) {
-          String key = entry.getKey();
-          // Ignore the keys which are local to source warehouse
-          if (key.startsWith(Utils.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
-                  || key.equals(ReplicationSpec.KEY.CURR_STATE_ID_SOURCE.toString())
-                  || key.equals(ReplicationSpec.KEY.CURR_STATE_ID_TARGET.toString())
-                  || key.equals(ReplUtils.REPL_CHECKPOINT_KEY)
-                  || key.equals(ReplChangeManager.SOURCE_OF_REPLICATION)
-                  || key.equals(ReplUtils.REPL_FIRST_INC_PENDING_FLAG)
-                  || key.equals(ReplConst.REPL_FAILOVER_ENDPOINT)) {
-            continue;
-          }
-          newDbProps.put(key, entry.getValue());
+          newDbProps.put(entry.getKey(), entry.getValue());
         }
         alterDbDesc = new AlterDatabaseSetPropertiesDesc(actualDbName, newDbProps, context.eventOnlyReplicationSpec());
       } else {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
@@ -58,4 +58,14 @@ public class ReplConst {
    * Tracks the event id with respect to the target cluster.
    */
   public static final String REPL_TARGET_DATABASE_PROPERTY = "repl.target.last.id";
+
+  public static final String SOURCE_OF_REPLICATION = "repl.source.for";
+
+  public static final String REPL_FIRST_INC_PENDING_FLAG = "hive.repl.first.inc.pending";
+
+  public static final String REPL_IS_CUSTOM_DB_LOC = "hive.repl.is.custom.db.loc";
+
+  public static final String REPL_IS_CUSTOM_DB_MANAGEDLOC = "hive.repl.is.custom.db.managedloc";
+
+  public static final String BOOTSTRAP_DUMP_STATE_KEY_PREFIX = "bootstrap.dump.state.";
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -45,6 +45,7 @@ import static org.apache.hadoop.fs.permission.AclEntryType.OTHER;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -74,7 +75,7 @@ public class ReplChangeManager {
   private static final String ORIG_LOC_TAG = "user.original-loc";
   static final String REMAIN_IN_TRASH_TAG = "user.remain-in-trash";
   private static final String URI_FRAGMENT_SEPARATOR = "#";
-  public static final String SOURCE_OF_REPLICATION = "repl.source.for";
+  public static final String SOURCE_OF_REPLICATION = ReplConst.SOURCE_OF_REPLICATION;
   private static final String TXN_WRITE_EVENT_FILE_SEPARATOR = "]";
   static final String CM_THREAD_NAME_PREFIX = "cmclearer-";
   private static final String NO_ENCRYPTION = "noEncryption";

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -553,8 +553,8 @@ public class ReplChangeManager {
   public static String getReplPolicyIdString(Database db) {
     if (db != null) {
       Map<String, String> m = db.getParameters();
-      if ((m != null) && (m.containsKey(SOURCE_OF_REPLICATION))) {
-        String replPolicyId = m.get(SOURCE_OF_REPLICATION);
+      if ((m != null) && (m.containsKey(ReplConst.SOURCE_OF_REPLICATION))) {
+        String replPolicyId = m.get(ReplConst.SOURCE_OF_REPLICATION);
         LOG.debug("repl policy for database {} is {}", db.getName(), replPolicyId);
         return replPolicyId;
       }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -293,6 +293,7 @@ public class MetaStoreUtils {
                 String prop = (String) field.get(String.class);
                 return prop.replace("\"", "");
               } catch (IllegalAccessException e) {
+                LOG.error("Failed to collect replication specific properties. Reason: ", e);
                 throw new RuntimeException(e);
               }
             }).collect(Collectors.toList());

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.metastore.utils;
 
 import java.io.File;
+import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
@@ -282,6 +283,19 @@ public class MetaStoreUtils {
       return true;
     }
     return false;
+  }
+
+  public static List<String> getReplicationDbProps() {
+    return Arrays.stream(ReplConst.class.getDeclaredFields())
+            .filter(field -> Modifier.isStatic(field.getModifiers()))
+            .map(field -> {
+              try {
+                String prop = (String) field.get(String.class);
+                return prop.replace("\"", "");
+              } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+              }
+            }).collect(Collectors.toList());
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1645,13 +1645,17 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
                 throw new RuntimeException(e);
               }
             }).collect(Collectors.toList());
+    boolean replSpecific = false;
     if (newDbProp != null) {
       for (Map.Entry<String, String> prop : newDbProp.entrySet()) {
         String propName = prop.getKey().replace("\"", "");
         String oldValue = (oldDbProp == null) ? null : oldDbProp.get(prop.getKey());
-        if (!prop.getValue().equals(oldValue) && !propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
-                && !replDbProps.contains(propName)) {
-          return false;
+        if (!prop.getValue().equals(oldValue)) {
+          if (propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX) || replDbProps.contains(propName)) {
+            replSpecific = true;
+          } else {
+            return false;
+          }
         }
       }
     }
@@ -1659,13 +1663,16 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       for (Map.Entry<String, String> prop : oldDbProp.entrySet()) {
         String propName = prop.getKey().replace("\"", "");
         String newValue = (newDbProp == null) ? null : newDbProp.get(prop.getKey());
-        if (!prop.getValue().equals(newValue) && !propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX)
-                && !replDbProps.contains(propName)) {
-          return false;
+        if (!prop.getValue().equals(newValue)) {
+          if (propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX) || replDbProps.contains(propName)) {
+            replSpecific = true;
+          } else {
+            return false;
+          }
         }
       }
     }
-    return true;
+    return replSpecific;
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -73,8 +73,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.jdo.JDOException;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
@@ -105,7 +103,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
@@ -1268,15 +1265,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   }
 
   static boolean isDbReplicationTarget(Database db) {
-    if (db.getParameters() == null) {
-      return false;
-    }
-
-    if (!db.getParameters().containsKey(ReplConst.REPL_TARGET_DB_PROPERTY)) {
-      return false;
-    }
-
-    return !db.getParameters().get(ReplConst.REPL_TARGET_DB_PROPERTY).trim().isEmpty();
+    String dbCkptStatus = (db.getParameters() == null) ? null : db.getParameters().get(ReplConst.REPL_TARGET_DB_PROPERTY);
+    return dbCkptStatus != null && !dbCkptStatus.trim().isEmpty();
   }
 
   // Assumes that the catalog has already been set.
@@ -1579,10 +1569,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     // database so that oldDB indicates that it's target or replication but not the newDB. So,
     // relying solely on newDB to check whether the database is target of replication works.
     boolean isReplicated = isDbReplicationTarget(newDB);
-
-    //Don't capture the alter database event that alters the replication related properties of the database.
-    boolean isAlterReplicationSpecific = false;
-
     try {
       oldDB = get_database_core(parsedDbName[CAT_NAME], parsedDbName[DB_NAME]);
       if (oldDB == null) {
@@ -1590,7 +1576,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
             "\". Could not retrieve old definition.");
       }
 
-      isAlterReplicationSpecific = isAlterReplSpecific(oldDB, newDB);
       // Add replication target event id.
       if (isReplicationEventIdUpdate(oldDB, newDB)) {
         Map<String, String> oldParams = new LinkedHashMap<>(newDB.getParameters());
@@ -1605,11 +1590,12 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       ms.openTransaction();
       ms.alterDatabase(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], newDB);
 
-      if (!transactionalListeners.isEmpty() && !isAlterReplicationSpecific) {
-        transactionalListenersResponses =
-            MetaStoreListenerNotifier.notifyEvent(transactionalListeners,
-                EventType.ALTER_DATABASE,
-                new AlterDatabaseEvent(oldDB, newDB, true, this, isReplicated));
+      if (!transactionalListeners.isEmpty()) {
+        AlterDatabaseEvent event = new AlterDatabaseEvent(oldDB, newDB, true, this, isReplicated);
+        if (!event.shouldSkipCapturing()) {
+          transactionalListenersResponses =
+                  MetaStoreListenerNotifier.notifyEvent(transactionalListeners, EventType.ALTER_DATABASE, event);
+        }
       }
 
       success = ms.commitTransaction();
@@ -1621,58 +1607,15 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         ms.rollbackTransaction();
       }
 
-      if ((null != oldDB) && (!listeners.isEmpty()) && !isAlterReplicationSpecific) {
-        MetaStoreListenerNotifier.notifyEvent(listeners,
-            EventType.ALTER_DATABASE,
-            new AlterDatabaseEvent(oldDB, newDB, success, this, isReplicated),
-            null,
-            transactionalListenersResponses, ms);
+      if ((null != oldDB) && (!listeners.isEmpty())) {
+        AlterDatabaseEvent event = new AlterDatabaseEvent(oldDB, newDB, success, this, isReplicated);
+        if (!event.shouldSkipCapturing()) {
+          MetaStoreListenerNotifier.notifyEvent(listeners,
+                  EventType.ALTER_DATABASE, event, null, transactionalListenersResponses, ms);
+        }
       }
       endFunction("alter_database", success, ex);
     }
-  }
-
-  private boolean isAlterReplSpecific(Database oldDb, Database newDb) {
-    Map<String, String> oldDbProp = oldDb.getParameters();
-    Map<String, String> newDbProp = newDb.getParameters();
-    List<String> replDbProps = Arrays.stream(ReplConst.class.getDeclaredFields())
-            .filter(field -> Modifier.isStatic(field.getModifiers()))
-            .map(field -> {
-              try {
-                String prop = (String) field.get(String.class);
-                return prop.replace("\"", "");
-              } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-              }
-            }).collect(Collectors.toList());
-    boolean replSpecific = false;
-    if (newDbProp != null) {
-      for (Map.Entry<String, String> prop : newDbProp.entrySet()) {
-        String propName = prop.getKey().replace("\"", "");
-        String oldValue = (oldDbProp == null) ? null : oldDbProp.get(prop.getKey());
-        if (!prop.getValue().equals(oldValue)) {
-          if (propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX) || replDbProps.contains(propName)) {
-            replSpecific = true;
-          } else {
-            return false;
-          }
-        }
-      }
-    }
-    if (oldDbProp != null) {
-      for (Map.Entry<String, String> prop : oldDbProp.entrySet()) {
-        String propName = prop.getKey().replace("\"", "");
-        String newValue = (newDbProp == null) ? null : newDbProp.get(prop.getKey());
-        if (!prop.getValue().equals(newValue)) {
-          if (propName.startsWith(ReplConst.BOOTSTRAP_DUMP_STATE_KEY_PREFIX) || replDbProps.contains(propName)) {
-            replSpecific = true;
-          } else {
-            return false;
-          }
-        }
-      }
-    }
-    return replSpecific;
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MDatabase.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MDatabase.java
@@ -21,7 +21,7 @@
  */
 package org.apache.hadoop.hive.metastore.model;
 
-import org.apache.hadoop.hive.metastore.ReplChangeManager;
+import org.apache.hadoop.hive.common.repl.ReplConst;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -174,9 +174,9 @@ public class MDatabase {
     Set<String> keys = new HashSet<>(parameters.keySet());
     for(String key : keys) {
       // Normalize the case for source of replication parameter
-      if (ReplChangeManager.SOURCE_OF_REPLICATION.equalsIgnoreCase(key)) {
+      if (ReplConst.SOURCE_OF_REPLICATION.equalsIgnoreCase(key)) {
         // TODO :  Some extra validation can also be added as this is a user provided parameter.
-        this.parameters.put(ReplChangeManager.SOURCE_OF_REPLICATION, parameters.get(key));
+        this.parameters.put(ReplConst.SOURCE_OF_REPLICATION, parameters.get(key));
       } else {
         this.parameters.put(key, parameters.get(key));
       }


### PR DESCRIPTION
Purpose: Currently, for every replication specific alter database operation, we log this entry in Notification Log table which gets replicated from source to target but is completely skipped on the target cluster since replication specific properties are not replayed for target database. Problem is even if it is going to be skipped, separate task is created during load operation which has performance impact.

Solution proposed: To avoid this, Simple approach will be to avoid logging of these alter db events in the Notification Log itself in first place. Since events would not be present in Notification Log, dump operation will not dump these events and hence, reducing the unnecessary tasks to be initiated.