### PR TITLE
HIVE-25845: Support ColumnIndexes for Parq files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.0.3</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.11.1</parquet.version>
+    <parquet.version>1.11.2</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>2.5.0</protobuf.version>

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
@@ -107,16 +107,19 @@ public class ParquetRecordReaderBase {
       final List<BlockMetaData> splitGroup = new ArrayList<BlockMetaData>();
       final long splitStart = ((FileSplit) oldSplit).getStart();
       final long splitLength = ((FileSplit) oldSplit).getLength();
+      long blockRowCount = 0;
       for (final BlockMetaData block : blocks) {
         final long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
         if (firstDataPage >= splitStart && firstDataPage < splitStart + splitLength) {
           splitGroup.add(block);
+          blockRowCount += block.getRowCount();
         }
       }
       if (splitGroup.isEmpty()) {
         LOG.warn("Skipping split, could not find row group in: " + oldSplit);
         return null;
       }
+      LOG.debug("split group size: {}, row count: {}", splitGroup.size(), blockRowCount);
 
       FilterCompat.Filter filter = setFilter(jobConf, fileMetaData.getSchema());
       if (filter != null) {


### PR DESCRIPTION
Had some issues with https://github.com/apache/hive/pull/3091 . Creating separate PR here for HIVE-25845.

### What changes were proposed in this pull request?
Make use of columnindexes when reading parquet files. More details in https://issues.apache.org/jira/browse/HIVE-25845 

Additional note:  Data cache for parquet wasn't there and "wrapPathForCache" has been disabled for parquet reader in VectorizedParquetRecordReader. When data caching with parquet is stabilized with LLAP, this can be re-enabled.

### Why are the changes needed?
To reduce IO load and improve perf.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
small internal cluster


With TPCH @ 100 GB scale (customer table has 15000000 records), here is the query which was tried out.

Note that with patch, it reads just 11 MB of data instead of 94 MB without patch. This will be highly beneficial for cloud stores.

select count(*) from customer where c_custkey > 14099999 and c_custkey < 14850991 ;

Without Patch:
===========
INFO  : File System Counters:
..
INFO  :    FILE_BYTES_WRITTEN: 4703
INFO  :    HDFS_BYTES_READ: 94174097
...
..


With Patch:
===========

INFO  : File System Counters:
....
INFO  :    HDFS_BYTES_READ: 11777945
...