### PR TITLE
HIVE-25918: Invalid stats after multi inserting into the same partition - ADDENDUM

### DIFF
--- a/ql/src/test/queries/clientpositive/stats_part_multi_insert_acid.q
+++ b/ql/src/test/queries/clientpositive/stats_part_multi_insert_acid.q
@@ -1,0 +1,21 @@
+-- Test multi inserting to the same partition
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table source(p int, key int,value string);
+insert into source(p, key, value) values (101,42,'string42');
+
+create table stats_part(key int,value string) partitioned by (p int) stored as orc tblproperties ("transactional"="true");
+
+from source
+insert into stats_part select key, value, p
+insert into stats_part select key, value, p;
+
+select p, key, value from stats_part;
+desc formatted stats_part;
+
+set hive.compute.query.using.stats=true;
+select count(*) from stats_part;
+
+set hive.compute.query.using.stats=false;
+select count(*) from stats_part;

--- a/ql/src/test/results/clientpositive/llap/stats_part_multi_insert_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_part_multi_insert_acid.q.out
@@ -1,0 +1,116 @@
+PREHOOK: query: create table source(p int, key int,value string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source
+POSTHOOK: query: create table source(p int, key int,value string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source
+PREHOOK: query: insert into source(p, key, value) values (101,42,'string42')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source(p, key, value) values (101,42,'string42')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+POSTHOOK: Lineage: source.key SCRIPT []
+POSTHOOK: Lineage: source.p SCRIPT []
+POSTHOOK: Lineage: source.value SCRIPT []
+PREHOOK: query: create table stats_part(key int,value string) partitioned by (p int) stored as orc tblproperties ("transactional"="true")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@stats_part
+POSTHOOK: query: create table stats_part(key int,value string) partitioned by (p int) stored as orc tblproperties ("transactional"="true")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@stats_part
+PREHOOK: query: from source
+insert into stats_part select key, value, p
+insert into stats_part select key, value, p
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source
+PREHOOK: Output: default@stats_part
+POSTHOOK: query: from source
+insert into stats_part select key, value, p
+insert into stats_part select key, value, p
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source
+POSTHOOK: Output: default@stats_part
+POSTHOOK: Output: default@stats_part@p=101
+POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
+POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select p, key, value from stats_part
+PREHOOK: type: QUERY
+PREHOOK: Input: default@stats_part
+PREHOOK: Input: default@stats_part@p=101
+#### A masked pattern was here ####
+POSTHOOK: query: select p, key, value from stats_part
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@stats_part
+POSTHOOK: Input: default@stats_part@p=101
+#### A masked pattern was here ####
+101	42	string42
+101	42	string42
+PREHOOK: query: desc formatted stats_part
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@stats_part
+POSTHOOK: query: desc formatted stats_part
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@stats_part
+# col_name            	data_type           	comment             
+key                 	int                 	                    
+value               	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+p                   	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	2                   
+	numPartitions       	1                   
+	numRows             	2                   
+	rawDataSize         	0                   
+	totalSize           	1470                
+	transactional       	true                
+	transactional_properties	default             
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: select count(*) from stats_part
+PREHOOK: type: QUERY
+PREHOOK: Input: default@stats_part
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from stats_part
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@stats_part
+#### A masked pattern was here ####
+2
+PREHOOK: query: select count(*) from stats_part
+PREHOOK: type: QUERY
+PREHOOK: Input: default@stats_part
+PREHOOK: Input: default@stats_part@p=101
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from stats_part
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@stats_part
+POSTHOOK: Input: default@stats_part@p=101
+#### A masked pattern was here ####
+2

--- a/ql/src/test/results/clientpositive/llap/stats_part_multi_insert_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_part_multi_insert_acid.q.out
@@ -39,8 +39,8 @@ POSTHOOK: Input: default@source
 POSTHOOK: Output: default@stats_part
 POSTHOOK: Output: default@stats_part@p=101
 POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
-POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: select p, key, value from stats_part
 PREHOOK: type: QUERY

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
@@ -501,6 +501,10 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
           throws TException {
     super.alter_partitions(catName, dbName, tblName, newParts, environmentContext, writeIdList, writeId);
 
+    if (!isCacheEnabledAndInitialized() || mscLocalCache == null) {
+      return;
+    }
+
     // invalidate cached Partition entries
     List<String> processorCapabilitiesList = getProcessorCapabilities() == null ?
             null : new ArrayList<>(Arrays.asList(getProcessorCapabilities()));

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
@@ -506,11 +506,12 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
     }
 
     // invalidate cached Partition entries
-    List<String> processorCapabilitiesList = getProcessorCapabilities() == null ?
-            null : new ArrayList<>(Arrays.asList(getProcessorCapabilities()));
+    String[] processorCapabilities = getProcessorCapabilities();
+    List<String> processorCapabilitiesList = processorCapabilities == null ?
+            null : new ArrayList<>(Arrays.asList(processorCapabilities));
 
     TableWatermark watermark = new TableWatermark(writeIdList, getTable(dbName, tblName).getId());
-    dbName =prependCatalogToDbName(catName, dbName, conf);
+    dbName = prependCatalogToDbName(catName, dbName, conf);
 
     for (Partition partition : newParts) {
       CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_BY_NAMES, watermark,


### PR DESCRIPTION
### What changes were proposed in this pull request?
HIVE-23949 introduces a caching layer between HS2 and HMS. This patch extend alter partition HMS API call with invalidating cached `Partition` entries after successful alter partition calls.
Alter partition calls has several versions but only the one which depends on the `writeIdList` is affected.

### Why are the changes needed?
Subsequent `getPartitionsByNames` calls return the cached `Partition` objects however alter partition may changed the underlying Partitions and the changes are not reflected in the cache objects. This can lead to data correctness issues for example when computing stats.

### Does this PR introduce _any_ user-facing change?
Yes. Incorrect results are fixed.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=stats_part_multi_insert_acid.q -pl itests/qtest -Pitests
```
