### PR TITLE
HIVE-26016: Remove duplicate table exists check in create_table_core api of HMSHandler

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -2333,11 +2333,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       isReplicated = isDbReplicationTarget(db);
 
       firePreEvent(new PreCreateTableEvent(tbl, db, this));
-      // get_table checks whether database exists, it should be moved here
-      if (is_table_exists(ms, tbl.getCatName(), tbl.getDbName(), tbl.getTableName())) {
-        throw new AlreadyExistsException("Table " + getCatalogQualifiedTableName(tbl)
-            + " already exists");
-      }
 
       if (!TableType.VIRTUAL_VIEW.toString().equals(tbl.getTableType())) {
         if (tbl.getSd().getLocation() == null


### PR DESCRIPTION

### What changes were proposed in this pull request?
Currently the `create_table_core` api will check if table exists twice, we can remove the second check.


### Why are the changes needed?
For code improvement.


### Does this PR introduce _any_ user-facing change?
No



### How was this patch tested?
Just remove duplicated code, no additional tests are introduced.

