### PR TITLE
HIVE-25937: Create view fails when definition contains a materialized view definition

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -2079,7 +2079,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
               mvRebuildMode == MaterializationRebuildMode.NONE &&
               !rootQB.isMaterializedView() && !ctx.isLoadingMaterializedView() && !rootQB.isCTAS() &&
               rootQB.getIsQuery() &&
-              rootQB.hasTableDefined();
+              rootQB.hasTableDefined() &&
+              !forViewCreation;
     }
 
     private RelNode applyMaterializedViewRewritingByText(

--- a/ql/src/test/queries/clientpositive/create_view_when_mv_exists.q
+++ b/ql/src/test/queries/clientpositive/create_view_when_mv_exists.q
@@ -1,5 +1,7 @@
+-- Calcite based automatic query rewrite should be disabled inside view creation
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.materializedview.rewriting.sql=false;
 
 create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true');
 

--- a/ql/src/test/queries/clientpositive/create_view_when_mv_exists2.q
+++ b/ql/src/test/queries/clientpositive/create_view_when_mv_exists2.q
@@ -1,0 +1,27 @@
+-- Calcite based automatic query rewrite is disabled because of the unsupported union operator
+-- However text based could work.
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true');
+
+insert into t1(col0) values (0),(1),(3),(10),(NULL);
+
+create materialized view mv1 as
+select * from t1 where col0 > 2 union select * from t1 where col0 = 0;
+
+-- Both automatic query rewrite is algorithm should be disabled inside view creation.
+explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10;
+
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10;
+
+explain cbo
+select * from v1;
+
+select * from v1;

--- a/ql/src/test/results/clientpositive/llap/create_view_when_mv_exists2.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_view_when_mv_exists2.q.out
@@ -1,0 +1,99 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1(col0) values (0),(1),(3),(10),(NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(col0) values (0),(1),(3),(10),(NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.col0 SCRIPT []
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
+PREHOOK: query: create materialized view mv1 as
+select * from t1 where col0 > 2 union select * from t1 where col0 = 0
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv1
+POSTHOOK: query: create materialized view mv1 as
+select * from t1 where col0 > 2 union select * from t1 where col0 = 0
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv1
+POSTHOOK: Lineage: mv1.col0 EXPRESSION [(t1)t1.FieldSchema(name:col0, type:int, comment:null), ]
+PREHOOK: query: explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@v1
+POSTHOOK: query: explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@v1
+CBO PLAN:
+HiveProject(col0=[CAST(10):INTEGER])
+  HiveAggregate(group=[{0}])
+    HiveProject($f0=[true])
+      HiveFilter(condition=[=($0, 10)])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@v1
+POSTHOOK: query: create view v1 as
+select sub.* from (select * from t1 where col0 > 2 union select * from t1 where col0 = 0) sub
+where sub.col0 = 10
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@v1
+POSTHOOK: Lineage: v1.col0 SIMPLE []
+PREHOOK: query: explain cbo
+select * from v1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@v1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from v1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@v1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(col0=[CAST(10):INTEGER])
+  HiveAggregate(group=[{0}])
+    HiveProject($f0=[true])
+      HiveFilter(condition=[=($0, 10)])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: select * from v1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@v1
+#### A masked pattern was here ####
+POSTHOOK: query: select * from v1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@v1
+#### A masked pattern was here ####
+10


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check whether the current command is a create view command when trying to apply materialized view rewrite by exact sql text match.

### Why are the changes needed?
Rewriting Views to MV scans are not supported currently.

### Does this PR introduce _any_ user-facing change?
Yes. Such views can be created and no error messages given.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=create_view_when_mv_exists.q,create_view_when_mv_exists2.q -pl itests/qtest -Pitests
```