### PR TITLE
HIVE-25961: Altering partition specification parameters for Iceberg tables are not working

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/PartitionTransform.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/PartitionTransform.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hive.ql.parse.PartitionTransformSpec.TransformType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -68,14 +69,14 @@ public class PartitionTransform {
           case HiveParser.TOK_MONTH:
           case HiveParser.TOK_DAY:
           case HiveParser.TOK_HOUR:
-            spec.setColumnName(grandChild.getChild(0).getText());
+            spec.setColumnName(grandChild.getChild(0).getText().toLowerCase());
             spec.setTransformType(TRANSFORMS.get(grandChild.getToken().getType()));
             break;
           case HiveParser.TOK_TRUNCATE:
           case HiveParser.TOK_BUCKET:
             spec.setTransformType(TRANSFORMS.get(grandChild.getToken().getType()));
             spec.setTransformParam(Optional.ofNullable(Integer.valueOf(grandChild.getChild(0).getText())));
-            spec.setColumnName(grandChild.getChild(1).getText());
+            spec.setColumnName(grandChild.getChild(1).getText().toLowerCase());
             break;
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Always drop and recreate the full partition specification for Iceberg tables when altering the partition specification.
Also fixed the upper/lower case issue when referencing columns.

### Why are the changes needed?
Altering the specification parameters were not recognised in the current code, so the specification for those columns are not changed when only the parameters were changed

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests