### PR TITLE
HIVE-25971: Closing the thread pool created for async cache

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ObjectCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ObjectCache.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -61,7 +62,7 @@ public class ObjectCache implements org.apache.hadoop.hive.ql.exec.ObjectCache {
 
   public static void setupObjectRegistry(ObjectRegistry objectRegistry) {
     staticRegistry = objectRegistry;
-    staticPool = Executors.newCachedThreadPool();
+    staticPool = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("Tez-object-cache %d").build());
   }
 
   @Override
@@ -119,5 +120,11 @@ public class ObjectCache implements org.apache.hadoop.hive.ql.exec.ObjectCache {
   public void remove(String key) {
     LOG.info("Removing key: " + key);
     registry.delete(key);
+  }
+
+  public static void close() {
+    if (staticPool != null) {
+      staticPool.shutdown();
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -155,6 +155,7 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
 
   @Override
   public void close() throws IOException {
+    ObjectCache.close();
     // we have to close in the processor's run method, because tez closes inputs
     // before calling close (TEZ-955) and we might need to read inputs
     // when we flush the pipeline.


### PR DESCRIPTION
For branch-2.3 : [CR](https://github.com/apache/hive/pull/3046)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We are closing the cached thread pool which is delaying the tez task jvm shutdown. 
The pool is used for loading [hash table](https://github.com/apache/hive/blob/7b7e8d4d7910b9b6dc2fe498a6a4228c628853c1/ql/src/java/org/apache/hadoop/hive/ql/exec/MapJoinOperator.java#L180) in case of mapjoin operator. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without the change, tez task jvm takes upto 1 min to shutdown.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Monitored the JVM exit time. 
`2022-02-03 16:47:54,432 [INFO] [main] |util.Debug|: Hook: class org.apache.hadoop.hive.ql.exec.tez.ObjectCache$2
2022-02-03 16:48:04,079 [DEBUG] [Thread-4] |util.ShutdownHookManager|: Completed shutdown in 0.001 seconds; Timeouts: 0
2022-02-03 16:48:04,088 [DEBUG] [Thread-4] |util.ShutdownHookManager|: ShutdownHookManger completed shutdown.
`

`2022-02-03 17:04:05,491 [INFO] [main] |util.Debug|: Hook: org.apache.hadoop.hive.ql.exec.tez.ObjectCache$2@67fa5445
2022-02-03 17:04:05,508 [DEBUG] [Thread-4] |util.ShutdownHookManager|: Completed shutdown in 0.014 seconds; Timeouts: 0
2022-02-03 17:04:05,523 [DEBUG] [Thread-4] |util.ShutdownHookManager|: ShutdownHookManger completed shutdown.`