### PR TITLE
HIVE-25893: NPE when reading Parquet data because ColumnVector isNull[] is not updated

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
@@ -414,6 +414,7 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
       System.arraycopy(((DecimalColumnVector) lcv.child).vector, start,
           ((DecimalColumnVector) resultCV).vector, 0, length);
     }
+    System.arraycopy(lcv.child.isNull, start, resultCV.isNull, 0, length);
     return resultCV;
   }
 
@@ -500,22 +501,37 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
   private boolean compareBytesColumnVector(BytesColumnVector cv1, BytesColumnVector cv2) {
     int length1 = cv1.vector.length;
     int length2 = cv2.vector.length;
-    if (length1 == length2) {
-      for (int i = 0; i < length1; i++) {
-        int innerLen1 = cv1.vector[i].length;
-        int innerLen2 = cv2.vector[i].length;
-        if (innerLen1 == innerLen2) {
-          for (int j = 0; j < innerLen1; j++) {
-            if (cv1.vector[i][j] != cv2.vector[i][j]) {
-              return false;
-            }
-          }
-        } else {
+    if (length1 != length2) {
+      return false;
+    }
+
+    for (int i = 0; i < length1; i++) {
+      // check for different nulls
+      if (columnVectorsDifferNullForSameIndex(cv1, cv2, i)) {
+        return false;
+      }
+
+      // if they are both null, continue
+      // else if one of them is null, return false
+      if (cv1.isNull[i] && cv2.isNull[i]) {
+        continue;
+      } else if (cv1.isNull[i] || cv2.isNull[i]) {
+        return false;
+      }
+
+      // check if value lengths are the same
+      int innerLen1 = cv1.vector[i].length;
+      int innerLen2 = cv2.vector[i].length;
+      if (innerLen1 != innerLen2) {
+        return false;
+      }
+
+      // compare value stored
+      for (int j = 0; j < innerLen1; j++) {
+        if (cv1.vector[i][j] != cv2.vector[i][j]) {
           return false;
         }
       }
-    } else {
-      return false;
     }
     return true;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
@@ -512,11 +512,8 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
       }
 
       // if they are both null, continue
-      // else if one of them is null, return false
       if (cv1.isNull[i] && cv2.isNull[i]) {
         continue;
-      } else if (cv1.isNull[i] || cv2.isNull[i]) {
-        return false;
       }
 
       // check if value lengths are the same


### PR DESCRIPTION
Refactor `compareBytesColumnVector(BytesColumnVector cv1, BytesColumnVector cv2)` for better readability, and copy `lcv.child.isNull` to `resultCV.isNull` which was not getting updated earlier.