### PR TITLE
HIVE-25945: Upgrade H2 database version to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <flatbuffers.version>1.6.0.1</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <h2database.version>1.3.166</h2database.version>
+    <h2database.version>2.1.210</h2database.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
### Why are the changes needed?
The 1.3.166 version suffers from the following security vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2021-42392
https://nvd.nist.gov/vuln/detail/CVE-2022-23221

In the project, we use H2 only for testing purposes (inside the jdbc-handler module) thus the H2 binaries are not present in the runtime classpath thus these CVEs do not pose a problem for Hive or its users.

Nevertheless, it would be good to upgrade to a more recent version to avoid Hive coming up in vulnerability scans due to this.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests