### PR TITLE
HIVE-26070: Remove the generated files from the source tarball

### DIFF
--- a/packaging/src/main/assembly/src.xml
+++ b/packaging/src/main/assembly/src.xml
@@ -46,7 +46,7 @@
         <exclude>common/src/gen/**</exclude>
         <exclude>kafka-handler/src/test/gen/**</exclude>
         <exclude>conf/hive-default.xml.template</exclude>
-        <exclude>ql/dependency-reduced-pom.xml</exclude>
+        <exclude>**/dependency-reduced-pom.xml</exclude>
       </excludes>
 
       <includes>

--- a/packaging/src/main/assembly/src.xml
+++ b/packaging/src/main/assembly/src.xml
@@ -41,6 +41,12 @@
         <exclude>**/.project</exclude>
         <exclude>**/.settings/**</exclude>
         <exclude>**/thirdparty/**</exclude>
+        <exclude>standalone-metastore/metastore-common/src/gen/version/**</exclude>
+        <exclude>standalone-metastore/metastore-server/src/gen/**</exclude>
+        <exclude>common/src/gen/**</exclude>
+        <exclude>kafka-handler/src/test/gen/**</exclude>
+        <exclude>conf/hive-default.xml.template</exclude>
+        <exclude>ql/dependency-reduced-pom.xml</exclude>
       </excludes>
 
       <includes>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the generated files from the source tarball

### Why are the changes needed?
Decreases the probability of an error, and decreases the size of the tarball

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Created the tarball, checked that the files are not there.
Also run `mvn clean install -DskipTests -Pitests,dist -T8` on the source and checked that the missing files are generated