### PR TITLE
HIVE-26099: Move patched-iceberg packages to org.apache.hive group

### DIFF
--- a/iceberg/iceberg-shading/pom.xml
+++ b/iceberg/iceberg-shading/pom.xml
@@ -35,7 +35,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>org.apache.hive</groupId>
       <artifactId>patched-iceberg-core</artifactId>
       <optional>true</optional>
     </dependency>

--- a/iceberg/patched-iceberg-api/pom.xml
+++ b/iceberg/patched-iceberg-api/pom.xml
@@ -7,7 +7,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.iceberg</groupId>
+  <groupId>org.apache.hive</groupId>
   <artifactId>patched-iceberg-api</artifactId>
   <version>patched-${iceberg.version}-${project.parent.version}</version>
   <name>Patched Iceberg API</name>
@@ -48,7 +48,7 @@
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/classes</outputDirectory>
                   <excludes>
-                                    </excludes>
+                  </excludes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/iceberg/patched-iceberg-core/pom.xml
+++ b/iceberg/patched-iceberg-core/pom.xml
@@ -7,7 +7,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.iceberg</groupId>
+  <groupId>org.apache.hive</groupId>
   <artifactId>patched-iceberg-core</artifactId>
   <version>patched-${iceberg.version}-${project.parent.version}</version>
   <name>Patched Iceberg Core</name>
@@ -39,7 +39,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>org.apache.hive</groupId>
       <artifactId>patched-iceberg-api</artifactId>
     </dependency>
     <dependency>

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -48,12 +48,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.iceberg</groupId>
+        <groupId>org.apache.hive</groupId>
         <artifactId>patched-iceberg-api</artifactId>
         <version>patched-${iceberg.version}-${project.parent.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.iceberg</groupId>
+        <groupId>org.apache.hive</groupId>
         <artifactId>patched-iceberg-core</artifactId>
         <version>patched-${iceberg.version}-${project.parent.version}</version>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move the patched iceberg modules under org.apache.hive package from org.apache.iceberg

### Why are the changes needed?
We do not want to accidentally put trash under other projects package

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Run the compilation