### PR TITLE
HIVE-25998: Build iceberg modules without a flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ export MAVEN_OPTS="-Xmx2g"
 export -n HIVE_CONF_DIR
 cp $SETTINGS .git/settings.xml
 OPTS=" -s $PWD/.git/settings.xml -B -Dtest.groups= "
-OPTS+=" -Pitests,qsplits,dist,errorProne,iceberg"
+OPTS+=" -Pitests,qsplits,dist,errorProne"
 OPTS+=" -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugin.surefire.SurefirePlugin=INFO"
 OPTS+=" -Dmaven.repo.local=$PWD/.git/m2"
 git config extra.mavenOpts "$OPTS"

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -41,6 +41,7 @@
     <module>hive-minikdc</module>
     <module>qtest-druid</module>
     <module>qtest-kudu</module>
+    <module>qtest-iceberg</module>
   </modules>
   <dependencyManagement>
     <dependencies>
@@ -488,12 +489,6 @@
       <id>spark-test</id>
       <modules>
         <module>qtest-spark</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>iceberg</id>
-      <modules>
-        <module>qtest-iceberg</module>
       </modules>
     </profile>
   </profiles>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -142,17 +142,6 @@
         </plugins>
       </build>
     </profile>
-    <!-- Add iceberg dependencies only with iceberg build -->
-    <profile>
-      <id>iceberg</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hive</groupId>
-          <artifactId>hive-iceberg-handler</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->
@@ -230,6 +219,16 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-druid-handler</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-catalog</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>standalone-metastore</module>
     <module>upgrade-acid</module>
     <module>kafka-handler</module>
+    <module>iceberg</module>
   </modules>
   <properties>
     <standalone-metastore.version>4.0.0-SNAPSHOT</standalone-metastore.version>
@@ -1924,12 +1925,6 @@
       <id>itests</id>
       <modules>
         <module>itests</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>iceberg</id>
-      <modules>
-        <module>iceberg</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the need for `-Piceberg` flag when compiling Iceberg

### Why are the changes needed?
Iceberg has matured a lot. Hopefully it will not create issues from now on.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually