### PR TITLE
HIVE-26077: Implement CTAS for Iceberg tables with partition spec

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -299,12 +300,14 @@ public class HiveIcebergTestUtils {
       Assert.assertEquals(record.size(), row.length);
       for (int j = 0; j < record.size(); ++j) {
         Object field = record.get(j);
-        if (field instanceof LocalDateTime) {
+        if (field == null) {
+          Assert.assertNull(row[j]);
+        } else if (field instanceof LocalDateTime) {
           Assert.assertEquals(((LocalDateTime) field).toInstant(ZoneOffset.UTC).toEpochMilli(),
               TimestampUtils.stringToTimestamp((String) row[j]).toEpochMilli());
         } else if (field instanceof OffsetDateTime) {
           Assert.assertEquals(((OffsetDateTime) field).toInstant().toEpochMilli(),
-              TimestampTZUtil.parse((String) row[j]).toEpochMilli());
+              TimestampTZUtil.parse((String) row[j], ZoneId.systemDefault()).toEpochMilli());
         } else {
           Assert.assertEquals(field.toString(), row[j].toString());
         }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -482,7 +482,9 @@ abstract class TestTables {
 
   private String getStringValueForInsert(Object value, Type type) {
     String template = "\'%s\'";
-    if (type.equals(Types.TimestampType.withoutZone())) {
+    if (value == null) {
+      return "NULL";
+    } else if (type.equals(Types.TimestampType.withoutZone())) {
       return String.format(template, Timestamp.valueOf((LocalDateTime) value).toString());
     } else if (type.equals(Types.TimestampType.withZone())) {
       return String.format(template, Timestamp.from(((OffsetDateTime) value).toInstant()).toString());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implements the following query:
```
CREATE TABLE t PARTITIONED BY SPEC(day(ts)) AS SELECT ...
```

### Why are the changes needed?
We need to have a way to create a table with the spec

### Does this PR introduce _any_ user-facing change?
Implements a new syntax

### How was this patch tested?
New unit test