### PR TITLE
HIVE-25899: Materialized view registry does not clean dropped views

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -372,6 +372,11 @@ public final class HiveMaterializedViewsRegistry {
     return materializedViewsCache.get(querySql);
   }
 
+  public boolean isEmpty() {
+    return materializedViewsCache.isEmpty();
+  }
+
+
   private static RelNode createMaterializedViewScan(HiveConf conf, Table viewTable) {
     // 0. Recreate cluster
     final RelOptPlanner planner = CalcitePlanner.createPlanner(conf);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
@@ -124,29 +124,43 @@ public class MaterializedViewsCache {
       // Delete only if the create time for the input materialized view table and the table
       // in the map match. Otherwise, keep the one in the map.
       dbMap.computeIfPresent(materializedViewTable.getTableName(), (mvTableName, oldMaterialization) -> {
-        if (HiveMaterializedViewUtils.extractTable(oldMaterialization).equals(materializedViewTable)) {
-          List<HiveRelOptMaterialization> materializationList =
-                  sqlToMaterializedView.get(materializedViewTable.getViewExpandedText());
-          materializationList.remove(oldMaterialization);
+        Table oldTable = HiveMaterializedViewUtils.extractTable(oldMaterialization);
+        if (oldTable.equals(materializedViewTable)) {
+          remove(oldMaterialization, oldTable);
           return null;
         }
         return oldMaterialization;
       });
+
+      if (dbMap.isEmpty()) {
+        materializedViews.remove(materializedViewTable.getDbName());
+      }
     }
 
     LOG.debug("Materialized view {}.{} removed from registry",
             materializedViewTable.getDbName(), materializedViewTable.getTableName());
   }
 
+  private void remove(HiveRelOptMaterialization materialization, Table mvTable) {
+    List<HiveRelOptMaterialization> materializationList =
+            sqlToMaterializedView.get(mvTable.getViewExpandedText());
+    materializationList.remove(materialization);
+    if (materializationList.isEmpty()) {
+      sqlToMaterializedView.remove(mvTable.getViewExpandedText());
+    }
+  }
+
   public void remove(String dbName, String tableName) {
     ConcurrentMap<String, HiveRelOptMaterialization> dbMap = materializedViews.get(dbName);
     if (dbMap != null) {
       dbMap.computeIfPresent(tableName, (mvTableName, materialization) -> {
-        String queryText = HiveMaterializedViewUtils.extractTable(materialization).getViewExpandedText();
-        List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.get(queryText);
-        materializationList.remove(materialization);
+        remove(materialization, HiveMaterializedViewUtils.extractTable(materialization));
         return null;
       });
+
+      if (dbMap.isEmpty()) {
+        materializedViews.remove(dbName);
+      }
 
       LOG.debug("Materialized view {}.{} removed from registry", dbName, tableName);
     }
@@ -179,5 +193,9 @@ public class MaterializedViewsCache {
     LOG.debug("{} materialized view(s) found with similar query text found in registry",
             relOptMaterializationList.size());
     return unmodifiableList(relOptMaterializationList);
+  }
+
+  public boolean isEmpty() {
+    return materializedViews.isEmpty();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
@@ -125,7 +125,7 @@ public class MaterializedViewsCache {
       // in the map match. Otherwise, keep the one in the map.
       dbMap.computeIfPresent(materializedViewTable.getTableName(), (mvTableName, oldMaterialization) -> {
         Table oldTable = HiveMaterializedViewUtils.extractTable(oldMaterialization);
-        if (oldTable.equals(materializedViewTable)) {
+        if (materializedViewTable.equals(oldTable)) {
           remove(oldMaterialization, oldTable);
           return null;
         }
@@ -142,8 +142,15 @@ public class MaterializedViewsCache {
   }
 
   private void remove(HiveRelOptMaterialization materialization, Table mvTable) {
-    List<HiveRelOptMaterialization> materializationList =
-            sqlToMaterializedView.get(mvTable.getViewExpandedText());
+    if (mvTable == null) {
+      return;
+    }
+
+    List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.get(mvTable.getViewExpandedText());
+    if (materializationList == null) {
+      return;
+    }
+
     materializationList.remove(materialization);
     if (materializationList.isEmpty()) {
       sqlToMaterializedView.remove(mvTable.getViewExpandedText());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -151,6 +151,7 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveMaterializedViewsRegistry;
 import org.apache.hadoop.hive.ql.metadata.HiveRelOptMaterialization;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.NotNullConstraint;
@@ -2074,6 +2075,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
     private boolean isMaterializedViewRewritingByTextEnabled() {
       return conf.getBoolVar(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SQL) &&
+              !HiveMaterializedViewsRegistry.get().isEmpty() &&
               mvRebuildMode == MaterializationRebuildMode.NONE &&
               !rootQB.isMaterializedView() && !ctx.isLoadingMaterializedView() && !rootQB.isCTAS() &&
               rootQB.getIsQuery() &&

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
@@ -92,6 +92,7 @@ class TestMaterializedViewsCache {
     MaterializedViewsCache emptyCache = new MaterializedViewsCache();
 
     assertThat(emptyCache.get("select 'any definition'").isEmpty(), is(true));
+    assertThat(emptyCache.isEmpty(), is(true));
     assertThat(emptyCache.values().isEmpty(), is(true));
   }
 
@@ -117,6 +118,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(defaultMaterialization1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).get(0), is(defaultMaterialization1));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(1));
     assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1));
   }
@@ -158,6 +160,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(2));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1Same));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(2));
   }
 
@@ -171,6 +174,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(2));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(db1Materialization1));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(2));
   }
 
@@ -181,6 +185,7 @@ class TestMaterializedViewsCache {
 
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(2));
   }
 
@@ -191,6 +196,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(defaultMaterialization1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(1));
     assertThat(materializedViewsCache.values(), hasItem(defaultMaterialization1));
   }
@@ -205,6 +211,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(newMaterialization));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(newMaterialization));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(1));
     assertThat(materializedViewsCache.values(), hasItem(newMaterialization));
   }
@@ -217,6 +224,7 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(defaultMaterialization1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()), hasItem(defaultMaterialization1));
+    assertThat(materializedViewsCache.isEmpty(), is(false));
     assertThat(materializedViewsCache.values().size(), is(1));
     assertThat(materializedViewsCache.values(), hasItem(defaultMaterialization1));
   }
@@ -229,6 +237,7 @@ class TestMaterializedViewsCache {
 
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(nullValue()));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).isEmpty(), is(true));
+    assertThat(materializedViewsCache.isEmpty(), is(true));
     assertThat(materializedViewsCache.values().isEmpty(), is(true));
   }
 
@@ -240,6 +249,7 @@ class TestMaterializedViewsCache {
 
     assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(nullValue()));
     assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).isEmpty(), is(true));
+    assertThat(materializedViewsCache.isEmpty(), is(true));
     assertThat(materializedViewsCache.values().isEmpty(), is(true));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`MaterializedViewsCache` nested maps.
```
somedb -> someview -> Materialization
```
1. When removing entries from the inner map check whether that map is empty and remove it from the outer map.
2. Add `isEmpty()` method to `HiveMaterializedViewsRegistry`

### Why are the changes needed?
See description of jira.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestMaterializedViewsCache -pl ql
```
