### PR TITLE
HIVE-26019 HIVE-26020: Improvements around transitive dependencies from calcite-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1210,16 +1210,19 @@
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
         <version>${json-path.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.janino</groupId>
         <artifactId>commons-compiler</artifactId>
         <version>${janino.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.janino</groupId>
         <artifactId>janino</artifactId>
         <version>${janino.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.tez</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <jjwt.version>0.10.5</jjwt.version>
     <re2j.version>1.2</re2j.version>
     <rs-api.version>2.0.1</rs-api.version>
-    <json-path.version>2.4.0</json-path.version>
+    <json-path.version>2.7.0</json-path.version>
     <janino.version>3.0.11</janino.version>
     <datasketches.version>1.1.0-incubating</datasketches.version>
     <spotbugs.version>4.0.3</spotbugs.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Upgrade com.jayway.jsonpath from 2.4.0 to 2.7.0
2. Set dependency scope for json-path, commons-compiler and janino to runtime

### Why are the changes needed?
See HIVE-26019 & HIVE-26020

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests
