### PR TITLE
HIVE-26006: TopNKey and PTF with more than one column is failing with IOBE

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TopNKeyFilter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TopNKeyFilter.java
@@ -28,8 +28,9 @@ import java.util.Set;
 
 /**
  * Implementation of filtering out keys.
- * An instance of this class is wrapped in {@link TopNKeyOperator} and
+ * Instances of this class is wrapped in {@link TopNKeyOperator} and
  * {@link org.apache.hadoop.hive.ql.exec.vector.VectorTopNKeyOperator}
+ * Empty key means forwarding all rows.
  */
 public final class TopNKeyFilter {
   private final int topN;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TopNKeyOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TopNKeyOperator.java
@@ -39,6 +39,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 
 /**
  * TopNKeyOperator passes rows that contains top N keys only.
+ *
+ * Wraps {@link TopNKeyFilter} instances mapped to partition key values.
+ * When processing a row a TopNKeyFilter is looked up for the row using the partition keys and
+ * the filter decides whether the row should be filtered out.
  */
 public class TopNKeyOperator extends Operator<TopNKeyDesc> implements Serializable {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
@@ -245,7 +245,8 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
     }
 
     final TopNKeyDesc newTopNKeyDesc = topNKeyDesc.combine(commonKeyPrefix);
-    if (newTopNKeyDesc.getKeyColumns().size() <= newTopNKeyDesc.getPartitionKeyColumns().size()) {
+    if (newTopNKeyDesc.getKeyColumns().size() > 0 &&
+            newTopNKeyDesc.getKeyColumns().size() <= newTopNKeyDesc.getPartitionKeyColumns().size()) {
       // All keys are partition keys -> bail out
       return;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
@@ -247,7 +247,8 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
     final TopNKeyDesc newTopNKeyDesc = topNKeyDesc.combine(commonKeyPrefix);
     if (newTopNKeyDesc.getKeyColumns().size() > 0 &&
             newTopNKeyDesc.getKeyColumns().size() <= newTopNKeyDesc.getPartitionKeyColumns().size()) {
-      // All keys are partition keys -> bail out
+      // All keys are partition keys which identical with the no key TNK operator. Such operator forwards all
+      // records and it can be removed.
       return;
     }
     LOG.debug("Pushing a copy of {} through {} and {}",

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
@@ -236,7 +236,7 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
 
   private <TDesc extends AbstractOperatorDesc, TParentDesc extends AbstractOperatorDesc> void pushDownThrough(
           CommonKeyPrefix commonKeyPrefix, TopNKeyOperator topNKey,
-          Operator<TDesc> join, Operator<TParentDesc> reduceSinkOperator)
+          Operator<TDesc> operator, Operator<TParentDesc> parentOperator)
           throws SemanticException {
 
     final TopNKeyDesc topNKeyDesc = topNKey.getConf();
@@ -251,12 +251,12 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
       return;
     }
     LOG.debug("Pushing a copy of {} through {} and {}",
-            topNKey.getName(), join.getName(), reduceSinkOperator.getName());
-    pushdown((TopNKeyOperator) copyDown(reduceSinkOperator, newTopNKeyDesc));
+            topNKey.getName(), operator.getName(), parentOperator.getName());
+    pushdown((TopNKeyOperator) copyDown(parentOperator, newTopNKeyDesc));
 
     if (topNKeyDesc.getKeyColumns().size() == commonKeyPrefix.size()) {
-      LOG.debug("Removing {} above {}", topNKey.getName(), join.getName());
-      join.removeChildAndAdoptItsChildren(topNKey);
+      LOG.debug("Removing {} above {}", topNKey.getName(), operator.getName());
+      operator.removeChildAndAdoptItsChildren(topNKey);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TopNKeyDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TopNKeyDesc.java
@@ -252,7 +252,8 @@ public class TopNKeyDesc extends AbstractOperatorDesc {
   public TopNKeyDesc combine(CommonKeyPrefix commonKeyPrefix) {
     return new TopNKeyDesc(topN, commonKeyPrefix.getMappedOrder(),
             commonKeyPrefix.getMappedNullOrder(), commonKeyPrefix.getMappedColumns(),
-            commonKeyPrefix.getMappedColumns().subList(0, partitionKeyColumns.size()),
+            commonKeyPrefix.getMappedColumns()
+                    .subList(0, Math.min(partitionKeyColumns.size(), commonKeyPrefix.getMappedColumns().size())),
             efficiencyThreshold, checkEfficiencyNumBatches, maxNumberOfPartitions);
   }
 

--- a/ql/src/test/queries/clientpositive/ptf_tnk.q
+++ b/ql/src/test/queries/clientpositive/ptf_tnk.q
@@ -1,10 +1,41 @@
+set hive.vectorized.execution.enabled=false;
+
 CREATE EXTERNAL TABLE t1(
    a int,
    b int,
    c int,
    d int);
 
+insert into t1(a, b, c, d) values
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4);
+
 explain
+SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1;
+
 SELECT * FROM (
   SELECT a,
          b,

--- a/ql/src/test/queries/clientpositive/ptf_tnk.q
+++ b/ql/src/test/queries/clientpositive/ptf_tnk.q
@@ -1,0 +1,22 @@
+CREATE EXTERNAL TABLE t1(
+   a int,
+   b int,
+   c int,
+   d int);
+
+explain
+SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1;

--- a/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
@@ -125,32 +125,25 @@ STAGE PLANS:
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
-              Top N Key Operator
-                sort order: +
-                keys: KEY._col0 (type: int)
-                null sort order: a
-                Map-reduce partition columns: KEY._col0 (type: int)
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                top n: 14
-                Group By Operator
-                  keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
-                  mode: mergepartial
-                  outputColumnNames: _col0, _col1, _col2, _col3
+                Top N Key Operator
+                  sort order: ++-
+                  keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                  null sort order: aaa
+                  Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
                   Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                  Top N Key Operator
-                    sort order: ++-
-                    keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                  top n: 14
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
                     null sort order: aaa
+                    sort order: ++-
                     Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
                     Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                    top n: 14
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
-                      null sort order: aaa
-                      sort order: ++-
-                      Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
-                      Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: int)
+                    value expressions: _col1 (type: int)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
@@ -1,0 +1,171 @@
+PREHOOK: query: CREATE EXTERNAL TABLE t1(
+   a int,
+   b int,
+   c int,
+   d int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE EXTERNAL TABLE t1(
+   a int,
+   b int,
+   c int,
+   d int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: explain
+SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: a (type: int), b (type: int), c (type: int), d (type: int)
+                    outputColumnNames: a, b, c, d
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                    Group By Operator
+                      keys: a (type: int), b (type: int), c (type: int), d (type: int)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int)
+                        null sort order: zzzz
+                        sort order: ++++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int)
+                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Top N Key Operator
+                sort order: +
+                keys: KEY._col0 (type: int)
+                null sort order: a
+                Map-reduce partition columns: KEY._col0 (type: int)
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                top n: 14
+                Group By Operator
+                  keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
+                  mode: mergepartial
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                  Top N Key Operator
+                    sort order: ++-
+                    keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                    null sort order: aaa
+                    Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                    top n: 14
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                      null sort order: aaa
+                      sort order: ++-
+                      Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col1 (type: int)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: int, _col1: int, _col2: int, _col3: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 DESC NULLS FIRST
+                        partition by: _col0, _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: DENSE_RANK_window_0
+                              arguments: _col3
+                              name: DENSE_RANK
+                              window function: GenericUDAFDenseRankEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (DENSE_RANK_window_0 <= 13) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                    Limit
+                      Number of rows: 1
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                      Select Operator
+                        expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), DENSE_RANK_window_0 (type: int)
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                        File Output Operator
+                          compressed: false
+                          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: 1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
@@ -91,32 +91,25 @@ STAGE PLANS:
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
-              Top N Key Operator
-                sort order: +
-                keys: KEY._col0 (type: int)
-                null sort order: a
-                Map-reduce partition columns: KEY._col0 (type: int)
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                top n: 14
-                Group By Operator
-                  keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
-                  mode: mergepartial
-                  outputColumnNames: _col0, _col1, _col2, _col3
+                Top N Key Operator
+                  sort order: ++-
+                  keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                  null sort order: aaa
+                  Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
                   Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                  Top N Key Operator
-                    sort order: ++-
-                    keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                  top n: 14
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
                     null sort order: aaa
+                    sort order: ++-
                     Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
                     Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                    top n: 14
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
-                      null sort order: aaa
-                      sort order: ++-
-                      Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
-                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col1 (type: int)
+                    value expressions: _col1 (type: int)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf_tnk.q.out
@@ -14,6 +14,40 @@ POSTHOOK: query: CREATE EXTERNAL TABLE t1(
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1(a, b, c, d) values
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(a, b, c, d) values
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4),
+(2,3,4,5),
+(1,2,3,4),
+(7,8,9,10),
+(7,7,2,4),
+(1,2,3,4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
 PREHOOK: query: explain
 SELECT * FROM (
   SELECT a,
@@ -69,54 +103,61 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 11 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: a (type: int), b (type: int), c (type: int), d (type: int)
                     outputColumnNames: a, b, c, d
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 11 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: a (type: int), b (type: int), c (type: int), d (type: int)
-                      minReductionHashAggr: 0.99
+                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3
-                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int)
                         null sort order: zzzz
                         sort order: ++++
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int)
-                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
+                        Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: vectorized, llap
+            Execution mode: llap
             Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                Top N Key Operator
-                  sort order: ++-
-                  keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
-                  null sort order: aaa
-                  Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                  top n: 14
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
-                    null sort order: aaa
+              Top N Key Operator
+                sort order: +
+                keys: KEY._col0 (type: int)
+                null sort order: a
+                Map-reduce partition columns: KEY._col0 (type: int)
+                Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                top n: 14
+                Group By Operator
+                  keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
+                  mode: mergepartial
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                  Top N Key Operator
                     sort order: ++-
+                    keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                    null sort order: aaa
                     Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int)
+                    Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                    top n: 14
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                      null sort order: aaa
+                      sort order: ++-
+                      Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
+                      Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int)
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -137,20 +178,20 @@ STAGE PLANS:
                               window function: GenericUDAFDenseRankEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 5 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (DENSE_RANK_window_0 <= 13) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Limit
                       Number of rows: 1
-                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: _col0 (type: int), _col1 (type: int), _col2 (type: int), _col3 (type: int), DENSE_RANK_window_0 (type: int)
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                         File Output Operator
                           compressed: false
-                          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                           table:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -162,3 +203,40 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM (
+  SELECT a,
+         b,
+         c,
+         d,
+         DENSE_RANK() OVER (PARTITION BY a,c ORDER BY d DESC) AS drank
+  FROM (
+     select distinct(a),
+            b,
+            c,
+            d
+     FROM t1
+     ) subA
+ ) subB
+ WHERE subB.drank <= 13 limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	2	3	4	1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When pushing TNK through GBY the new TNK operator created on top should contain the common key prefix of the original TNK and the GBY.
```
Group By Operator
  keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: int)
  Top N Key Operator
    keys: _col0 (type: int), _col2 (type: int), _col3 (type: int)
    Map-reduce partition columns: _col0 (type: int), _col2 (type: int)
```
The common key prefix is: `_col0 (type: int)`
Map-reduce partition columns is also a prefix of the keys. When calculating the new TNK's Map-reduce partition columns take the whole common key prefix if common key prefix of the original TNK and the GBY is smaller than the original TNK's Map-reduce partition columns.

### Why are the changes needed?
When calculating the new TNK's Map-reduce partition columns `ArrayIndexOutOfBoundsException` is thrown when the common key prefix of the original TNK and the GBY is smaller than the original TNK's Map-reduce partition columns.

### Does this PR introduce _any_ user-facing change?
No `ArrayIndexOutOfBoundsException` is thrown.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=ptf_tnk.q -pl itests/qtest -Pitests
```