### PR TITLE
HIVE-25983  The error thrown by CONCAT_WS function when the array passed in is a non string array is a problem

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
@@ -57,27 +57,31 @@ public class GenericUDFConcatWS extends GenericUDF {
   public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
     if (arguments.length < 2) {
       throw new UDFArgumentLengthException(
-          "The function CONCAT_WS(separator,[string | array(string)]+) "
-            + "needs at least two arguments.");
+              "The function CONCAT_WS(separator,[string | array(string)]+) "
+                      + "needs at least two arguments.");
     }
 
     // check if argument is a string or an array of strings
     for (int i = 0; i < arguments.length; i++) {
+      boolean flag = false;
       switch(arguments[i].getCategory()) {
         case LIST:
           if (isStringOrVoidType(
-              ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
+                  ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
             break;
-          }
+          }else flag=true;
         case PRIMITIVE:
           if (isStringOrVoidType(arguments[i])) {
-          break;
+            break;
           }
         default:
+          String outError = arguments[i].getTypeName();
+          //(PrimitiveObjectInspector) oi).getPrimitiveCategory()
+          if (flag) outError="the element in this array is " + ((PrimitiveObjectInspector)((ListObjectInspector) arguments[i]).getListElementObjectInspector()).getPrimitiveCategory().name();
           throw new UDFArgumentTypeException(i, "Argument " + (i + 1)
-            + " of function CONCAT_WS must be \"" + serdeConstants.STRING_TYPE_NAME
-            + " or " + serdeConstants.LIST_TYPE_NAME + "<" + serdeConstants.STRING_TYPE_NAME
-            + ">\", but \"" + arguments[i].getTypeName() + "\" was found.");
+                  + " of function CONCAT_WS must be \"" + serdeConstants.STRING_TYPE_NAME
+                  + " or " + serdeConstants.LIST_TYPE_NAME + "<" + serdeConstants.STRING_TYPE_NAME
+                  + ">\", but " + outError + " was found.");
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
@@ -67,7 +67,7 @@ public class GenericUDFConcatWS extends GenericUDF {
       switch(arguments[i].getCategory()) {
         case LIST:
           if (isStringOrVoidType(
-               ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
+              ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
             break;
           }else flag=true;
         case PRIMITIVE:

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
@@ -58,7 +58,7 @@ public class GenericUDFConcatWS extends GenericUDF {
     if (arguments.length < 2) {
       throw new UDFArgumentLengthException(
           "The function CONCAT_WS(separator,[string | array(string)]+) "
-                + "needs at least two arguments.");
+            + "needs at least two arguments.");
     }
 
     // check if argument is a string or an array of strings
@@ -67,21 +67,21 @@ public class GenericUDFConcatWS extends GenericUDF {
       switch(arguments[i].getCategory()) {
         case LIST:
           if (isStringOrVoidType(
-                  ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
+               ((ListObjectInspector) arguments[i]).getListElementObjectInspector())) {
             break;
           }else flag=true;
         case PRIMITIVE:
           if (isStringOrVoidType(arguments[i])) {
-            break;
+          break;
           }
         default:
           String outError = arguments[i].getTypeName();
           //(PrimitiveObjectInspector) oi).getPrimitiveCategory()
           if (flag) outError="the element in this array is " + ((PrimitiveObjectInspector)((ListObjectInspector) arguments[i]).getListElementObjectInspector()).getPrimitiveCategory().name();
           throw new UDFArgumentTypeException(i, "Argument " + (i + 1)
-                  + " of function CONCAT_WS must be \"" + serdeConstants.STRING_TYPE_NAME
-                  + " or " + serdeConstants.LIST_TYPE_NAME + "<" + serdeConstants.STRING_TYPE_NAME
-                  + ">\", but " + outError + " was found.");
+            + " of function CONCAT_WS must be \"" + serdeConstants.STRING_TYPE_NAME
+            + " or " + serdeConstants.LIST_TYPE_NAME + "<" + serdeConstants.STRING_TYPE_NAME
+            + ">\", but " + outError + " was found.");
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
@@ -57,7 +57,7 @@ public class GenericUDFConcatWS extends GenericUDF {
   public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
     if (arguments.length < 2) {
       throw new UDFArgumentLengthException(
-              "The function CONCAT_WS(separator,[string | array(string)]+) "
+           "The function CONCAT_WS(separator,[string | array(string)]+) "
                       + "needs at least two arguments.");
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFConcatWS.java
@@ -57,8 +57,8 @@ public class GenericUDFConcatWS extends GenericUDF {
   public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
     if (arguments.length < 2) {
       throw new UDFArgumentLengthException(
-           "The function CONCAT_WS(separator,[string | array(string)]+) "
-                      + "needs at least two arguments.");
+          "The function CONCAT_WS(separator,[string | array(string)]+) "
+                + "needs at least two arguments.");
     }
 
     // check if argument is a string or an array of strings

--- a/ql/src/test/queries/clientnegative/udf_concat_ws_wrong4.q
+++ b/ql/src/test/queries/clientnegative/udf_concat_ws_wrong4.q
@@ -1,0 +1,3 @@
+--! qt:dataset:src
+-- invalid argument type
+SELECT concat_ws(',', array(1, 2, 3)) FROM src LIMIT 1;

--- a/ql/src/test/results/clientnegative/udf_concat_ws_wrong4.q.out
+++ b/ql/src/test/results/clientnegative/udf_concat_ws_wrong4.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException [Error 10016]: Line 3:22 Argument type mismatch '3': Argument 2 of function CONCAT_WS must be "string or array<string>", but the element in this array is INT was found.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
CONCAT_ The error thrown by WS function when the array passed in is a non string array is a problem。
This error still prompts the user to pass in an array, but the real error is not to pass in an array. It should prompt the user to pass in an array of string type


### Why are the changes needed?

fix bug,Improve user experience


### Does this PR introduce _any_ user-facing change?
not


### How was this patch tested?
not
