### PR TITLE
HIVE-26096: Select on single column MultiDelimitSerDe table throws AIOBE

### DIFF
--- a/ql/src/test/queries/clientpositive/serde_multi_delimit.q
+++ b/ql/src/test/queries/clientpositive/serde_multi_delimit.q
@@ -67,7 +67,15 @@ LOAD DATA LOCAL INPATH "../../data/files/t4_multi_delimit.csv" INTO TABLE t4_mul
 
 SELECT * FROM t4_multi_delimit;
 
+create table test_multidelim(col string)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.MultiDelimitSerDe'
+with serdeproperties('field.delim'='!^') STORED AS TEXTFILE;
 
+insert into test_multidelim values('aa'),('bb'),('cc'),('dd');
+
+select * from test_multidelim;
+
+DROP TABLE test_multidelim;
 DROP TABLE t1_multi_delimit;
 DROP TABLE t11_csv_serde;
 DROP TABLE t2_multi_delimit;

--- a/ql/src/test/results/clientpositive/llap/serde_multi_delimit.q.out
+++ b/ql/src/test/results/clientpositive/llap/serde_multi_delimit.q.out
@@ -235,6 +235,47 @@ POSTHOOK: Input: default@t4_multi_delimit
 		
 áűáűáűáű		
 űűű	ááá	óóó
+PREHOOK: query: create table test_multidelim(col string)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.MultiDelimitSerDe'
+with serdeproperties('field.delim'='!^') STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_multidelim
+POSTHOOK: query: create table test_multidelim(col string)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.MultiDelimitSerDe'
+with serdeproperties('field.delim'='!^') STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_multidelim
+PREHOOK: query: insert into test_multidelim values('aa'),('bb'),('cc'),('dd')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_multidelim
+POSTHOOK: query: insert into test_multidelim values('aa'),('bb'),('cc'),('dd')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_multidelim
+POSTHOOK: Lineage: test_multidelim.col SCRIPT []
+PREHOOK: query: select * from test_multidelim
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_multidelim
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_multidelim
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_multidelim
+#### A masked pattern was here ####
+aa
+bb
+cc
+dd
+PREHOOK: query: DROP TABLE test_multidelim
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_multidelim
+PREHOOK: Output: default@test_multidelim
+POSTHOOK: query: DROP TABLE test_multidelim
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_multidelim
+POSTHOOK: Output: default@test_multidelim
 PREHOOK: query: DROP TABLE t1_multi_delimit
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@t1_multi_delimit

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyStruct.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyStruct.java
@@ -300,7 +300,7 @@ public class LazyStruct extends LazyNonPrimitive<LazySimpleStructObjectInspector
     // first field always starts from 0, even when missing
     startPosition[0] = 0;
     for (int i = 1; i <= fields.length; i++) {
-      if (delimitIndexes[i - 1] != -1) {
+      if (fields.length > 1 && delimitIndexes[i - 1] != -1) {
         int start = delimitIndexes[i - 1] + fieldDelimit.length;
         startPosition[i] = start - i * diff;
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
To support reading single column from a text table which is delimited by multiple characters.

### Why are the changes needed?
Select query fails without this fix.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
testcase is included in the patch