### PR TITLE
HIVE-25912: Drop external table throw NPE if the location set to ROOT path

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -743,6 +743,11 @@ public final class FileUtils {
       return;
     }
 
+    if(path.getParent() == null) {
+      // no file/dir to be deleted, because of the path is root dir, hive table forbid set the location to root dir.
+      return;
+    }
+
     final FileSystem fs = path.getFileSystem(conf);
     // check user has write permissions on the parent dir
     FileStatus stat = null;

--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -743,11 +743,6 @@ public final class FileUtils {
       return;
     }
 
-    if(path.getParent() == null) {
-      // no file/dir to be deleted, because of the path is root dir, hive table forbid set the location to root dir.
-      return;
-    }
-
     final FileSystem fs = path.getFileSystem(conf);
     // check user has write permissions on the parent dir
     FileStatus stat = null;

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -1797,6 +1797,12 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         throw new InvalidObjectException(tbl.getTableName()
             + " is not a valid object name");
       }
+
+      if (!MetaStoreUtils.validateTblStorage(tbl.getSd())) {
+        throw new InvalidObjectException(tbl.getTableName()
+                + " location must not be root path");
+      }
+
       String validate = MetaStoreUtils.validateTblColumns(tbl.getSd().getCols());
       if (validate != null) {
         throw new InvalidObjectException("Invalid column " + validate);

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -500,6 +500,14 @@ public class MetaStoreUtils {
   }
 
   /*
+   * Check the table storage location must not be root path.
+   */
+  static public boolean validateTblStorage(StorageDescriptor sd) {
+    return !(StringUtils.isNotBlank(sd.getLocation())
+            && new Path(sd.getLocation()).getParent() == null);
+  }
+
+  /*
    * At the Metadata level there are no restrictions on Column Names.
    */
   public static boolean validateColumnName(String name) {

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreUtils.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreUtils.java
@@ -353,7 +353,7 @@ public class TestMetaStoreUtils {
   }
 
   @Test
-  public void throwFailExceptionWithStorageIsRootPath() {
+  public void throwFailExceptionWithHDFSStorageIsRootPath() {
     StorageDescriptor sd = new StorageDescriptor();
     sd.setLocation("hdfs://localhost:8020");
     Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
@@ -362,6 +362,19 @@ public class TestMetaStoreUtils {
     Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
 
     sd.setLocation("hdfs://localhost:8020/other_path");
+    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
+  }
+
+  @Test
+  public void throwFailExceptionWithS3StorageIsRootPath() {
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("s3a://bucket/");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("s3a://bucket");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("s3a://bucket/other_path");
     Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
   }
 }

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreUtils.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreUtils.java
@@ -22,12 +22,14 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
@@ -348,6 +350,19 @@ public class TestMetaStoreUtils {
     }
     newPartition.setParameters(newStats);
     Assert.assertFalse(MetaStoreUtils.isFastStatsSame(oldPartition, newPartition));
+  }
+
+  @Test
+  public void throwFailExceptionWithStorageIsRootPath() {
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("hdfs://localhost:8020");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("hdfs://localhost:8020/");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("hdfs://localhost:8020/other_path");
+    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

modify the HiveMetaStore. create_table_core function add this check:

```
if (!MetaStoreUtils.validateTblStorage(tbl.getSd())) {
    throw new InvalidObjectException(tbl.getTableName()
        + " location must not be root path");
}
```
If the path.getParent() is NULL we can be sure the location is ROOT path.  

the validateTblStorage implements:

```
/*
  * Check the table storage location must not be root path.
  */
 static public boolean validateTblStorage(StorageDescriptor sd) {
   return !(StringUtils.isNotBlank(sd.getLocation())
           && new Path(sd.getLocation()).getParent() == null);
 }
```

I add a test for this feature:

```
  @Test
  public void throwFailExceptionWithStorageIsRootPath() {
    StorageDescriptor sd = new StorageDescriptor();
    sd.setLocation("hdfs://localhost:8020");
    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));

    sd.setLocation("hdfs://localhost:8020/");
    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));

    sd.setLocation("hdfs://localhost:8020/other_path");
    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
  }
```

### Why are the changes needed?
If I create an external table using the ROOT path, the table was created successfully, but when I drop the table throw the NPE.  So I can't drop the table forever.

This is not a good phenomenon.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreUtils.java

test func is: throwFailExceptionWithStorageIsRootPath

mvn test -Dtest=SomeTest --pl common
