### PR TITLE
HIVE-25645: Query-based compaction doesn't work when partition column type is boolean

### DIFF
--- a/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
+++ b/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
@@ -586,7 +586,7 @@ public class HCatClientHMSImpl extends HCatClient {
     LOG.info("HCatClient: Dropping partitions using partition-predicate Expressions.");
     ExprNodeGenericFuncDesc partitionExpression = new ExpressionBuilder(table, partitionSpec).build();
     Pair<Integer, byte[]> serializedPartitionExpression = Pair.of(partitionSpec.size(),
-            SerializationUtilities.serializeExpressionToKryo(partitionExpression));
+            SerializationUtilities.serializeObjectWithTypeInformation(partitionExpression));
     hmsClient.dropPartitions(table.getDbName(), table.getTableName(), Arrays.asList(serializedPartitionExpression),
         deleteData && !isExternal(table),  // Delete data?
         ifExists,                          // Fail if table doesn't exist?

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckAnalyzer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.ddl.misc.msck;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -81,8 +82,8 @@ public class MsckAnalyzer extends AbstractFunctionAnalyzer {
             "to be set to org.apache.hadoop.hive.ql.optimizer.ppr.PartitionExpressionForMetastore");
       }
       // fetch the first value of partitionSpecs map since it will always have one key, value pair
-      filterExp = SerializationUtilities.serializeExpressionToKryo(
-          (ExprNodeGenericFuncDesc) ((List) partitionSpecs.values().toArray()[0]).get(0));
+      filterExp = SerializationUtilities.serializeObjectWithTypeInformation(
+          (Serializable) ((List) partitionSpecs.values().toArray()[0]).get(0));
     }
 
     if (repair && AcidUtils.isTransactionalTable(table)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AlterTableDropPartitionOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AlterTableDropPartitionOperation.java
@@ -123,7 +123,7 @@ public class AlterTableDropPartitionOperation extends DDLOperation<AlterTableDro
     List<Pair<Integer, byte[]>> partitionExpressions = new ArrayList<>(desc.getPartSpecs().size());
     for (AlterTableDropPartitionDesc.PartitionDesc partSpec : desc.getPartSpecs()) {
       partitionExpressions.add(Pair.of(partSpec.getPrefixLength(),
-          SerializationUtilities.serializeExpressionToKryo(partSpec.getPartSpec())));
+          SerializationUtilities.serializeObjectWithTypeInformation(partSpec.getPartSpec())));
     }
 
     PartitionDropOptions options =

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/SerializationUtilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/SerializationUtilities.java
@@ -843,7 +843,7 @@ public class SerializationUtilities {
 
   public static String serializeExpression(ExprNodeGenericFuncDesc expr) {
     return new String(Base64.encodeBase64(serializeObjectToKryo(expr)),
-            StandardCharsets.UTF_8);
+        StandardCharsets.UTF_8);
   }
 
   public static ExprNodeGenericFuncDesc deserializeExpression(String s) {
@@ -879,7 +879,7 @@ public class SerializationUtilities {
 
   public static String serializeObject(Serializable expr) {
     return new String(Base64.encodeBase64(serializeObjectToKryo(expr)),
-            StandardCharsets.UTF_8);
+        StandardCharsets.UTF_8);
   }
 
   public static <T extends Serializable> T deserializeObject(String s,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/SerializationUtilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/SerializationUtilities.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.plan.AbstractOperatorDesc;
 import org.apache.hadoop.hive.ql.plan.BaseWork;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
@@ -810,12 +811,20 @@ public class SerializationUtilities {
   }
 
   /**
-   * Serializes expression via Kryo.
-   * @param expr Expression.
+   * Serializes any object via Kryo. Type information will be serialized as well, allowing dynamic deserialization
+   * without the need to pass the class.
+   * @param object The object to serialize.
    * @return Bytes.
    */
-  public static byte[] serializeExpressionToKryo(ExprNodeGenericFuncDesc expr) {
-    return serializeObjectToKryo(expr);
+  public static byte[] serializeObjectWithTypeInformation(Serializable object) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    Kryo kryo = borrowKryo();
+    try (Output output = new Output(baos)) {
+      kryo.writeClassAndObject(output, object);
+    } finally {
+      releaseKryo(kryo);
+    }
+    return baos.toByteArray();
   }
 
   /**
@@ -823,18 +832,23 @@ public class SerializationUtilities {
    * @param bytes Bytes containing the expression.
    * @return Expression; null if deserialization succeeded, but the result type is incorrect.
    */
-  public static ExprNodeGenericFuncDesc deserializeExpressionFromKryo(byte[] bytes) {
-    return deserializeObjectFromKryo(bytes, ExprNodeGenericFuncDesc.class);
+  public static <T> T deserializeObjectWithTypeInformation(byte[] bytes) {
+    Kryo kryo = borrowKryo();
+    try (Input inp = new Input(new ByteArrayInputStream(bytes))) {
+      return (T) kryo.readClassAndObject(inp);
+    } finally {
+      releaseKryo(kryo);
+    }
   }
 
   public static String serializeExpression(ExprNodeGenericFuncDesc expr) {
-    return new String(Base64.encodeBase64(serializeExpressionToKryo(expr)),
-        StandardCharsets.UTF_8);
+    return new String(Base64.encodeBase64(serializeObjectToKryo(expr)),
+            StandardCharsets.UTF_8);
   }
 
   public static ExprNodeGenericFuncDesc deserializeExpression(String s) {
     byte[] bytes = Base64.decodeBase64(s.getBytes(StandardCharsets.UTF_8));
-    return deserializeExpressionFromKryo(bytes);
+    return deserializeObjectFromKryo(bytes, ExprNodeGenericFuncDesc.class);
   }
 
   public static byte[] serializeObjectToKryo(Serializable object) {
@@ -865,13 +879,13 @@ public class SerializationUtilities {
 
   public static String serializeObject(Serializable expr) {
     return new String(Base64.encodeBase64(serializeObjectToKryo(expr)),
-        StandardCharsets.UTF_8);
+            StandardCharsets.UTF_8);
   }
 
   public static <T extends Serializable> T deserializeObject(String s,
-      Class<T> clazz) {
+                                                             Class<T> clazz) {
     return deserializeObjectFromKryo(
-        Base64.decodeBase64(s.getBytes(StandardCharsets.UTF_8)), clazz);
+            Base64.decodeBase64(s.getBytes(StandardCharsets.UTF_8)), clazz);
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -209,6 +209,7 @@ import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils;
 import org.apache.hadoop.hive.ql.optimizer.listbucketingpruner.ListBucketingPrunerUtils;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc.LoadFileType;
@@ -3909,7 +3910,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     // the exprBytes should not be null by thrift definition
     byte[] exprBytes = {(byte)-1};
     if (expr != null) {
-      exprBytes = SerializationUtilities.serializeExpressionToKryo(expr);
+      exprBytes = SerializationUtilities.serializeObjectWithTypeInformation(expr);
     }
     try {
       String defaultPartitionName = HiveConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
@@ -4273,13 +4274,13 @@ private void constructOneLBLocationMap(FileStatus fSta,
    * @param partitions the resulting list of partitions
    * @return whether the resulting list contains partitions which may or may not match the expr
    */
-  public boolean getPartitionsByExpr(Table tbl, ExprNodeGenericFuncDesc expr, HiveConf conf,
+  public boolean getPartitionsByExpr(Table tbl, ExprNodeDesc expr, HiveConf conf,
       List<Partition> partitions) throws HiveException, TException {
     PerfLogger perfLogger = SessionState.getPerfLogger();
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.HIVE_GET_PARTITIONS_BY_EXPR);
     try {
       Preconditions.checkNotNull(partitions);
-      byte[] exprBytes = SerializationUtilities.serializeExpressionToKryo(expr);
+      byte[] exprBytes = SerializationUtilities.serializeObjectWithTypeInformation(expr);
       String defaultPartitionName = HiveConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
       List<org.apache.hadoop.hive.metastore.api.PartitionSpec> msParts =
               new ArrayList<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartExprEvalUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartExprEvalUtils.java
@@ -103,7 +103,7 @@ public class PartExprEvalUtils {
   }
 
   public static Pair<PrimitiveObjectInspector, ExprNodeEvaluator> prepareExpr(
-      ExprNodeGenericFuncDesc expr, List<String> partColumnNames,
+      ExprNodeDesc expr, List<String> partColumnNames,
       List<PrimitiveTypeInfo> partColumnTypeInfos) throws HiveException {
     // Create the row object
     List<ObjectInspector> partObjectInspectors = new ArrayList<ObjectInspector>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionExpressionForMetastore.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionExpressionForMetastore.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -51,7 +52,7 @@ public class PartitionExpressionForMetastore implements PartitionExpressionProxy
   @Override
   public String convertExprToFilter(byte[] exprBytes, String defaultPartitionName, boolean decodeFilterExpToStr)
       throws MetaException {
-    ExprNodeGenericFuncDesc expr;
+    ExprNodeDesc expr;
     try {
       expr = deserializeExpr(exprBytes);
     } catch (MetaException e) {
@@ -84,7 +85,7 @@ public class PartitionExpressionForMetastore implements PartitionExpressionProxy
       partColumnNames.add(fs.getName());
       partColumnTypeInfos.add(TypeInfoFactory.getPrimitiveTypeInfo(fs.getType()));
     }
-    ExprNodeGenericFuncDesc expr = deserializeExpr(exprBytes);
+    ExprNodeDesc expr = deserializeExpr(exprBytes);
     try {
       ExprNodeDescUtils.replaceEqualDefaultPartition(expr, defaultPartitionName);
     } catch (SemanticException ex) {
@@ -104,10 +105,10 @@ public class PartitionExpressionForMetastore implements PartitionExpressionProxy
     }
   }
 
-  private ExprNodeGenericFuncDesc deserializeExpr(byte[] exprBytes) throws MetaException {
-    ExprNodeGenericFuncDesc expr = null;
+  private ExprNodeDesc deserializeExpr(byte[] exprBytes) throws MetaException {
+    ExprNodeDesc expr = null;
     try {
-      expr = SerializationUtilities.deserializeExpressionFromKryo(exprBytes);
+      expr = SerializationUtilities.deserializeObjectWithTypeInformation(exprBytes);
     } catch (Exception ex) {
       LOG.error("Failed to deserialize the expression", ex);
       throw new MetaException(ex.getMessage());

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
@@ -498,7 +498,7 @@ public class PartitionPruner extends Transform {
    * @return true iff the partition pruning expression contains non-partition columns.
    */
   static private boolean pruneBySequentialScan(Table tab, List<Partition> partitions,
-                                               ExprNodeDesc prunerExpr, HiveConf conf) throws HiveException, MetaException {
+      ExprNodeDesc prunerExpr, HiveConf conf) throws HiveException, MetaException {
     PerfLogger perfLogger = SessionState.getPerfLogger();
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.PRUNE_LISTING);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
@@ -225,7 +225,7 @@ public class PartitionPruner extends Transform {
       return ppList;
     }
 
-    ppList = getPartitionsFromServer(tab, key, (ExprNodeGenericFuncDesc) compactExpr,
+    ppList = getPartitionsFromServer(tab, key, compactExpr,
         conf, alias, partColsUsedInFilter, oldFilter.equals(compactExprString));
     prunedPartitionsMap.put(key, ppList);
     return ppList;
@@ -437,7 +437,7 @@ public class PartitionPruner extends Transform {
     return false;
   }
 
-  private static PrunedPartitionList getPartitionsFromServer(Table tab, final String key, final ExprNodeGenericFuncDesc compactExpr,
+  private static PrunedPartitionList getPartitionsFromServer(Table tab, final String key, final ExprNodeDesc compactExpr,
       HiveConf conf, String alias, Set<String> partColsUsedInFilter, boolean isPruningByExactFilter) throws SemanticException {
     try {
 
@@ -498,7 +498,7 @@ public class PartitionPruner extends Transform {
    * @return true iff the partition pruning expression contains non-partition columns.
    */
   static private boolean pruneBySequentialScan(Table tab, List<Partition> partitions,
-      ExprNodeGenericFuncDesc prunerExpr, HiveConf conf) throws HiveException, MetaException {
+                                               ExprNodeDesc prunerExpr, HiveConf conf) throws HiveException, MetaException {
     PerfLogger perfLogger = SessionState.getPerfLogger();
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.PRUNE_LISTING);
 
@@ -549,7 +549,7 @@ public class PartitionPruner extends Transform {
    * @return Whether the list has any partitions for which the expression may or may not match.
    */
   public static boolean prunePartitionNames(List<String> partColumnNames,
-      List<PrimitiveTypeInfo> partColumnTypeInfos, ExprNodeGenericFuncDesc prunerExpr,
+      List<PrimitiveTypeInfo> partColumnTypeInfos, ExprNodeDesc prunerExpr,
       String defaultPartitionName, List<String> partNames) throws HiveException, MetaException {
     // Prepare the expression to filter on the columns.
     Pair<PrimitiveObjectInspector, ExprNodeEvaluator> handle =

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.txn.compactor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
+import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -29,7 +30,6 @@ import org.apache.hadoop.hive.metastore.api.SkewedInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
-import org.apache.hadoop.hive.ql.ddl.table.create.show.ShowCreateTableOperation;
 import org.apache.hadoop.hive.ql.exec.DDLPlanUtils;
 import org.apache.hadoop.hive.ql.io.AcidDirectory;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
@@ -348,14 +348,11 @@ class CompactionQueryBuilder {
       query.append(" where ");
       for (int i = 0; i < keys.size(); ++i) {
         FieldSchema keySchema = keys.get(i);
-        boolean isBooleanKey = keySchema.getType().equalsIgnoreCase("boolean");
-        query.append(i == 0 ? "`" : " and `").append(keySchema.getName()).append("`=");
-        if (!isBooleanKey) {
-          query.append("'");
-        }
-        query.append(vals.get(i));
-        if (!isBooleanKey) {
-          query.append("'");
+        boolean isBooleanKey = keySchema.getType().equalsIgnoreCase(ColumnType.BOOLEAN_TYPE_NAME);
+        if (isBooleanKey) {
+          query.append("'").append(vals.get(i)).append("'");
+        } else {
+          query.append(vals.get(i));
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
@@ -348,8 +348,8 @@ class CompactionQueryBuilder {
       query.append(" where ");
       for (int i = 0; i < keys.size(); ++i) {
         FieldSchema keySchema = keys.get(i);
-        boolean isBooleanKey = keySchema.getType().equalsIgnoreCase(ColumnType.BOOLEAN_TYPE_NAME);
-        if (isBooleanKey) {
+        query.append(i == 0 ? "`" : " and `").append(keySchema.getName()).append("`=");
+        if (!keySchema.getType().equalsIgnoreCase(ColumnType.BOOLEAN_TYPE_NAME)) {
           query.append("'").append(vals.get(i)).append("'");
         } else {
           query.append(vals.get(i));

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
@@ -347,8 +347,16 @@ class CompactionQueryBuilder {
 
       query.append(" where ");
       for (int i = 0; i < keys.size(); ++i) {
-        query.append(i == 0 ? "`" : " and `").append(keys.get(i).getName()).append("`='")
-            .append(vals.get(i)).append("'");
+        FieldSchema keySchema = keys.get(i);
+        boolean isBooleanKey = keySchema.getType().equalsIgnoreCase("boolean");
+        query.append(i == 0 ? "`" : " and `").append(keySchema.getName()).append("`=");
+        if (!isBooleanKey) {
+          query.append("'");
+        }
+        query.append(vals.get(i));
+        if (!isBooleanKey) {
+          query.append("'");
+        }
       }
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/metastore/TestMetastoreExpr.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/TestMetastoreExpr.java
@@ -188,7 +188,7 @@ public class TestMetastoreExpr {
 
     // check with partition spec as well
     PartitionsByExprRequest req = new PartitionsByExprRequest(dbName, tblName,
-            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(expr)));
+        ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(expr)));
     req.setMaxParts((short)-1);
     req.setId(t.getId());
 

--- a/ql/src/test/org/apache/hadoop/hive/metastore/TestMetastoreExpr.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/TestMetastoreExpr.java
@@ -183,12 +183,12 @@ public class TestMetastoreExpr {
       String dbName, String tblName, ExprNodeGenericFuncDesc expr, Table t) throws Exception {
     List<Partition> parts = new ArrayList<Partition>();
     client.listPartitionsByExpr(dbName, tblName,
-        SerializationUtilities.serializeExpressionToKryo(expr), null, (short)-1, parts);
+        SerializationUtilities.serializeObjectWithTypeInformation(expr), null, (short)-1, parts);
     assertEquals("Partition check failed: " + expr.getExprString(), numParts, parts.size());
 
     // check with partition spec as well
     PartitionsByExprRequest req = new PartitionsByExprRequest(dbName, tblName,
-            ByteBuffer.wrap(SerializationUtilities.serializeExpressionToKryo(expr)));
+            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(expr)));
     req.setMaxParts((short)-1);
     req.setId(t.getId());
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientListPartitionsTempTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientListPartitionsTempTable.java
@@ -246,7 +246,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     request.setTblName(TABLE_NAME);
     byte[] exprs = {(byte)-1};
     if (expr != null) {
-      exprs = SerializationUtilities.serializeExpressionToKryo(expr);
+      exprs = SerializationUtilities.serializeObjectWithTypeInformation(expr);
     }
     request.setExpr(exprs);
     request.setMaxParts(numParts);
@@ -335,7 +335,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
   public void testListPartitionsByExprNullResult() throws Exception {
     createTable4PartColsParts(getClient());
     TestMetastoreExpr.ExprBuilder e = new TestMetastoreExpr.ExprBuilder(TABLE_NAME);
-    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeExpressionToKryo(
+    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeObjectWithTypeInformation(
         e.strCol("yyyy").val("2017").pred("=", 2).build()), null,
         (short)-1, null);
   }
@@ -345,7 +345,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     createTable4PartColsParts(getClient());
     TestMetastoreExpr.ExprBuilder e = new TestMetastoreExpr.ExprBuilder(TABLE_NAME);
     List<Partition> result = new ArrayList<>();
-    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeExpressionToKryo(
+    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeObjectWithTypeInformation(
         e.strCol("yyyy").val("2017").pred(">=", 2).build()), null, (short)3, result);
     assertEquals(3, result.size());
   }
@@ -355,7 +355,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     createTable4PartColsParts(getClient());
     TestMetastoreExpr.ExprBuilder e = new TestMetastoreExpr.ExprBuilder(TABLE_NAME);
     List<Partition> result = new ArrayList<>();
-    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeExpressionToKryo(
+    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeObjectWithTypeInformation(
         e.strCol("yyyy").val("2017").pred(">=", 2).build()), null, (short)100, result);
     assertEquals(4, result.size());
   }
@@ -400,7 +400,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
 
   private void checkExpr(int numParts, ExprNodeGenericFuncDesc expr) throws Exception {
     List<Partition> parts = new ArrayList<>();
-    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeExpressionToKryo(expr),
+    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeObjectWithTypeInformation(expr),
         null, (short) -1, parts);
     assertEquals("Partition check failed: " + expr.getExprString(), numParts, parts.size());
   }
@@ -427,7 +427,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     TestMetastoreExpr.ExprBuilder e = new TestMetastoreExpr.ExprBuilder(TABLE_NAME);
 
     PartitionsByExprRequest req = new PartitionsByExprRequest(DB_NAME, TABLE_NAME,
-            ByteBuffer.wrap(SerializationUtilities.serializeExpressionToKryo(
+            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(
                     e.strCol("yyyy").val("2017").pred("=", 2).build())));
     req.setMaxParts((short)-1);
     req.setId(t.getId());
@@ -444,7 +444,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     List<PartitionSpec> result = new ArrayList<>();
 
     PartitionsByExprRequest req = new PartitionsByExprRequest(DB_NAME, TABLE_NAME,
-            ByteBuffer.wrap(SerializationUtilities.serializeExpressionToKryo(
+            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(
                     e.strCol("yyyy").val("2017").pred(">=", 2).build())));
     req.setMaxParts((short)3);
     req.setId(t.getId());
@@ -460,7 +460,7 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     List<PartitionSpec> result = new ArrayList<>();
 
     PartitionsByExprRequest req = new PartitionsByExprRequest(DB_NAME, TABLE_NAME,
-            ByteBuffer.wrap(SerializationUtilities.serializeExpressionToKryo(
+            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(
                     e.strCol("yyyy").val("2017").pred(">=", 2).build())));
     req.setMaxParts((short)100);
     req.setId(t.getId());
@@ -530,12 +530,12 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
 
   private void checkExprPartitionSpec(int numParts, ExprNodeGenericFuncDesc expr, Table t) throws Exception {
     List<Partition> parts = new ArrayList<>();
-    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeExpressionToKryo(expr),
+    getClient().listPartitionsByExpr(DB_NAME, TABLE_NAME, SerializationUtilities.serializeObjectWithTypeInformation(expr),
         null, (short) -1, parts);
     assertEquals("Partition check failed: " + expr.getExprString(), numParts, parts.size());
     // check with partition spec as well
     PartitionsByExprRequest req = new PartitionsByExprRequest(DB_NAME, TABLE_NAME,
-            ByteBuffer.wrap(SerializationUtilities.serializeExpressionToKryo(expr)));
+            ByteBuffer.wrap(SerializationUtilities.serializeObjectWithTypeInformation(expr)));
     req.setMaxParts((short)-1);
     req.setId(t.getId());
 


### PR DESCRIPTION
What changes were proposed in this pull request?

This PR fixes the issue, when compaction fails on tables with boolean partition column.

@zabetak , @kgyrtkirk This PR affects some classes which are really not my table, and I'm unsure if my changes are fine. Could you please also review it?
Why are the changes needed?

Compaction must work properly on tables with boolean partition column as well.
Does this PR introduce any user-facing change?

No
How was this patch tested?

Using automated tests.
