### PR TITLE
HIVE-25728: ParseException while gathering Column Stats

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
@@ -18,14 +18,7 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
-import static org.apache.hadoop.hive.ql.metadata.HiveUtils.unparseIdentifier;
-
 import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.hadoop.hive.common.HiveStatsUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -48,9 +41,14 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hadoop.hive.ql.metadata.HiveUtils.unparseIdentifier;
 
 /**
  * ColumnStatsSemanticAnalyzer.
@@ -259,7 +257,7 @@ public class ColumnStatsSemanticAnalyzer extends SemanticAnalyzer {
       final TypeInfo typeInfo = TypeInfoUtils.getTypeInfoFromTypeString(colTypes.get(i));
       genComputeStats(rewrittenQueryBuilder, conf, i, columnName, typeInfo);
 
-      columnNamesBuilder.append(unparseIdentifier(columnName, conf));
+      columnNamesBuilder.append(columnName);
 
       columnDummyValuesBuilder.append(
           "cast(null as " + typeInfo.toString() + ")");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
@@ -18,7 +18,14 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
+import static org.apache.hadoop.hive.ql.metadata.HiveUtils.unparseIdentifier;
+
 import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.hadoop.hive.common.HiveStatsUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -41,14 +48,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import static org.apache.hadoop.hive.ql.metadata.HiveUtils.unparseIdentifier;
 
 /**
  * ColumnStatsSemanticAnalyzer.

--- a/ql/src/test/queries/clientpositive/columnstats_columnname_parse.q
+++ b/ql/src/test/queries/clientpositive/columnstats_columnname_parse.q
@@ -1,0 +1,21 @@
+
+CREATE TABLE table1(
+   t1_col1 bigint);
+
+ CREATE TABLE table2(
+   t2_col1 bigint,
+   t2_col2 int)
+ PARTITIONED BY (
+   t2_col3 date);
+
+insert into table1 values(1);
+insert into table2 values("1","1","1");
+
+--set hive.stats.autogather=false;
+set hive.support.quoted.identifiers=none;
+
+create external table ext_table STORED AS ORC tblproperties('compression'='snappy','external.table.purge'='true') as
+SELECT a.* ,d.`(t2_col1|t2_col3)?+.+`
+FROM table1 a
+LEFT JOIN (SELECT * FROM table2 where t2_col3 like '2021-01-%') d
+on a.t1_col1 = d.t2_col1;

--- a/ql/src/test/queries/clientpositive/columnstats_columnname_parse.q
+++ b/ql/src/test/queries/clientpositive/columnstats_columnname_parse.q
@@ -11,7 +11,6 @@ CREATE TABLE table1(
 insert into table1 values(1);
 insert into table2 values("1","1","1");
 
---set hive.stats.autogather=false;
 set hive.support.quoted.identifiers=none;
 
 create external table ext_table STORED AS ORC tblproperties('compression'='snappy','external.table.purge'='true') as

--- a/ql/src/test/results/clientpositive/llap/columnstats_columnname_parse.q.out
+++ b/ql/src/test/results/clientpositive/llap/columnstats_columnname_parse.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: CREATE TABLE table1(
+   t1_col1 bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table1
+POSTHOOK: query: CREATE TABLE table1(
+   t1_col1 bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table1
+PREHOOK: query: CREATE TABLE table2(
+   t2_col1 bigint,
+   t2_col2 int)
+ PARTITIONED BY (
+   t2_col3 date)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table2
+POSTHOOK: query: CREATE TABLE table2(
+   t2_col1 bigint,
+   t2_col2 int)
+ PARTITIONED BY (
+   t2_col3 date)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table2
+PREHOOK: query: insert into table1 values(1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table1
+POSTHOOK: query: insert into table1 values(1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table1
+POSTHOOK: Lineage: table1.t1_col1 SCRIPT []
+PREHOOK: query: insert into table2 values("1","1","1")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table2
+POSTHOOK: query: insert into table2 values("1","1","1")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table2
+POSTHOOK: Output: default@table2@t2_col3=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Lineage: table2 PARTITION(t2_col3=__HIVE_DEFAULT_PARTITION__).t2_col1 SCRIPT []
+POSTHOOK: Lineage: table2 PARTITION(t2_col3=__HIVE_DEFAULT_PARTITION__).t2_col2 SCRIPT []
+PREHOOK: query: create external table ext_table STORED AS ORC tblproperties('compression'='snappy','external.table.purge'='true') as
+SELECT a.* ,d.`(t2_col1|t2_col3)?+.+`
+FROM table1 a
+LEFT JOIN (SELECT * FROM table2 where t2_col3 like '2021-01-%') d
+on a.t1_col1 = d.t2_col1
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@table1
+PREHOOK: Input: default@table2
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ext_table
+POSTHOOK: query: create external table ext_table STORED AS ORC tblproperties('compression'='snappy','external.table.purge'='true') as
+SELECT a.* ,d.`(t2_col1|t2_col3)?+.+`
+FROM table1 a
+LEFT JOIN (SELECT * FROM table2 where t2_col3 like '2021-01-%') d
+on a.t1_col1 = d.t2_col1
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@table1
+POSTHOOK: Input: default@table2
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ext_table
+POSTHOOK: Lineage: ext_table.t1_col1 SIMPLE [(table1)a.FieldSchema(name:t1_col1, type:bigint, comment:null), ]
+POSTHOOK: Lineage: ext_table.t2_col2 SIMPLE [(table2)table2.FieldSchema(name:t2_col2, type:int, comment:null), ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Remove second `unparseIdentifier` on `columnName`

### Why are the changes needed?
`unparseIdentifier` was applied twice on `columnName`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
`mvn test -pl itests/qtest -Pitests -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile=columnstats_columnname_parse.q`
