### PR TITLE
HIVE-25906: Clean MaterializedViewCache after q test run

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -363,6 +363,7 @@ public class QTestUtil {
           continue;
         }
         db.dropTable(dbName, tblName, true, true, fsType == FsType.ENCRYPTED_HDFS);
+        HiveMaterializedViewsRegistry.get().dropMaterializedView(tblObj);
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the MV entry from `HiveMaterializedViewsRegistry` created by q tests in `QTestUtil`.

### Why are the changes needed?
Uncleaned `HiveMaterializedViewsRegistry` caused interference with other q tests when running them in batch.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
1. Remove the `DROP MATERIALIZED VIEW` statements from some qtests which deals with MVs and run them in batch. Attache a debugger and check the state of `HiveMaterializedViewsRegistry` after each test run in `QTestUtil`.

2. Both tests creates MV with the same name and the interference affects the MV rebuild plan in materialized_view_partitioned_2.q
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_partitioned.q,materialized_view_partitioned_2.q -pl itests/qtest -Pitests
```