### PR TITLE
HIVE-26010: Compactions not picked up by cleaner if CQ_COMMIT_TIME is null and delayed cleaning is enabled

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -354,7 +354,7 @@ class CompactionTxnHandler extends TxnHandler {
           whereClause += " AND (\"CQ_NEXT_TXN_ID\" <= " + minOpenTxnWaterMark + " OR \"CQ_NEXT_TXN_ID\" IS NULL)";
         }
         if (retentionTime > 0) {
-          whereClause += " AND \"CQ_COMMIT_TIME\" < (" + getEpochFn(dbProduct) + " - " + retentionTime + ")";
+          whereClause += " AND (\"CQ_COMMIT_TIME\" < (" + getEpochFn(dbProduct) + " - " + retentionTime + ") OR \"CQ_COMMIT_TIME\" IS NULL)";
         }
         String s = "SELECT \"CQ_ID\", \"cq1\".\"CQ_DATABASE\", \"cq1\".\"CQ_TABLE\", \"cq1\".\"CQ_PARTITION\"," +
             "   \"CQ_TYPE\", \"CQ_RUN_AS\", \"CQ_HIGHEST_WRITE_ID\", \"CQ_TBLPROPERTIES\"" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the isse that if the the delayed cleaner start is enabled, the compaction requests with null CQ_COMMIT_TIME (this can happen if the compaction worker runs on an older version of hive) are never picked up by the cleaner.

### Why are the changes needed?
This issue can cause that the compaction requests are stuck in 'ready for cleaning' state and accumulating.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Through unit and integration tests