### PR TITLE
HIVE-25979: Order of Lineage is flaky in qtest output

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecutePrinter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecutePrinter.java
@@ -80,8 +80,8 @@ public class PostExecutePrinter implements ExecuteWithHookContext {
         if (o1.getKey().getDataContainer().isPartition() &&
             o2.getKey().getDataContainer().isPartition()) {
           // Both are partitioned tables.
-          ret = o1.getKey().getDataContainer().getPartition().toString()
-          .compareTo(o2.getKey().getDataContainer().getPartition().toString());
+          ret = o1.getKey().getDataContainer().getPartition().getValues().toString()
+          .compareTo(o2.getKey().getDataContainer().getPartition().getValues().toString());
 
           if (ret != 0) {
             return ret;

--- a/ql/src/test/results/clientpositive/llap/stats_part_multi_insert.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_part_multi_insert.q.out
@@ -39,8 +39,8 @@ POSTHOOK: Input: default@source
 POSTHOOK: Output: default@stats_part
 POSTHOOK: Output: default@stats_part@p=101
 POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
-POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 POSTHOOK: Lineage: stats_part PARTITION(p=101).key SIMPLE [(source)source.FieldSchema(name:key, type:int, comment:null), ]
+POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 POSTHOOK: Lineage: stats_part PARTITION(p=101).value SIMPLE [(source)source.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: select p, key, value from stats_part
 PREHOOK: type: QUERY


### PR DESCRIPTION
### What changes were proposed in this pull request?
Lineage entries are sorted before printing them. The comparator used for the sorting uses the string representation of `Partition` objects for comparing them.
This patch propose to use only the partition values for Partition comparison instead

### Why are the changes needed?
More than one partition objects may represents the same partition in the lineage info map. This is very common since each column has a different entry but the same partition. There are cases when more than one branches of the statement updates the same partition. In this case properties of the cached Partition objects may different:
```
stats_part PARTITION(p=101).key ...]   -> Partition[(p=101)... transient_lastDdlTime=1645697627,...]
stats_part PARTITION(p=101).value ...] -> Partition[(p=101)... transient_lastDdlTime=1645697627,...]
stats_part PARTITION(p=101).key ...]   -> Partition[(p=101)... transient_lastDdlTime=1645697628,...]
stats_part PARTITION(p=101).value ...] -> Partition[(p=101)... transient_lastDdlTime=1645697628,...]
```
This difference changes the behavior of the comparator used for sorting Lineage entries. The printed entries contain the partition values only and this is the only value should be used when comparing partitions this case.

### Does this PR introduce _any_ user-facing change?
Yes. Lineage order is more stable when running the same statement several time.

### How was this patch tested?
Run flaky-check: http://ci.hive.apache.org/job/hive-flaky-check/530/
Parameters:
```
-Dtest=TestMiniLlapLocalCliDriver -Dqfile=stats_part_multi_insert_acid.q -pl itests/qtest -Pitests
```