### PR TITLE
HIVE-26026: Use the new "REFUSED" compaction state where it makes sense

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -1396,7 +1396,7 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     ShowCompactResponse resp = txnHandler.showCompact(new ShowCompactRequest());
     Assert.assertEquals("Unexpected number of compactions in history", 2, resp.getCompactsSize());
     Assert.assertEquals("Unexpected 0 compaction state", TxnStore.CLEANING_RESPONSE, resp.getCompacts().get(0).getState());
-    Assert.assertEquals("Unexpected 1 compaction state", TxnStore.SUCCEEDED_RESPONSE,
+    Assert.assertEquals("Unexpected 1 compaction state", TxnStore.REFUSED_RESPONSE,
         resp.getCompacts().get(1).getState());
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -362,11 +362,11 @@ public class TestWorker extends CompactorTest {
 
     startWorker();
 
-    // since compaction was not run, state should not be "ready for cleaning" but "succeeded"
+    // since compaction was not run, state should not be "ready for cleaning" but "refused"
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     List<ShowCompactResponseElement> compacts = rsp.getCompacts();
     Assert.assertEquals(1, compacts.size());
-    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, compacts.get(0).getState());
+    Assert.assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(0).getState());
 
     // There should still be 4 directories in the location
     FileSystem fs = FileSystem.get(conf);
@@ -1123,7 +1123,7 @@ public class TestWorker extends CompactorTest {
     List<ShowCompactResponseElement> compacts =
         txnHandler.showCompact(new ShowCompactRequest()).getCompacts();
     Assert.assertEquals(compactionNum + 1, compacts.size());
-    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, compacts.get(compactionNum).getState());
+    Assert.assertEquals(TxnStore.REFUSED_RESPONSE, compacts.get(compactionNum).getState());
 
     // assert transaction with txnId=1 is still aborted after cleaner is run
     startCleaner();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -1324,8 +1324,9 @@ class CompactionTxnHandler extends TxnHandler {
 
 
   private void updateStatus(CompactionInfo ci) throws MetaException {
+    String strState = compactorStateToResponse(ci.state);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Marking as failed: CompactionInfo: " + ci.toString());
+      LOG.debug("Marking as " + strState + ": CompactionInfo: " + ci);
     }
     try {
       Connection dbConn = null;
@@ -1386,15 +1387,12 @@ class CompactionTxnHandler extends TxnHandler {
         CompactionInfo.insertIntoCompletedCompactions(pStmt, ci, getDbTime(dbConn));
         int updCount = pStmt.executeUpdate();
         LOG.debug("Inserted " + updCount + " entries into COMPLETED_COMPACTIONS");
-        LOG.debug("Going to commit");
         closeStmt(pStmt);
         dbConn.commit();
       } catch (SQLException e) {
-        LOG.warn("markFailed(" + ci.id + "):" + e.getMessage());
-        LOG.debug("Going to rollback");
+        LOG.error("Failed to mark compaction request as " + strState + ", rolling back transaction: " + ci, e);
         rollbackDBConn(dbConn);
-        checkRetryable(e, "markFailed(" + ci + ")");
-        LOG.error("markFailed(" + ci + ") failed: " + e.getMessage(), e);
+        checkRetryable(e, "updateStatus(" + ci + ")");
       } finally {
         close(rs, stmt, null);
         close(null, pStmt, dbConn);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3881,7 +3881,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     }
   }
   
-  private static String compactorStateToResponse(char s) {
+  protected static String compactorStateToResponse(char s) {
     switch (s) {
       case INITIATED_STATE: return INITIATED_RESPONSE;
       case WORKING_STATE: return WORKING_RESPONSE;


### PR DESCRIPTION
### What changes were proposed in this pull request?
When the pre-compaction checks fail in Worker, the compaction state should be set to "REFUSED" instead of "SUCCEEDED" among with the appropriate error message.


### Why are the changes needed?
The org.apache.hadoop.hive.ql.txn.compactor.Worker#findNextCompactionAndExecute method does several checks (The table/partition exists, is not sorted, there are enough files to compact, etc.) before it actually executes the compaction request. If the compaction request fails on any of these checks, it is put to "SUCCEEDED" state which is often misleading for users. SHOW COMPACTIONS will show these requests as succeeded without an error, while the table is not compacted at all.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually and through unit tests.