### PR TITLE
HIVE-25942: Upgrade commons-io to 2.8.0 due to CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <commons-compress.version>1.21</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-exec.version>1.1</commons-exec.version>
-    <commons-io.version>2.6</commons-io.version>
+    <commons-io.version>2.8.0</commons-io.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.7.0</commons-dbcp2.version>


### PR DESCRIPTION
Due to [CVE-2021-29425](https://nvd.nist.gov/vuln/detail/CVE-2021-29425) all the commons-io versions below 2.7 are affected.

Tez and Hadoop have upgraded commons-io to 2.8.0 in [TEZ-4353](https://issues.apache.org/jira/browse/TEZ-4353) and [HADOOP-17683](https://issues.apache.org/jira/browse/HADOOP-17683) respectively and it will be good if Hive also follows the same.