### PR TITLE
HIVE-26110

### DIFF
--- a/iceberg/iceberg-handler/src/test/results/positive/dynamic_partition_writes.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/dynamic_partition_writes.q.out
@@ -75,6 +75,7 @@ Stage-3
                   Output:["_col0","_col1","_col1"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   PARTITION_ONLY_SHUFFLE [RS_13]
+                    PartitionCols:_col1
                     Select Operator [SEL_12] (rows=20 width=91)
                       Output:["_col0","_col1"]
                       TableScan [TS_0] (rows=20 width=91)
@@ -166,6 +167,7 @@ Stage-3
                   Output:["_col0","_col1","iceberg_bucket(_col1, 2)"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   PARTITION_ONLY_SHUFFLE [RS_13]
+                    PartitionCols:iceberg_bucket(_col1, 2)
                     Select Operator [SEL_12] (rows=20 width=91)
                       Output:["_col0","_col1"]
                       TableScan [TS_0] (rows=20 width=91)
@@ -257,6 +259,7 @@ Stage-3
                   Output:["_col0","_col1","_col2","_col1","iceberg_bucket(_col2, 3)"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   PARTITION_ONLY_SHUFFLE [RS_13]
+                    PartitionCols:_col1, iceberg_bucket(_col2, 3)
                     Select Operator [SEL_12] (rows=20 width=99)
                       Output:["_col0","_col1","_col2"]
                       TableScan [TS_0] (rows=20 width=99)
@@ -387,6 +390,7 @@ Stage-3
                   Output:["_col0","_col1","_col2","_col1","iceberg_bucket(_col2, 3)"]
                 <-Map 1 [SIMPLE_EDGE] vectorized
                   PARTITION_ONLY_SHUFFLE [RS_16]
+                    PartitionCols:_col1, iceberg_bucket(_col2, 3)
                     Select Operator [SEL_15] (rows=4 width=99)
                       Output:["_col0","_col1","_col2"]
                       Filter Operator [FIL_14] (rows=4 width=99)

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
@@ -648,7 +648,12 @@ public class SortedDynPartitionOptimizer extends Transform {
       ArrayList<ExprNodeDesc> partCols = Lists.newArrayList();
 
       for (Function<List<ExprNodeDesc>, ExprNodeDesc> customSortExpr : customSortExprs) {
-        keyCols.add(customSortExpr.apply(allCols));
+        ExprNodeDesc colExpr = customSortExpr.apply(allCols);
+        // Custom sort expressions are marked as KEYs, which is required for sorting the rows that are going for
+        // a particular reducer instance. They also need to be marked as 'partition' columns for MapReduce shuffle
+        // phase, in order to gather the same keys to the same reducer instances.
+        keyCols.add(colExpr);
+        partCols.add(colExpr);
       }
 
       // we will clone here as RS will update bucket column key with its


### PR DESCRIPTION
Bulk insert into partitioned table creates lots of files in iceberg, because the SortedDynPartitionOptimizer doesn't set the key->reducer affinity that could be done by just marking the sort expressions as 'partition' columns.