### PR TITLE
HIVE-26001: LlapServiceDriver: forward hiveconf from commandline to AsyncTaskCreateUdfFile

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
@@ -35,10 +35,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.stream.Stream;
@@ -275,5 +277,14 @@ public class HiveConfUtil {
     }
     String propertyValue = HiveStringUtils.insertValue(keyName, newKeyValue, existingValue);
     jobConf.set(property, propertyValue);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void copyFromProperties(Properties propSource, HiveConf confTarget) {
+    Enumeration<String> props = (Enumeration<String>) propSource.propertyNames();
+    while (props.hasMoreElements()) {
+      String key = props.nextElement();
+      confTarget.set(key, propSource.getProperty(key));
+    }
   }
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCreateUdfFile.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCreateUdfFile.java
@@ -90,7 +90,7 @@ class AsyncTaskCreateUdfFile implements Callable<Void> {
 
   private Set<String> downloadPermanentFunctions() throws HiveException, URISyntaxException, IOException {
     Map<String, String> udfs = new HashMap<String, String>();
-    HiveConf hiveConf = new HiveConf();
+    HiveConf hiveConf = new HiveConf(conf);
     // disable expensive operations on the metastore
     hiveConf.setBoolean(MetastoreConf.ConfVars.INIT_METADATA_COUNT_ENABLED.getVarname(), false);
     hiveConf.setBoolean(MetastoreConf.ConfVars.METRICS_ENABLED.getVarname(), false);

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceDriver.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConfUtil;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.llap.LlapUtil;
 import org.apache.hadoop.hive.llap.cli.LlapSliderUtils;
@@ -73,6 +74,9 @@ public class LlapServiceDriver {
 
     SessionState ss = SessionState.get();
     this.conf = (ss != null) ? ss.getConf() : new HiveConf(SessionState.class);
+
+    HiveConfUtil.copyFromProperties(cl.getConfig(), this.conf);
+
     if (conf == null) {
       throw new Exception("Cannot load any configuration to run command");
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case a command like:
```
hive --skiphadoopversion --skiphbasecp --service jar /usr/lib/hive/lib/hive-llap-server.jar org.apache.hadoop.hive.llap.cli.service.LlapServiceDriver -i 1 -skipValidateConf --partialDownload --downloadType udffile  --hiveconf a=b
```
the configuration a=b doesn't make its way to AsyncTaskCreateUdfFile, and adding a single option or a few options is much easier through --hiveconf than hacking a new config file to the classpath somehow

### Why are the changes needed?
Describe above.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tested on cluster by above command.
