### PR TITLE
HIVE-25936: ValidWriteIdList & table id are sometimes missing when requesting partitions by name via HS2

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4142,7 +4142,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
         req.setDb_name(tbl.getDbName());
         req.setTbl_name(tbl.getTableName());
         req.setNames(partNames.subList(i*batchSize, (i+1)*batchSize));
-        req.setGet_col_stats(false);
+        req.setGet_col_stats(getColStats);
         List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
 
         if (tParts != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4136,38 +4136,34 @@ private void constructOneLBLocationMap(FileStatus fSta,
     int nParts = partNames.size();
     int nBatches = nParts / batchSize;
 
-    try {
-      for (int i = 0; i < nBatches; ++i) {
-        GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
-        req.setDb_name(tbl.getDbName());
-        req.setTbl_name(tbl.getTableName());
-        req.setNames(partNames.subList(i*batchSize, (i+1)*batchSize));
-        req.setGet_col_stats(getColStats);
-        List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
+    for (int i = 0; i < nBatches; ++i) {
+      GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
+      req.setDb_name(tbl.getDbName());
+      req.setTbl_name(tbl.getTableName());
+      req.setNames(partNames.subList(i * batchSize, (i + 1) * batchSize));
+      req.setGet_col_stats(getColStats);
+      List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
 
-        if (tParts != null) {
-          for (org.apache.hadoop.hive.metastore.api.Partition tpart: tParts) {
-            partitions.add(new Partition(tbl, tpart));
-          }
+      if (tParts != null) {
+        for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+          partitions.add(new Partition(tbl, tpart));
         }
       }
+    }
 
-      if (nParts > nBatches * batchSize) {
-        GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
-        req.setDb_name(tbl.getDbName());
-        req.setTbl_name(tbl.getTableName());
-        req.setNames(partNames.subList(nBatches * batchSize, nParts));
-        req.setGet_col_stats(getColStats);
-        req.setEngine(Constants.HIVE_ENGINE);
-        List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
-        if (tParts != null) {
-          for (org.apache.hadoop.hive.metastore.api.Partition tpart: tParts) {
-            partitions.add(new Partition(tbl, tpart));
-          }
+    if (nParts > nBatches * batchSize) {
+      GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
+      req.setDb_name(tbl.getDbName());
+      req.setTbl_name(tbl.getTableName());
+      req.setNames(partNames.subList(nBatches * batchSize, nParts));
+      req.setGet_col_stats(getColStats);
+      req.setEngine(Constants.HIVE_ENGINE);
+      List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
+      if (tParts != null) {
+        for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+          partitions.add(new Partition(tbl, tpart));
         }
       }
-    } catch (Exception e) {
-      throw new HiveException(e);
     }
     return partitions;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4153,18 +4153,13 @@ private void constructOneLBLocationMap(FileStatus fSta,
       }
 
       if (nParts > nBatches * batchSize) {
-        String validWriteIdList = null;
-        Long tableId = null;
-        if (AcidUtils.isTransactionalTable(tbl)) {
-          ValidWriteIdList vWriteIdList = getValidWriteIdList(tbl.getDbName(), tbl.getTableName());
-          validWriteIdList = vWriteIdList != null ? vWriteIdList.toString() : null;
-          tableId = tbl.getTTable().getId();
-        }
-        GetPartitionsByNamesRequest req = convertToGetPartitionsByNamesRequest(tbl.getDbName(), tbl.getTableName(),
-            partNames.subList(nBatches*batchSize, nParts), getColStats, Constants.HIVE_ENGINE, validWriteIdList,
-            tableId);
-        List<org.apache.hadoop.hive.metastore.api.Partition> tParts =
-            getMSC().getPartitionsByNames(req).getPartitions();
+        GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
+        req.setDb_name(tbl.getDbName());
+        req.setTbl_name(tbl.getTableName());
+        req.setNames(partNames.subList(nBatches * batchSize, nParts));
+        req.setGet_col_stats(getColStats);
+        req.setEngine(Constants.HIVE_ENGINE);
+        List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getPartitionsByNames(req, tbl);
         if (tParts != null) {
           for (org.apache.hadoop.hive.metastore.api.Partition tpart: tParts) {
             partitions.add(new Partition(tbl, tpart));

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
@@ -80,6 +80,8 @@ public class TestHiveMetaStoreClientApiArgumentsChecker {
     hive.getConf().set(ValidTxnList.VALID_TXNS_KEY, "1:");
     hive.getConf().set(ValidWriteIdList.VALID_WRITEIDS_KEY, TABLE_NAME + ":1:");
     hive.getConf().setVar(HiveConf.ConfVars.HIVE_TXN_MANAGER, "org.apache.hadoop.hive.ql.lockmgr.TestTxnManager");
+    // Pick a small number for the batch size to easily test code with multiple batches.
+    hive.getConf().setIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX, 2);
     SessionState.start(hive.getConf());
     SessionState.get().initTxnMgr(hive.getConf());
     Context ctx = new Context(hive.getConf());
@@ -138,6 +140,16 @@ public class TestHiveMetaStoreClientApiArgumentsChecker {
   @Test
   public void testGetPartitionsByNames3() throws HiveException {
     hive.getPartitionsByNames(t, new ArrayList<>(), true);
+  }
+
+  @Test
+  public void testGetPartitionsByNamesWithPartitionNamesInSingleBatch() throws HiveException {
+    hive.getPartitionsByNames(t, Arrays.asList("Greece", "Italy"), true);
+  }
+
+  @Test
+  public void testGetPartitionsByNamesWithPartitionNamesInMultipleBatches() throws HiveException {
+    hive.getPartitionsByNames(t, Arrays.asList("Greece", "Italy", "France"), true);
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
@@ -132,17 +132,11 @@ public class TestHiveMetaStoreClientApiArgumentsChecker {
 
   @Test
   public void testGetPartitionsByNames2() throws HiveException {
-    GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
-    req.setDb_name(DB_NAME);
-    req.setTbl_name(TABLE_NAME);
     hive.getPartitionsByNames(DB_NAME,TABLE_NAME,null, t);
   }
 
   @Test
   public void testGetPartitionsByNames3() throws HiveException {
-    GetPartitionsByNamesRequest req = new GetPartitionsByNamesRequest();
-    req.setDb_name(DB_NAME);
-    req.setTbl_name(TABLE_NAME);
     hive.getPartitionsByNames(t, new ArrayList<>(), true);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Refactor code handling remaining batches to use `GetPartitionsByNamesRequest` and `getPartitionsByNames(GetPartitionsByNamesRequest,Table)` method
2. Use method parameter to determine if column stats must be fetched instead of harcoding the value to false when sending the request to HMS.
3. Remove redundant exception wrapping
4. Unify batch creation/execution logic using Guava's Lists#partition method.
5. Drop unused requests from TestHiveMetaStoreClientApiArgumentsChecker
6. Add tests for getPartitionsByName with non-empty partition name lists

### Why are the changes needed?
1. The write id list & table id are not set when the number of names is not an exact multiple of the batch size which can have an impact in the consistency of the cache.
2. Column stats for partitions are always missing since the request was hardcoded to false.
3. Improve code readability and remove duplicated fragments.

### Does this PR introduce _any_ user-facing change?
Fixes the bugs.

### How was this patch tested?
`mvn test -Dtest=TestHiveMetaStoreClientApiArgumentsChecker`
