### PR TITLE
HIVE-26095: Add queryid in QueryLifeTimeHookContext

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
@@ -164,14 +164,14 @@ public class Compiler {
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.PARSE);
 
     // Trigger query hook before compilation
-    driverContext.getHookRunner().runBeforeParseHook(context.getCmd());
+    driverContext.getHookRunner().runBeforeParseHook(context);
 
     boolean success = false;
     try {
       tree = ParseUtils.parse(context.getCmd(), context);
       success = true;
     } finally {
-      driverContext.getHookRunner().runAfterParseHook(context.getCmd(), !success);
+      driverContext.getHookRunner().runAfterParseHook(context, !success);
     }
     perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.PARSE);
   }
@@ -179,7 +179,7 @@ public class Compiler {
   private BaseSemanticAnalyzer analyze() throws Exception {
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.ANALYZE);
 
-    driverContext.getHookRunner().runBeforeCompileHook(context.getCmd());
+    driverContext.getHookRunner().runBeforeCompileHook(context);
 
     // clear CurrentFunctionsInUse set, to capture new set of functions
     // that SemanticAnalyzer finds are in use

--- a/ql/src/java/org/apache/hadoop/hive/ql/HookRunner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/HookRunner.java
@@ -66,13 +66,16 @@ public class HookRunner {
    * {@link QueryLifeTimeHookWithParseHooks#beforeParse(QueryLifeTimeHookContext)} method for each
    * {@link QueryLifeTimeHookWithParseHooks}.
    *
-   * @param command the Hive command that is being run
+   * @param ctx
    */
-  void runBeforeParseHook(String command) {
+  void runBeforeParseHook(Context ctx) {
     List<QueryLifeTimeHook> queryHooks = hooks.getHooks(QUERY_LIFETIME_HOOKS);
     if (!queryHooks.isEmpty()) {
       QueryLifeTimeHookContext qhc =
-          new QueryLifeTimeHookContextImpl.Builder().withHiveConf(conf).withCommand(command).build();
+          new QueryLifeTimeHookContextImpl.Builder()
+              .withHiveConf(conf)
+              .withCommand(ctx.getCmd())
+              .build(ctx.getWmContext().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         if (hook instanceof QueryLifeTimeHookWithParseHooks) {
@@ -87,14 +90,17 @@ public class HookRunner {
    * {@link QueryLifeTimeHookWithParseHooks#afterParse(QueryLifeTimeHookContext, boolean)} method for each
    * {@link QueryLifeTimeHookWithParseHooks}.
    *
-   * @param command the Hive command that is being run
+   * @param ctx
    * @param parseError true if there was an error while parsing the command, false otherwise
    */
-  void runAfterParseHook(String command, boolean parseError) {
+  void runAfterParseHook(Context ctx, boolean parseError) {
     List<QueryLifeTimeHook> queryHooks = hooks.getHooks(QUERY_LIFETIME_HOOKS);
     if (!queryHooks.isEmpty()) {
       QueryLifeTimeHookContext qhc =
-          new QueryLifeTimeHookContextImpl.Builder().withHiveConf(conf).withCommand(command).build();
+          new QueryLifeTimeHookContextImpl.Builder()
+              .withHiveConf(conf)
+              .withCommand(ctx.getCmd())
+              .build(ctx.getWmContext().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         if (hook instanceof QueryLifeTimeHookWithParseHooks) {
@@ -107,13 +113,16 @@ public class HookRunner {
   /**
    * Dispatches {@link QueryLifeTimeHook#beforeCompile(QueryLifeTimeHookContext)}.
    *
-   * @param command the Hive command that is being run
+   * @param ctx
    */
-  void runBeforeCompileHook(String command) {
+  void runBeforeCompileHook(Context ctx) {
     List<QueryLifeTimeHook> queryHooks = hooks.getHooks(QUERY_LIFETIME_HOOKS);
     if (!queryHooks.isEmpty()) {
       QueryLifeTimeHookContext qhc =
-          new QueryLifeTimeHookContextImpl.Builder().withHiveConf(conf).withCommand(command).build();
+          new QueryLifeTimeHookContextImpl.Builder()
+              .withHiveConf(conf)
+              .withCommand(ctx.getCmd())
+              .build(ctx.getWmContext().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         hook.beforeCompile(qhc);
@@ -141,7 +150,7 @@ public class HookRunner {
               .withHiveConf(conf)
               .withCommand(analyzerContext.getCmd())
               .withHookContext(hookContext)
-              .build();
+              .build(analyzerContext.getWmContext().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         hook.afterCompile(qhc, compileException != null);
@@ -159,7 +168,7 @@ public class HookRunner {
     List<QueryLifeTimeHook> queryHooks = hooks.getHooks(QUERY_LIFETIME_HOOKS);
     if (!queryHooks.isEmpty()) {
       QueryLifeTimeHookContext qhc = new QueryLifeTimeHookContextImpl.Builder().withHiveConf(conf).withCommand(command)
-          .withHookContext(hookContext).build();
+          .withHookContext(hookContext).build(hookContext.getQueryState().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         hook.beforeExecution(qhc);
@@ -178,7 +187,7 @@ public class HookRunner {
     List<QueryLifeTimeHook> queryHooks = hooks.getHooks(QUERY_LIFETIME_HOOKS);
     if (!queryHooks.isEmpty()) {
       QueryLifeTimeHookContext qhc = new QueryLifeTimeHookContextImpl.Builder().withHiveConf(conf).withCommand(command)
-          .withHookContext(hookContext).build();
+          .withHookContext(hookContext).build(hookContext.getQueryState().getQueryId());
 
       for (QueryLifeTimeHook hook : queryHooks) {
         hook.afterExecution(qhc, executionError);

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContext.java
@@ -54,6 +54,12 @@ public interface QueryLifeTimeHookContext {
    */
   void setCommand(String command);
 
+  /**
+   * Get the id of the query/command.
+   *
+   * @return the id of the query/command, never null.
+   */
+  String getQueryId();
 
   /**
    * Get the hook context for query execution.

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContextImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContextImpl.java
@@ -20,12 +20,17 @@ package org.apache.hadoop.hive.ql.hooks;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 
+import java.util.Objects;
 
 public class QueryLifeTimeHookContextImpl implements QueryLifeTimeHookContext {
 
   private HiveConf conf;
   private String command;
+  private String queryId;
   private HookContext hc;
+
+  private QueryLifeTimeHookContextImpl(){
+  }
 
   @Override
   public HiveConf getHiveConf() {
@@ -40,6 +45,11 @@ public class QueryLifeTimeHookContextImpl implements QueryLifeTimeHookContext {
   @Override
   public String getCommand() {
     return command;
+  }
+
+  @Override
+  public String getQueryId() {
+    return queryId;
   }
 
   @Override
@@ -78,11 +88,12 @@ public class QueryLifeTimeHookContextImpl implements QueryLifeTimeHookContext {
       return this;
     }
 
-    public QueryLifeTimeHookContextImpl build() {
+    public QueryLifeTimeHookContextImpl build(String queryId) {
       QueryLifeTimeHookContextImpl queryLifeTimeHookContext = new QueryLifeTimeHookContextImpl();
       queryLifeTimeHookContext.setHiveConf(this.conf);
       queryLifeTimeHookContext.setCommand(this.command);
       queryLifeTimeHookContext.setHookContext(this.hc);
+      queryLifeTimeHookContext.queryId = Objects.requireNonNull(queryId);
       return queryLifeTimeHookContext;
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContextImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/QueryLifeTimeHookContextImpl.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hive.ql.hooks;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 
-import java.util.Objects;
-
 public class QueryLifeTimeHookContextImpl implements QueryLifeTimeHookContext {
 
   private HiveConf conf;
@@ -89,11 +87,13 @@ public class QueryLifeTimeHookContextImpl implements QueryLifeTimeHookContext {
     }
 
     public QueryLifeTimeHookContextImpl build(String queryId) {
+      // QUERYID = USERNAME + UNDERSCORES + DATETIME + UUID Type4 = X + 2 + 14 + 36 = X + 52
+      assert queryId != null && queryId.length() >= 52 : "Specified query id ("+queryId+") is invalid";
       QueryLifeTimeHookContextImpl queryLifeTimeHookContext = new QueryLifeTimeHookContextImpl();
       queryLifeTimeHookContext.setHiveConf(this.conf);
       queryLifeTimeHookContext.setCommand(this.command);
       queryLifeTimeHookContext.setHookContext(this.hc);
-      queryLifeTimeHookContext.queryId = Objects.requireNonNull(queryId);
+      queryLifeTimeHookContext.queryId = queryId;
       return queryLifeTimeHookContext;
     }
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestMetricsQueryLifeTimeHook.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestMetricsQueryLifeTimeHook.java
@@ -53,7 +53,7 @@ public class TestMetricsQueryLifeTimeHook {
     metricRegistry = ((CodahaleMetrics) MetricsFactory.getInstance()).getMetricRegistry();
 
     hook = new MetricsQueryLifeTimeHook();
-    ctx = new QueryLifeTimeHookContextImpl();
+    ctx = new QueryLifeTimeHookContextImpl.Builder().build("fake-query-id");
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestMetricsQueryLifeTimeHook.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestMetricsQueryLifeTimeHook.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
 import org.apache.hadoop.hive.common.metrics.metrics2.CodahaleMetrics;
 import org.apache.hadoop.hive.common.metrics.metrics2.MetricsReporting;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryPlan;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,7 +54,7 @@ public class TestMetricsQueryLifeTimeHook {
     metricRegistry = ((CodahaleMetrics) MetricsFactory.getInstance()).getMetricRegistry();
 
     hook = new MetricsQueryLifeTimeHook();
-    ctx = new QueryLifeTimeHookContextImpl.Builder().build("fake-query-id");
+    ctx = new QueryLifeTimeHookContextImpl.Builder().build(QueryPlan.makeQueryId());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add queryid in QueryLifeTimeHookContext

### Why are the changes needed?
See HIVE-26095

### Does this PR introduce _any_ user-facing change?
Yes, it introduces a new public API

### How was this patch tested?
`mvn test -Dtest=TestQueryLifeTimeHooksWithSQLOperation`
Plus existing tests cause we ensure that the queryid that is passed in the context is never null.