### PR TITLE
HIVE-25929: Let secret config properties to be propagated to Tez

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5455,6 +5455,22 @@ public class HiveConf extends Configuration {
         + ",hive.zookeeper.ssl.truststore.location"
         + ",hive.zookeeper.ssl.truststore.password",
         "Comma separated list of configuration options which should not be read by normal user like passwords"),
+    HIVE_CONF_PROPAGATE_EXEC_ENGINES("hive.conf.propagate.exec.engines",
+        "fs.s3.awsAccessKeyId"
+        + ",fs.s3.awsSecretAccessKey"
+        + ",fs.s3n.awsAccessKeyId"
+        + ",fs.s3n.awsSecretAccessKey"
+        + ",fs.s3a.access.key"
+        + ",fs.s3a.secret.key"
+        + ",fs.s3a.proxy.password"
+        + ",dfs.adls.oauth2.credential"
+        + ",fs.adl.oauth2.credential"
+        + ",fs.azure.account.oauth2.client.secret",
+        "Comma separated list of configuration options which must be propagated to execution engines." +
+        " The options listed here are still excluded from everywhere that the user would expect them to be excluded" +
+        " (e.g. set command output) because of 'hive.conf.hidden.list', but they are included into the Configuration" +
+        " that is passed to the execution engines. This is needed as long as Hadoop enables users" +
+        " to store passwords in config (instead of CredentialProvider API)."),
     HIVE_CONF_INTERNAL_VARIABLE_LIST("hive.conf.internal.variable.list",
         "hive.added.files.path,hive.added.jars.path,hive.added.archives.path",
         "Comma separated list of variables which are used internally and should not be configurable."),
@@ -6835,6 +6851,16 @@ public class HiveConf extends Configuration {
    */
   public void stripHiddenConfigurations(Configuration conf) {
     HiveConfUtil.stripConfigurations(conf, hiddenSet);
+  }
+
+  /**
+   * Strips hidden config entries from configuration, but takes care of entries for execution engines.
+   */
+  public void stripHiddenConfigurationsForExecutionEngines(Configuration conf) {
+    Set<String> propsToBePropagatedToExecEngines = HiveConfUtil.getPropagateToExecutionEnginesList(conf);
+    Set<String> propsToBeStripped = new HashSet<>(hiddenSet);
+    propsToBeStripped.removeAll(propsToBePropagatedToExecEngines);
+    HiveConfUtil.stripConfigurations(conf, propsToBeStripped);
   }
 
   /**

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
@@ -86,14 +86,20 @@ public class HiveConfUtil {
    * @return The list of the configuration values to hide
    */
   public static Set<String> getHiddenSet(Configuration configuration) {
-    Set<String> hiddenSet = new HashSet<String>();
-    String hiddenListStr = HiveConf.getVar(configuration, HiveConf.ConfVars.HIVE_CONF_HIDDEN_LIST);
-    if (hiddenListStr != null) {
-      for (String entry : hiddenListStr.split(",")) {
-        hiddenSet.add(entry.trim());
-      }
+    return getConfigurationKeyset(configuration, HiveConf.ConfVars.HIVE_CONF_HIDDEN_LIST);
+  }
+
+  public static Set<String> getPropagateToExecutionEnginesList(Configuration configuration) {
+    return getConfigurationKeyset(configuration, HiveConf.ConfVars.HIVE_CONF_PROPAGATE_EXEC_ENGINES);
+  }
+
+  private static Set<String> getConfigurationKeyset(Configuration configuration, ConfVars name) {
+    Set<String> confSet = new HashSet<>();
+    String confSetList = HiveConf.getVar(configuration, name);
+    if (confSetList != null) {
+      Collections.addAll(confSet, confSetList.split(","));
     }
-    return hiddenSet;
+    return confSet;
   }
 
   /**

--- a/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
@@ -176,6 +176,39 @@ public class TestHiveConf {
   }
 
   @Test
+  public void testHiddenConfigWithExecutionEngines() throws Exception {
+    HiveConf conf = new HiveConf();
+
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD, "secret");
+    conf.set("fs.azure.account.oauth2.client.secret", "secret");
+
+
+    Assert.assertEquals("secret", conf.get(HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname));
+    Assert.assertEquals("secret", conf.get("fs.azure.account.oauth2.client.secret"));
+
+    conf.stripHiddenConfigurations(conf);
+
+    // stripHiddenConfigurations strips every hidden option without respecting options for execution engines
+    Assert.assertEquals("", conf.get(HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname));
+    Assert.assertEquals("", conf.get("fs.azure.account.oauth2.client.secret"));
+
+
+    conf = new HiveConf();
+
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD, "secret");
+    conf.set("fs.azure.account.oauth2.client.secret", "secret");
+
+    Assert.assertEquals("secret", conf.get(HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname));
+    Assert.assertEquals("secret", conf.get("fs.azure.account.oauth2.client.secret"));
+
+    conf.stripHiddenConfigurationsForExecutionEngines(conf);
+
+    // stripHiddenConfigurationsForExecutionEngines doesn't touch options defined in HIVE_CONF_PROPAGATE_EXEC_ENGINES
+    Assert.assertEquals("", conf.get(HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname));
+    Assert.assertEquals("secret", conf.get("fs.azure.account.oauth2.client.secret"));
+  }
+
+  @Test
   public void testEncodingDecoding() throws UnsupportedEncodingException {
     HiveConf conf = new HiveConf();
     String query = "select blah, '\u0001' from random_table";

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
@@ -181,7 +181,7 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
     initializeFiles("tmpfiles", getResource(conf, SessionState.ResourceType.FILE));
     initializeFiles("tmparchives", getResource(conf, SessionState.ResourceType.ARCHIVE));
 
-    conf.stripHiddenConfigurations(job);
+    conf.stripHiddenConfigurationsForExecutionEngines(job);
     this.jobExecHelper = new HadoopJobExecHelper(job, console, this, this);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1540,7 +1540,7 @@ public class DagUtils {
     conf.unset("mapreduce.job.credentials.binary");
 
     // TODO: convert this to a predicate too
-    hiveConf.stripHiddenConfigurations(conf);
+    hiveConf.stripHiddenConfigurationsForExecutionEngines(conf);
 
     // Remove hive configs which are used only in HS2 and not needed for execution
     conf.unset(ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST.varname); 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -316,7 +316,7 @@ public class TezSessionState {
 
     // set up the staging directory to use
     tezConfig.set(TezConfiguration.TEZ_AM_STAGING_DIR, tezScratchDir.toUri().toString());
-    conf.stripHiddenConfigurations(tezConfig);
+    conf.stripHiddenConfigurationsForExecutionEngines(tezConfig);
 
     ServicePluginsDescriptor servicePluginsDescriptor;
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
@@ -123,4 +123,18 @@ public class TestDagUtils {
 
     Assert.assertEquals("value", reduce.getTaskEnvironment().get("key"));
   }
+
+  @Test
+  public void testCreateConfigurationStripHiddenConf() throws IOException {
+    HiveConf conf = new HiveConf();
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD, "secret");
+    conf.set("fs.azure.account.oauth2.client.secret", "secret");
+
+    JobConf jobConf = DagUtils.getInstance().createConfiguration(conf);
+
+    // createConfiguration -> stripHiddenConfigurationsForExecutionEngines doesn't touch
+    // options defined in HIVE_CONF_PROPAGATE_EXEC_ENGINES
+    Assert.assertEquals("", jobConf.get(HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname));
+    Assert.assertEquals("secret", jobConf.get("fs.azure.account.oauth2.client.secret"));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Prevent removing some config properties from Configuration object which are passed to execution engines.

### Why are the changes needed?
Described in jira.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit test included.
