### PR TITLE
HIVE-25970: Missing messages in HS2 operation logs 

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithTez.java
@@ -57,6 +57,8 @@ public class TestOperationLoggingAPIWithTez extends OperationLoggingAPITestBase 
     };
     hiveConf = UtilsForTest.getHiveOnTezConfFromDir("../../data/conf/tez/");
     hiveConf.set(ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LEVEL.varname, "verbose");
+    // Decrease time to live to increase the likehood of hitting HIVE-25970
+    hiveConf.set(ConfVars.HIVE_SERVER2_OPERATION_LOG_PURGEPOLICY_TIMETOLIVE.varname, "1s");
     // Set tez execution summary to false.
     hiveConf.setBoolVar(ConfVars.TEZ_EXEC_SUMMARY, false);
     miniHS2 = new MiniHS2(hiveConf, MiniClusterType.TEZ);

--- a/ql/src/java/org/apache/hadoop/hive/ql/log/HushableRandomAccessFileAppender.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/HushableRandomAccessFileAppender.java
@@ -20,11 +20,7 @@ package org.apache.hadoop.hive.ql.log;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
@@ -51,17 +47,6 @@ import org.apache.logging.log4j.core.util.Integers;
 public final class HushableRandomAccessFileAppender extends
     AbstractOutputStreamAppender<RandomAccessFileManager> {
 
-  private static final LoadingCache<String, String> CLOSED_FILES =
-      CacheBuilder.newBuilder().maximumSize(1000)
-          .expireAfterWrite(1, TimeUnit.SECONDS)
-          .build(new CacheLoader<String, String>() {
-            @Override
-            public String load(String key) throws Exception {
-              return key;
-            }
-          });
-
-
   private final String fileName;
   private Object advertisement;
   private final Advertiser advertiser;
@@ -86,7 +71,6 @@ public final class HushableRandomAccessFileAppender extends
   @Override
   public void stop() {
     super.stop();
-    CLOSED_FILES.put(fileName, fileName);
     if (advertiser != null) {
       advertiser.unadvertise(advertisement);
     }
@@ -188,22 +172,6 @@ public final class HushableRandomAccessFileAppender extends
           + name);
       return null;
     }
-
-    /**
-     * In corner cases (e.g exceptions), there seem to be some race between
-     * com.lmax.disruptor.BatchEventProcessor and HS2 thread which is actually
-     * stopping the logs. Because of this, same filename is recreated and
-     * stop() would never be invoked on that instance, causing a mem leak.
-     * To prevent same file being recreated within very short time,
-     * CLOSED_FILES are tracked in cache with TTL of 1 second. This
-     * also helps in avoiding the stale directories created.
-     */
-    if (CLOSED_FILES.getIfPresent(fileName) != null) {
-      // Do not create another file, which got closed in last 5 seconds
-      LOGGER.error(fileName + " was closed recently.");
-      return null;
-    }
-
     if (layout == null) {
       layout = PatternLayout.createDefaultLayout();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revert HIVE-22753 (commit 6a5c0cd04a2e88a545a96d10a942c86b2be18daa).

### Why are the changes needed?
Preventing the creation of the appender (by returning null) leads to the message triggering the creation to be lost forever. Given that the memory leak that was observed in HIVE-22753 is no longer feasible with the fix for HIVE-24590 the changes in HIVE-22753 are redundant and problematic.

### Does this PR introduce _any_ user-facing change?
Fixes a bug.

### How was this patch tested?
`mvn test -Dtest=TestOperationLoggingAPIWithTez#testFetchResultsOfLogWithExecutionMode`

I changed the property (https://github.com/apache/hive/commit/bc6ac75266aa360ce32aa975cf4f7b655cbfd22e) controlling how often appenders are closed to increase the likelihood of hitting the problem and run `TestOperationLoggingAPIWithTez` multiple times.

Without the fix the test fails 80% of the time on my machine.