### PR TITLE
HIVE-25960: Fix S3a recursive listing logic.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -361,7 +361,7 @@ public final class FileUtils {
     RemoteIterator<LocatedFileStatus> remoteIterator = fs.listFiles(base.getPath(), true);
     while (remoteIterator.hasNext()) {
       LocatedFileStatus each = remoteIterator.next();
-      Path relativePath = new Path(each.getPath().toString().replace(base.toString(), ""));
+      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.toString(), ""));
       if (org.apache.hadoop.hive.metastore.utils.FileUtils.RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
         results.add(each);
       }

--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -361,11 +361,25 @@ public final class FileUtils {
     RemoteIterator<LocatedFileStatus> remoteIterator = fs.listFiles(base.getPath(), true);
     while (remoteIterator.hasNext()) {
       LocatedFileStatus each = remoteIterator.next();
-      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.getPath().toString(), ""));
+      Path relativePath = makeRelative(base.getPath(), each.getPath());
       if (org.apache.hadoop.hive.metastore.utils.FileUtils.RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
         results.add(each);
       }
     }
+  }
+
+  /**
+   * Returns a relative path wrt the parent path.
+   * @param parentPath the parent path.
+   * @param childPath the child path.
+   * @return childPath relative to parent path.
+   */
+  public static Path makeRelative(Path parentPath, Path childPath) {
+    String parentString =
+        parentPath.toString().endsWith(Path.SEPARATOR) ? parentPath.toString() : parentPath.toString() + Path.SEPARATOR;
+    String childString =
+        childPath.toString().endsWith(Path.SEPARATOR) ? childPath.toString() : childPath.toString() + Path.SEPARATOR;
+    return new Path(childString.replaceFirst(parentString, ""));
   }
 
   public static boolean isS3a(FileSystem fs) {

--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -361,7 +361,7 @@ public final class FileUtils {
     RemoteIterator<LocatedFileStatus> remoteIterator = fs.listFiles(base.getPath(), true);
     while (remoteIterator.hasNext()) {
       LocatedFileStatus each = remoteIterator.next();
-      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.toString(), ""));
+      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.getPath().toString(), ""));
       if (org.apache.hadoop.hive.metastore.utils.FileUtils.RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
         results.add(each);
       }

--- a/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
@@ -264,4 +264,21 @@ public class TestFileUtils {
               equalsIgnoreCase("Distcp is called with doAsUser and delete source set as true"));
     }
   }
+
+  @Test
+  public void testMakeRelative() {
+    Path parentPath = new Path("/user/hive/database");
+    Path childPath = new Path(parentPath, "table/dir/subdir");
+    Path relativePath = FileUtils.makeRelative(parentPath, childPath);
+    assertEquals("table/dir/subdir", relativePath.toString());
+
+    // try with parent as Root.
+    relativePath = FileUtils.makeRelative(new Path(Path.SEPARATOR), childPath);
+    assertEquals("user/hive/database/table/dir/subdir", relativePath.toString());
+
+    // try with non child path, it should return the child path as is.
+    childPath = new Path("/user/hive/database1/table/dir/subdir");
+    relativePath = FileUtils.makeRelative(parentPath, childPath);
+    assertEquals(childPath.toString(), relativePath.toString());
+  }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
@@ -404,11 +404,25 @@ public class FileUtils {
     RemoteIterator<LocatedFileStatus> remoteIterator = fs.listFiles(base, true);
     while (remoteIterator.hasNext()) {
       LocatedFileStatus each = remoteIterator.next();
-      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.toString(), ""));
+      Path relativePath = makeRelative(base, each.getPath());
       if (RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
         results.add(each);
       }
     }
+  }
+
+  /**
+   * Returns a relative path wrt the parent path.
+   * @param parentPath the parent path.
+   * @param childPath the child path.
+   * @return childPath relative to parent path.
+   */
+  public static Path makeRelative(Path parentPath, Path childPath) {
+    String parentString =
+        parentPath.toString().endsWith(Path.SEPARATOR) ? parentPath.toString() : parentPath.toString() + Path.SEPARATOR;
+    String childString =
+        childPath.toString().endsWith(Path.SEPARATOR) ? childPath.toString() : childPath.toString() + Path.SEPARATOR;
+    return new Path(childString.replaceFirst(parentString, ""));
   }
 
   public static boolean isS3a(FileSystem fs) {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
@@ -404,7 +404,7 @@ public class FileUtils {
     RemoteIterator<LocatedFileStatus> remoteIterator = fs.listFiles(base, true);
     while (remoteIterator.hasNext()) {
       LocatedFileStatus each = remoteIterator.next();
-      Path relativePath = new Path(each.getPath().toString().replace(base.toString(), ""));
+      Path relativePath = new Path(each.getPath().toString().replaceFirst(base.toString(), ""));
       if (RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
         results.add(each);
       }


### PR DESCRIPTION
Changes replace to replaceFirst and rather than comparing with FileStatus, changes to compare with the Actual Path