### PR TITLE
HIVE-25495: Upgrade JLine to version 3

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -108,6 +108,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -81,7 +81,7 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/beeline/src/java/org/apache/hive/beeline/AbstractCommandHandler.java
+++ b/beeline/src/java/org/apache/hive/beeline/AbstractCommandHandler.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import jline.console.completer.Completer;
-import jline.console.completer.NullCompleter;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.NullCompleter;
 
 /**
  * An abstract implementation of CommandHandler.

--- a/beeline/src/java/org/apache/hive/beeline/BeeLineCommandCompleter.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLineCommandCompleter.java
@@ -21,10 +21,10 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import jline.console.completer.AggregateCompleter;
-import jline.console.completer.Completer;
-import jline.console.completer.NullCompleter;
-import jline.console.completer.StringsCompleter;
+import org.apache.hive.common.util.MatchingStringsCompleter;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
 
 class BeeLineCommandCompleter extends AggregateCompleter {
   public BeeLineCommandCompleter(Iterable<CommandHandler> handlers) {
@@ -32,17 +32,17 @@ class BeeLineCommandCompleter extends AggregateCompleter {
   }
 
   public static List<Completer> getCompleters(Iterable<CommandHandler> handlers){
-    List<Completer> completers = new LinkedList<Completer>();
+    List<Completer> completers = new LinkedList<>();
 
     for (CommandHandler handler : handlers) {
       String[] commandNames = handler.getNames();
       if (commandNames != null) {
         for (String commandName : commandNames) {
-          List<Completer> compl = new LinkedList<Completer>();
-          compl.add(new StringsCompleter(BeeLine.COMMAND_PREFIX + commandName));
+          List<Completer> compl = new LinkedList<>();
+          compl.add(new MatchingStringsCompleter(BeeLine.COMMAND_PREFIX + commandName));
           compl.addAll(Arrays.asList(handler.getParameterCompleters()));
           compl.add(new NullCompleter()); // last param no complete
-          completers.add(new AggregateCompleter(compl.toArray(new Completer[compl.size()])));
+          completers.add(new AggregateCompleter(compl.toArray(new Completer[0])));
         }
       }
     }

--- a/beeline/src/java/org/apache/hive/beeline/BeeLineCompleter.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLineCompleter.java
@@ -24,7 +24,10 @@ package org.apache.hive.beeline;
 
 import java.util.List;
 
-import jline.console.completer.Completer;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
 
 /**
  * Completor for BeeLine. It dispatches to sub-completors based on the
@@ -42,16 +45,14 @@ class BeeLineCompleter implements Completer {
   }
 
   @Override
-  public int complete(String buf, int pos, List cand) {
-    if (buf != null && buf.startsWith(BeeLine.COMMAND_PREFIX)
-        && !buf.startsWith(BeeLine.COMMAND_PREFIX + "all")
-        && !buf.startsWith(BeeLine.COMMAND_PREFIX + "sql")) {
-      return beeLine.getCommandCompletor().complete(buf, pos, cand);
+  public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+    if (line != null && line.line().startsWith(BeeLine.COMMAND_PREFIX)
+        && !line.line().startsWith(BeeLine.COMMAND_PREFIX + "all")
+        && !line.line().startsWith(BeeLine.COMMAND_PREFIX + "sql")) {
+       beeLine.getCommandCompletor().complete(reader, line, candidates);
     } else {
       if (beeLine.getDatabaseConnection() != null && beeLine.getDatabaseConnection().getSQLCompleter() != null) {
-        return beeLine.getDatabaseConnection().getSQLCompleter().complete(buf, pos, cand);
-      } else {
-        return -1;
+         beeLine.getDatabaseConnection().getSQLCompleter().complete(reader, line, candidates);
       }
     }
   }

--- a/beeline/src/java/org/apache/hive/beeline/BeeLineOpts.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLineOpts.java
@@ -22,6 +22,15 @@
  */
 package org.apache.hive.beeline;
 
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.common.util.MatchingStringsCompleter;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -40,13 +49,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
-
-import jline.Terminal;
-import jline.TerminalFactory;
-import jline.console.completer.Completer;
-import jline.console.completer.StringsCompleter;
-import jline.console.history.MemoryHistory;
-import org.apache.hadoop.hive.conf.HiveConf;
 
 public class BeeLineOpts implements Completer {
   public static final int DEFAULT_MAX_WIDTH = 80;
@@ -86,7 +88,7 @@ public class BeeLineOpts implements Completer {
   private boolean showElapsedTime = true;
   private boolean entireLineAsCommand = false;
   private String numberFormat = "default";
-  private final Terminal terminal = TerminalFactory.get();
+  private Terminal terminal;
   private int maxWidth = DEFAULT_MAX_WIDTH;
   private int maxHeight = DEFAULT_MAX_HEIGHT;
   private int maxColumnWidth = DEFAULT_MAX_COLUMN_WIDTH;
@@ -106,7 +108,7 @@ public class BeeLineOpts implements Completer {
 
   private final File rcFile = new File(saveDir(), "beeline.properties");
   private String historyFile = new File(saveDir(), "history").getAbsolutePath();
-  private int maxHistoryRows = MemoryHistory.DEFAULT_MAX_SIZE;
+  private int maxHistoryRows = 500; // as in MemoryHistory of JLine 2
 
   private String scriptFile = null;
   private String[] initFiles = null;
@@ -152,6 +154,11 @@ public class BeeLineOpts implements Completer {
 
   public BeeLineOpts(BeeLine beeLine, Properties props) {
     this.beeLine = beeLine;
+    try {
+      terminal = TerminalBuilder.terminal();
+    } catch(IOException e) {
+      // nothing to do
+    }
     if (terminal.getWidth() > 0) {
       maxWidth = terminal.getWidth();
     }
@@ -195,12 +202,11 @@ public class BeeLineOpts implements Completer {
 
 
   @Override
-  public int complete(String buf, int pos, List cand) {
+  public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
     try {
-      return new StringsCompleter(propertyNames()).complete(buf, pos, cand);
+      new MatchingStringsCompleter(propertyNames()).complete(reader, line, candidates);
     } catch (Exception e) {
       beeLine.handleException(e);
-      return -1;
     }
   }
 
@@ -742,4 +748,3 @@ public class BeeLineOpts implements Completer {
     env = envToUse;
   }
 }
-

--- a/beeline/src/java/org/apache/hive/beeline/BooleanCompleter.java
+++ b/beeline/src/java/org/apache/hive/beeline/BooleanCompleter.java
@@ -17,15 +17,14 @@
  */
 package org.apache.hive.beeline;
 
-import jline.console.completer.StringsCompleter;
+import org.apache.hive.common.util.MatchingStringsCompleter;
 
 /**
  * JLine completor boolean value (true/false)
  */
-class BooleanCompleter extends StringsCompleter {
+class BooleanCompleter extends MatchingStringsCompleter {
 
   public BooleanCompleter(){
-    super(new String[] {"true", "false"});
+    super("true", "false");
   }
-
 }

--- a/beeline/src/java/org/apache/hive/beeline/CommandHandler.java
+++ b/beeline/src/java/org/apache/hive/beeline/CommandHandler.java
@@ -22,7 +22,7 @@
  */
 package org.apache.hive.beeline;
 
-import jline.console.completer.Completer;
+import org.jline.reader.Completer;
 
 /**
  * A generic command to be executed. Execution of the command

--- a/beeline/src/java/org/apache/hive/beeline/DatabaseConnection.java
+++ b/beeline/src/java/org/apache/hive/beeline/DatabaseConnection.java
@@ -39,8 +39,8 @@ import java.util.TreeSet;
 
 import org.apache.hive.jdbc.HiveConnection;
 
-import jline.console.completer.ArgumentCompleter;
-import jline.console.completer.Completer;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.ArgumentCompleter;
 
 class DatabaseConnection {
   private static final String HIVE_VAR_PREFIX = "hivevar:";
@@ -79,24 +79,7 @@ class DatabaseConnection {
             : getDatabaseMetaData().getExtraNameCharacters();
 
     // setup the completer for the database
-    sqlCompleter = new ArgumentCompleter(
-        new ArgumentCompleter.AbstractArgumentDelimiter() {
-          // delimiters for SQL statements are any
-          // non-letter-or-number characters, except
-          // underscore and characters that are specified
-          // by the database to be valid name identifiers.
-          @Override
-          public boolean isDelimiterChar(CharSequence buffer, int pos) {
-            char c = buffer.charAt(pos);
-            if (Character.isWhitespace(c)) {
-              return true;
-            }
-            return !(Character.isLetterOrDigit(c))
-                && c != '_'
-                && extraNameCharacters.indexOf(c) == -1;
-          }
-        },
-        new SQLCompleter(SQLCompleter.getSQLCompleters(beeLine, skipmeta)));
+    sqlCompleter = new ArgumentCompleter(new SQLCompleter(SQLCompleter.getSQLCompleters(beeLine, skipmeta)));
     // not all argument elements need to hold true
     ((ArgumentCompleter) sqlCompleter).setStrict(false);
   }

--- a/beeline/src/java/org/apache/hive/beeline/ReflectiveCommandHandler.java
+++ b/beeline/src/java/org/apache/hive/beeline/ReflectiveCommandHandler.java
@@ -22,9 +22,9 @@
  */
 package org.apache.hive.beeline;
 
-import jline.console.completer.Completer;
-
 import org.apache.hadoop.fs.shell.Command;
+import org.jline.reader.Completer;
+
 
 /**
  * A {@link Command} implementation that uses reflection to

--- a/beeline/src/java/org/apache/hive/beeline/SQLCompleter.java
+++ b/beeline/src/java/org/apache/hive/beeline/SQLCompleter.java
@@ -30,11 +30,11 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
 
-import jline.console.completer.StringsCompleter;
+import org.apache.hive.common.util.MatchingStringsCompleter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class SQLCompleter extends StringsCompleter {
+class SQLCompleter extends MatchingStringsCompleter {
   private static final Logger LOG = LoggerFactory.getLogger(SQLCompleter.class.getName());
 
 

--- a/beeline/src/java/org/apache/hive/beeline/TableNameCompletor.java
+++ b/beeline/src/java/org/apache/hive/beeline/TableNameCompletor.java
@@ -24,8 +24,11 @@ package org.apache.hive.beeline;
 
 import java.util.List;
 
-import jline.console.completer.Completer;
-import jline.console.completer.StringsCompleter;
+import org.apache.hive.common.util.MatchingStringsCompleter;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
 
 class TableNameCompletor implements Completer {
   private final BeeLine beeLine;
@@ -38,11 +41,11 @@ class TableNameCompletor implements Completer {
   }
 
   @Override
-  public int complete(String buf, int pos, List cand) {
-    if (beeLine.getDatabaseConnection() == null) {
-      return -1;
+  public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+    final DatabaseConnection connection = beeLine.getDatabaseConnection();
+    if (connection != null) {
+      new MatchingStringsCompleter(beeLine.getDatabaseConnection().getTableNames(true))
+              .complete(reader, line, candidates);
     }
-    return new StringsCompleter(beeLine.getDatabaseConnection().getTableNames(true))
-        .complete(buf, pos, cand);
   }
 }

--- a/beeline/src/test/org/apache/hive/beeline/TestBeeLineHistory.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeeLineHistory.java
@@ -62,7 +62,7 @@ public class TestBeeLineHistory {
     Method method = beeline.getClass().getDeclaredMethod("setupHistory");
     method.setAccessible(true);
     method.invoke(beeline);
-    beeline.initializeConsoleReader(null);
+    beeline.initializeLineReader(null);
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     int numHistories = output.split("\n").length;
@@ -80,7 +80,7 @@ public class TestBeeLineHistory {
     Method method = beeline.getClass().getDeclaredMethod("setupHistory");
     method.setAccessible(true);
     method.invoke(beeline);
-    beeline.initializeConsoleReader(null);
+    beeline.initializeLineReader(null);
     beeline.dispatch("!history");
     String output = os.toString("UTF-8");
     String[] tmp = output.split("\n");

--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -70,7 +70,7 @@ public class TestBeelineArgParsing {
     this.defaultSupported = defaultSupported;
   }
 
-  public class TestBeeline extends BeeLine {
+  public static class TestBeeline extends BeeLine {
 
     String connectArgs = null;
     List<String> properties = new ArrayList<String>();

--- a/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
+++ b/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
@@ -292,8 +292,8 @@ public class TestHiveCli {
   public void setup() throws IOException, URISyntaxException {
     System.setProperty("datanucleus.schema.autoCreateAll", "true");
     cli = new HiveCli();
-    initFromFile();
     redirectOutputStream();
+    initFromFile();
   }
 
   private void redirectOutputStream() {

--- a/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
+++ b/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 
 public class TestHiveCli {
   private static final Logger LOG = LoggerFactory.getLogger(TestHiveCli.class.getName());
@@ -245,7 +246,7 @@ public class TestHiveCli {
     int ret = 0;
     try {
       if (input != null) {
-        inputStream = IOUtils.toInputStream(input);
+        inputStream = IOUtils.toInputStream(input, Charset.defaultCharset());
       }
       ret = cli.runWithArgs(args, inputStream);
     } catch (Throwable e) {

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -82,7 +82,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -113,6 +113,10 @@
       <artifactId>hadoop-mapreduce-client-core</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -18,25 +18,7 @@
 
 package org.apache.hadoop.hive.cli;
 
-import static org.apache.hadoop.util.StringUtils.stringifyException;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Splitter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -72,24 +54,42 @@ import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hive.common.util.HiveStringUtils;
+import org.apache.hive.common.util.MatchingStringsCompleter;
 import org.apache.hive.common.util.ShutdownHookManager;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.history.DefaultHistory;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.Terminal.Signal;
+import org.jline.terminal.Terminal.SignalHandler;
+import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Splitter;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import jline.console.ConsoleReader;
-import jline.console.completer.ArgumentCompleter;
-import jline.console.completer.ArgumentCompleter.AbstractArgumentDelimiter;
-import jline.console.completer.ArgumentCompleter.ArgumentDelimiter;
-import jline.console.completer.Completer;
-import jline.console.completer.StringsCompleter;
-import jline.console.history.FileHistory;
-import jline.console.history.History;
-import jline.console.history.PersistentHistory;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
-
+import static org.apache.hadoop.util.StringUtils.stringifyException;
 
 /**
  * CliDriver.
@@ -105,7 +105,7 @@ public class CliDriver {
   public static final String HIVERCFILE = ".hiverc";
 
   private final LogHelper console;
-  protected ConsoleReader reader;
+  protected LineReader reader;
   private Configuration conf;
 
   public CliDriver() {
@@ -369,8 +369,8 @@ public class CliDriver {
     if (allowInterrupting) {
       // Remember all threads that were running at the time we started line processing.
       // Hook up the custom Ctrl+C handler while processing this line
-      interruptSignal = new Signal("INT");
-      oldSignal = Signal.handle(interruptSignal, new SignalHandler() {
+      interruptSignal = Terminal.Signal.INT;
+      oldSignal = reader.getTerminal().handle(interruptSignal, new SignalHandler() {
         private boolean interruptRequested;
 
         @Override
@@ -432,8 +432,8 @@ public class CliDriver {
       return lastRet;
     } finally {
       // Once we are done processing the line, restore the old handler
-      if (oldSignal != null && interruptSignal != null) {
-        Signal.handle(interruptSignal, oldSignal);
+      if (oldSignal != null) {
+        reader.getTerminal().handle(interruptSignal, oldSignal);
       }
     }
   }
@@ -585,7 +585,7 @@ public class CliDriver {
   public static Completer[] getCommandCompleter() {
     // StringsCompleter matches against a pre-defined wordlist
     // We start with an empty wordlist and build it up
-    List<String> candidateStrings = new ArrayList<String>();
+    List<String> candidateStrings = new ArrayList<>();
 
     // We add Hive function names
     // For functions that aren't infix operators, we add an open
@@ -604,23 +604,11 @@ public class CliDriver {
       candidateStrings.add(s.toLowerCase());
     }
 
-    StringsCompleter strCompleter = new StringsCompleter(candidateStrings);
-
-    // Because we use parentheses in addition to whitespace
-    // as a keyword delimiter, we need to define a new ArgumentDelimiter
-    // that recognizes parenthesis as a delimiter.
-    ArgumentDelimiter delim = new AbstractArgumentDelimiter() {
-      @Override
-      public boolean isDelimiterChar(CharSequence buffer, int pos) {
-        char c = buffer.charAt(pos);
-        return (Character.isWhitespace(c) || c == '(' || c == ')' ||
-            c == '[' || c == ']');
-      }
-    };
+    Completer strCompleter = new MatchingStringsCompleter(candidateStrings);
 
     // The ArgumentCompletor allows us to match multiple tokens
     // in the same line.
-    final ArgumentCompleter argCompleter = new ArgumentCompleter(delim, strCompleter);
+    final ArgumentCompleter argCompleter = new ArgumentCompleter(strCompleter);
     // By default ArgumentCompletor is in "strict" mode meaning
     // a token is only auto-completed if all prior tokens
     // match. We don't want that since there are valid tokens
@@ -632,19 +620,16 @@ public class CliDriver {
     // the opening parenthesis is unnecessary (and uncommon) in Hive.
     // We stack a custom Completor on top of our ArgumentCompletor
     // to reverse this.
-    Completer customCompletor = new Completer () {
-      @Override
-      public int complete (String buffer, int offset, List completions) {
-        List<String> comp = completions;
-        int ret = argCompleter.complete(buffer, offset, completions);
-        // ConsoleReader will do the substitution if and only if there
-        // is exactly one valid completion, so we ignore other cases.
-        if (completions.size() == 1) {
-          if (comp.get(0).endsWith("( ")) {
-            comp.set(0, comp.get(0).trim());
-          }
+    Completer customCompletor = (reader, line, candidates) -> {
+      argCompleter.complete(reader, line, candidates);
+      candidates.forEach(System.out::println);
+      // ConsoleReader will do the substitution if and only if there
+      // is exactly one valid completion, so we ignore other cases.
+      if (candidates.size() == 1) {
+        String candidateStr = candidates.get(0).value();
+        if (candidateStr.endsWith("( ")) {
+          candidates.set(0, new Candidate(candidateStr.trim()));
         }
-        return ret;
       }
     };
 
@@ -653,61 +638,55 @@ public class CliDriver {
       vars.add(conf.varname);
     }
 
-    StringsCompleter confCompleter = new StringsCompleter(vars) {
+    Completer confCompleter = new MatchingStringsCompleter(vars) {
       @Override
-      public int complete(final String buffer, final int cursor, final List<CharSequence> clist) {
-        int result = super.complete(buffer, cursor, clist);
-        if (clist.isEmpty() && cursor > 1 && buffer.charAt(cursor - 1) == '=') {
-          HiveConf.ConfVars var = HiveConf.getConfVars(buffer.substring(0, cursor - 1));
+      public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        super.complete(reader, line, candidates);
+        final int cursor = line.cursor();
+        if (candidates.isEmpty() && cursor > 1 && line.word().charAt(cursor - 1) == '=') {
+          HiveConf.ConfVars var = HiveConf.getConfVars(line.word().substring(0, cursor - 1));
           if (var == null) {
-            return result;
+            return;
           }
           if (var.getValidator() instanceof Validator.StringSet) {
             Validator.StringSet validator = (Validator.StringSet)var.getValidator();
-            clist.addAll(validator.getExpected());
+            validator.getExpected().stream().map(Candidate::new).forEach(candidates::add);
           } else if (var.getValidator() != null) {
-            clist.addAll(Arrays.asList(var.getValidator().toDescription(), ""));
+            candidates.add(new Candidate(var.getValidator().toDescription()));
           } else {
-            clist.addAll(Arrays.asList("Expects " + var.typeString() + " type value", ""));
+            candidates.add(new Candidate("Expects " + var.typeString() + " type value"));
           }
-          return cursor;
+          return;
         }
-        if (clist.size() > DELIMITED_CANDIDATE_THRESHOLD) {
-          Set<CharSequence> delimited = new LinkedHashSet<CharSequence>();
-          for (CharSequence candidate : clist) {
+        if (candidates.size() > DELIMITED_CANDIDATE_THRESHOLD) {
+          Set<Candidate> delimited = new LinkedHashSet<>();
+          for (Candidate candidate : candidates) {
             Iterator<String> it = Splitter.on(".").split(
-                candidate.subSequence(cursor, candidate.length())).iterator();
+                candidate.value().subSequence(cursor, candidate.value().length())).iterator();
             if (it.hasNext()) {
               String next = it.next();
               if (next.isEmpty()) {
                 next = ".";
               }
-              candidate = buffer != null ? buffer.substring(0, cursor) + next : next;
+              candidate = new Candidate(line.line() != null ? line.line().substring(0, cursor) + next : next);
             }
             delimited.add(candidate);
           }
-          clist.clear();
-          clist.addAll(delimited);
+          candidates.clear();
+          candidates.addAll(delimited);
         }
-        return result;
       }
     };
 
-    StringsCompleter setCompleter = new StringsCompleter("set") {
-      @Override
-      public int complete(String buffer, int cursor, List<CharSequence> clist) {
-        return buffer != null && buffer.equals("set") ? super.complete(buffer, cursor, clist) : -1;
-      }
-    };
+    Completer setCompleter = new MatchingStringsCompleter("set");
 
     ArgumentCompleter propCompleter = new ArgumentCompleter(setCompleter, confCompleter) {
       @Override
-      public int complete(String buffer, int offset, List<CharSequence> completions) {
-        int ret = super.complete(buffer, offset, completions);
-        if (completions.size() == 1) {
-          completions.set(0, ((String)completions.get(0)).trim());
+      public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        super.complete(reader, line, candidates);
+        if (candidates.size() == 1) {
+          candidates.set(0, new Candidate(candidates.get(0).value().trim()));
         }
-        return ret;
       }
     };
     return new Completer[] {propCompleter, customCompletor};
@@ -846,7 +825,7 @@ public class CliDriver {
       console.printInfo(HiveConf.generateMrDeprecationWarning());
     }
 
-    setupConsoleReader();
+    setupLineReader();
 
     String line;
     CommandProcessorResponse response = new CommandProcessorResponse();
@@ -879,15 +858,12 @@ public class CliDriver {
     return response;
   }
 
-  private void setupCmdHistory() {
+  private String setupCmdHistory() {
     final String HISTORYFILE = ".hivehistory";
     String historyDirectory = System.getProperty("user.home");
-    PersistentHistory history = null;
     try {
       if ((new File(historyDirectory)).exists()) {
-        String historyFile = historyDirectory + File.separator + HISTORYFILE;
-        history = new FileHistory(new File(historyFile));
-        reader.setHistory(history);
+        return historyDirectory + File.separator + HISTORYFILE;
       } else {
         System.err.println("WARNING: Directory for Hive history file: " + historyDirectory +
                            " does not exist.   History will not be available during this session.");
@@ -896,32 +872,48 @@ public class CliDriver {
       System.err.println("WARNING: Encountered an error while trying to initialize Hive's " +
                          "history file.  History will not be available during this session.");
       System.err.println(e.getMessage());
+      return null;
     }
 
     // add shutdown hook to flush the history to history file
-    ShutdownHookManager.addShutdownHook(new Runnable() {
-      @Override
-      public void run() {
-        History h = reader.getHistory();
-        if (h instanceof FileHistory) {
-          try {
-            ((FileHistory) h).flush();
-          } catch (IOException e) {
-            System.err.println("WARNING: Failed to write command history file: " + e.getMessage());
-          }
-        }
+    ShutdownHookManager.addShutdownHook(() -> {
+      History h = reader.getHistory();
+      try {
+        h.save();
+      } catch (IOException e) {
+        System.err.println("WARNING: Failed to write command history file: " + e.getMessage());
       }
     });
+    return null;
   }
 
-  protected void setupConsoleReader() throws IOException {
-    reader = new ConsoleReader();
-    reader.setExpandEvents(false);
-    reader.setBellEnabled(false);
-    for (Completer completer : getCommandCompleter()) {
-      reader.addCompleter(completer);
+  protected void setupLineReader() throws IOException {
+    LineReaderBuilder builder = LineReaderBuilder.builder();
+    builder.variable(LineReader.BELL_STYLE, "audible");
+    Arrays.stream(getCommandCompleter()).forEach(builder::completer);
+    builder.terminal(TerminalBuilder.terminal());
+    builder.parser(getDefaultParser());
+    builder.history(new DefaultHistory());
+
+    String historyFile = setupCmdHistory();
+    if (historyFile != null) {
+      builder.variable(LineReader.HISTORY_FILE, historyFile);
     }
-    setupCmdHistory();
+    reader = builder.build();
+  }
+
+  static DefaultParser getDefaultParser() {
+    return new DefaultParser() {
+      @Override
+      public boolean isDelimiterChar(CharSequence buffer, int pos) {
+        // Because we use parentheses in addition to whitespace
+        // as a keyword delimiter, we need to define a new ArgumentDelimiter
+        // that recognizes parenthesis as a delimiter.
+        final char c = buffer.charAt(pos);
+        return (Character.isWhitespace(c) || c == '(' || c == ')' ||
+                c == '[' || c == ']');
+      }
+    };
   }
 
   /**
@@ -961,5 +953,4 @@ public class CliDriver {
   public void setHiveVariables(Map<String, String> hiveVariables) {
     SessionState.get().setHiveVariables(hiveVariables);
   }
-
 }

--- a/cli/src/test/org/apache/hadoop/hive/cli/TestCliDriverMethods.java
+++ b/cli/src/test/org/apache/hadoop/hive/cli/TestCliDriverMethods.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
@@ -39,11 +38,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import jline.console.ConsoleReader;
-import jline.console.completer.ArgumentCompleter;
-import jline.console.completer.Completer;
-
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -56,6 +50,9 @@ import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
@@ -142,7 +139,7 @@ public class TestCliDriverMethods {
       CliDriver cliDriver = new CliDriver();
       // issue a command with bad options
       cliDriver.processCmd("!ls --abcdefghijklmnopqrstuvwxyz123456789");
-      assertTrue("Comments with '--; should not have been stripped, so command should fail", false);
+      fail("Comments with '--; should not have been stripped, so command should fail");
     } catch (CommandProcessorException e) {
       // this is expected to happen
     } finally {
@@ -165,8 +162,6 @@ public class TestCliDriverMethods {
    *          Schema to throw against test
    * @return Output that would have been sent to the user
    * @throws CommandProcessorException
-   * @throws CommandNeedRetryException
-   *           won't actually be thrown
    */
   private PrintStream headerPrintingTestDriver(Schema mockSchema) throws CommandProcessorException {
     CliDriver cliDriver = new CliDriver();
@@ -203,20 +198,24 @@ public class TestCliDriverMethods {
     Completer[] completors = CliDriver.getCommandCompleter();
     assertEquals(2, completors.length);
     assertTrue(completors[0] instanceof ArgumentCompleter);
-    assertTrue(completors[1] instanceof Completer);
+    assertNotNull(completors[1]);
 
-    List<CharSequence> testList = Arrays.asList(")");
-    completors[1].complete("fdsdfsdf", 0, testList);
-    assertEquals(")", testList.get(0));
-    testList=new ArrayList<CharSequence>();
-    completors[1].complete("len", 0, testList);
-    assertTrue(testList.get(0).toString().endsWith("length("));
+    final List<Candidate> candidates1 = new ArrayList<>();
+    candidates1.add(new Candidate(")"));
+    completors[1].complete(null, CliDriver.getDefaultParser().parse("fdsdfsdf", 0), candidates1);
+    assertEquals(")", candidates1.get(0).value());
 
-    testList=new ArrayList<CharSequence>();
-    completors[0].complete("set f", 0, testList);
-    assertEquals("set", testList.get(0));
+    final List<Candidate> candidates2 = new ArrayList<>();
+    completors[1].complete(null,  CliDriver.getDefaultParser().parse("length", 0), candidates2);
+    System.out.printf("--- --> %s%n", candidates2.get(0).value());
+    assertTrue(candidates2.get(0).value().endsWith("length("));
 
+    final List<Candidate> candidates3 = new ArrayList<>();
+    completors[0].complete(null, CliDriver.getDefaultParser().parse("set f", 0), candidates3);
+    assertEquals("set", candidates3.get(0).value());
   }
+
+
 
   @Test
   public void testRun() throws Exception {
@@ -417,59 +416,9 @@ public class TestCliDriverMethods {
   }
 
   private static class FakeCliDriver extends CliDriver {
-
     @Override
-    protected void setupConsoleReader() throws IOException {
-      reader = new FakeConsoleReader();
-    }
-
-  }
-
-  private static class FakeConsoleReader extends ConsoleReader {
-    private int counter = 0;
-    File temp = null;
-
-    public FakeConsoleReader() throws IOException {
-      super();
-
-    }
-
-    @Override
-    public String readLine(String prompt) throws IOException {
-      FileWriter writer;
-      switch (counter++) {
-      case 0:
-        return "!echo test message;";
-      case 1:
-        temp = File.createTempFile("hive", "test");
-        temp.deleteOnExit();
-        return "source  " + temp.getAbsolutePath() + ";";
-      case 2:
-        temp = File.createTempFile("hive", "test");
-        temp.deleteOnExit();
-        writer = new FileWriter(temp);
-        writer.write("bla bla bla");
-        writer.close();
-        return "list file file://" + temp.getAbsolutePath() + ";";
-      case 3:
-        return "!echo ";
-      case 4:
-        return "test message;";
-      case 5:
-        return "source  fakeFile;";
-      case 6:
-        temp = File.createTempFile("hive", "test");
-        temp.deleteOnExit();
-        writer = new FileWriter(temp);
-        writer.write("source  fakeFile;");
-        writer.close();
-        return "list file file://" + temp.getAbsolutePath() + ";";
-
-
-        // drop table over10k;
-      default:
-        return null;
-      }
+    protected void setupLineReader() throws IOException {
+      reader = null;
     }
   }
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>jetty-webapp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda.version}</version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -71,7 +71,7 @@
       <artifactId>orc-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/common/src/java/org/apache/hive/common/util/MatchingStringsCompleter.java
+++ b/common/src/java/org/apache/hive/common/util/MatchingStringsCompleter.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.common.util;
+
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * A matching string Completer based on JLine2's StringCompleter
+ */
+public class MatchingStringsCompleter implements Completer {
+  protected SortedSet<String> candidateStrings = new TreeSet<>();
+
+  public MatchingStringsCompleter() {
+    // empty
+  }
+
+  public MatchingStringsCompleter(String... strings) {
+    this(Arrays.asList(strings));
+  }
+
+  public MatchingStringsCompleter(Iterable<String> strings) {
+    strings.forEach(candidateStrings::add);
+  }
+
+  public MatchingStringsCompleter(Candidate... candidates) {
+    Arrays.stream(candidates).map(Candidate::value).forEach(candidateStrings::add);
+  }
+
+  public Collection<String> getStrings() {
+    return candidateStrings;
+  }
+
+  @Override
+  public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+    assert candidates != null;
+
+    if (line == null) {
+      candidateStrings.stream().map(Candidate::new).forEach(candidates::add);
+    } else {
+      for (String match : this.candidateStrings.tailSet(line.word())) {
+        if (!match.startsWith(line.word())) {
+          break;
+        }
+        candidates.add(new Candidate(match));
+      }
+    }
+  }
+}

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -30,6 +30,7 @@
   <name>Hive HCatalog Pig Adapter</name>
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
+    <jline.version>3.21.0</jline.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->
@@ -107,9 +108,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
-      <version>0.9.94</version>
+      <version>${jline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceCommandLine.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceCommandLine.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.hive.llap.cli.service;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
-import jline.TerminalFactory;
-
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.Set;
@@ -36,6 +34,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.llap.log.LogHelpers;
+import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix;
@@ -401,7 +400,7 @@ class LlapServiceCommandLine {
     HelpFormatter hf = new HelpFormatter();
     try {
       int width = hf.getWidth();
-      int jlineWidth = TerminalFactory.get().getWidth();
+      int jlineWidth = TerminalBuilder.terminal().getWidth();
       width = Math.min(160, Math.max(jlineWidth, width));
       hf.setWidth(width);
     } catch (Throwable t) { // Ignore

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceCommandLine.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/status/LlapStatusServiceCommandLine.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.hive.llap.cli.status;
 import java.util.Arrays;
 import java.util.Properties;
 
-import jline.TerminalFactory;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -30,6 +28,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,7 +237,7 @@ public class LlapStatusServiceCommandLine {
     HelpFormatter hf = new HelpFormatter();
     try {
       int width = hf.getWidth();
-      int jlineWidth = TerminalFactory.get().getWidth();
+      int jlineWidth = TerminalBuilder.terminal().getWidth();
       width = Math.min(160, Math.max(jlineWidth, width));
       hf.setWidth(width);
     } catch (Throwable t) { // Ignore

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <jettison.version>1.1</jettison.version>
     <jetty.version>9.3.27.v20190418</jetty.version>
     <jersey.version>1.19</jersey.version>
-    <jline.version>2.14.6</jline.version>
+    <jline.version>3.21.0</jline.version>
     <jms.version>2.0.2</jms.version>
     <joda.version>2.9.9</joda.version>
     <jodd.version>6.0.0</jodd.version>
@@ -430,7 +430,7 @@
         <version>${javolution.version}</version>
       </dependency>
       <dependency>
-        <groupId>jline</groupId>
+        <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
       </dependency>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -241,7 +241,7 @@
       <artifactId>sqlline</artifactId>
     </dependency>
     <dependency>
-      <groupId>jline</groupId>
+      <groupId>org.jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/HiveMetaToolCommandLine.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/HiveMetaToolCommandLine.java
@@ -27,10 +27,10 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jline.TerminalFactory;
 
 class HiveMetaToolCommandLine {
   private static final Logger LOGGER = LoggerFactory.getLogger(HiveMetaToolCommandLine.class.getName());
@@ -199,7 +199,7 @@ class HiveMetaToolCommandLine {
     HelpFormatter hf = new HelpFormatter();
     try {
       int width = hf.getWidth();
-      int jlineWidth = TerminalFactory.get().getWidth();
+      int jlineWidth = TerminalBuilder.terminal().getWidth();
       width = Math.min(160, Math.max(jlineWidth, width));
       hf.setWidth(width);
     } catch (Throwable t) { // Ignore

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -91,7 +91,7 @@
     <protobuf.group>com.google.protobuf</protobuf.group>
     <protobuf.version>2.6.1</protobuf.version>
     <protobuf-exc.version>2.6.1</protobuf-exc.version>
-    <sqlline.version>1.9.0</sqlline.version>
+    <sqlline.version>1.12.0</sqlline.version>
     <jline.version>3.21.0</jline.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>4.0.0-alpha-2-SNAPSHOT</storage-api.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -92,7 +92,7 @@
     <protobuf.version>2.6.1</protobuf.version>
     <protobuf-exc.version>2.6.1</protobuf-exc.version>
     <sqlline.version>1.9.0</sqlline.version>
-    <jline.version>2.14.6</jline.version>
+    <jline.version>3.21.0</jline.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>4.0.0-alpha-2-SNAPSHOT</storage-api.version>
     <beanutils.version>1.9.4</beanutils.version>
@@ -297,7 +297,7 @@
         <version>${sqlline.version}</version>
       </dependency>
       <dependency>
-        <groupId>jline</groupId>
+        <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Update jline to 3.21 - the behaviour is quite different. So a modified version of the JLine2's StringCompleter is added in hive-common.
- Update sqlline to 1.12 as it uses jline 3.21
- Add some missing dependencies to pom.xml files (the lack of these didn't cause issue possibly due to transitive dependency)


### Why are the changes needed?
It's a step required to use JDK 17


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By existing tests.
