### PR TITLE
HIVE-25959: Expose Compaction Observability delta metrics using the JsonReporter

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -161,7 +161,7 @@ public abstract class CompactorTest {
   }
 
   protected Table newTable(String dbName, String tableName, boolean partitioned) throws TException {
-    return newTable(dbName, tableName, partitioned, new HashMap<String, String>(), null, false);
+    return newTable(dbName, tableName, partitioned, new HashMap<>(), null, false);
   }
 
   protected Table newTable(String dbName, String tableName, boolean partitioned,
@@ -180,7 +180,7 @@ public abstract class CompactorTest {
     table.setDbName(dbName);
     table.setOwner("me");
     table.setSd(newStorageDescriptor(getLocation(tableName, null), sortCols));
-    List<FieldSchema> partKeys = new ArrayList<FieldSchema>(1);
+    List<FieldSchema> partKeys = new ArrayList<>(1);
     if (partitioned) {
       partKeys.add(new FieldSchema("ds", "string", "no comment"));
       table.setPartitionKeys(partKeys);
@@ -673,14 +673,16 @@ public abstract class CompactorTest {
     return compactorTxnId;
   }
 
-  protected Map<String, String> gaugeToMap(String metric) throws Exception {
+
+  protected static Map<String, Integer> gaugeToMap(String metric) throws Exception {
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
     ObjectName oname = new ObjectName(AcidMetricService.OBJECT_NAME_PREFIX + metric);
     MBeanInfo mbeanInfo = mbs.getMBeanInfo(oname);
 
-    Map<String, String> result = new HashMap<>();
+    Map<String, Integer> result = new HashMap<>();
     for (MBeanAttributeInfo attr : mbeanInfo.getAttributes()) {
-      result.put(attr.getName(), String.valueOf(mbs.getAttribute(oname, attr.getName())));
+      Object attribute = mbs.getAttribute(oname, attr.getName());
+      result.put(attr.getName(), Integer.valueOf(String.valueOf(attribute)));
     }
     return result;
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestDeltaFilesMetricFlags.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestDeltaFilesMetricFlags.java
@@ -17,14 +17,17 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
-import org.junit.Assert;
+import org.apache.hadoop.hive.metastore.metrics.Metrics;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_NUM_DELTAS;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_NUM_OBSOLETE_DELTAS;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_NUM_SMALL_DELTAS;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestDeltaFilesMetricFlags extends CompactorTest {
 
@@ -43,7 +46,9 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METRICS_ENABLED.getVarname(), false);
     setup(conf);
     startInitiator();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_DELTAS).size());
+    assertThat(Metrics.getOrCreateMapMetrics(COMPACTION_NUM_DELTAS).get(),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_DELTAS);
   }
 
   @Test(expected = javax.management.InstanceNotFoundException.class)
@@ -52,7 +57,9 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METRICS_ENABLED.getVarname(), false);
     setup(conf);
     startWorker();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_SMALL_DELTAS).size());
+    assertThat(gaugeToMap(COMPACTION_NUM_SMALL_DELTAS),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_SMALL_DELTAS);
   }
 
   @Test(expected = javax.management.InstanceNotFoundException.class)
@@ -61,7 +68,9 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METRICS_ENABLED.getVarname(), false);
     setup(conf);
     startCleaner();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS).size());
+    assertThat(gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS);
   }
 
   @Test(expected = javax.management.InstanceNotFoundException.class)
@@ -70,7 +79,9 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_THREAD_ON.getVarname(), false);
     setup(conf);
     startInitiator();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_DELTAS).size());
+    assertThat(gaugeToMap(COMPACTION_NUM_DELTAS),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_DELTAS);
   }
 
   @Test(expected = javax.management.InstanceNotFoundException.class)
@@ -79,7 +90,9 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_THREAD_ON.getVarname(), false);
     setup(conf);
     startWorker();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_SMALL_DELTAS).size());
+    assertThat(gaugeToMap(COMPACTION_NUM_SMALL_DELTAS),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_SMALL_DELTAS);
   }
 
   @Test(expected = javax.management.InstanceNotFoundException.class)
@@ -88,7 +101,8 @@ public class TestDeltaFilesMetricFlags extends CompactorTest {
     conf.setBoolean(MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_THREAD_ON.getVarname(), false);
     setup(conf);
     startCleaner();
-    Assert.assertEquals(0, gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS).size());
+    assertThat(gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS),
+        CoreMatchers.is(ImmutableMap.of()));
+    gaugeToMap(COMPACTION_NUM_OBSOLETE_DELTAS);
   }
-
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/metrics/metrics2/CodahaleMetrics.java
@@ -84,13 +84,13 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
   private ConcurrentHashMap<String, Gauge> gauges;
 
   private Configuration conf;
-  private final Set<Closeable> reporters = new HashSet<Closeable>();
+  private final Set<Closeable> reporters = new HashSet<>();
 
   private final ThreadLocal<HashMap<String, CodahaleMetricsScope>> threadLocalScopes
     = new ThreadLocal<HashMap<String, CodahaleMetricsScope>>() {
     @Override
     protected HashMap<String, CodahaleMetricsScope> initialValue() {
-      return new HashMap<String, CodahaleMetricsScope>();
+      return new HashMap<>();
     }
   };
 
@@ -173,7 +173,7 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
           }
         }
     );
-    gauges = new ConcurrentHashMap<String, Gauge>();
+    gauges = new ConcurrentHashMap<>();
 
     //register JVM metrics
     registerAll("gc", new GarbageCollectorMetricSet());
@@ -284,7 +284,6 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
     addGaugeInternal(name, gauge);
   }
 
-
   @Override
   public void removeGauge(String name) {
     try {
@@ -327,7 +326,6 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
 
   @Override
   public void markMeter(String name) {
-    String key = name;
     try {
       metersLock.lock();
       Meter meter = meters.get(name);
@@ -382,7 +380,6 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
    * Note: if both confs are defined, only  HIVE_CODAHALE_METRICS_REPORTER_CLASSES will be used.
    */
   private void initReporting() {
-
     if (!(initCodahaleMetricsReporterClasses() || initMetricsReporter())) {
       LOGGER.warn("Unable to initialize metrics reporting");
     }
@@ -398,7 +395,6 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
    */
   private boolean initCodahaleMetricsReporterClasses() {
 
-
     List<String> reporterClasses = Lists.newArrayList(Splitter.on(",").trimResults().
         omitEmptyStrings().split(MetastoreConf.getVar(conf,
         MetastoreConf.ConfVars.HIVE_CODAHALE_METRICS_REPORTER_CLASSES)));
@@ -407,7 +403,7 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
     }
 
     for (String reporterClass : reporterClasses) {
-      Class name = null;
+      Class<?> name;
       try {
         name = conf.getClassByName(reporterClass);
       } catch (ClassNotFoundException e) {
@@ -417,7 +413,7 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
       }
       try {
         // Note: Hadoop metric reporter does not support tags. We create a single reporter for all metrics.
-        Constructor constructor = name.getConstructor(MetricRegistry.class, Configuration.class);
+        Constructor<?> constructor = name.getConstructor(MetricRegistry.class, Configuration.class);
         CodahaleReporter reporter = (CodahaleReporter) constructor.newInstance(metricRegistry, conf);
         reporter.start();
         reporters.add(reporter);
@@ -444,7 +440,7 @@ public class CodahaleMetrics implements org.apache.hadoop.hive.common.metrics.co
       return false;
     }
 
-    MetricsReporting reporter = null;
+    MetricsReporting reporter;
     for (String metricsReportingName : metricsReporterNames) {
       try {
         reporter = MetricsReporting.valueOf(metricsReportingName.trim().toUpperCase());

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/metrics/metrics2/JsonFileMetricsReporter.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/metrics/metrics2/JsonFileMetricsReporter.java
@@ -68,7 +68,7 @@ public class JsonFileMetricsReporter implements CodahaleReporter, Runnable {
   //    dumps metrics to a temporary file in the same directory as the actual metrics
   //    file and then renames it to the destination. Since both are located on the same
   //    filesystem, this rename is likely to be atomic (as long as the underlying OS
-  //    support atomic renames.
+  //    support atomic renames).
   //
   // NOTE: This reporter is very similar to
   //       org.apache.hadoop.hive.metastore.metrics.JsonReporter.
@@ -139,7 +139,7 @@ public class JsonFileMetricsReporter implements CodahaleReporter, Runnable {
     Path tmpFile = null;
     try {
       // Dump metrics to string as JSON
-      String json = null;
+      String json;
       try {
         json = jsonWriter.writeValueAsString(metricRegistry);
       } catch (JsonProcessingException e) {
@@ -159,7 +159,7 @@ public class JsonFileMetricsReporter implements CodahaleReporter, Runnable {
         return;
       } catch (UnsupportedOperationException e) {
         // This shouldn't ever happen
-        LOGGER.error("failed to create temp file for JSON metrics: operartion not supported", e);
+        LOGGER.error("failed to create temp file for JSON metrics: operation not supported", e);
         return;
       }
 
@@ -179,7 +179,7 @@ public class JsonFileMetricsReporter implements CodahaleReporter, Runnable {
         LOGGER.error("Exception during rename", e);
       }
     } catch (Throwable t) {
-      // catch all errors (throwable and execptions to prevent subsequent tasks from being suppressed)
+      // catch all errors (throwable and exceptions to prevent subsequent tasks from being suppressed)
       LOGGER.error("Error executing scheduled task ", t);
     } finally {
       // If something happened and we were not able to rename the temp file, attempt to remove it

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/JsonReporter.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/JsonReporter.java
@@ -25,7 +25,6 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.Timer;
-import com.codahale.metrics.json.MetricsModule;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -72,7 +70,7 @@ public class JsonReporter extends ScheduledReporter {
   //    dumps metrics to a temporary file in the same directory as the actual metrics
   //    file and then renames it to the destination. Since both are located on the same
   //    filesystem, this rename is likely to be atomic (as long as the underlying OS
-  //    support atomic renames.
+  //    support atomic renames).
   //
   // NOTE: This reporter is very similar to
   //       org.apache.hadoop.hive.common.metrics.metrics2.JsonFileMetricsReporter.
@@ -119,8 +117,9 @@ public class JsonReporter extends ScheduledReporter {
         return;
       }
     }
-    jsonWriter = new ObjectMapper().registerModule(new MetricsModule(TimeUnit.MILLISECONDS,
-        TimeUnit.MILLISECONDS, false)).writerWithDefaultPrettyPrinter();
+    jsonWriter = new ObjectMapper().registerModule(
+            new MapCapableJsonMetricsModule(TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS, false))
+        .writerWithDefaultPrettyPrinter();
     super.start(period, unit);
   }
 
@@ -128,7 +127,6 @@ public class JsonReporter extends ScheduledReporter {
   public void report(SortedMap<String, Gauge> sortedMap, SortedMap<String, Counter> sortedMap1,
                      SortedMap<String, Histogram> sortedMap2, SortedMap<String, Meter> sortedMap3,
                      SortedMap<String, Timer> sortedMap4) {
-
     String json;
     try {
       json = jsonWriter.writeValueAsString(registry);
@@ -138,7 +136,7 @@ public class JsonReporter extends ScheduledReporter {
     }
 
     // Metrics are first dumped to a temp file which is then renamed to the destination
-    Path tmpFile = null;
+    Path tmpFile;
     try {
       tmpFile = Files.createTempFile(metricsDir, "hmsmetrics", "json", FILE_ATTRS);
     } catch (IOException e) {
@@ -150,7 +148,7 @@ public class JsonReporter extends ScheduledReporter {
       return;
     } catch (UnsupportedOperationException e) {
       // This shouldn't ever happen
-      LOG.error("failed to create temp file for JSON metrics: operartion not supported", e);
+      LOG.error("failed to create temp file for JSON metrics: operation not supported", e);
       return;
     }
 
@@ -160,7 +158,7 @@ public class JsonReporter extends ScheduledReporter {
       try (BufferedWriter bw = Files.newBufferedWriter(tmpFile, StandardCharsets.UTF_8)) {
         bw.write(json);
       } catch (IOException e) {
-        LOG.error("Unable to write to temp file {}" + tmpFile, e);
+        LOG.error("Unable to write to temp file {}", tmpFile, e);
         return;
       }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MapCapableJsonMetricsModule.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MapCapableJsonMetricsModule.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+public class MapCapableJsonMetricsModule extends MetricsModule {
+
+  public MapCapableJsonMetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples) {
+    super(rateUnit, durationUnit, showSamples, MetricFilter.ALL);
+  }
+
+  public void setupModule(SetupContext context) {
+    super.setupModule(context);
+    context.addSerializers(
+        new SimpleSerializers(
+            ImmutableList.of(
+                new MetricRegistrySerializer(version(), MetricFilter.ALL),
+                new MapMetricsBeanSerializer())));
+  }
+
+  private static class MetricRegistrySerializer extends StdSerializer<MetricRegistry> {
+    private final Version version;
+    private final MetricFilter filter;
+
+    private MetricRegistrySerializer(Version version, MetricFilter filter) {
+      super(MetricRegistry.class);
+      this.version = version;
+      this.filter = filter;
+    }
+
+    public void serialize(MetricRegistry registry, JsonGenerator json, SerializerProvider provider) throws IOException {
+      json.writeStartObject();
+      SortedMetrics metrics = new SortedMetrics(registry, filter);
+      json.writeStringField("version", version.toString());
+      json.writeObjectField("gauges", metrics.getGauges());
+      json.writeObjectField("counters", metrics.getCounters());
+      json.writeObjectField("histograms", metrics.getHistograms());
+      json.writeObjectField("meters", metrics.getMeters());
+      json.writeObjectField("timers", metrics.getTimers());
+      json.writeObjectField("mbeans", metrics.getMaps());
+      json.writeEndObject();
+    }
+  }
+
+  private static class MapMetricsBeanSerializer extends StdSerializer<MapMetrics> {
+
+    private MapMetricsBeanSerializer() {
+      super(MapMetrics.class);
+    }
+
+    public void serialize(MapMetrics map, JsonGenerator json, SerializerProvider provider) throws IOException {
+      json.writeStartObject();
+      for (Map.Entry<String, Integer> entry : map.get().entrySet()) {
+        json.writeObjectField(entry.getKey(), entry.getValue());
+      }
+      json.writeEndObject();
+    }
+  }
+
+  private static class SortedMetrics {
+    private final TreeMap<String, Metric> gauges = new TreeMap<>();
+    private final TreeMap<String, Metric> counters = new TreeMap<>();
+    private final TreeMap<String, Metric> histograms = new TreeMap<>();
+    private final TreeMap<String, Metric> meters = new TreeMap<>();
+    private final TreeMap<String, Metric> timers = new TreeMap<>();
+    private final TreeMap<String, Metric> maps = new TreeMap<>();
+
+    public SortedMetrics(MetricRegistry registry, MetricFilter filter) {
+      Iterator<Map.Entry<String, Metric>> iterator = registry.getMetrics().entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<String, Metric> entry = iterator.next();
+        String name = entry.getKey();
+        Metric metric = entry.getValue();
+        if(filter != null && !filter.matches(name, metric)) {
+          continue;
+        }
+        if (metric instanceof Gauge) {
+          gauges.put(name, metric);
+        } else if (metric instanceof Counter) {
+          counters.put(name, metric);
+        } else if (metric instanceof Histogram) {
+          histograms.put(name, metric);
+        } else if (metric instanceof Timer) {
+          timers.put(name, metric);
+        } else if (metric instanceof MapMetrics) {
+          maps.put(name, metric);
+        }
+      }
+    }
+
+    public TreeMap<String, Metric> getGauges() {
+      return gauges;
+    }
+
+    public TreeMap<String, Metric> getCounters() {
+      return counters;
+    }
+
+    public TreeMap<String, Metric> getHistograms() {
+      return histograms;
+    }
+
+    public TreeMap<String, Metric> getMeters() {
+      return meters;
+    }
+
+    public TreeMap<String, Metric> getTimers() {
+      return timers;
+    }
+
+    public TreeMap<String, Metric> getMaps() {
+      return maps;
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MapMetrics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MapMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.metrics;
+
+import com.codahale.metrics.Metric;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapMetrics implements Metric {
+
+  private final Map<String, Integer> metrics = new HashMap<>();
+
+  public MapMetrics() {
+  }
+
+  public void update(Map<String, Integer> data) {
+    synchronized (metrics) {
+      metrics.clear();
+      if (MapUtils.isNotEmpty(data)) {
+        metrics.putAll(data);
+      }
+    }
+  }
+
+  public Map<String, Integer> get() {
+    synchronized (metrics) {
+      return new HashMap<>(metrics);
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/Metrics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/Metrics.java
@@ -57,8 +57,7 @@ public class Metrics {
   private static Metrics self;
   private static final AtomicInteger singletonAtomicInteger = new AtomicInteger();
   private static final Counter dummyCounter = new Counter();
-  private static final Pair<AtomicInteger, AtomicInteger> dummyRatio =
-          Pair.of(singletonAtomicInteger, singletonAtomicInteger);
+  private static final MapMetrics dummyMapMetrics = new MapMetrics();
 
   private final MetricRegistry registry;
   private List<Reporter> reporters;
@@ -157,6 +156,54 @@ public class Metrics {
         }
       });
       return ai;
+    }
+  }
+
+  /**
+   * Get a Map that represents a multi-field metric,
+   * or create a new one if it does not already exist.
+   * @param name Name of map metric.  This should come from MetricConstants
+   * @return MapMetric .
+   */
+  public static MapMetrics getOrCreateMapMetrics(String name) {
+    if (self == null) {
+      return dummyMapMetrics;
+    }
+
+    Map<String, Metric> metrics = self.registry.getMetrics();
+    Metric map = metrics.get(name);
+    if (map instanceof MapMetrics) {
+      return (MapMetrics) map;
+    }
+
+    // Looks like it doesn't exist.  Lock so that two threads don't create it at once.
+    synchronized (Metrics.class) {
+      // Recheck to make sure someone didn't create it while we waited.
+      map = self.registry
+          .getMetrics()
+          .get(name);
+      if (map instanceof MapMetrics) {
+        return (MapMetrics) map;
+      }
+
+      try {
+        self.registry.register(name, new MapMetrics());
+      } catch (IllegalArgumentException e) {
+        // HIVE-25959: The registry's register function will call the MetricRegistry#onMetricAdded
+        //   which forward the call to the MetricRegistry#notifyListenerOfAddedMetric method.
+        // This method will throw an IllegalArgumentException because our custom MapMetrics type not supported
+        //   to avoid this we handle this.
+        if (!e.getMessage().contains("Unknown metric type")) {
+          throw new IllegalArgumentException("Failed to register metric", e);
+        }
+      }
+      map = self.registry
+          .getMetrics()
+          .get(name);
+      if (map instanceof MapMetrics) {
+        return (MapMetrics) map;
+      }
+      return dummyMapMetrics;
     }
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMetricRegistry.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/metrics/TestMetricRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MetastoreUnitTest.class)
+public class TestMetricRegistry {
+
+  @Test
+  public void testCheckRegisterFunctionThrowsIllegalArgumentWithASpecificMessage() {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    try {
+      metricRegistry.register("my-name", new MapMetrics());
+    } catch (IllegalArgumentException e) {
+      if (!e.getMessage().equals("Unknown metric type")) {
+        Assert.fail("As part of the HIVE-25959 we expect the message in the exception to be 'Unknown metric type'.\n"
+            + "If this has changed please adjust the code of the Metrics#getOrCreateMapMetrics.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Expose Compaction Observability delta metrics using the JsonReporter
- Custom MapMetrics has been included into the MetricsRegistry.
- The MetricsRegistry will call the listeners for the built-in metrics. Since the MapMetrics is not a built-in one it causing an IllegalArgument Exception. To avoid this exception to happen We handle a specific case.
- A new Jackson JSON module has been added (MapCapableJsonMetricsModule) to add serialization of the `mbeans`
- MapCapableJsonMetricsModule has been registered to the JsonReporter
- AcidMetricsService now leveraging both on the new metrics instead and the MetricsMBeanImpl + JMX