### PR TITLE
Hive 25921: Overwrite table metadata for bootstraped tables.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableOperation.java
@@ -66,7 +66,8 @@ public class CreateTableOperation extends DDLOperation<CreateTableDesc> {
       Table existingTable = context.getDb().getTable(tbl.getDbName(), tbl.getTableName(), false);
       if (existingTable != null) {
         Map<String, String> dbParams = context.getDb().getDatabase(existingTable.getDbName()).getParameters();
-        if (desc.getReplicationSpec().allowEventReplacementInto(dbParams)) {
+        if (desc.getReplicationSpec().allowEventReplacementInto(dbParams) || desc.getReplicationSpec()
+            .isForceOverwrite()) {
           desc.setReplaceMode(true); // we replace existing table.
           // If location of an existing managed table is changed, then need to delete the old location if exists.
           // This scenario occurs when a managed table is converted into external table at source. In this case,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -311,7 +311,7 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
         } else {
           LoadTable loadTable = new LoadTable(tableEvent, loadContext, iterator.replLogger(), tableContext,
               loadTaskTracker, work.getMetricCollector());
-          tableTracker = loadTable.tasks(work.isIncrementalLoad());
+          tableTracker = loadTable.tasks(work.isIncrementalLoad(), work.isSecondFailover);
         }
 
         setUpDependencies(dbTracker, tableTracker);
@@ -336,7 +336,7 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
           // for a table we explicitly try to load partitions as there is no separate partitions events.
           LoadPartitions loadPartitions =
               new LoadPartitions(loadContext, iterator.replLogger(), loadTaskTracker, tableEvent,
-                  work.dbNameToLoadIn, tableContext, work.getMetricCollector());
+                  work.dbNameToLoadIn, tableContext, work.getMetricCollector(), work.tablesToBootstrap);
           TaskTracker partitionsTracker = loadPartitions.tasks();
           partitionsPostProcessing(iterator, scope, loadTaskTracker, tableTracker,
               partitionsTracker);
@@ -446,7 +446,7 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
     LoadPartitions loadPartitions =
         new LoadPartitions(loadContext, iterator.replLogger(), tableContext, loadTaskTracker,
         event.asTableEvent(), work.dbNameToLoadIn, event.lastPartitionReplicated(), work.getMetricCollector(),
-          event.lastPartSpecReplicated(), event.lastStageReplicated());
+          event.lastPartSpecReplicated(), event.lastStageReplicated(), getWork().tablesToBootstrap);
         /*
              the tableTracker here should be a new instance and not an existing one as this can
              only happen when we break in between loading partitions.
@@ -734,10 +734,11 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
         return 0;
       }
     } else if (work.isSecondFailover) {
-      // DROP the tables to be bootstrapped.
+      // DROP the tables extra on target, which are not on source cluster.
 
       Hive db = getHive();
-      for (String table : work.tablesToBootstrap) {
+      for (String table : work.tablesToDrop) {
+        LOG.info("Dropping table {} for optimised bootstarap", work.dbNameToLoadIn + "." + table);
         db.dropTable(work.dbNameToLoadIn + "." + table, true);
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadWork.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -95,7 +96,7 @@ public class ReplLoadWork implements Serializable, ReplLoadWorkMBean {
   public boolean isFirstFailover;
   public boolean isSecondFailover;
   public List<String> tablesToBootstrap = new ArrayList<>();
-  public List<String> tablesToDrop = new ArrayList<>();
+  public List<String> tablesToDrop = new LinkedList<>();
 
   /*
   these are sessionState objects that are copied over to work to allow for parallel execution.
@@ -160,10 +161,10 @@ public class ReplLoadWork implements Serializable, ReplLoadWorkMBean {
       if (fs.exists(incBootstrapDir)) {
         if (isSecondFailover) {
           String[] bootstrappedTables = getBootstrapTableList(new Path(dumpDirectory).getParent(), hiveConf);
-          tablesToBootstrap = new ArrayList<String>(Arrays.asList(bootstrappedTables));
+          tablesToBootstrap = Arrays.asList(bootstrappedTables);
           LOG.info("Optimised bootstrap for database {} with load with bootstrapped table list as {}", dbNameToLoadIn,
               tablesToBootstrap);
-          ArrayList<String> tableList = new ArrayList<String>(Arrays.asList(bootstrappedTables));
+          LinkedList<String> tableList = new LinkedList<String>(Arrays.asList(bootstrappedTables));
           // Get list of tables bootstrapped.
           Path tableMetaPath = new Path(incBootstrapDir, EximUtil.METADATA_PATH_NAME + "/" + sourceDbName);
           FileStatus[] listing = fs.listStatus(tableMetaPath);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadWork.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hive.ql.exec.repl;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.repl.ReplScope;
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hadoop.hive.conf.Constants.SCHEDULED_QUERY_EXECUTIONID;
 import static org.apache.hadoop.hive.conf.Constants.SCHEDULED_QUERY_SCHEDULENAME;
@@ -161,19 +162,14 @@ public class ReplLoadWork implements Serializable, ReplLoadWorkMBean {
       if (fs.exists(incBootstrapDir)) {
         if (isSecondFailover) {
           String[] bootstrappedTables = getBootstrapTableList(new Path(dumpDirectory).getParent(), hiveConf);
-          tablesToBootstrap = new LinkedList<String>(Arrays.asList(bootstrappedTables));
           LOG.info("Optimised bootstrap load for database {} with initial bootstrapped table list as {}",
               dbNameToLoadIn, tablesToBootstrap);
-          LinkedList<String> tableList = new LinkedList<String>(Arrays.asList(bootstrappedTables));
           // Get list of tables bootstrapped.
           Path tableMetaPath = new Path(incBootstrapDir, EximUtil.METADATA_PATH_NAME + "/" + sourceDbName);
-          FileStatus[] listing = fs.listStatus(tableMetaPath);
-          for (FileStatus tablePath : listing) {
-            tableList.remove(tablePath.getPath().getName());
-          }
-          tablesToDrop = tableList;
-          // Remove the table to be dropped from the list of tables to be bootstrapped.
-          tablesToBootstrap.removeAll(tablesToDrop);
+          tablesToBootstrap =
+              Stream.of(fs.listStatus(tableMetaPath)).map(st -> st.getPath().getName()).collect(Collectors.toList());
+          List<String> tableList = Arrays.asList(bootstrappedTables);
+          tablesToDrop = ListUtils.subtract(tableList, tablesToBootstrap);
           LOG.info("Optimised bootstrap for database {} with drop table list as {} and bootstrap table list as {}",
               dbNameToLoadIn, tablesToDrop, tablesToBootstrap);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
@@ -82,7 +82,7 @@ public class LoadTable {
     this.metricCollector = metricCollector;
   }
 
-  public TaskTracker tasks(boolean isBootstrapDuringInc) throws Exception {
+  public TaskTracker tasks(boolean isBootstrapDuringInc, boolean isSecondFailover) throws Exception {
     // Path being passed to us is a table dump location. We go ahead and load it in as needed.
     // If tblName is null, then we default to the table name specified in _metadata, which is good.
     // or are both specified, in which case, that's what we are intended to create the new table as.
@@ -94,6 +94,10 @@ public class LoadTable {
     // Executed if relevant, and used to contain all the other details about the table if not.
     ImportTableDesc tableDesc = event.tableDesc(dbName);
     Table table = ImportSemanticAnalyzer.tableIfExists(tableDesc, context.hiveDb);
+
+    if (isSecondFailover) {
+      tableDesc.setForceOverwriteTable();
+    }
 
     // Normally, on import, trying to create a table or a partition in a db that does not yet exist
     // is a error condition. However, in the case of a REPL LOAD, it is possible that we are trying
@@ -112,7 +116,7 @@ public class LoadTable {
     }
 
     Task<?> tblRootTask = null;
-    ReplLoadOpType loadTblType = getLoadTableType(table, isBootstrapDuringInc);
+    ReplLoadOpType loadTblType = getLoadTableType(table, isBootstrapDuringInc, isSecondFailover);
     switch (loadTblType) {
       case LOAD_NEW:
         break;
@@ -138,7 +142,7 @@ public class LoadTable {
        or in the case of an unpartitioned table. In all other cases, it should
        behave like a noop or a pure MD alter.
     */
-    newTableTasks(tableDesc, tblRootTask, tableLocationTuple);
+    newTableTasks(tableDesc, tblRootTask, tableLocationTuple, isSecondFailover && table !=null);
 
     // Set Checkpoint task as dependant to create table task. So, if same dump is retried for
     // bootstrap, we skip current table update.
@@ -159,9 +163,9 @@ public class LoadTable {
     return tracker;
   }
 
-  private ReplLoadOpType getLoadTableType(Table table, boolean isBootstrapDuringInc)
+  private ReplLoadOpType getLoadTableType(Table table, boolean isBootstrapDuringInc, boolean isSecondFailover)
           throws InvalidOperationException, HiveException {
-    if (table == null) {
+    if (table == null || isSecondFailover) {
       return ReplLoadOpType.LOAD_NEW;
     }
 
@@ -180,11 +184,11 @@ public class LoadTable {
     return ReplLoadOpType.LOAD_REPLACE;
   }
 
-  private void newTableTasks(ImportTableDesc tblDesc, Task<?> tblRootTask, TableLocationTuple tuple)
+  private void newTableTasks(ImportTableDesc tblDesc, Task<?> tblRootTask, TableLocationTuple tuple, boolean setLoc)
       throws Exception {
     Table table = tblDesc.toTable(context.hiveConf);
     ReplicationSpec replicationSpec = event.replicationSpec();
-    if (!tblDesc.isExternal()) {
+    if (!tblDesc.isExternal() && !setLoc) {
       tblDesc.setLocation(null);
     }
     Task<?> createTableTask =

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
@@ -142,7 +142,7 @@ public class LoadTable {
        or in the case of an unpartitioned table. In all other cases, it should
        behave like a noop or a pure MD alter.
     */
-    newTableTasks(tableDesc, tblRootTask, tableLocationTuple, isSecondFailover && table !=null);
+    newTableTasks(tableDesc, tblRootTask, tableLocationTuple, isSecondFailover && table != null);
 
     // Set Checkpoint task as dependant to create table task. So, if same dump is retried for
     // bootstrap, we skip current table update.
@@ -165,6 +165,10 @@ public class LoadTable {
 
   private ReplLoadOpType getLoadTableType(Table table, boolean isBootstrapDuringInc, boolean isSecondFailover)
           throws InvalidOperationException, HiveException {
+    // In case of second iteration of the optimised bootstrap, we don't drop & re create the table, instead we
+    // re-write the metadata, in order to prevent deletion of the data in the target cluster. So, that while copying
+    // data from the source cluster, we just operate on the modified/missing/additional files and can get rid of
+    // copying the files which are already there on both cluster and are same.
     if (table == null || isSecondFailover) {
       return ReplLoadOpType.LOAD_NEW;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSpec.java
@@ -49,6 +49,7 @@ public class ReplicationSpec {
   //Determine if replication is done using repl or export-import
   private boolean isRepl = false;
   private boolean isMetadataOnlyForExternalTables = false;
+  private boolean isForceOverwrite = false;
 
   public void setInReplicationScope(boolean inReplicationScope) {
     isInReplicationScope = inReplicationScope;
@@ -417,5 +418,13 @@ public class ReplicationSpec {
 
   public void setRepl(boolean repl) {
     isRepl = repl;
+  }
+
+  public boolean isForceOverwrite() {
+    return isForceOverwrite;
+  }
+
+  public void setForceOverwrite(boolean forceOverwrite) {
+    isForceOverwrite = forceOverwrite;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
@@ -190,4 +190,8 @@ public class ImportTableDesc {
   public Long getReplWriteId() {
     return this.createTblDesc.getReplWriteId();
   }
+
+  public void setForceOverwriteTable(){
+    this.createTblDesc.getReplicationSpec().setForceOverwrite(true);
+  }
 }


### PR DESCRIPTION
Rather than dropping tables, overwrite the metadata of the tables, so that data copy can be optimised 