### PR TITLE
HIVE-25969: Unable to reference table column named default

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -62,6 +62,13 @@ tableOrColumn
     identifier -> ^(TOK_TABLE_OR_COL identifier)
     ;
 
+defaultValue
+@init { gParent.pushMsg("default value", state); }
+@after { gParent.popMsg(state); }
+    :
+    KW_DEFAULT -> ^(TOK_TABLE_OR_COL TOK_DEFAULT_VALUE)
+    ;
+
 expressionList
 @init { gParent.pushMsg("expression list", state); }
 @after { gParent.popMsg(state); }

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -2777,8 +2777,15 @@ deleteStatement
 /*SET <columName> = (3 + col2)*/
 columnAssignmentClause
    :
-   tableOrColumn EQUAL^ precedencePlusExpression
+   | tableOrColumn EQUAL^ precedencePlusExpressionOrDefault
    ;
+
+precedencePlusExpressionOrDefault
+    :
+    (KW_DEFAULT (~DOT|EOF)) => defaultValue
+    | precedencePlusExpression
+    ;
+
 
 /*SET col1 = 5, col2 = (4 + col4), ...*/
 setColumnsClause

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
@@ -528,6 +528,7 @@ atomExpression
     | (subQueryExpression)=> (subQueryExpression)
         -> ^(TOK_SUBQUERY_EXPR TOK_SUBQUERY_OP subQueryExpression)
     | (functionName LPAREN) => function
+    | (KW_DEFAULT) => defaultValue
     | tableOrColumn
     | expressionsInParenthesis[true, false]
     ;

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
@@ -528,7 +528,7 @@ atomExpression
     | (subQueryExpression)=> (subQueryExpression)
         -> ^(TOK_SUBQUERY_EXPR TOK_SUBQUERY_OP subQueryExpression)
     | (functionName LPAREN) => function
-    | (KW_DEFAULT) => defaultValue
+    | (KW_DEFAULT ~DOT) => defaultValue
     | tableOrColumn
     | expressionsInParenthesis[true, false]
     ;

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/IdentifiersParser.g
@@ -160,7 +160,7 @@ expressionsInParenthesis[boolean isStruct, boolean forceStruct]
 
 expressionsNotInParenthesis[boolean isStruct, boolean forceStruct]
     :
-    first=expression more=expressionPart[$expression.tree, isStruct]?
+    first=expressionOrDefault more=expressionPart[$expressionOrDefault.tree, isStruct]?
     -> {forceStruct && more==null}?
        ^(TOK_FUNCTION Identifier["struct"] {$first.tree})
     -> {more==null}?
@@ -170,9 +170,15 @@ expressionsNotInParenthesis[boolean isStruct, boolean forceStruct]
 
 expressionPart[CommonTree firstExprTree, boolean isStruct]
     :
-    (COMMA expression)+
-    -> {isStruct}? ^(TOK_FUNCTION Identifier["struct"] {$firstExprTree} expression+)
-    -> {$firstExprTree} expression+
+    (COMMA expressionOrDefault)+
+    -> {isStruct}? ^(TOK_FUNCTION Identifier["struct"] {$firstExprTree} expressionOrDefault+)
+    -> {$firstExprTree} expressionOrDefault+
+    ;
+
+expressionOrDefault
+    :
+    (KW_DEFAULT ~DOT) => defaultValue
+    | expression
     ;
 
 // Parses comma separated list of expressions with optionally specified aliases.
@@ -528,7 +534,6 @@ atomExpression
     | (subQueryExpression)=> (subQueryExpression)
         -> ^(TOK_SUBQUERY_EXPR TOK_SUBQUERY_OP subQueryExpression)
     | (functionName LPAREN) => function
-    | (KW_DEFAULT ~DOT) => defaultValue
     | tableOrColumn
     | expressionsInParenthesis[true, false]
     ;

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestParseDefault {
@@ -53,5 +54,21 @@ public class TestParseDefault {
                 "WHEN NOT MATCHED THEN INSERT VALUES (s.a, DEFAuLT, DEFAULT)", null).getTree();
 
     assertEquals(3, StringUtils.countMatches(tree.toStringTree(), "(tok_table_or_col tok_default_value)"));
+  }
+
+  @Test
+  public void testParseStructNamedDefault() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "select default.src.`end`.key from s_n1\n", null).getTree();
+
+    assertFalse(tree.toStringTree().contains("tok_default_value"));
+  }
+
+  @Test
+  public void testParseStructFieldNamedDefault() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "select col0.default.key from s_n1\n", null).getTree();
+
+    assertFalse(tree.toStringTree().contains("tok_default_value"));
   }
 }

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
@@ -30,7 +30,7 @@ public class TestParseDefault {
   @Test
   public void testParseDefaultKeywordInInsert() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "INSERT INTO TABLE t1 values(deFaUlt, DEFAULT)", null).getTree();
+        "INSERT INTO TABLE t1 values(DEFAULT, deFaUlt)", null).getTree();
 
     assertTrue(tree.toStringTree().contains(
             "(tok_table_or_col tok_default_value) (tok_table_or_col tok_default_value)"));

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
@@ -71,4 +71,12 @@ public class TestParseDefault {
 
     assertFalse(tree.toStringTree().contains("tok_default_value"));
   }
+
+  @Test
+  public void testSelectColumNamedDefault() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "select default from s_n1\n", null).getTree();
+
+    assertFalse(tree.toStringTree().contains("tok_default_value"));
+  }
 }

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestParseDefault {
+  ParseDriver parseDriver = new ParseDriver();
+
+  @Test
+  public void testParseDefaultKeywordInInsert() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "INSERT INTO TABLE t1 values(deFaUlt, DEFAULT)", null).getTree();
+
+    assertTrue(tree.toStringTree().contains(
+            "(tok_table_or_col tok_default_value) (tok_table_or_col tok_default_value)"));
+  }
+
+  @Test
+  public void testParseDefaultKeywordInUpdate() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "update t1 set b = default where a = 1", null).getTree();
+
+    assertTrue(tree.toStringTree().contains(
+            "(tok_table_or_col tok_default_value)"));
+
+  }
+
+  @Test
+  public void testParseDefaultKeywordInMerge() throws Exception {
+    ASTNode tree = parseDriver.parse(
+        "MERGE INTO t1 AS t USING t2 as s ON t.a = s.a\n" +
+                "WHEN MATCHED THEN UPDATE SET b = defauLt " +
+                "WHEN NOT MATCHED THEN INSERT VALUES (s.a, DEFAuLT, DEFAULT)", null).getTree();
+
+    assertEquals(3, StringUtils.countMatches(tree.toStringTree(), "(tok_table_or_col tok_default_value)"));
+  }
+}

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDefault.java
@@ -30,53 +30,79 @@ public class TestParseDefault {
   @Test
   public void testParseDefaultKeywordInInsert() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "INSERT INTO TABLE t1 values(DEFAULT, deFaUlt)", null).getTree();
+            "INSERT INTO TABLE t1 values(DEFAULT, deFaUlt)", null).getTree();
 
-    assertTrue(tree.toStringTree().contains(
+    assertTrue(tree.dump(), tree.toStringTree().contains(
             "(tok_table_or_col tok_default_value) (tok_table_or_col tok_default_value)"));
   }
 
   @Test
   public void testParseDefaultKeywordInUpdate() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "update t1 set b = default where a = 1", null).getTree();
+            "update t1 set b = default", null).getTree();
 
-    assertTrue(tree.toStringTree().contains(
+    assertTrue(tree.dump(), tree.toStringTree().contains(
             "(tok_table_or_col tok_default_value)"));
 
   }
 
   @Test
+  public void testParseDefaultKeywordInUpdateWithWhere() throws Exception {
+    ASTNode tree = parseDriver.parse(
+            "update t1 set b = default where a = 10", null).getTree();
+
+    assertTrue(tree.dump(), tree.toStringTree().contains(
+            "(tok_table_or_col tok_default_value)"));
+
+  }
+
+  @Test
+  public void testParseStructFieldNamedDefaultInSetClause() throws Exception {
+    ASTNode tree = parseDriver.parse(
+            "update t1 set b = default.field0\n", null).getTree();
+
+    assertFalse(tree.dump(), tree.toStringTree().contains("tok_default_value"));
+  }
+
+  @Test
+  public void testParseStructFieldNamedDefaultInBeginningOdSetClause() throws Exception {
+    ASTNode tree = parseDriver.parse(
+            "update t1 set b = default.field0, a = 10\n", null).getTree();
+
+    assertFalse(tree.dump(), tree.toStringTree().contains("tok_default_value"));
+  }
+
+  @Test
   public void testParseDefaultKeywordInMerge() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "MERGE INTO t1 AS t USING t2 as s ON t.a = s.a\n" +
-                "WHEN MATCHED THEN UPDATE SET b = defauLt " +
-                "WHEN NOT MATCHED THEN INSERT VALUES (s.a, DEFAuLT, DEFAULT)", null).getTree();
+            "MERGE INTO t1 AS t USING t2 as s ON t.a = s.a\n" +
+                    "WHEN MATCHED THEN UPDATE SET b = defauLt " +
+                    "WHEN NOT MATCHED THEN INSERT VALUES (s.a, DEFAuLT, DEFAULT)", null).getTree();
 
-    assertEquals(3, StringUtils.countMatches(tree.toStringTree(), "(tok_table_or_col tok_default_value)"));
+    assertEquals(tree.dump(), 3, StringUtils.countMatches(tree.toStringTree(), "(tok_table_or_col tok_default_value)"));
   }
 
   @Test
   public void testParseStructNamedDefault() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "select default.src.`end`.key from s_n1\n", null).getTree();
+            "select default.src.`end`.key from s_n1\n", null).getTree();
 
-    assertFalse(tree.toStringTree().contains("tok_default_value"));
+    assertFalse(tree.dump(), tree.toStringTree().contains("tok_default_value"));
   }
 
   @Test
   public void testParseStructFieldNamedDefault() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "select col0.default.key from s_n1\n", null).getTree();
+            "select col0.default.key from s_n1\n", null).getTree();
 
-    assertFalse(tree.toStringTree().contains("tok_default_value"));
+    assertFalse(tree.dump(), tree.toStringTree().contains("tok_default_value"));
   }
 
   @Test
   public void testSelectColumNamedDefault() throws Exception {
     ASTNode tree = parseDriver.parse(
-        "select default from s_n1\n", null).getTree();
+            "select default from s_n1\n", null).getTree();
 
-    assertFalse(tree.toStringTree().contains("tok_default_value"));
+    assertFalse(tree.dump(), tree.toStringTree().contains("tok_default_value"));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
@@ -634,7 +634,8 @@ public class MergeSemanticAnalyzer extends RewriteSemanticAnalyzer {
 
     UnparseTranslator defaultValuesTranslator = new UnparseTranslator(conf);
     defaultValuesTranslator.enable();
-    collectDefaultValues(valuesNode, targetTable, defaultValuesTranslator);
+    List<String> targetSchema = processTableColumnNames(columnListNode, targetTable.getFullyQualifiedName());
+    collectDefaultValues(valuesNode, targetTable, targetSchema, defaultValuesTranslator);
     defaultValuesTranslator.applyTranslations(ctx.getTokenRewriteStream());
     String valuesClause = getMatchedText(valuesNode);
     valuesClause = valuesClause.substring(1, valuesClause.length() - 1); //strip '(' and ')'
@@ -649,11 +650,12 @@ public class MergeSemanticAnalyzer extends RewriteSemanticAnalyzer {
     rewrittenQueryStr.append('\n');
   }
 
-  private void collectDefaultValues(ASTNode valueClause, Table targetTable, UnparseTranslator unparseTranslator)
+  private void collectDefaultValues(
+          ASTNode valueClause, Table targetTable, List<String> targetSchema, UnparseTranslator unparseTranslator)
           throws SemanticException {
-    List<String> defaultConstraints = getDefaultConstraints(targetTable, null);
-    for (int j = 1; j < valueClause.getChildCount(); j++) {
-      unparseTranslator.addDefaultValueTranslation((ASTNode) valueClause.getChild(j), defaultConstraints.get(j - 1));
+    List<String> defaultConstraints = getDefaultConstraints(targetTable, targetSchema);
+    for (int j = 0; j < defaultConstraints.size(); j++) {
+      unparseTranslator.addDefaultValueTranslation((ASTNode) valueClause.getChild(j + 1), defaultConstraints.get(j));
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
@@ -307,6 +307,10 @@ public abstract class RewriteSemanticAnalyzer extends CalcitePlanner {
     // not, recurse on any children
     if (node.getToken().getType() == HiveParser.TOK_TABLE_OR_COL) {
       ASTNode colName = (ASTNode)node.getChildren().get(0);
+      if (colName.getToken().getType() == HiveParser.TOK_DEFAULT_VALUE) {
+        return;
+      }
+
       assert colName.getToken().getType() == HiveParser.Identifier :
           "Expected column name";
       setRCols.add(normalizeColName(colName.getText()));

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -794,7 +794,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   protected List<String> getDefaultConstraints(Table tbl, List<String> targetSchema) throws SemanticException{
     Map<String, String> colNameToDefaultVal = getColNameToDefaultValueMap(tbl);
     List<String> defaultConstraints = new ArrayList<>();
-    if(targetSchema != null) {
+    if(targetSchema != null && !targetSchema.isEmpty()) {
       for (String colName : targetSchema) {
         defaultConstraints.add(colNameToDefaultVal.get(colName));
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/UnparseTranslator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/UnparseTranslator.java
@@ -189,6 +189,19 @@ public class UnparseTranslator {
     addTranslation(identifier, replacementText);
   }
 
+  public void addDefaultValueTranslation(ASTNode exprNode, String defaultValue) {
+    if (!(exprNode.getType() == HiveParser.TOK_TABLE_OR_COL
+            && exprNode.getChild(0).getType() == HiveParser.TOK_DEFAULT_VALUE)) {
+      return;
+    }
+
+    if (defaultValue == null) {
+      defaultValue = "NULL";
+    }
+    addTranslation(exprNode, defaultValue);
+  }
+
+
   /**
    * Register a "copy" translation in which a node will be translated into
    * whatever the translation turns out to be for another node (after

--- a/ql/src/test/queries/clientpositive/insert_into_default_keyword_2.q
+++ b/ql/src/test/queries/clientpositive/insert_into_default_keyword_2.q
@@ -1,0 +1,15 @@
+-- A table has a column named 'default' and try to assign it in an update
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+-- SORT_QUERY_RESULTS
+
+-- with default constraint
+CREATE TABLE t1 (a int, `default` int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into t1 values (1, 2), (10, 11);
+
+explain
+update t1 set a = `default`;
+update t1 set a = `default`;
+
+select * from t1;

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword_2.q.out
@@ -1,0 +1,112 @@
+PREHOOK: query: CREATE TABLE t1 (a int, `default` int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1 (a int, `default` int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1 values (1, 2), (10, 11)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 values (1, 2), (10, 11)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.default SCRIPT []
+PREHOOK: query: explain
+update t1 set a = `default`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@t1
+POSTHOOK: query: explain
+update t1 set a = `default`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@t1
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  Statistics: Num rows: 2 Data size: 7010 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), null (type: int), null (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.t1
+                  Write Type: UPDATE
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.t1
+          Write Type: UPDATE
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+
+PREHOOK: query: update t1 set a = `default`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@t1
+POSTHOOK: query: update t1 set a = `default`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@t1
+PREHOOK: query: select * from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+NULL	NULL
+NULL	NULL

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword_2.q.out
@@ -44,29 +44,30 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  Statistics: Num rows: 2 Data size: 7010 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), default (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), null (type: int), null (type: int)
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -108,5 +109,5 @@ POSTHOOK: query: select * from t1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 #### A masked pattern was here ####
-NULL	NULL
-NULL	NULL
+11	11
+2	2


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce parser token and rule for `default` keyword.
Use the Token in SemanticAnalyzers when replacing `default` keyword with default constraint values.

### Why are the changes needed?
Prior this patch 
* the `default` keyword was treated as an identifier.
* and the lookup in the sql text was done by exact match of the string `default` in some cases.

### Does this PR introduce _any_ user-facing change?
Yes, see jira for example.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=insert_into_default_keyword.q,insert_into_default_keyword_2.q -pl itests/qtest -Pitests
mvn test -Dtest=TestParseDefault -pl parser
```