### PR TITLE
HIVE-26068: Add README with build instructions to the src tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Getting Started
 - Installation Instructions and a quick tutorial:
   https://cwiki.apache.org/confluence/display/Hive/GettingStarted
 
+- Instructions to build Hive from source:
+  https://cwiki.apache.org/confluence/display/Hive/GettingStarted#GettingStarted-BuildingHivefromSource
+
 - A longer tutorial that covers more features of HiveQL:
   https://cwiki.apache.org/confluence/display/Hive/Tutorial
 

--- a/packaging/src/main/assembly/src.xml
+++ b/packaging/src/main/assembly/src.xml
@@ -50,7 +50,7 @@
         <include>.gitignore</include>
         <include>.reviewboardrc</include>
         <include>DEVNOTES</include>
-        <include>README.txt</include>
+        <include>README*</include>
         <include>LICENSE</include>
         <include>NOTICE</include>
         <include>CHANGELOG</include>


### PR DESCRIPTION
### Why are the changes needed?
Give people who download a source release a grasp on how to build the project.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

1. `mvn package -DskipTests -Pdist`
2. `tar -xvf unzipped apache-hive-4.0.0-alpha-1-SNAPSHOT-src.tar.gz`
3. `find . -name "README*"` inside apache-hive-4.0.0-alpha-1-SNAPSHOT-src`