### PR TITLE
HIVE-26072: Enable vectorization for stats gathering (tablescan op).

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -253,8 +253,8 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
         if (vectorized) {
           VectorizedRowBatch rowBatch = (VectorizedRowBatch) row;
           ArrayList<ColumnVector> cv = new ArrayList<>();
-          for (int i = 0; i < rowBatch.numCols; i++) {
-            ColumnVector col = rowBatch.cols[i];
+          for (int i = 0; i < conf.getPartColumns().size(); i++) {
+            ColumnVector col = rowBatch.cols[dpStartCol + i];
             if (col != null) {
               cv.add(col);
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -252,10 +252,19 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
 
         if (vectorized) {
           VectorizedRowBatch rowBatch = (VectorizedRowBatch) row;
+          ArrayList<ColumnVector> cv = new ArrayList<>();
           for (int i = 0; i < rowBatch.numCols; i++) {
             ColumnVector col = rowBatch.cols[i];
-            // TODO: may not be correct, find some method to get exact values.....
-            values.add(col == null ? defaultPartitionName : col.toString());
+            if (col != null) {
+              cv.add(col);
+            }
+          }
+          for (int i = 0; i < rowBatch.size; i++) {
+            for (ColumnVector c : cv) {
+              StringBuilder sb = new StringBuilder();
+              c.stringifyValue(sb, i);
+              values.add(sb.toString().equalsIgnoreCase("null") ? defaultPartitionName : sb.toString());
+            }
           }
         } else {
           ObjectInspectorUtils.partialCopyToStandardObject(writable, row, dpStartCol, conf.getPartColumns().size(),

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.ErrorMsg;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContextRegion;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -252,7 +253,9 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
         if (vectorized) {
           VectorizedRowBatch rowBatch = (VectorizedRowBatch) row;
           for (int i = 0; i < rowBatch.numCols; i++) {
-            values.add(rowBatch.cols[0].toString());
+            ColumnVector col = rowBatch.cols[i];
+            // TODO: may not be correct, find some method to get exact values.....
+            values.add(col == null ? defaultPartitionName : col.toString());
           }
         } else {
           ObjectInspectorUtils.partialCopyToStandardObject(writable, row, dpStartCol, conf.getPartColumns().size(),

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -2055,11 +2055,8 @@ public class Vectorizer implements PhysicalPlanResolver {
       // Set "global" member indicating where to store "not vectorized" information if necessary.
       currentBaseWork = mapWork;
 
-      if (!validateTableScanOperator(tableScanOperator, mapWork)) {
-
-        // The "not vectorized" information has been stored in the MapWork vertex.
-        return false;
-      }
+      // After HIVE-24510, stats should be able to support vectorization, so removed the previous check in
+      // validateTableScanOperator.
       try {
         validateAndVectorizeMapOperators(tableScanOperator, isTezOrSpark, vectorTaskColumnInfo);
       } catch (VectorizerCannotVectorizeException e) {
@@ -2570,16 +2567,6 @@ public class Vectorizer implements PhysicalPlanResolver {
     SMBJoinDesc desc = op.getConf();
     // Validation is the same as for map join, since the 'small' tables are not vectorized
     return validateMapJoinDesc(desc);
-  }
-
-  private boolean validateTableScanOperator(TableScanOperator op, MapWork mWork) {
-    TableScanDesc desc = op.getConf();
-    if (desc.isGatherStats()) {
-      setOperatorIssue("gather stats not supported");
-      return false;
-    }
-
-    return true;
   }
 
   private boolean validateMapJoinOperator(MapJoinOperator op) {


### PR DESCRIPTION
After https://issues.apache.org/jira/browse/HIVE-23530 , almost all compute stats functions are vectorizable. Only function that is not vectorizable is "compute_bit_vector" for ndv statistics computation. This causes "create table as select" and "insert overwrite select" queries to run in non-vectorized mode. 

Even a very naive implementation of vectorized compute_bit_vector gives about 50% performance improvement on simple "insert overwrite select" queries. That is because entire mapper or reducer can run in vectorized mode.