### PR TITLE
HIVE-24820: MaterializedViewCache enables adding multiple entries of the same Materialization instance

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
@@ -56,7 +56,7 @@ public class MaterializedViewUpdateOperation extends DDLOperation<MaterializedVi
                 context.getConf().get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY));
         context.getDb().updateCreationMetadata(mvTable.getDbName(), mvTable.getTableName(), newMetadata);
         mvTable.setMaterializedViewMetadata(newMetadata);
-        HiveMaterializedViewsRegistry.get().createMaterializedView(context.getDb().getConf(), mvTable);
+        HiveMaterializedViewsRegistry.get().refreshMaterializedView(context.getDb().getConf(), mvTable);
       }
     } catch (HiveException e) {
       LOG.debug("Exception during materialized view cache update", e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -284,6 +284,19 @@ public final class HiveMaterializedViewsRegistry {
   }
 
   /**
+   * Update the materialized view in the registry (if materialized view exists).
+   */
+  public void refreshMaterializedView(HiveConf conf, Table materializedViewTable) {
+    RelOptMaterialization cached = materializedViewsCache.get(
+        materializedViewTable.getDbName(), materializedViewTable.getTableName());
+    if (cached == null) {
+      return;
+    }
+    Table cachedTable = HiveMaterializedViewUtils.extractTable(cached);
+    refreshMaterializedView(conf, cachedTable, materializedViewTable);
+  }
+
+  /**
    * Update the materialized view in the registry (if existing materialized view matches).
    */
   public void refreshMaterializedView(HiveConf conf, Table oldMaterializedViewTable, Table materializedViewTable) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
@@ -56,7 +56,7 @@ public class MaterializedViewsCache {
     ConcurrentMap<String, HiveRelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
 
     // You store the materialized view
-    dbMap.compute(materializedViewTable.getTableName(), (mvTableName, aMaterialization) -> {
+    dbMap.computeIfAbsent(materializedViewTable.getTableName(), (mvTableName) -> {
       List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.computeIfAbsent(
               materializedViewTable.getViewExpandedText(), s -> new ArrayList<>());
       materializationList.add(materialization);

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
@@ -121,6 +121,18 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1));
   }
 
+  @Test
+  void testAddSameMVTwice() {
+    materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
+    materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
+
+    assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(defaultMaterialization1));
+    assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
+    assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).get(0), is(defaultMaterialization1));
+    assertThat(materializedViewsCache.values().size(), is(1));
+    assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1));
+  }
+
   private Table getTable(String db, String tableName, String definition) {
     Table table = new Table(new org.apache.hadoop.hive.metastore.api.Table());
     table.setDbName(db);

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned.q
@@ -60,3 +60,7 @@ ALTER MATERIALIZED VIEW partition_mv_3 REBUILD;
 ALTER MATERIALIZED VIEW partition_mv_3 REBUILD;
 
 SELECT * FROM partition_mv_3 where key = 238;
+
+DROP MATERIALIZED VIEW partition_mv_1;
+DROP MATERIALIZED VIEW partition_mv_2;
+DROP MATERIALIZED VIEW partition_mv_3;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned.q.out
@@ -1161,3 +1161,27 @@ val_238	238
 val_238	238
 val_238_n2	238
 val_238_n2	238
+PREHOOK: query: DROP MATERIALIZED VIEW partition_mv_1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@partition_mv_1
+PREHOOK: Output: default@partition_mv_1
+POSTHOOK: query: DROP MATERIALIZED VIEW partition_mv_1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@partition_mv_1
+POSTHOOK: Output: default@partition_mv_1
+PREHOOK: query: DROP MATERIALIZED VIEW partition_mv_2
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@partition_mv_2
+PREHOOK: Output: default@partition_mv_2
+POSTHOOK: query: DROP MATERIALIZED VIEW partition_mv_2
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@partition_mv_2
+POSTHOOK: Output: default@partition_mv_2
+PREHOOK: query: DROP MATERIALIZED VIEW partition_mv_3
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@partition_mv_3
+PREHOOK: Output: default@partition_mv_3
+POSTHOOK: query: DROP MATERIALIZED VIEW partition_mv_3
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@partition_mv_3
+POSTHOOK: Output: default@partition_mv_3


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Replace ConcurrentMap.compute to computeIfAbsent in MaterializedViewsCache.putIfAbsent
2. Add a new version of `HiveMaterializedViewsRegistry.refresh()`
3. When rebuilding Instead of adding a new instance of the same MV refresh the existing one in the cache.

### Why are the changes needed?
Using ConcurrentMap.compute enabled adding multiple entries of the same Materialization instance to the sqlText -> materialization map.
`HiveMaterializedViewsRegistry.refresh(HiveConf conf, Table oldMaterializedViewTable, Table materializedViewTable)` did not removed outdated cache entry since a newer version of the passed table object was loaded from MetaStore in `MaterializedViewUpdateOperation`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestMaterializedViewsCache -pl ql
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite_3.q -pl itests/qtest -Pitests
```