### PR TITLE
HIVE-25898: Compaction txn heartbeating after Worker timeout

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -22,6 +22,11 @@ import static org.apache.hadoop.hive.ql.TestTxnCommands2.runCleaner;
 import static org.apache.hadoop.hive.ql.TestTxnCommands2.runInitiator;
 import static org.apache.hadoop.hive.ql.TestTxnCommands2.runWorker;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -85,6 +90,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,6 +175,76 @@ public class TestCompactor {
     if (driver != null) {
       driver.close();
     }
+  }
+
+
+  @Test
+  public void testHeartbeatShutdownOnFailedCompaction() throws Exception {
+    String dbName = "default";
+    String tblName = "compaction_test";
+    executeStatementOnDriver("drop table if exists " + tblName, driver);
+    executeStatementOnDriver("CREATE TABLE " + tblName + "(a INT, b STRING) " +
+            " PARTITIONED BY(bkt INT)" +
+            " CLUSTERED BY(a) INTO 4 BUCKETS" + //currently ACID requires table to be bucketed
+            " STORED AS ORC  TBLPROPERTIES ('transactional'='true')", driver);
+
+    StrictDelimitedInputWriter writer = StrictDelimitedInputWriter.newBuilder()
+            .withFieldDelimiter(',')
+            .build();
+    HiveStreamingConnection connection = HiveStreamingConnection.newBuilder()
+            .withDatabase(dbName)
+            .withTable(tblName)
+            .withStaticPartitionValues(Arrays.asList("0"))
+            .withAgentInfo("UT_" + Thread.currentThread().getName())
+            .withHiveConf(conf)
+            .withRecordWriter(writer)
+            .connect();
+    connection.beginTransaction();
+    connection.write("55, 'London'".getBytes());
+    connection.commitTransaction();
+    connection.beginTransaction();
+    connection.write("56, 'Paris'".getBytes());
+    connection.commitTransaction();
+    connection.close();
+
+    executeStatementOnDriver("INSERT INTO TABLE " + tblName + " PARTITION(bkt=1)" +
+            " values(57, 'Budapest')", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tblName + " PARTITION(bkt=1)" +
+            " values(58, 'Milano')", driver);
+    execSelectAndDumpData("select * from " + tblName, driver, "Dumping data for " +
+            tblName + " after load:");
+
+    TxnStore txnHandler = TxnUtils.getTxnStore(conf);
+
+    // Commit will throw an exception
+    IMetaStoreClient mockedClient = Mockito.spy(new HiveMetaStoreClient(conf));
+    doThrow(new RuntimeException("Simulating RuntimeException from CompactionTxn.commit")).when(mockedClient).commitTxn(Mockito.anyLong());
+    doAnswer(invocation -> {
+      Object o = invocation.callRealMethod();
+      //Check if the heartbeating is running
+      Assert.assertTrue(Thread.getAllStackTraces().keySet()
+              .stream().anyMatch(k -> k.getName().contains("CompactionTxn Heartbeater")));
+      return o;
+    }).when(mockedClient).openTxn(any(), any());
+
+    //Do a major compaction
+    CompactionRequest rqst = new CompactionRequest(dbName, tblName, CompactionType.MAJOR);
+    rqst.setPartitionname("bkt=0");
+    txnHandler.compact(rqst);
+
+    Worker worker = Mockito.spy(new Worker());
+    worker.setThreadId((int) worker.getId());
+    worker.setConf(conf);
+    worker.init(new AtomicBoolean(true));
+    FieldSetter.setField(worker, RemoteCompactorThread.class.getDeclaredField("msc"), mockedClient);
+
+    worker.run();
+
+    //Check if the transaction was opened
+    verify(mockedClient, times(1)).openTxn(any(), any());
+    //Check if the heartbeating is properly terminated
+    Assert.assertTrue(Thread.getAllStackTraces().keySet()
+            .stream().noneMatch(k -> k.getName().contains("CompactionTxn Heartbeater")));
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorUtil.java
@@ -88,4 +88,5 @@ public class CompactorUtil {
     }
     return null;
   }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hive.ql.txn.compactor;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ScheduledExecutorService;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ValidCompactorWriteIdList;
@@ -202,26 +204,16 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
     }
   }
 
-  static final class CompactionHeartbeater extends Thread {
+  static final class CompactionHeartbeater implements Runnable {
     static final private Logger LOG = LoggerFactory.getLogger(CompactionHeartbeater.class);
     private final CompactionTxn compactionTxn;
     private final String tableName;
     private final HiveConf conf;
-    private final AtomicBoolean errorLogEnabled;
 
     public CompactionHeartbeater(CompactionTxn compactionTxn, String tableName, HiveConf conf) {
       this.tableName = Objects.requireNonNull(tableName);
       this.compactionTxn = Objects.requireNonNull(compactionTxn);
       this.conf = Objects.requireNonNull(conf);
-      this.errorLogEnabled = new AtomicBoolean(true);
-
-      setDaemon(true);
-      setPriority(MIN_PRIORITY);
-      setName("CompactionHeartbeater-" + compactionTxn.getTxnId());
-    }
-
-    public void shouldLogError(boolean shouldLogError) {
-      this.errorLogEnabled.set(shouldLogError);
     }
 
     @Override
@@ -233,9 +225,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         msc = HiveMetaStoreUtils.getHiveMetastoreClient(conf);
         msc.heartbeat(compactionTxn.getTxnId(), compactionTxn.getLockId());
       } catch (Exception e) {
-        if (errorLogEnabled.get()) {
           LOG.error("Error while heartbeating transaction id {} for table: {}", compactionTxn, tableName, e);
-        }
       } finally {
         if (msc != null) {
           msc.close();
@@ -334,15 +324,19 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
     CompactionInfo ci = null;
     boolean computeStats = false;
     Table t1 = null;
-    try (CompactionTxn compactionTxn = new CompactionTxn()) {
-      if (msc == null) {
-        try {
-          msc = HiveMetaStoreUtils.getHiveMetastoreClient(conf);
-        } catch (Exception e) {
-          LOG.error("Failed to connect to HMS", e);
-          return false;
-        }
+
+    // If an exception is thrown in the try-with-resources block below, msc is closed and nulled, so a new instance
+    // is need to be obtained here.
+    if (msc == null) {
+      try {
+        msc = HiveMetaStoreUtils.getHiveMetastoreClient(conf);
+      } catch (Exception e) {
+        LOG.error("Failed to connect to HMS", e);
+        return false;
       }
+    }
+
+    try (CompactionTxn compactionTxn = new CompactionTxn()) {
 
       FindNextCompactRequest findNextCompactRequest = new FindNextCompactRequest();
       findNextCompactRequest.setWorkerId(workerName);
@@ -663,7 +657,6 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
 
     private TxnStatus status = TxnStatus.UNKNOWN;
     private boolean succeessfulCompaction = false;
-    private CompactionHeartbeater heartbeater;
     private ScheduledExecutorService heartbeatExecutor;
 
     /**
@@ -671,10 +664,6 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
      * @throws TException
      */
     void open(CompactionInfo ci) throws TException {
-      if (msc == null) {
-        LOG.error("Metastore client was null. Could not open a new transaction.");
-        return;
-      }
       this.txnId = msc.openTxn(ci.runAs, TxnType.COMPACTION);
       status = TxnStatus.OPEN;
 
@@ -685,11 +674,18 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
             + "}, status {" + res.getState() + "}, reason {" + res.getErrorMessage() + "}");
       }
       lockId = res.getLockid();
-
-      heartbeatExecutor = Executors.newSingleThreadScheduledExecutor();
+      heartbeatExecutor = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
+                .setPriority(Thread.MIN_PRIORITY)
+                .setDaemon(true)
+                .setNameFormat("CompactionTxnHeartbeater-" + txnId)
+                .build());
       long txnTimeout = MetastoreConf.getTimeVar(conf, MetastoreConf.ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS);
-      heartbeater = new CompactionHeartbeater(this, TxnUtils.getFullTableName(ci.dbname, ci.tableName), conf);
-      heartbeatExecutor.scheduleAtFixedRate(heartbeater, txnTimeout / 4, txnTimeout / 2, TimeUnit.MILLISECONDS);
+      heartbeatExecutor.scheduleAtFixedRate(
+              new CompactionHeartbeater(this, TxnUtils.getFullTableName(ci.dbname, ci.tableName), conf),
+              txnTimeout / 4,
+              txnTimeout / 2,
+              TimeUnit.MILLISECONDS
+      );
     }
 
     /**
@@ -704,16 +700,15 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
      * @throws Exception
      */
     @Override public void close() throws Exception {
+      //the transaction is about to close, we can stop heartbeating regardless of it's state
+      shutdownHeartbeater();
       if (status != TxnStatus.UNKNOWN) {
-        // turn off error logging in heartbeater in case of race condition between commit/abort and heartbeating
-        heartbeater.shouldLogError(false);
         if (succeessfulCompaction) {
           commit();
         } else {
           abort();
         }
       }
-      shutdownHeartbeater();
     }
 
     private void shutdownHeartbeater() {
@@ -721,11 +716,12 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         heartbeatExecutor.shutdownNow();
         try {
           if (!heartbeatExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-            heartbeatExecutor.shutdownNow();
+            LOG.warn("Heartbeating for transaction {} did not stop in 5 seconds, do not wait any longer.", this);
           }
-          LOG.debug("Successfully stopped heartbeating for transaction {}", this);
         } catch (InterruptedException ex) {
-          heartbeatExecutor.shutdownNow();
+          //Caller thread was interrupted while waiting for heartbeater to terminate.
+          //Nothing to do, just restore the interrupted state.
+          Thread.currentThread().interrupt();
         }
       }
     }
@@ -745,37 +741,22 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
     /**
      * Commit the txn if open.
      */
-    private void commit() {
-      if (msc == null) {
-        LOG.error("Metastore client was null. Could not commit txn " + this);
-        return;
-      }
+    private void commit() throws TException {
       if (status == TxnStatus.OPEN) {
-        try {
-          msc.commitTxn(txnId);
-          status = TxnStatus.COMMITTED;
-        } catch (TException e) {
-          LOG.error("Caught an exception while committing compaction txn in worker " + workerName, e);
-        }
+        msc.commitTxn(txnId);
+        status = TxnStatus.COMMITTED;
       }
     }
 
     /**
      * Abort the txn if open.
      */
-    private void abort() {
-      if (msc == null) {
-        LOG.error("Metastore client was null. Could not abort txn " + this);
-        return;
-      }
+    private void abort() throws TException {
       if (status == TxnStatus.OPEN) {
-        try {
-          msc.abortTxns(Collections.singletonList(txnId));
-          status = TxnStatus.ABORTED;
-        } catch (TException e) {
-          LOG.error("Caught an exception while aborting compaction txn in worker " + workerName, e);
-        }
+        msc.abortTxns(Collections.singletonList(txnId));
+        status = TxnStatus.ABORTED;
       }
     }
   }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the issue when the Heartbeater of the CompactionTxn is not shut down. This could happen if an exception is thrown from CompactionTxn.abort() or CompactionTxn.commit() which is not caught by the catch block. The fix reworks heartbeat handling the following way:
1. The heartbeater is shut down BEFORE calling abort() or commit(), so regardless of the outcome of the transaction, or if an exception is thrown or not, the heartbeater won't stay alive. Another benefit that, this approach solves the logging after commit()/abort() issue too, without the need of the previously introduced additional logic (See: HIVE-25740).

### Why are the changes needed?
To fix the issue that in some cases the heartbeater of a CompactionTxn is not shut down properly.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Through unit tests.