### PR TITLE
HIVE-26040: Fix DirectSqlUpdateStat.getNextCSIdForMPartitionColumnStatistics for mssql

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
@@ -668,9 +668,9 @@ class DirectSqlUpdateStat {
       // the caller gets a reserved range for CSId not used by any other thread.
       boolean insertDone = false;
       while (maxCsId == 0) {
-        String query = "SELECT \"NEXT_VAL\" FROM \"SEQUENCE_TABLE\" WHERE \"SEQUENCE_NAME\"= "
-                + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics")
-                + " FOR UPDATE";
+        String query = sqlGenerator.addForUpdateClause("SELECT \"NEXT_VAL\" FROM \"SEQUENCE_TABLE\" "
+                + "WHERE \"SEQUENCE_NAME\"= "
+                + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics"));
         LOG.debug("Going to execute query " + query);
         statement = dbConn.createStatement();
         rs = statement.executeQuery(query);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix directsql `FOR UPDATE` to work with all of the databases

### Why are the changes needed?
`mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=list_bucket_dml_9.q -Dtest.metastore.db=mssql` was failing

### Does this PR introduce _any_ user-facing change?
Fixing the issue

### How was this patch tested?
By running the unit test above