### PR TITLE
HIVE-25912: Drop external table throw NPE if the location set to ROOT…

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -186,6 +186,14 @@ public class MetaStoreUtils {
     return colNames;
   }
 
+  /*
+   * Check the table storage location must not be root path.
+   */
+  public static boolean validateTblStorage(StorageDescriptor sd) {
+    return !(StringUtils.isNotBlank(sd.getLocation())
+            && new Path(sd.getLocation()).getParent() == null);
+  }
+
   /**
    * validateName
    *

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -2362,6 +2362,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
           + " is not a valid object name");
     }
 
+    if (!MetaStoreUtils.validateTblStorage(tbl.getSd())) {
+      throw new InvalidObjectException(tbl.getTableName()
+              + " location must not be root path");
+    }
+
     if (!tbl.isSetCatName()) {
       tbl.setCatName(getDefaultCatalog(conf));
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
@@ -361,13 +361,12 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
 
   @Test
   public void testCreateTableRooPathLocationInSpecificDatabase() throws TException {
-    String tableName = "test_table_2_with_path";
     Table table = new Table();
     StorageDescriptor sd = new StorageDescriptor();
     List<FieldSchema> cols = new ArrayList<>();
     sd.setLocation("hdfs://localhost:8020");
     table.setDbName(DEFAULT_DATABASE);
-    table.setTableName(tableName);
+    table.setTableName("test_table_2_with_path");
     cols.add(new FieldSchema("column_name", "int", null));
     sd.setCols(cols);
     sd.setSerdeInfo(new SerDeInfo());
@@ -384,7 +383,7 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
 
     Table createdTable = client.getTable(table.getDbName(), table.getTableName());
     Assert.assertNotNull(createdTable);
-    client.dropTable(DEFAULT_DATABASE, tableName, true, true);
+    client.dropTable(table.getDbName(), table.getTableName(), true, true);
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
@@ -360,13 +360,13 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
 
 
   @Test
-  public void testCreateTableRooPathLocationInSpecificDatabase() throws TException {
+  public void testCreateTableRooPathLocationInSpecificDatabase() {
     Table table = new Table();
     StorageDescriptor sd = new StorageDescriptor();
     List<FieldSchema> cols = new ArrayList<>();
     sd.setLocation("hdfs://localhost:8020");
     table.setDbName(DEFAULT_DATABASE);
-    table.setTableName("test_table_2_with_path");
+    table.setTableName("test_table_2_with_root_path");
     cols.add(new FieldSchema("column_name", "int", null));
     sd.setCols(cols);
     sd.setSerdeInfo(new SerDeInfo());
@@ -376,14 +376,6 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
     Assert.assertEquals("Storage descriptor location",
             table.getTableName() + " location must not be root path",
             exception.getMessage());
-
-    sd.setLocation("hdfs://localhost:8020/other_path");
-
-    client.createTable(table);
-
-    Table createdTable = client.getTable(table.getDbName(), table.getTableName());
-    Assert.assertNotNull(createdTable);
-    client.dropTable(table.getDbName(), table.getTableName(), true, true);
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
@@ -361,12 +361,13 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
 
   @Test
   public void testCreateTableRooPathLocationInSpecificDatabase() throws TException {
+    String tableName = "test_table_2_with_path";
     Table table = new Table();
     StorageDescriptor sd = new StorageDescriptor();
     List<FieldSchema> cols = new ArrayList<>();
     sd.setLocation("hdfs://localhost:8020");
     table.setDbName(DEFAULT_DATABASE);
-    table.setTableName("test_table_2_with_path");
+    table.setTableName(tableName);
     cols.add(new FieldSchema("column_name", "int", null));
     sd.setCols(cols);
     sd.setSerdeInfo(new SerDeInfo());
@@ -383,6 +384,7 @@ public class TestTablesCreateDropAlterTruncate extends MetaStoreClientTest {
 
     Table createdTable = client.getTable(table.getDbName(), table.getTableName());
     Assert.assertNotNull(createdTable);
+    client.dropTable(DEFAULT_DATABASE, tableName, true, true);
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -862,5 +862,27 @@ public class TestMetaStoreServerUtils {
     assertEquals("-1.01", MetaStoreServerUtils.getNormalisedPartitionValue("-0001.0100", "decimal"));
   }
 
+  @Test
+  public void throwFailExceptionWithHDFSStorageIsRootPath() {
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("hdfs://localhost:8020");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("hdfs://localhost:8020/other_path");
+    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
+  }
+
+  @Test
+  public void throwFailExceptionWithS3StorageIsRootPath() {
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("s3a://bucket/");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("s3a://bucket");
+    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));
+
+    sd.setLocation("s3a://bucket/other_path");
+    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
+  }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

modify the HMSHandler. create_table_core function add this check:

```
if (!MetaStoreUtils.validateTblStorage(tbl.getSd())) {
    throw new InvalidObjectException(tbl.getTableName()
        + " location must not be root path");
}
```
If the path.getParent() is NULL we can be sure the location is ROOT path.  

the validateTblStorage implements:

```
/*
  * Check the table storage location must not be root path.
  */
 static public boolean validateTblStorage(StorageDescriptor sd) {
   return !(StringUtils.isNotBlank(sd.getLocation())
           && new Path(sd.getLocation()).getParent() == null);
 }
```

I add a test for this feature:

```
  @Test
  public void throwFailExceptionWithHDFSStorageIsRootPath() {
    StorageDescriptor sd = new StorageDescriptor();
    sd.setLocation("hdfs://localhost:8020");
    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));

    sd.setLocation("hdfs://localhost:8020/other_path");
    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
  }

  @Test
  public void throwFailExceptionWithS3StorageIsRootPath() {
    StorageDescriptor sd = new StorageDescriptor();
    sd.setLocation("s3a://bucket/");
    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));

    sd.setLocation("s3a://bucket");
    Assert.assertFalse(MetaStoreUtils.validateTblStorage(sd));

    sd.setLocation("s3a://bucket/other_path");
    Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
  }
```

### Why are the changes needed?
If I create an external table using the ROOT path, the table was created successfully, but when I drop the table throw the NPE.  So I can't drop the table forever.

This is not a good phenomenon.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java

test func is: throwFailExceptionWithS3StorageIsRootPath and throwFailExceptionWithHDFSStorageIsRootPath

mvn test -Dtest=SomeTest --pl common
