### PR TITLE
Hive 25987 - Fix the incorrectly formatted beeline/pom.xml

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -226,6 +226,53 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>jar-with-dependencies</finalName>
+              <transformers>
+                <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                  Shading signed JARs will fail without this.
+                  http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+
     </plugins>
   </build>
 </project>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -241,7 +241,7 @@
               </descriptorRefs>
               <finalName>jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
+                <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                 </transformer>
@@ -271,8 +271,6 @@
           </dependency>
         </dependencies>
       </plugin>
-
-
     </plugins>
   </build>
 </project>

--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -86,6 +86,7 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.conf.Constants;
@@ -1340,7 +1341,7 @@ public class BeeLine implements Closeable {
       } else {
         org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(fileName);
         FileSystem fs;
-        HiveConf conf = new HiveConf();
+        Configuration conf = new Configuration();
         if (!path.toUri().isAbsolute()) {
           fs = FileSystem.getLocal(conf);
           path = fs.makeQualified(path);

--- a/packaging/src/main/assembly/beeline.xml
+++ b/packaging/src/main/assembly/beeline.xml
@@ -73,6 +73,15 @@
             </includes>
             <outputDirectory>/</outputDirectory>
         </fileSet>
+
+        <fileSet>
+            <fileMode>755</fileMode>
+            <directory>${project.parent.basedir}/beeline/target</directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>original-jar-with-dependencies.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
 
 </assembly>


### PR DESCRIPTION
After applying the patch https://github.com/apache/hive/pull/3043, [HIVE-25750](https://issues.apache.org/jira/browse/HIVE-25750), the precommit tests have started complaining of this
!!! incorrectly formatted pom.xmls detected; see above!
The code built fine locally and the pre-commit tests had run fine. Need to investigate further why this was not caught earlier but the pom.xml file needs to be fixed for now.
