### PR TITLE
HIVE-25919: ClassCastException when pushing boolean column predicate in HBaseStorageHandler

### DIFF
--- a/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
+++ b/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
@@ -1,0 +1,8 @@
+CREATE TABLE hbase_table(row_key string, c1 boolean, c2 boolean)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+"hbase.columns.mapping" = ":key,cf:c1,cf:c2"
+);
+
+explain select * from hbase_table where c1 and c2;
+explain select * from hbase_table where c1=true and c2=true;

--- a/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
+++ b/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
@@ -11,6 +11,7 @@ values ('Alex', true, true),
        ('Chris', null, false),
        ('Rob', false, null);
 
+-- Although we are hitting the code for predicate pushdown the push does not happen at the moment (see HIVE-25939).
 explain select * from hbase_table where c1 and c2;
 select * from hbase_table where c1 and c2;
 explain select * from hbase_table where c1=true and c2=true;

--- a/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
+++ b/hbase-handler/src/test/queries/positive/hbase_ppd_boolean_cols.q
@@ -3,6 +3,15 @@ STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
 WITH SERDEPROPERTIES (
 "hbase.columns.mapping" = ":key,cf:c1,cf:c2"
 );
+insert into hbase_table
+values ('Alex', true, true),
+       ('George', true, false),
+       ('Stam', false, false),
+       ('Alice', false, true),
+       ('Chris', null, false),
+       ('Rob', false, null);
 
 explain select * from hbase_table where c1 and c2;
+select * from hbase_table where c1 and c2;
 explain select * from hbase_table where c1=true and c2=true;
+select * from hbase_table where c1=true and c2=true;

--- a/hbase-handler/src/test/results/positive/hbase_ppd_boolean_cols.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_ppd_boolean_cols.q.out
@@ -14,6 +14,26 @@ WITH SERDEPROPERTIES (
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@hbase_table
+PREHOOK: query: insert into hbase_table
+values ('Alex', true, true),
+       ('George', true, false),
+       ('Stam', false, false),
+       ('Alice', false, true),
+       ('Chris', null, false),
+       ('Rob', false, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hbase_table
+POSTHOOK: query: insert into hbase_table
+values ('Alex', true, true),
+       ('George', true, false),
+       ('Stam', false, false),
+       ('Alice', false, true),
+       ('Chris', null, false),
+       ('Rob', false, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hbase_table
 PREHOOK: query: explain select * from hbase_table where c1 and c2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@hbase_table
@@ -55,6 +75,15 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: select * from hbase_table where c1 and c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_table where c1 and c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+Alex	true	true
 PREHOOK: query: explain select * from hbase_table where c1=true and c2=true
 PREHOOK: type: QUERY
 PREHOOK: Input: default@hbase_table
@@ -96,3 +125,12 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: select * from hbase_table where c1=true and c2=true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_table where c1=true and c2=true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+Alex	true	true

--- a/hbase-handler/src/test/results/positive/hbase_ppd_boolean_cols.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_ppd_boolean_cols.q.out
@@ -1,0 +1,98 @@
+PREHOOK: query: CREATE TABLE hbase_table(row_key string, c1 boolean, c2 boolean)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+"hbase.columns.mapping" = ":key,cf:c1,cf:c2"
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hbase_table
+POSTHOOK: query: CREATE TABLE hbase_table(row_key string, c1 boolean, c2 boolean)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+"hbase.columns.mapping" = ":key,cf:c1,cf:c2"
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hbase_table
+PREHOOK: query: explain select * from hbase_table where c1 and c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_table where c1 and c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: hbase_table
+            Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (c1 and c2) (type: boolean)
+              Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: row_key (type: string), c1 (type: boolean), c2 (type: boolean)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+      Execution mode: vectorized
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from hbase_table where c1=true and c2=true
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_table where c1=true and c2=true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: hbase_table
+            Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (c1 and c2) (type: boolean)
+              Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: row_key (type: string), c1 (type: boolean), c2 (type: boolean)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+      Execution mode: vectorized
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/java/org/apache/hadoop/hive/ql/index/IndexPredicateAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/index/IndexPredicateAnalyzer.java
@@ -160,7 +160,11 @@ public class IndexPredicateAnalyzer {
           }
         }
 
-        return analyzeExpr((ExprNodeGenericFuncDesc) nd, searchConditions, nodeOutputs);
+        if (nd instanceof ExprNodeGenericFuncDesc) {
+          return analyzeExpr((ExprNodeGenericFuncDesc) nd, searchConditions, nodeOutputs);
+        } else {
+          return nd;
+        }
       }
     };
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The predicate analyzer can only handle expressions of the form:
1. `col comp_op constant`
2. `constant comp_op col`
and these are always `ExprNodeGenericFuncDesc`.

The new if clause ensures that we are never going to handle anything that is not supported.

### Why are the changes needed?
Avoids the `ClassCastException` during predicate pushdown.

### Does this PR introduce _any_ user-facing change?
No apart from solving the problem.

### How was this patch tested?
`mvn test -Dtest=TestHBaseCliDriver -Dqfile="hbase_ppd_boolean_cols.q"`