### PR TITLE
Hive 25980: Support HiveMetaStoreChecker.checkTable operation with multi-threaded

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -271,8 +271,6 @@
           </dependency>
         </dependencies>
       </plugin>
-
-
     </plugins>
   </build>
 </project>

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -949,6 +949,8 @@ public class HiveConf extends Configuration {
         "Used to avoid all of the proxies and object copies in the metastore.  Note, if this is " +
             "set, you MUST use a local metastore (hive.metastore.uris must be empty) otherwise " +
             "undefined and most likely undesired behavior will result"),
+    METASTORE_MSCK_FS_HANDLER_THREADS_COUNT("hive.metastore.msck.fshandler.threads", 1,
+            "Number of threads to be allocated for metastore handler for msck fs operations."),
     /**
      * @deprecated Use MetastoreConf.FS_HANDLER_THREADS_COUNT
      */

--- a/ql/src/test/queries/clientpositive/msck_repair_multi_thread.q
+++ b/ql/src/test/queries/clientpositive/msck_repair_multi_thread.q
@@ -1,0 +1,50 @@
+set hive.metastore.fshandler.threads=2;
+set hive.metastore.msck.fshandler.threads=2;
+
+DROP TABLE IF EXISTS repairtable_hive_25980;
+
+CREATE EXTERNAL TABLE repairtable_hive_25980(col STRING) PARTITIONED BY (p1 STRING, p2 STRING) LOCATION '${system:test.warehouse.dir}/repairtable_hive_25980';
+
+MSCK REPAIR TABLE repairtable_hive_25980;
+
+show partitions repairtable_hive_25980;
+
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=a/p2=aa;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ab;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ac;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ad;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ae;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=af;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ag;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ah;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ai;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=aj;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ak;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=al;
+
+MSCK REPAIR TABLE repairtable_hive_25980;
+
+show partitions repairtable_hive_25980;
+
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ai;
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=aj;
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ak;
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=al;
+
+MSCK REPAIR TABLE default.repairtable_hive_25980 DROP PARTITIONS;
+
+show partitions default.repairtable_hive_25980;
+
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ai;
+dfs ${system:test.dfs.mkdir} ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=aj;
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ag;
+dfs -rmdir ${system:test.warehouse.dir}/repairtable_hive_25980/p1=b/p2=ah;
+
+set hive.metastore.fshandler.threads=30;
+set hive.metastore.msck.fshandler.threads=30;
+
+MSCK REPAIR TABLE repairtable_hive_25980 SYNC PARTITIONS;
+
+show partitions repairtable_hive_25980;
+
+DROP TABLE default.repairtable_hive_25980;

--- a/ql/src/test/results/clientpositive/llap/msck_repair_multi_thread.q.out
+++ b/ql/src/test/results/clientpositive/llap/msck_repair_multi_thread.q.out
@@ -1,0 +1,110 @@
+PREHOOK: query: DROP TABLE IF EXISTS repairtable_hive_25980
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS repairtable_hive_25980
+POSTHOOK: type: DROPTABLE
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@repairtable_hive_25980
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@repairtable_hive_25980
+PREHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980
+PREHOOK: type: MSCK
+PREHOOK: Output: default@repairtable_hive_25980
+POSTHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980
+POSTHOOK: type: MSCK
+POSTHOOK: Output: default@repairtable_hive_25980
+PREHOOK: query: show partitions repairtable_hive_25980
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@repairtable_hive_25980
+POSTHOOK: query: show partitions repairtable_hive_25980
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@repairtable_hive_25980
+PREHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980
+PREHOOK: type: MSCK
+PREHOOK: Output: default@repairtable_hive_25980
+POSTHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980
+POSTHOOK: type: MSCK
+POSTHOOK: Output: default@repairtable_hive_25980
+Partitions not in metastore:	repairtable_hive_25980:p1=a/p2=aa	repairtable_hive_25980:p1=b/p2=ab	repairtable_hive_25980:p1=b/p2=ac	repairtable_hive_25980:p1=b/p2=ad	repairtable_hive_25980:p1=b/p2=ae	repairtable_hive_25980:p1=b/p2=af	repairtable_hive_25980:p1=b/p2=ag	repairtable_hive_25980:p1=b/p2=ah	repairtable_hive_25980:p1=b/p2=ai	repairtable_hive_25980:p1=b/p2=aj	repairtable_hive_25980:p1=b/p2=ak	repairtable_hive_25980:p1=b/p2=al
+#### A masked pattern was here ####
+PREHOOK: query: show partitions repairtable_hive_25980
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@repairtable_hive_25980
+POSTHOOK: query: show partitions repairtable_hive_25980
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@repairtable_hive_25980
+p1=a/p2=aa
+p1=b/p2=ab
+p1=b/p2=ac
+p1=b/p2=ad
+p1=b/p2=ae
+p1=b/p2=af
+p1=b/p2=ag
+p1=b/p2=ah
+p1=b/p2=ai
+p1=b/p2=aj
+p1=b/p2=ak
+p1=b/p2=al
+PREHOOK: query: MSCK REPAIR TABLE default.repairtable_hive_25980 DROP PARTITIONS
+PREHOOK: type: MSCK
+PREHOOK: Output: default@repairtable_hive_25980
+POSTHOOK: query: MSCK REPAIR TABLE default.repairtable_hive_25980 DROP PARTITIONS
+POSTHOOK: type: MSCK
+POSTHOOK: Output: default@repairtable_hive_25980
+Partitions missing from filesystem:	repairtable_hive_25980:p1=b/p2=ai	repairtable_hive_25980:p1=b/p2=aj	repairtable_hive_25980:p1=b/p2=ak	repairtable_hive_25980:p1=b/p2=al
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=ai
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=aj
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=ak
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=al
+PREHOOK: query: show partitions default.repairtable_hive_25980
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@repairtable_hive_25980
+POSTHOOK: query: show partitions default.repairtable_hive_25980
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@repairtable_hive_25980
+p1=a/p2=aa
+p1=b/p2=ab
+p1=b/p2=ac
+p1=b/p2=ad
+p1=b/p2=ae
+p1=b/p2=af
+p1=b/p2=ag
+p1=b/p2=ah
+PREHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980 SYNC PARTITIONS
+PREHOOK: type: MSCK
+PREHOOK: Output: default@repairtable_hive_25980
+POSTHOOK: query: MSCK REPAIR TABLE repairtable_hive_25980 SYNC PARTITIONS
+POSTHOOK: type: MSCK
+POSTHOOK: Output: default@repairtable_hive_25980
+Partitions not in metastore:	repairtable_hive_25980:p1=b/p2=ai	repairtable_hive_25980:p1=b/p2=aj
+Partitions missing from filesystem:	repairtable_hive_25980:p1=b/p2=ag	repairtable_hive_25980:p1=b/p2=ah
+#### A masked pattern was here ####
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=ag
+Repair: Dropped partition from metastore hive.default.repairtable_hive_25980:p1=b/p2=ah
+PREHOOK: query: show partitions repairtable_hive_25980
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@repairtable_hive_25980
+POSTHOOK: query: show partitions repairtable_hive_25980
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@repairtable_hive_25980
+p1=a/p2=aa
+p1=b/p2=ab
+p1=b/p2=ac
+p1=b/p2=ad
+p1=b/p2=ae
+p1=b/p2=af
+p1=b/p2=ai
+p1=b/p2=aj
+PREHOOK: query: DROP TABLE default.repairtable_hive_25980
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@repairtable_hive_25980
+PREHOOK: Output: default@repairtable_hive_25980
+POSTHOOK: query: DROP TABLE default.repairtable_hive_25980
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@repairtable_hive_25980
+POSTHOOK: Output: default@repairtable_hive_25980

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -876,6 +876,8 @@ public class MetastoreConf {
         "will call its Authenticate(user, passed) method to authenticate requests.\n" +
         "The implementation may optionally implement Hadoop's\n" +
         "org.apache.hadoop.conf.Configurable class to grab MetaStore's Configuration object."),
+    METASTORE_MSCK_FS_HANDLER_THREADS_COUNT("metastore.msck.fshandler.threads", "hive.metastore.msck.fshandler.threads", 1,
+            "Number of threads to be allocated for metastore handler for msck fs operations."),
     METASTORE_PLAIN_LDAP_URL("metastore.authentication.ldap.url",
             "hive.metastore.authentication.ldap.url", "",
 "LDAP connection URL(s),\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -110,16 +110,22 @@ public class HiveMetaStoreChecker {
      * Check the metastore for inconsistencies, data missing in either the
      * metastore or on the dfs.
      *
-     * @param catName   name of the catalog, if not specified default catalog will be used.
-     * @param dbName    name of the database, if not specified the default will be used.
-     * @param tableName Table we want to run the check for. If null we'll check all the
-     *                  tables in the database.
-     * @param filterExp Filter expression which is used to prune th partition from the
-     *                  metastore and FileSystem.
+     * @param catName
+     *          name of the catalog, if not specified default catalog will be used.
+     * @param dbName
+     *          name of the database, if not specified the default will be used.
+     * @param tableName
+     *          Table we want to run the check for. If null we'll check all the
+     *          tables in the database.
+     * @param filterExp
+     *          Filter expression which is used to prune th partition from the
+     *          metastore and FileSystem.
      * @param table
      * @return Results of the check
-     * @throws MetastoreException Failed to get required information from the metastore.
-     * @throws IOException        Most likely filesystem related
+     * @throws MetastoreException
+     *           Failed to get required information from the metastore.
+     * @throws IOException
+     *           Most likely filesystem related
      */
     public CheckResult checkMetastore(String catName, String dbName, String tableName,
                                       byte[] filterExp, Table table)
@@ -134,9 +140,9 @@ public class HiveMetaStoreChecker {
                 // TODO: I do not think this is used by anything other than tests
                 // no table specified, check all tables and all partitions.
                 List<String> tables = new ArrayList<>();
-                try {
+                try{
                     tables = getMsc().getTables(catName, dbName, ".*");
-                } catch (UnknownDBException ex) {
+                }catch(UnknownDBException ex){
                     //ignore database exception.
                 }
                 for (String currentTableName : tables) {
@@ -166,14 +172,22 @@ public class HiveMetaStoreChecker {
     /**
      * Check for table directories that aren't in the metastore.
      *
-     * @param catName name of the catalog, if not specified default catalog will be used.
-     * @param dbName  Name of the database
-     * @param tables  List of table names
-     * @param result  Add any found tables to this
-     * @throws IOException           Most likely filesystem related
-     * @throws MetaException         Failed to get required information from the metastore.
-     * @throws NoSuchObjectException Failed to get required information from the metastore.
-     * @throws TException            Thrift communication error.
+     * @param catName
+     *          name of the catalog, if not specified default catalog will be used.
+     * @param dbName
+     *          Name of the database
+     * @param tables
+     *          List of table names
+     * @param result
+     *          Add any found tables to this
+     * @throws IOException
+     *           Most likely filesystem related
+     * @throws MetaException
+     *           Failed to get required information from the metastore.
+     * @throws NoSuchObjectException
+     *           Failed to get required information from the metastore.
+     * @throws TException
+     *           Thrift communication error.
      */
     void findUnknownTables(String catName, String dbName, List<String> tables, CheckResult result)
             throws IOException, MetaException, TException {
@@ -210,16 +224,24 @@ public class HiveMetaStoreChecker {
      * Check the metastore for inconsistencies, data missing in either the
      * metastore or on the dfs.
      *
-     * @param catName   name of the catalog, if not specified default catalog will be used.
-     * @param dbName    Name of the database
-     * @param tableName Name of the table
-     * @param filterExp Filter expression which is used to prune th partition from the
-     *                  metastore and FileSystem.
-     * @param table     Table we want to run the check for.
-     * @param result    Result object
-     * @throws MetastoreException Failed to get required information from the metastore.
-     * @throws IOException        Most likely filesystem related
-     * @throws MetaException      Failed to get required information from the metastore.
+     * @param catName
+     *          name of the catalog, if not specified default catalog will be used.
+     * @param dbName
+     *          Name of the database
+     * @param tableName
+     *          Name of the table
+     * @param filterExp
+     *          Filter expression which is used to prune th partition from the
+     *          metastore and FileSystem.
+     * @param table Table we want to run the check for.
+     * @param result
+     *          Result object
+     * @throws MetastoreException
+     *           Failed to get required information from the metastore.
+     * @throws IOException
+     *           Most likely filesystem related
+     * @throws MetaException
+     *           Failed to get required information from the metastore.
      */
     void checkTable(String catName, String dbName, String tableName, byte[] filterExp, Table table, CheckResult result)
             throws MetaException, IOException, MetastoreException {
@@ -261,13 +283,19 @@ public class HiveMetaStoreChecker {
      * Check the metastore for inconsistencies, data missing in either the
      * metastore or on the dfs.
      *
-     * @param table     Table to check
-     * @param parts     Partitions to check
-     * @param result    Result object
-     * @param filterExp Filter expression which is used to prune th partition from the
-     *                  metastore and FileSystem.
-     * @throws IOException        Could not get information from filesystem
-     * @throws MetastoreException Could not create Partition object
+     * @param table
+     *          Table to check
+     * @param parts
+     *          Partitions to check
+     * @param result
+     *          Result object
+     * @param filterExp
+     *          Filter expression which is used to prune th partition from the
+     *          metastore and FileSystem.
+     * @throws IOException
+     *           Could not get information from filesystem
+     * @throws MetastoreException
+     *           Could not create Partition object
      */
     void checkTable(Table table, PartitionIterable parts, byte[] filterExp, CheckResult result) throws IOException,
             MetastoreException, MetaException {
@@ -301,7 +329,7 @@ public class HiveMetaStoreChecker {
                         // most likely the user specified an invalid partition
                         continue;
                     }
-                    final Path[] partPath = {getDataLocation(table, partition)};
+                    Path[] partPath = {getDataLocation(table, partition)};
                     if (partPath[0] == null) {
                         continue;
                     }
@@ -419,12 +447,17 @@ public class HiveMetaStoreChecker {
     /**
      * Find partitions on the fs that are unknown to the metastore.
      *
-     * @param table     Table where the partitions would be located
-     * @param partPaths Paths of the partitions the ms knows about
-     * @param filterExp Filter expression which is used to prune th partition from the
-     *                  metastore and FileSystem.
-     * @param result    Result object
-     * @throws IOException        Thrown if we fail at fetching listings from the fs.
+     * @param table
+     *          Table where the partitions would be located
+     * @param partPaths
+     *          Paths of the partitions the ms knows about
+     * @param filterExp
+     *          Filter expression which is used to prune th partition from the
+     *          metastore and FileSystem.
+     * @param result
+     *          Result object
+     * @throws IOException
+     *           Thrown if we fail at fetching listings from the fs.
      * @throws MetastoreException ex
      */
     void findUnknownPartitions(Table table, Set<Path> partPaths, byte[] filterExp,
@@ -473,7 +506,7 @@ public class HiveMetaStoreChecker {
         allPartDirs.removeAll(partPaths);
 
         Set<String> partColNames = Sets.newHashSet();
-        for (FieldSchema fSchema : getPartCols(table)) {
+        for(FieldSchema fSchema : getPartCols(table)) {
             partColNames.add(fSchema.getName());
         }
 
@@ -517,9 +550,8 @@ public class HiveMetaStoreChecker {
 
     /**
      * Calculate the maximum seen writeId from the acid directory structure
-     *
      * @param partPath Path of the partition directory
-     * @param res      Partition result to write the max ids
+     * @param res Partition result to write the max ids
      * @throws IOException ex
      */
     private void setMaxTxnAndWriteIdFromPartition(Path partPath, CheckResult.PartitionResult res) throws IOException {
@@ -572,10 +604,14 @@ public class HiveMetaStoreChecker {
      * tblPath/a=1/b=2/c=3 => return a=1/b=2
      * tblPath/a=1/b=2/c=3/file => return a=1/b=2
      *
-     * @param basePath     Start directory
-     * @param allDirs      This set will contain the leaf paths at the end.
-     * @param partColNames Partition column names
-     * @throws IOException        Thrown if we can't get lists from the fs.
+     * @param basePath
+     *          Start directory
+     * @param allDirs
+     *          This set will contain the leaf paths at the end.
+     * @param partColNames
+     *          Partition column names
+     * @throws IOException
+     *           Thrown if we can't get lists from the fs.
      * @throws MetastoreException ex
      */
 
@@ -669,7 +705,7 @@ public class HiveMetaStoreChecker {
         }
 
         private void logOrThrowExceptionWithMsg(String msg) throws MetastoreException {
-            if (throwException) {
+            if(throwException) {
                 throw new MetastoreException(msg);
             } else {
                 LOG.warn(msg);
@@ -680,7 +716,6 @@ public class HiveMetaStoreChecker {
     private static class PathDepthInfo {
         private final Path p;
         private final int depth;
-
         PathDepthInfo(Path p, int depth) {
             this.p = p;
             this.depth = depth;
@@ -702,14 +737,14 @@ public class HiveMetaStoreChecker {
             //have to add the complex mechanisms to let the free worker threads know when new levels are
             //discovered using notify()/wait() mechanisms which can potentially lead to bugs if
             //not done right
-            while (!nextLevel.isEmpty()) {
+            while(!nextLevel.isEmpty()) {
                 ConcurrentLinkedQueue<PathDepthInfo> tempQueue = new ConcurrentLinkedQueue<>();
                 //process each level in parallel
-                while (!nextLevel.isEmpty()) {
+                while(!nextLevel.isEmpty()) {
                     futures.add(
                             executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue)));
                 }
-                while (!futures.isEmpty()) {
+                while(!futures.isEmpty()) {
                     Path p = futures.poll().get();
                     if (p != null) {
                         result.add(p);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,604 +83,645 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  */
 public class HiveMetaStoreChecker {
 
-  public static final Logger LOG = LoggerFactory.getLogger(HiveMetaStoreChecker.class);
+    public static final Logger LOG = LoggerFactory.getLogger(HiveMetaStoreChecker.class);
 
-  private final IMetaStoreClient msc;
-  private final Configuration conf;
-  private final long partitionExpirySeconds;
-  public static final PathFilter HIDDEN_FILES_PATH_FILTER =
-      p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
+    private final IMetaStoreClient msc;
+    private final Configuration conf;
+    private final long partitionExpirySeconds;
+    public static final PathFilter HIDDEN_FILES_PATH_FILTER =
+            p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
-  public HiveMetaStoreChecker(IMetaStoreClient msc, Configuration conf) {
-    this(msc, conf, -1);
-  }
-
-  public HiveMetaStoreChecker(IMetaStoreClient msc, Configuration conf, long partitionExpirySeconds) {
-    super();
-    this.msc = msc;
-    this.conf = conf;
-    this.partitionExpirySeconds = partitionExpirySeconds;
-  }
-
-  public IMetaStoreClient getMsc() {
-    return msc;
-  }
-
-  /**
-   * Check the metastore for inconsistencies, data missing in either the
-   * metastore or on the dfs.
-   *
-   * @param catName
-   *          name of the catalog, if not specified default catalog will be used.
-   * @param dbName
-   *          name of the database, if not specified the default will be used.
-   * @param tableName
-   *          Table we want to run the check for. If null we'll check all the
-   *          tables in the database.
-   * @param filterExp
-   *          Filter expression which is used to prune th partition from the
-   *          metastore and FileSystem.
-   * @param table
-   * @return Results of the check
-   * @throws MetastoreException
-   *           Failed to get required information from the metastore.
-   * @throws IOException
-   *           Most likely filesystem related
-   */
-  public CheckResult checkMetastore(String catName, String dbName, String tableName,
-                             byte[] filterExp, Table table)
-      throws MetastoreException, IOException {
-    CheckResult result = new CheckResult();
-    if (dbName == null || "".equalsIgnoreCase(dbName)) {
-      dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    public HiveMetaStoreChecker(IMetaStoreClient msc, Configuration conf) {
+        this(msc, conf, -1);
     }
 
-    try {
-      if (tableName == null || "".equals(tableName)) {
-        // TODO: I do not think this is used by anything other than tests
-        // no table specified, check all tables and all partitions.
-        List<String> tables = new ArrayList<>();
-        try{
-          tables = getMsc().getTables(catName, dbName, ".*");
-        }catch(UnknownDBException ex){
-          //ignore database exception.
-        }
-        for (String currentTableName : tables) {
-          checkTable(catName, dbName, currentTableName, null, null, result);
+    public HiveMetaStoreChecker(IMetaStoreClient msc, Configuration conf, long partitionExpirySeconds) {
+        super();
+        this.msc = msc;
+        this.conf = conf;
+        this.partitionExpirySeconds = partitionExpirySeconds;
+    }
+
+    public IMetaStoreClient getMsc() {
+        return msc;
+    }
+
+    /**
+     * Check the metastore for inconsistencies, data missing in either the
+     * metastore or on the dfs.
+     *
+     * @param catName   name of the catalog, if not specified default catalog will be used.
+     * @param dbName    name of the database, if not specified the default will be used.
+     * @param tableName Table we want to run the check for. If null we'll check all the
+     *                  tables in the database.
+     * @param filterExp Filter expression which is used to prune th partition from the
+     *                  metastore and FileSystem.
+     * @param table
+     * @return Results of the check
+     * @throws MetastoreException Failed to get required information from the metastore.
+     * @throws IOException        Most likely filesystem related
+     */
+    public CheckResult checkMetastore(String catName, String dbName, String tableName,
+                                      byte[] filterExp, Table table)
+            throws MetastoreException, IOException {
+        CheckResult result = new CheckResult();
+        if (dbName == null || "".equalsIgnoreCase(dbName)) {
+            dbName = Warehouse.DEFAULT_DATABASE_NAME;
         }
 
-        findUnknownTables(catName, dbName, tables, result);
-      } else if (filterExp != null) {
-        // check for specified partitions which matches filter expression
-        checkTable(catName, dbName, tableName, filterExp, table, result);
-      } else {
-        // only one table, let's check all partitions
-        checkTable(catName, dbName, tableName, null, table, result);
-      }
+        try {
+            if (tableName == null || "".equals(tableName)) {
+                // TODO: I do not think this is used by anything other than tests
+                // no table specified, check all tables and all partitions.
+                List<String> tables = new ArrayList<>();
+                try {
+                    tables = getMsc().getTables(catName, dbName, ".*");
+                } catch (UnknownDBException ex) {
+                    //ignore database exception.
+                }
+                for (String currentTableName : tables) {
+                    checkTable(catName, dbName, currentTableName, null, null, result);
+                }
 
-      LOG.info("Number of partitionsNotInMs=" + result.getPartitionsNotInMs()
-              + ", partitionsNotOnFs=" + result.getPartitionsNotOnFs()
-              + ", tablesNotInMs=" + result.getTablesNotInMs()
-              + ", tablesNotOnFs=" + result.getTablesNotOnFs()
-              + ", expiredPartitions=" + result.getExpiredPartitions());
-    } catch (TException e) {
-      throw new MetastoreException(e);
-    }
-    return result;
-  }
-
-  /**
-   * Check for table directories that aren't in the metastore.
-   *
-   * @param catName
-   *          name of the catalog, if not specified default catalog will be used.
-   * @param dbName
-   *          Name of the database
-   * @param tables
-   *          List of table names
-   * @param result
-   *          Add any found tables to this
-   * @throws IOException
-   *           Most likely filesystem related
-   * @throws MetaException
-   *           Failed to get required information from the metastore.
-   * @throws NoSuchObjectException
-   *           Failed to get required information from the metastore.
-   * @throws TException
-   *           Thrift communication error.
-   */
-  void findUnknownTables(String catName, String dbName, List<String> tables, CheckResult result)
-      throws IOException, MetaException, TException {
-
-    Set<Path> dbPaths = new HashSet<>();
-    Set<String> tableNames = new HashSet<>(tables);
-
-    for (String tableName : tables) {
-      Table table = getMsc().getTable(catName, dbName, tableName);
-      // hack, instead figure out a way to get the db paths
-      String isExternal = table.getParameters().get("EXTERNAL");
-      if (!"TRUE".equalsIgnoreCase(isExternal)) {
-        Path tablePath = getPath(table);
-        if (tablePath != null) {
-          dbPaths.add(tablePath.getParent());
-        }
-      }
-    }
-
-    for (Path dbPath : dbPaths) {
-      FileSystem fs = dbPath.getFileSystem(conf);
-      FileStatus[] statuses = fs.listStatus(dbPath, FileUtils.HIDDEN_FILES_PATH_FILTER);
-      for (FileStatus status : statuses) {
-
-        if (status.isDirectory() && !tableNames.contains(status.getPath().getName())) {
-
-          result.getTablesNotInMs().add(status.getPath().getName());
-        }
-      }
-    }
-  }
-
-  /**
-   * Check the metastore for inconsistencies, data missing in either the
-   * metastore or on the dfs.
-   *
-   * @param catName
-   *          name of the catalog, if not specified default catalog will be used.
-   * @param dbName
-   *          Name of the database
-   * @param tableName
-   *          Name of the table
-   * @param filterExp
-   *          Filter expression which is used to prune th partition from the
-   *          metastore and FileSystem.
-   * @param table Table we want to run the check for.
-   * @param result
-   *          Result object
-   * @throws MetastoreException
-   *           Failed to get required information from the metastore.
-   * @throws IOException
-   *           Most likely filesystem related
-   * @throws MetaException
-   *           Failed to get required information from the metastore.
-   */
-  void checkTable(String catName, String dbName, String tableName, byte[] filterExp, Table table, CheckResult result)
-      throws MetaException, IOException, MetastoreException {
-
-    if (table == null) {
-      try {
-        table = getMsc().getTable(catName, dbName, tableName);
-      } catch (TException e) {
-        result.getTablesNotInMs().add(tableName);
-        return;
-      }
-    }
-
-    PartitionIterable parts;
-
-    if (isPartitioned(table)) {
-      if (filterExp != null) {
-        List<Partition> results = new ArrayList<>();
-        getPartitionListByFilterExp(getMsc(), table, filterExp,
-            MetastoreConf.getVar(conf, MetastoreConf.ConfVars.DEFAULTPARTITIONNAME), results);
-        parts = new PartitionIterable(results);
-      } else {
-        int batchSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
-        if (batchSize > 0) {
-          parts = new PartitionIterable(getMsc(), table, batchSize);
-        } else {
-          List<Partition> loadedPartitions = getAllPartitionsOf(getMsc(), table);
-          parts = new PartitionIterable(loadedPartitions);
-        }
-      }
-    } else {
-      parts = new PartitionIterable(Collections.emptyList());
-    }
-
-    checkTable(table, parts, filterExp, result);
-  }
-
-  /**
-   * Check the metastore for inconsistencies, data missing in either the
-   * metastore or on the dfs.
-   *
-   * @param table
-   *          Table to check
-   * @param parts
-   *          Partitions to check
-   * @param result
-   *          Result object
-   * @param filterExp
-   *          Filter expression which is used to prune th partition from the
-   *          metastore and FileSystem.
-   * @throws IOException
-   *           Could not get information from filesystem
-   * @throws MetastoreException
-   *           Could not create Partition object
-   */
-  void checkTable(Table table, PartitionIterable parts, byte[] filterExp, CheckResult result) throws IOException,
-    MetastoreException, MetaException {
-
-    Path tablePath = getPath(table);
-    if (tablePath == null) {
-      return;
-    }
-    FileSystem fs = tablePath.getFileSystem(conf);
-    if (!fs.exists(tablePath)) {
-      result.getTablesNotOnFs().add(table.getTableName());
-      return;
-    }
-
-    Set<Path> partPaths = new HashSet<>();
-
-    // check that the partition folders exist on disk
-    for (Partition partition : parts) {
-      if (partition == null) {
-        // most likely the user specified an invalid partition
-        continue;
-      }
-      Path partPath = getDataLocation(table, partition);
-      if (partPath == null) {
-        continue;
-      }
-      fs = partPath.getFileSystem(conf);
-
-      CheckResult.PartitionResult prFromMetastore = new CheckResult.PartitionResult();
-      prFromMetastore.setPartitionName(getPartitionName(table, partition));
-      prFromMetastore.setTableName(partition.getTableName());
-      if (!fs.exists(partPath)) {
-        result.getPartitionsNotOnFs().add(prFromMetastore);
-      } else {
-        result.getCorrectPartitions().add(prFromMetastore);
-      }
-
-      if (partitionExpirySeconds > 0) {
-        long currentEpochSecs = Instant.now().getEpochSecond();
-        long createdTime = partition.getCreateTime();
-        long partitionAgeSeconds = currentEpochSecs - createdTime;
-        if (partitionAgeSeconds > partitionExpirySeconds) {
-          CheckResult.PartitionResult pr = new CheckResult.PartitionResult();
-          pr.setPartitionName(getPartitionName(table, partition));
-          pr.setTableName(partition.getTableName());
-          result.getExpiredPartitions().add(pr);
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("{}.{}.{}.{} expired. createdAt: {} current: {} age: {}s expiry: {}s", partition.getCatName(),
-                partition.getDbName(), partition.getTableName(), pr.getPartitionName(), createdTime, currentEpochSecs,
-                partitionAgeSeconds, partitionExpirySeconds);
-          }
-        }
-      }
-
-      for (int i = 0; i < getPartitionSpec(table, partition).size(); i++) {
-        Path qualifiedPath = partPath.makeQualified(fs);
-        partPaths.add(qualifiedPath);
-        partPath = partPath.getParent();
-      }
-    }
-
-    findUnknownPartitions(table, partPaths, filterExp, result);
-
-    if (!isPartitioned(table) && TxnUtils.isTransactionalTable(table)) {
-      // Check for writeIds in the table directory
-      CheckResult.PartitionResult tableResult = new CheckResult.PartitionResult();
-      setMaxTxnAndWriteIdFromPartition(tablePath, tableResult);
-      result.setMaxWriteId(tableResult.getMaxWriteId());
-      result.setMaxTxnId(tableResult.getMaxTxnId());
-    }
-  }
-
-  /**
-   * Find partitions on the fs that are unknown to the metastore.
-   *
-   * @param table
-   *          Table where the partitions would be located
-   * @param partPaths
-   *          Paths of the partitions the ms knows about
-   * @param filterExp
-   *          Filter expression which is used to prune th partition from the
-   *          metastore and FileSystem.
-   * @param result
-   *          Result object
-   * @throws IOException
-   *           Thrown if we fail at fetching listings from the fs.
-   * @throws MetastoreException ex
-   */
-  void findUnknownPartitions(Table table, Set<Path> partPaths, byte[] filterExp,
-      CheckResult result) throws IOException, MetastoreException, MetaException {
-
-    Path tablePath = getPath(table);
-    if (tablePath == null) {
-      return;
-    }
-    boolean transactionalTable = TxnUtils.isTransactionalTable(table);
-    // now check the table folder and see if we find anything
-    // that isn't in the metastore
-    Set<Path> allPartDirs = new HashSet<>();
-    List<FieldSchema> partColumns = table.getPartitionKeys();
-    checkPartitionDirs(tablePath, allPartDirs, Collections.unmodifiableList(getPartColNames(table)));
-
-    if (filterExp != null) {
-      PartitionExpressionProxy expressionProxy = createExpressionProxy(conf);
-      List<String> paritions = new ArrayList<>();
-      Set<Path> partDirs = new HashSet<Path>();
-      String tablePathStr = tablePath.toString();
-      for (Path path : allPartDirs) {
-        // remove the table's path from the partition path
-        // eg: <tablePath>/p1=1/p2=2/p3=3 ---> p1=1/p2=2/p3=3
-        if (tablePathStr.endsWith("/")) {
-          paritions.add(path.toString().substring(tablePathStr.length()));
-        } else {
-          paritions.add(path.toString().substring(tablePathStr.length() + 1));
-        }
-      }
-      // Remove all partition paths which does not matches the filter expression.
-      expressionProxy.filterPartitionsByExpr(partColumns, filterExp,
-          conf.get(MetastoreConf.ConfVars.DEFAULTPARTITIONNAME.getVarname()), paritions);
-
-      // now the partition list will contain all the paths that matches the filter expression.
-      // add them back to partDirs.
-      for (String path : paritions) {
-        partDirs.add(new Path(tablePath, path));
-      }
-      allPartDirs = partDirs;
-    }
-    // don't want the table dir
-    allPartDirs.remove(tablePath);
-
-    // remove the partition paths we know about
-    allPartDirs.removeAll(partPaths);
-
-    Set<String> partColNames = Sets.newHashSet();
-    for(FieldSchema fSchema : getPartCols(table)) {
-      partColNames.add(fSchema.getName());
-    }
-
-    Map<String, String> partitionColToTypeMap = getPartitionColtoTypeMap(table.getPartitionKeys());
-    // we should now only have the unexpected folders left
-    for (Path partPath : allPartDirs) {
-      FileSystem fs = partPath.getFileSystem(conf);
-      String partitionName = getPartitionName(fs.makeQualified(tablePath),
-          partPath, partColNames, partitionColToTypeMap);
-      LOG.debug("PartitionName: " + partitionName);
-
-      if (partitionName != null) {
-        CheckResult.PartitionResult pr = new CheckResult.PartitionResult();
-        pr.setPartitionName(partitionName);
-        pr.setTableName(table.getTableName());
-        // Also set the correct partition path here as creating path from Warehouse.makePartPath will always return
-        // lowercase keys/path. Even if we add the new partition with lowerkeys, get queries on such partition
-        // will not return any results.
-        pr.setPath(partPath);
-
-        // Check if partition already exists. No need to check for those partition which are present in db
-        // but no in fs as msck will override the partition location in db
-        if (result.getCorrectPartitions().contains(pr)) {
-          String msg = "The partition '" + pr.toString() + "' already exists for table" + table.getTableName();
-          throw new MetastoreException(msg);
-        } else if (result.getPartitionsNotInMs().contains(pr)) {
-          String msg = "Found two paths for same partition '" + pr.toString() + "' for table " + table.getTableName();
-          throw new MetastoreException(msg);
-        }
-        if (transactionalTable) {
-          setMaxTxnAndWriteIdFromPartition(partPath, pr);
-        }
-        result.getPartitionsNotInMs().add(pr);
-        if (result.getPartitionsNotOnFs().contains(pr)) {
-          result.getPartitionsNotOnFs().remove(pr);
-        }
-      }
-    }
-    LOG.debug("Number of partitions not in metastore : " + result.getPartitionsNotInMs().size());
-  }
-
-  /**
-   * Calculate the maximum seen writeId from the acid directory structure
-   * @param partPath Path of the partition directory
-   * @param res Partition result to write the max ids
-   * @throws IOException ex
-   */
-  private void setMaxTxnAndWriteIdFromPartition(Path partPath, CheckResult.PartitionResult res) throws IOException {
-    FileSystem fs = partPath.getFileSystem(conf);
-    FileStatus[] deltaOrBaseFiles = fs.listStatus(partPath, HIDDEN_FILES_PATH_FILTER);
-
-    // Read the writeIds from every base and delta directory and find the max
-    long maxWriteId = 0L;
-    long maxVisibilityId = 0L;
-    for (FileStatus fileStatus : deltaOrBaseFiles) {
-      if (!fileStatus.isDirectory()) {
-        continue;
-      }
-      long writeId = 0L;
-      long visibilityId = 0L;
-      String folder = fileStatus.getPath().getName();
-      String visParts[] = folder.split(VISIBILITY_PREFIX);
-      if (visParts.length > 1) {
-        visibilityId = Long.parseLong(visParts[1]);
-        folder = visParts[0];
-      }
-      if (folder.startsWith(BASE_PREFIX)) {
-        writeId = Long.parseLong(folder.substring(BASE_PREFIX.length()));
-      } else if (folder.startsWith(DELTA_PREFIX) || folder.startsWith(DELETE_DELTA_PREFIX)) {
-        // See AcidUtils.parseDelta
-        boolean isDeleteDelta = folder.startsWith(DELETE_DELTA_PREFIX);
-        String rest = folder.substring((isDeleteDelta ? DELETE_DELTA_PREFIX : DELTA_PREFIX).length());
-        String[] nameParts = rest.split("_");
-        // We always want the second part (it is either the same or greater if it is a compacted delta)
-        writeId = Long.parseLong(nameParts.length > 1 ? nameParts[1] : nameParts[0]);
-      }
-      if (writeId > maxWriteId) {
-        maxWriteId = writeId;
-      }
-      if (visibilityId > maxVisibilityId) {
-        maxVisibilityId = visibilityId;
-      }
-    }
-    LOG.debug("Max writeId {}, max txnId {} found in partition {}", maxWriteId, maxVisibilityId,
-        partPath.toUri().toString());
-    res.setMaxWriteId(maxWriteId);
-    res.setMaxTxnId(maxVisibilityId);
-  }
-
-  /**
-   * Assume that depth is 2, i.e., partition columns are a and b
-   * tblPath/a=1  => throw exception
-   * tblPath/a=1/file => throw exception
-   * tblPath/a=1/b=2/file => return a=1/b=2
-   * tblPath/a=1/b=2/c=3 => return a=1/b=2
-   * tblPath/a=1/b=2/c=3/file => return a=1/b=2
-   *
-   * @param basePath
-   *          Start directory
-   * @param allDirs
-   *          This set will contain the leaf paths at the end.
-   * @param partColNames
-   *          Partition column names
-   * @throws IOException
-   *           Thrown if we can't get lists from the fs.
-   * @throws MetastoreException ex
-   */
-
-  private void checkPartitionDirs(Path basePath, Set<Path> allDirs, final List<String> partColNames)
-      throws IOException, MetastoreException {
-    // Here we just reuse the THREAD_COUNT configuration for
-    // METASTORE_FS_HANDLER_THREADS_COUNT since this results in better performance
-    // The number of missing partitions discovered are later added by metastore using a
-    // threadpool of size METASTORE_FS_HANDLER_THREADS_COUNT. If we have different sized
-    // pool here the smaller sized pool of the two becomes a bottleneck
-    int poolSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.FS_HANDLER_THREADS_COUNT);
-
-    ExecutorService executor;
-    if (poolSize <= 1) {
-      LOG.debug("Using single-threaded version of MSCK-GetPaths");
-      executor = MoreExecutors.newDirectExecutorService();
-    } else {
-      LOG.debug("Using multi-threaded version of MSCK-GetPaths with number of threads " + poolSize);
-      ThreadFactory threadFactory =
-          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("MSCK-GetPaths-%d").build();
-      executor = Executors.newFixedThreadPool(poolSize, threadFactory);
-    }
-    checkPartitionDirs(executor, basePath, allDirs, basePath.getFileSystem(conf), partColNames);
-
-    executor.shutdown();
-  }
-
-  private final class PathDepthInfoCallable implements Callable<Path> {
-    private final List<String> partColNames;
-    private final FileSystem fs;
-    private final ConcurrentLinkedQueue<PathDepthInfo> pendingPaths;
-    private final boolean throwException;
-    private final PathDepthInfo pd;
-
-    private PathDepthInfoCallable(PathDepthInfo pd, List<String> partColNames, FileSystem fs,
-        ConcurrentLinkedQueue<PathDepthInfo> basePaths) {
-      this.partColNames = partColNames;
-      this.pd = pd;
-      this.fs = fs;
-      this.pendingPaths = basePaths;
-      this.throwException = "throw".equals(MetastoreConf.getVar(conf, MetastoreConf.ConfVars.MSCK_PATH_VALIDATION));
-    }
-
-    @Override
-    public Path call() throws Exception {
-      return processPathDepthInfo(pd);
-    }
-
-    private Path processPathDepthInfo(final PathDepthInfo pd)
-        throws IOException, MetastoreException {
-      final Path currentPath = pd.p;
-      final int currentDepth = pd.depth;
-      if (currentDepth == partColNames.size()) {
-        return currentPath;
-      }
-      FileStatus[] fileStatuses = fs.listStatus(currentPath, FileUtils.HIDDEN_FILES_PATH_FILTER);
-      // found no files under a sub-directory under table base path; it is possible that the table
-      // is empty and hence there are no partition sub-directories created under base path
-      if (fileStatuses.length == 0 && currentDepth > 0) {
-        // since maxDepth is not yet reached, we are missing partition
-        // columns in currentPath
-        logOrThrowExceptionWithMsg(
-            "MSCK is missing partition columns under " + currentPath.toString());
-      } else {
-        // found files under currentPath add them to the queue if it is a directory
-        for (FileStatus fileStatus : fileStatuses) {
-          if (!fileStatus.isDirectory()) {
-            // found a file at depth which is less than number of partition keys
-            logOrThrowExceptionWithMsg(
-                "MSCK finds a file rather than a directory when it searches for "
-                    + fileStatus.getPath().toString());
-          } else {
-            // found a sub-directory at a depth less than number of partition keys
-            // validate if the partition directory name matches with the corresponding
-            // partition colName at currentDepth
-            Path nextPath = fileStatus.getPath();
-            String[] parts = nextPath.getName().split("=");
-            if (parts.length != 2) {
-              logOrThrowExceptionWithMsg("Invalid partition name " + nextPath);
-            } else if (!parts[0].equalsIgnoreCase(partColNames.get(currentDepth))) {
-              logOrThrowExceptionWithMsg(
-                  "Unexpected partition key " + parts[0] + " found at " + nextPath);
+                findUnknownTables(catName, dbName, tables, result);
+            } else if (filterExp != null) {
+                // check for specified partitions which matches filter expression
+                checkTable(catName, dbName, tableName, filterExp, table, result);
             } else {
-              // add sub-directory to the work queue if maxDepth is not yet reached
-              pendingPaths.add(new PathDepthInfo(nextPath, currentDepth + 1));
+                // only one table, let's check all partitions
+                checkTable(catName, dbName, tableName, null, table, result);
             }
-          }
+
+            LOG.info("Number of partitionsNotInMs=" + result.getPartitionsNotInMs()
+                    + ", partitionsNotOnFs=" + result.getPartitionsNotOnFs()
+                    + ", tablesNotInMs=" + result.getTablesNotInMs()
+                    + ", tablesNotOnFs=" + result.getTablesNotOnFs()
+                    + ", expiredPartitions=" + result.getExpiredPartitions());
+        } catch (TException e) {
+            throw new MetastoreException(e);
         }
-      }
-      return null;
+        return result;
     }
 
-    private void logOrThrowExceptionWithMsg(String msg) throws MetastoreException {
-      if(throwException) {
-        throw new MetastoreException(msg);
-      } else {
-        LOG.warn(msg);
-      }
-    }
-  }
+    /**
+     * Check for table directories that aren't in the metastore.
+     *
+     * @param catName name of the catalog, if not specified default catalog will be used.
+     * @param dbName  Name of the database
+     * @param tables  List of table names
+     * @param result  Add any found tables to this
+     * @throws IOException           Most likely filesystem related
+     * @throws MetaException         Failed to get required information from the metastore.
+     * @throws NoSuchObjectException Failed to get required information from the metastore.
+     * @throws TException            Thrift communication error.
+     */
+    void findUnknownTables(String catName, String dbName, List<String> tables, CheckResult result)
+            throws IOException, MetaException, TException {
 
-  private static class PathDepthInfo {
-    private final Path p;
-    private final int depth;
-    PathDepthInfo(Path p, int depth) {
-      this.p = p;
-      this.depth = depth;
-    }
-  }
+        Set<Path> dbPaths = new HashSet<>();
+        Set<String> tableNames = new HashSet<>(tables);
 
-  @VisibleForTesting
-  void checkPartitionDirs(final ExecutorService executor,
-      final Path basePath, final Set<Path> result,
-      final FileSystem fs, final List<String> partColNames) throws MetastoreException {
-    try {
-      Queue<Future<Path>> futures = new LinkedList<>();
-      ConcurrentLinkedQueue<PathDepthInfo> nextLevel = new ConcurrentLinkedQueue<>();
-      nextLevel.add(new PathDepthInfo(basePath, 0));
-      //Uses level parallel implementation of a bfs. Recursive DFS implementations
-      //have a issue where the number of threads can run out if the number of
-      //nested sub-directories is more than the pool size.
-      //Using a two queue implementation is simpler than one queue since then we will
-      //have to add the complex mechanisms to let the free worker threads know when new levels are
-      //discovered using notify()/wait() mechanisms which can potentially lead to bugs if
-      //not done right
-      while(!nextLevel.isEmpty()) {
-        ConcurrentLinkedQueue<PathDepthInfo> tempQueue = new ConcurrentLinkedQueue<>();
-        //process each level in parallel
-        while(!nextLevel.isEmpty()) {
-          futures.add(
-              executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue)));
+        for (String tableName : tables) {
+            Table table = getMsc().getTable(catName, dbName, tableName);
+            // hack, instead figure out a way to get the db paths
+            String isExternal = table.getParameters().get("EXTERNAL");
+            if (!"TRUE".equalsIgnoreCase(isExternal)) {
+                Path tablePath = getPath(table);
+                if (tablePath != null) {
+                    dbPaths.add(tablePath.getParent());
+                }
+            }
         }
-        while(!futures.isEmpty()) {
-          Path p = futures.poll().get();
-          if (p != null) {
-            result.add(p);
-          }
+
+        for (Path dbPath : dbPaths) {
+            FileSystem fs = dbPath.getFileSystem(conf);
+            FileStatus[] statuses = fs.listStatus(dbPath, FileUtils.HIDDEN_FILES_PATH_FILTER);
+            for (FileStatus status : statuses) {
+
+                if (status.isDirectory() && !tableNames.contains(status.getPath().getName())) {
+
+                    result.getTablesNotInMs().add(status.getPath().getName());
+                }
+            }
         }
-        //update the nextlevel with newly discovered sub-directories from the above
-        nextLevel = tempQueue;
-      }
-    } catch (InterruptedException | ExecutionException e) {
-      LOG.error("Exception received while listing partition directories", e);
-      executor.shutdownNow();
-      throw new MetastoreException(e.getCause());
     }
-  }
+
+    /**
+     * Check the metastore for inconsistencies, data missing in either the
+     * metastore or on the dfs.
+     *
+     * @param catName   name of the catalog, if not specified default catalog will be used.
+     * @param dbName    Name of the database
+     * @param tableName Name of the table
+     * @param filterExp Filter expression which is used to prune th partition from the
+     *                  metastore and FileSystem.
+     * @param table     Table we want to run the check for.
+     * @param result    Result object
+     * @throws MetastoreException Failed to get required information from the metastore.
+     * @throws IOException        Most likely filesystem related
+     * @throws MetaException      Failed to get required information from the metastore.
+     */
+    void checkTable(String catName, String dbName, String tableName, byte[] filterExp, Table table, CheckResult result)
+            throws MetaException, IOException, MetastoreException {
+
+        if (table == null) {
+            try {
+                table = getMsc().getTable(catName, dbName, tableName);
+            } catch (TException e) {
+                result.getTablesNotInMs().add(tableName);
+                return;
+            }
+        }
+
+        PartitionIterable parts;
+
+        if (isPartitioned(table)) {
+            if (filterExp != null) {
+                List<Partition> results = new ArrayList<>();
+                getPartitionListByFilterExp(getMsc(), table, filterExp,
+                        MetastoreConf.getVar(conf, MetastoreConf.ConfVars.DEFAULTPARTITIONNAME), results);
+                parts = new PartitionIterable(results);
+            } else {
+                int batchSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
+                if (batchSize > 0) {
+                    parts = new PartitionIterable(getMsc(), table, batchSize);
+                } else {
+                    List<Partition> loadedPartitions = getAllPartitionsOf(getMsc(), table);
+                    parts = new PartitionIterable(loadedPartitions);
+                }
+            }
+        } else {
+            parts = new PartitionIterable(Collections.emptyList());
+        }
+
+        checkTable(table, parts, filterExp, result);
+    }
+
+    /**
+     * Check the metastore for inconsistencies, data missing in either the
+     * metastore or on the dfs.
+     *
+     * @param table     Table to check
+     * @param parts     Partitions to check
+     * @param result    Result object
+     * @param filterExp Filter expression which is used to prune th partition from the
+     *                  metastore and FileSystem.
+     * @throws IOException        Could not get information from filesystem
+     * @throws MetastoreException Could not create Partition object
+     */
+    void checkTable(Table table, PartitionIterable parts, byte[] filterExp, CheckResult result) throws IOException,
+            MetastoreException, MetaException {
+
+        Path tablePath = getPath(table);
+        if (tablePath == null) {
+            return;
+        }
+        final FileSystem[] fs = {tablePath.getFileSystem(conf)};
+        if (!fs[0].exists(tablePath)) {
+            result.getTablesNotOnFs().add(table.getTableName());
+            return;
+        }
+
+        Set<Path> partPaths = new HashSet<>();
+
+        int threadCount = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.METASTORE_MSCK_FS_HANDLER_THREADS_COUNT);
+
+        final ExecutorService pool = (threadCount > 1) ?
+                Executors.newFixedThreadPool(threadCount,
+                        new ThreadFactoryBuilder()
+                                .setDaemon(true)
+                                .setNameFormat("CheckTable-PartitionOptimizer-%d").build()) : null;
+
+        try {
+            Queue<Future<String>> futures = new LinkedList<>();
+            if (pool != null) {
+                // check that the partition folders exist on disk using multi-thread
+                for (Partition partition : parts) {
+                    if (partition == null) {
+                        // most likely the user specified an invalid partition
+                        continue;
+                    }
+                    final Path[] partPath = {getDataLocation(table, partition)};
+                    if (partPath[0] == null) {
+                        continue;
+                    }
+                    futures.add(pool.submit(new Callable() {
+                        @Override
+                        public Object call() throws Exception {
+                            fs[0] = partPath[0].getFileSystem(conf);
+                            CheckResult.PartitionResult prFromMetastore = new CheckResult.PartitionResult();
+                            prFromMetastore.setPartitionName(getPartitionName(table, partition));
+                            prFromMetastore.setTableName(partition.getTableName());
+                            if (!fs[0].exists(partPath[0])) {
+                                result.getPartitionsNotOnFs().add(prFromMetastore);
+                            } else {
+                                result.getCorrectPartitions().add(prFromMetastore);
+                            }
+
+                            if (partitionExpirySeconds > 0) {
+                                long currentEpochSecs = Instant.now().getEpochSecond();
+                                long createdTime = partition.getCreateTime();
+                                long partitionAgeSeconds = currentEpochSecs - createdTime;
+                                if (partitionAgeSeconds > partitionExpirySeconds) {
+                                    CheckResult.PartitionResult pr = new CheckResult.PartitionResult();
+                                    pr.setPartitionName(getPartitionName(table, partition));
+                                    pr.setTableName(partition.getTableName());
+                                    result.getExpiredPartitions().add(pr);
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug("{}.{}.{}.{} expired. createdAt: {} current: {} age: {}s expiry: {}s", partition.getCatName(),
+                                                partition.getDbName(), partition.getTableName(), pr.getPartitionName(), createdTime, currentEpochSecs,
+                                                partitionAgeSeconds, partitionExpirySeconds);
+                                    }
+                                }
+                            }
+
+                            for (int i = 0; i < getPartitionSpec(table, partition).size(); i++) {
+                                final Path qualifiedPath = partPath[0].makeQualified(fs[0]);
+                                partPaths.add(qualifiedPath);
+                                partPath[0] = partPath[0].getParent();
+                            }
+                            return "CheckTable multi-thread task complete.";
+                        }
+                    }));
+                }
+            } else {
+                // check that the partition folders exist on disk using single thread
+                for (Partition partition : parts) {
+                    if (partition == null) {
+                        // most likely the user specified an invalid partition
+                        continue;
+                    }
+                    Path partPath = getDataLocation(table, partition);
+                    if (partPath == null) {
+                        continue;
+                    }
+                    fs[0] = partPath.getFileSystem(conf);
+
+                    CheckResult.PartitionResult prFromMetastore = new CheckResult.PartitionResult();
+                    prFromMetastore.setPartitionName(getPartitionName(table, partition));
+                    prFromMetastore.setTableName(partition.getTableName());
+                    if (!fs[0].exists(partPath)) {
+                        result.getPartitionsNotOnFs().add(prFromMetastore);
+                    } else {
+                        result.getCorrectPartitions().add(prFromMetastore);
+                    }
+
+                    if (partitionExpirySeconds > 0) {
+                        long currentEpochSecs = Instant.now().getEpochSecond();
+                        long createdTime = partition.getCreateTime();
+                        long partitionAgeSeconds = currentEpochSecs - createdTime;
+                        if (partitionAgeSeconds > partitionExpirySeconds) {
+                            CheckResult.PartitionResult pr = new CheckResult.PartitionResult();
+                            pr.setPartitionName(getPartitionName(table, partition));
+                            pr.setTableName(partition.getTableName());
+                            result.getExpiredPartitions().add(pr);
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{}.{}.{}.{} expired. createdAt: {} current: {} age: {}s expiry: {}s", partition.getCatName(),
+                                        partition.getDbName(), partition.getTableName(), pr.getPartitionName(), createdTime, currentEpochSecs,
+                                        partitionAgeSeconds, partitionExpirySeconds);
+                            }
+                        }
+                    }
+
+                    for (int i = 0; i < getPartitionSpec(table, partition).size(); i++) {
+                        Path qualifiedPath = partPath.makeQualified(fs[0]);
+                        partPaths.add(qualifiedPath);
+                        partPath = partPath.getParent();
+                    }
+                }
+            }
+            while (!futures.isEmpty()) {
+                String message = futures.poll().get();
+                LOG.debug(message);
+            }
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            LOG.info("Partition exists check complete.");
+            if (pool != null) {
+                pool.shutdownNow();
+            }
+        }
+
+        findUnknownPartitions(table, partPaths, filterExp, result);
+
+        if (!isPartitioned(table) && TxnUtils.isTransactionalTable(table)) {
+            // Check for writeIds in the table directory
+            CheckResult.PartitionResult tableResult = new CheckResult.PartitionResult();
+            setMaxTxnAndWriteIdFromPartition(tablePath, tableResult);
+            result.setMaxWriteId(tableResult.getMaxWriteId());
+            result.setMaxTxnId(tableResult.getMaxTxnId());
+        }
+    }
+
+    /**
+     * Find partitions on the fs that are unknown to the metastore.
+     *
+     * @param table     Table where the partitions would be located
+     * @param partPaths Paths of the partitions the ms knows about
+     * @param filterExp Filter expression which is used to prune th partition from the
+     *                  metastore and FileSystem.
+     * @param result    Result object
+     * @throws IOException        Thrown if we fail at fetching listings from the fs.
+     * @throws MetastoreException ex
+     */
+    void findUnknownPartitions(Table table, Set<Path> partPaths, byte[] filterExp,
+                               CheckResult result) throws IOException, MetastoreException, MetaException {
+
+        Path tablePath = getPath(table);
+        if (tablePath == null) {
+            return;
+        }
+        boolean transactionalTable = TxnUtils.isTransactionalTable(table);
+        // now check the table folder and see if we find anything
+        // that isn't in the metastore
+        Set<Path> allPartDirs = new HashSet<>();
+        List<FieldSchema> partColumns = table.getPartitionKeys();
+        checkPartitionDirs(tablePath, allPartDirs, Collections.unmodifiableList(getPartColNames(table)));
+
+        if (filterExp != null) {
+            PartitionExpressionProxy expressionProxy = createExpressionProxy(conf);
+            List<String> paritions = new ArrayList<>();
+            Set<Path> partDirs = new HashSet<Path>();
+            String tablePathStr = tablePath.toString();
+            for (Path path : allPartDirs) {
+                // remove the table's path from the partition path
+                // eg: <tablePath>/p1=1/p2=2/p3=3 ---> p1=1/p2=2/p3=3
+                if (tablePathStr.endsWith("/")) {
+                    paritions.add(path.toString().substring(tablePathStr.length()));
+                } else {
+                    paritions.add(path.toString().substring(tablePathStr.length() + 1));
+                }
+            }
+            // Remove all partition paths which does not matches the filter expression.
+            expressionProxy.filterPartitionsByExpr(partColumns, filterExp,
+                    conf.get(MetastoreConf.ConfVars.DEFAULTPARTITIONNAME.getVarname()), paritions);
+
+            // now the partition list will contain all the paths that matches the filter expression.
+            // add them back to partDirs.
+            for (String path : paritions) {
+                partDirs.add(new Path(tablePath, path));
+            }
+            allPartDirs = partDirs;
+        }
+        // don't want the table dir
+        allPartDirs.remove(tablePath);
+
+        // remove the partition paths we know about
+        allPartDirs.removeAll(partPaths);
+
+        Set<String> partColNames = Sets.newHashSet();
+        for (FieldSchema fSchema : getPartCols(table)) {
+            partColNames.add(fSchema.getName());
+        }
+
+        Map<String, String> partitionColToTypeMap = getPartitionColtoTypeMap(table.getPartitionKeys());
+        // we should now only have the unexpected folders left
+        for (Path partPath : allPartDirs) {
+            FileSystem fs = partPath.getFileSystem(conf);
+            String partitionName = getPartitionName(fs.makeQualified(tablePath),
+                    partPath, partColNames, partitionColToTypeMap);
+            LOG.debug("PartitionName: " + partitionName);
+
+            if (partitionName != null) {
+                CheckResult.PartitionResult pr = new CheckResult.PartitionResult();
+                pr.setPartitionName(partitionName);
+                pr.setTableName(table.getTableName());
+                // Also set the correct partition path here as creating path from Warehouse.makePartPath will always return
+                // lowercase keys/path. Even if we add the new partition with lowerkeys, get queries on such partition
+                // will not return any results.
+                pr.setPath(partPath);
+
+                // Check if partition already exists. No need to check for those partition which are present in db
+                // but no in fs as msck will override the partition location in db
+                if (result.getCorrectPartitions().contains(pr)) {
+                    String msg = "The partition '" + pr.toString() + "' already exists for table" + table.getTableName();
+                    throw new MetastoreException(msg);
+                } else if (result.getPartitionsNotInMs().contains(pr)) {
+                    String msg = "Found two paths for same partition '" + pr.toString() + "' for table " + table.getTableName();
+                    throw new MetastoreException(msg);
+                }
+                if (transactionalTable) {
+                    setMaxTxnAndWriteIdFromPartition(partPath, pr);
+                }
+                result.getPartitionsNotInMs().add(pr);
+                if (result.getPartitionsNotOnFs().contains(pr)) {
+                    result.getPartitionsNotOnFs().remove(pr);
+                }
+            }
+        }
+        LOG.debug("Number of partitions not in metastore : " + result.getPartitionsNotInMs().size());
+    }
+
+    /**
+     * Calculate the maximum seen writeId from the acid directory structure
+     *
+     * @param partPath Path of the partition directory
+     * @param res      Partition result to write the max ids
+     * @throws IOException ex
+     */
+    private void setMaxTxnAndWriteIdFromPartition(Path partPath, CheckResult.PartitionResult res) throws IOException {
+        FileSystem fs = partPath.getFileSystem(conf);
+        FileStatus[] deltaOrBaseFiles = fs.listStatus(partPath, HIDDEN_FILES_PATH_FILTER);
+
+        // Read the writeIds from every base and delta directory and find the max
+        long maxWriteId = 0L;
+        long maxVisibilityId = 0L;
+        for (FileStatus fileStatus : deltaOrBaseFiles) {
+            if (!fileStatus.isDirectory()) {
+                continue;
+            }
+            long writeId = 0L;
+            long visibilityId = 0L;
+            String folder = fileStatus.getPath().getName();
+            String visParts[] = folder.split(VISIBILITY_PREFIX);
+            if (visParts.length > 1) {
+                visibilityId = Long.parseLong(visParts[1]);
+                folder = visParts[0];
+            }
+            if (folder.startsWith(BASE_PREFIX)) {
+                writeId = Long.parseLong(folder.substring(BASE_PREFIX.length()));
+            } else if (folder.startsWith(DELTA_PREFIX) || folder.startsWith(DELETE_DELTA_PREFIX)) {
+                // See AcidUtils.parseDelta
+                boolean isDeleteDelta = folder.startsWith(DELETE_DELTA_PREFIX);
+                String rest = folder.substring((isDeleteDelta ? DELETE_DELTA_PREFIX : DELTA_PREFIX).length());
+                String[] nameParts = rest.split("_");
+                // We always want the second part (it is either the same or greater if it is a compacted delta)
+                writeId = Long.parseLong(nameParts.length > 1 ? nameParts[1] : nameParts[0]);
+            }
+            if (writeId > maxWriteId) {
+                maxWriteId = writeId;
+            }
+            if (visibilityId > maxVisibilityId) {
+                maxVisibilityId = visibilityId;
+            }
+        }
+        LOG.debug("Max writeId {}, max txnId {} found in partition {}", maxWriteId, maxVisibilityId,
+                partPath.toUri().toString());
+        res.setMaxWriteId(maxWriteId);
+        res.setMaxTxnId(maxVisibilityId);
+    }
+
+    /**
+     * Assume that depth is 2, i.e., partition columns are a and b
+     * tblPath/a=1  => throw exception
+     * tblPath/a=1/file => throw exception
+     * tblPath/a=1/b=2/file => return a=1/b=2
+     * tblPath/a=1/b=2/c=3 => return a=1/b=2
+     * tblPath/a=1/b=2/c=3/file => return a=1/b=2
+     *
+     * @param basePath     Start directory
+     * @param allDirs      This set will contain the leaf paths at the end.
+     * @param partColNames Partition column names
+     * @throws IOException        Thrown if we can't get lists from the fs.
+     * @throws MetastoreException ex
+     */
+
+    private void checkPartitionDirs(Path basePath, Set<Path> allDirs, final List<String> partColNames)
+            throws IOException, MetastoreException {
+        // Here we just reuse the THREAD_COUNT configuration for
+        // METASTORE_FS_HANDLER_THREADS_COUNT since this results in better performance
+        // The number of missing partitions discovered are later added by metastore using a
+        // threadpool of size METASTORE_FS_HANDLER_THREADS_COUNT. If we have different sized
+        // pool here the smaller sized pool of the two becomes a bottleneck
+        int poolSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.FS_HANDLER_THREADS_COUNT);
+
+        ExecutorService executor;
+        if (poolSize <= 1) {
+            LOG.debug("Using single-threaded version of MSCK-GetPaths");
+            executor = MoreExecutors.newDirectExecutorService();
+        } else {
+            LOG.debug("Using multi-threaded version of MSCK-GetPaths with number of threads " + poolSize);
+            ThreadFactory threadFactory =
+                    new ThreadFactoryBuilder().setDaemon(true).setNameFormat("MSCK-GetPaths-%d").build();
+            executor = Executors.newFixedThreadPool(poolSize, threadFactory);
+        }
+        checkPartitionDirs(executor, basePath, allDirs, basePath.getFileSystem(conf), partColNames);
+
+        executor.shutdown();
+    }
+
+    private final class PathDepthInfoCallable implements Callable<Path> {
+        private final List<String> partColNames;
+        private final FileSystem fs;
+        private final ConcurrentLinkedQueue<PathDepthInfo> pendingPaths;
+        private final boolean throwException;
+        private final PathDepthInfo pd;
+
+        private PathDepthInfoCallable(PathDepthInfo pd, List<String> partColNames, FileSystem fs,
+                                      ConcurrentLinkedQueue<PathDepthInfo> basePaths) {
+            this.partColNames = partColNames;
+            this.pd = pd;
+            this.fs = fs;
+            this.pendingPaths = basePaths;
+            this.throwException = "throw".equals(MetastoreConf.getVar(conf, MetastoreConf.ConfVars.MSCK_PATH_VALIDATION));
+        }
+
+        @Override
+        public Path call() throws Exception {
+            return processPathDepthInfo(pd);
+        }
+
+        private Path processPathDepthInfo(final PathDepthInfo pd)
+                throws IOException, MetastoreException {
+            final Path currentPath = pd.p;
+            final int currentDepth = pd.depth;
+            if (currentDepth == partColNames.size()) {
+                return currentPath;
+            }
+            FileStatus[] fileStatuses = fs.listStatus(currentPath, FileUtils.HIDDEN_FILES_PATH_FILTER);
+            // found no files under a sub-directory under table base path; it is possible that the table
+            // is empty and hence there are no partition sub-directories created under base path
+            if (fileStatuses.length == 0 && currentDepth > 0) {
+                // since maxDepth is not yet reached, we are missing partition
+                // columns in currentPath
+                logOrThrowExceptionWithMsg(
+                        "MSCK is missing partition columns under " + currentPath.toString());
+            } else {
+                // found files under currentPath add them to the queue if it is a directory
+                for (FileStatus fileStatus : fileStatuses) {
+                    if (!fileStatus.isDirectory()) {
+                        // found a file at depth which is less than number of partition keys
+                        logOrThrowExceptionWithMsg(
+                                "MSCK finds a file rather than a directory when it searches for "
+                                        + fileStatus.getPath().toString());
+                    } else {
+                        // found a sub-directory at a depth less than number of partition keys
+                        // validate if the partition directory name matches with the corresponding
+                        // partition colName at currentDepth
+                        Path nextPath = fileStatus.getPath();
+                        String[] parts = nextPath.getName().split("=");
+                        if (parts.length != 2) {
+                            logOrThrowExceptionWithMsg("Invalid partition name " + nextPath);
+                        } else if (!parts[0].equalsIgnoreCase(partColNames.get(currentDepth))) {
+                            logOrThrowExceptionWithMsg(
+                                    "Unexpected partition key " + parts[0] + " found at " + nextPath);
+                        } else {
+                            // add sub-directory to the work queue if maxDepth is not yet reached
+                            pendingPaths.add(new PathDepthInfo(nextPath, currentDepth + 1));
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private void logOrThrowExceptionWithMsg(String msg) throws MetastoreException {
+            if (throwException) {
+                throw new MetastoreException(msg);
+            } else {
+                LOG.warn(msg);
+            }
+        }
+    }
+
+    private static class PathDepthInfo {
+        private final Path p;
+        private final int depth;
+
+        PathDepthInfo(Path p, int depth) {
+            this.p = p;
+            this.depth = depth;
+        }
+    }
+
+    @VisibleForTesting
+    void checkPartitionDirs(final ExecutorService executor,
+                            final Path basePath, final Set<Path> result,
+                            final FileSystem fs, final List<String> partColNames) throws MetastoreException {
+        try {
+            Queue<Future<Path>> futures = new LinkedList<>();
+            ConcurrentLinkedQueue<PathDepthInfo> nextLevel = new ConcurrentLinkedQueue<>();
+            nextLevel.add(new PathDepthInfo(basePath, 0));
+            //Uses level parallel implementation of a bfs. Recursive DFS implementations
+            //have a issue where the number of threads can run out if the number of
+            //nested sub-directories is more than the pool size.
+            //Using a two queue implementation is simpler than one queue since then we will
+            //have to add the complex mechanisms to let the free worker threads know when new levels are
+            //discovered using notify()/wait() mechanisms which can potentially lead to bugs if
+            //not done right
+            while (!nextLevel.isEmpty()) {
+                ConcurrentLinkedQueue<PathDepthInfo> tempQueue = new ConcurrentLinkedQueue<>();
+                //process each level in parallel
+                while (!nextLevel.isEmpty()) {
+                    futures.add(
+                            executor.submit(new PathDepthInfoCallable(nextLevel.poll(), partColNames, fs, tempQueue)));
+                }
+                while (!futures.isEmpty()) {
+                    Path p = futures.poll().get();
+                    if (p != null) {
+                        result.add(p);
+                    }
+                }
+                //update the nextlevel with newly discovered sub-directories from the above
+                nextLevel = tempQueue;
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            LOG.error("Exception received while listing partition directories", e);
+            executor.shutdownNow();
+            throw new MetastoreException(e.getCause());
+        }
+    }
 }


### PR DESCRIPTION
…lti-threaded

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Make [HiveMetaStoreChecker.checkTable](https://github.com/apache/hive/blob/master/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java#L299) operation run with multi threaded plus allow user to configure number of threads. 

### Why are the changes needed?
Currently [HiveMetaStoreChecker.checkTable](https://github.com/apache/hive/blob/master/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java#L299) is implemented with serialized operation to check current partitions in a table as part of MSCK operation, this can be run in parallel to improve the overall performance for MSCK Repair table queries.
If the table has 1000s of partitions on Cloud Storage (S3), this operation could take longer to run. Changing it to run multithreaded will improve performance.


### Does this PR introduce _any_ user-facing change?
Yes, PR introduces new configuration property with no changes for user by default.
Property: hive.metastore.msck.fshandler.threads/metastore.msck.fshandler.threads which defaults to 1 and that is current behavior, however based on user requirement it can be configured at the service/session level.


### How was this patch tested?
For stability of the patch added new clientpositive test case -> msck_repair_multi_thread.q
additionally the patch was tested manually in terms of performance.
i.e with 33k partitions without patch MSCK operation took 2000 seconds vs with Patch 200 seconds.
