### PR TITLE
HIVE-26036: NPE caused by getMTable() in ObjectStore

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2567,6 +2567,11 @@ public class ObjectStore implements RawStore, Configurable {
       List<MTablePrivilege> tabGrants = null;
       List<MTableColumnPrivilege> tabColumnGrants = null;
       MTable table = this.getMTable(catName, dbName, tblName);
+      if (table == null) {
+        throw new InvalidObjectException("Unable to add partitions because "
+            + TableName.getQualified(catName, dbName, tblName) +
+            " does not exist");
+      }
       if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
         tabGrants = this.listAllTableGrants(catName, dbName, tblName);
         tabColumnGrants = this.listTableAllColumnGrants(catName, dbName, tblName);
@@ -2635,6 +2640,11 @@ public class ObjectStore implements RawStore, Configurable {
       List<MTablePrivilege> tabGrants = null;
       List<MTableColumnPrivilege> tabColumnGrants = null;
       MTable table = this.getMTable(catName, dbName, tblName);
+      if (table == null) {
+        throw new InvalidObjectException("Unable to add partitions because "
+            + TableName.getQualified(catName, dbName, tblName) +
+            " does not exist");
+      }
       if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
         tabGrants = this.listAllTableGrants(catName, dbName, tblName);
         tabColumnGrants = this.listTableAllColumnGrants(catName, dbName, tblName);
@@ -2695,6 +2705,11 @@ public class ObjectStore implements RawStore, Configurable {
       openTransaction();
       String catName = part.isSetCatName() ? part.getCatName() : getDefaultCatalog(conf);
       MTable table = this.getMTable(catName, part.getDbName(), part.getTableName());
+      if (table == null) {
+        throw new InvalidObjectException("Unable to add partition because "
+            + TableName.getQualified(catName, part.getDbName(), part.getTableName()) +
+            " does not exist");
+      }
       List<MTablePrivilege> tabGrants = null;
       List<MTableColumnPrivilege> tabColumnGrants = null;
       if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
@@ -2757,6 +2772,11 @@ public class ObjectStore implements RawStore, Configurable {
     try {
       openTransaction();
       MTable table = this.getMTable(catName, dbName, tableName);
+      if (table == null) {
+        throw new NoSuchObjectException("Unable to get partition because "
+            + TableName.getQualified(catName, dbName, tableName) +
+            " does not exist");
+      }
       MPartition mpart = getMPartition(catName, dbName, tableName, part_vals, table);
       part = convertToPart(mpart, false);
       committed = commitTransaction();
@@ -5152,6 +5172,10 @@ public class ObjectStore implements RawStore, Configurable {
       openTransaction();
 
       MTable table = this.getMTable(catName, dbName, tblName);
+      if (table == null) {
+        throw new NoSuchObjectException(
+            TableName.getQualified(catName, dbName, tblName) + " table not found");
+      }
       List<String> partNames = new ArrayList<>();
       for (List<String> partVal : part_vals) {
         partNames.add(
@@ -9997,6 +10021,9 @@ public class ObjectStore implements RawStore, Configurable {
     Boolean isCompliant = null;
     if (writeIdList != null) {
       MTable table = this.getMTable(catName, dbName, tableName);
+      if (table == null) {
+        throw new NoSuchObjectException(TableName.getQualified(catName, dbName, tableName) + " table not found");
+      }
       isCompliant = !TxnUtils.isTransactionalTable(table.getParameters())
         || (areTxnStatsSupported && isCurrentStatsValidForTheQuery(table, writeIdList, false));
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -393,6 +393,14 @@ public class TestObjectStore {
     try (AutoCloseable c = deadline()) {
       objectStore.addPartition(part2);
     }
+    List<String> value3 = Arrays.asList("US", "MA");
+    Partition part3 = new Partition(value3, DB1, "not_existed_table", 333, 333, sd, partitionParams);
+    part3.setCatName(DEFAULT_CATALOG_NAME);
+    try (AutoCloseable c = deadline()) {
+      objectStore.addPartition(part3);
+    } catch (InvalidObjectException e) {
+      // expected
+    }
 
     List<Partition> partitions;
     try (AutoCloseable c = deadline()) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -51,6 +51,8 @@ import org.apache.hadoop.hive.metastore.api.NotificationEventRequest;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.hadoop.hive.metastore.api.Package;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PartitionListComposingSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionSpec;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
@@ -76,6 +78,7 @@ import org.apache.hadoop.hive.metastore.metrics.Metrics;
 import org.apache.hadoop.hive.metastore.metrics.MetricsConstants;
 import org.apache.hadoop.hive.metastore.model.MNotificationLog;
 import org.apache.hadoop.hive.metastore.model.MNotificationNextId;
+import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -349,6 +352,12 @@ public class TestObjectStore {
     objectStore.dropDatabase(db1.getCatalogName(), DB1);
   }
 
+  @Test (expected = NoSuchObjectException.class)
+  public void testTableOpsWhenTableDoesNotExist() throws NoSuchObjectException, MetaException {
+    List<String> colNames = Arrays.asList("c0", "c1");
+    objectStore.getTableColumnStatistics(DEFAULT_CATALOG_NAME, DB1, "not_existed_table", colNames, ENGINE, "");
+  }
+
   private StorageDescriptor createFakeSd(String location) {
     return new StorageDescriptor(null, location, null, null, false, 0,
         new SerDeInfo("SerDeName", "serializationLib", null), null, null, null);
@@ -393,14 +402,6 @@ public class TestObjectStore {
     try (AutoCloseable c = deadline()) {
       objectStore.addPartition(part2);
     }
-    List<String> value3 = Arrays.asList("US", "MA");
-    Partition part3 = new Partition(value3, DB1, "not_existed_table", 333, 333, sd, partitionParams);
-    part3.setCatName(DEFAULT_CATALOG_NAME);
-    try (AutoCloseable c = deadline()) {
-      objectStore.addPartition(part3);
-    } catch (InvalidObjectException e) {
-      // expected
-    }
 
     List<Partition> partitions;
     try (AutoCloseable c = deadline()) {
@@ -444,6 +445,52 @@ public class TestObjectStore {
       objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, value2);
       objectStore.dropTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
       objectStore.dropDatabase(db1.getCatalogName(), DB1);
+    }
+  }
+
+  @Test
+  public void testPartitionOpsWhenTableDoesNotExist() throws InvalidObjectException, MetaException {
+    List<String> value1 = Arrays.asList("US", "CA");
+    StorageDescriptor sd1 = createFakeSd("location1");
+    HashMap<String, String> partitionParams = new HashMap<>();
+    partitionParams.put("PARTITION_LEVEL_PRIVILEGE", "true");
+    Partition part1 = new Partition(value1, DB1, "not_existed_table", 111, 111, sd1, partitionParams);
+    try {
+      objectStore.addPartition(part1);
+    } catch (InvalidObjectException e) {
+      // expected
+    }
+    try {
+      objectStore.getPartition(DEFAULT_CATALOG_NAME, DB1, "not_existed_table", value1);
+    } catch (NoSuchObjectException e) {
+      // expected
+    }
+
+    List<String> value2 = Arrays.asList("US", "MA");
+    StorageDescriptor sd2 = createFakeSd("location2");
+    Partition part2 = new Partition(value2, DB1, "not_existed_table", 222, 222, sd2, partitionParams);
+    List<Partition> parts = Arrays.asList(part1, part2);
+    try {
+      objectStore.addPartitions(DEFAULT_CATALOG_NAME, DB1, "not_existed_table", parts);
+    } catch (InvalidObjectException e) {
+      // expected
+    }
+
+    PartitionSpec partitionSpec1 = new PartitionSpec(DB1, "not_existed_table", "location1");
+    partitionSpec1.setPartitionList(new PartitionListComposingSpec(parts));
+    PartitionSpecProxy partitionSpecProxy = PartitionSpecProxy.Factory.get(Arrays.asList(partitionSpec1));
+    try {
+      objectStore.addPartitions(DEFAULT_CATALOG_NAME, DB1, "not_existed_table", partitionSpecProxy, true);
+    } catch (InvalidObjectException e) {
+      // expected
+    }
+
+    List<List<String>> part_vals = Arrays.asList(Arrays.asList("US", "GA"), Arrays.asList("US", "WA"));
+    try {
+      objectStore.alterPartitions(DEFAULT_CATALOG_NAME, DB1, "not_existed_table", part_vals, parts, 0, "");
+    } catch (MetaException e) {
+      // expected
+      Assert.assertTrue(e.getCause() instanceof NoSuchObjectException);
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Some api in ObjectStore invoke `getMTable()` but not check that if the returned value is null, which may cause the NPE, like `addPartitions()`, `addPartition()`, `alterPartition()` et.

Such api described above will check that whether the table exists in `HMSHandler` (first check), but if the table is dropped by other threads after the first check, the NPE will happen.

**The simple idea is that we can check the table each time we get from `getMTable()`.**


### Why are the changes needed?

To fix the NPE from `getMTable()` while others dropping this table.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Just add one test in `TestObjectStore`, can use the minimal test command:
```
mvn test -Dtest=org.apache.hadoop.hive.metastore.TestObjectStore#testPartitionOps -pl :hive-standalone-metastore-server
```
