### PR TITLE
HIVE-26000: DirectSQL to prune partitions fails with postgres backend for Skewed-Partition tables

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -399,7 +399,7 @@ class MetastoreDirectSqlUtils {
     String queryText;
     queryText =
           "select " + SKEWED_COL_VALUE_LOC_MAP + ".\"SD_ID\","
-        + " " + SKEWED_STRING_LIST_VALUES + ".STRING_LIST_ID,"
+        + " " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_ID\","
         + " " + SKEWED_COL_VALUE_LOC_MAP + ".\"LOCATION\","
         + " " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_VALUE\" "
         + "from " + SKEWED_COL_VALUE_LOC_MAP + ""


### PR DESCRIPTION
### What changes were proposed in this pull request?
PartitionPruning via directSql is failing in postgres db for skewed tables

### Why are the changes needed?
Fallback to ORM is taking long time

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
We already have a testcase covering the issue (list_bucket_dml_4.q), it happens in postgres backend db.
