### PR TITLE
addendum for HIVE-25967

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -124,8 +124,7 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
   @Override
   public void write(DataOutput out) throws IOException {
     for (FileScanTask fileScanTask : icebergSplit().task().files()) {
-      if (fileScanTask.residual() != Expressions.alwaysTrue() &&
-          fileScanTask.getClass().isAssignableFrom(SPLIT_SCAN_TASK_CLAZZ)) {
+      if (fileScanTask.getClass().isAssignableFrom(SPLIT_SCAN_TASK_CLAZZ)) {
 
         Object residuals = RESIDUALS_FIELD.get(FILE_SCAN_TASK_FIELD.get(fileScanTask));
 


### PR DESCRIPTION
I originally thought that we only need the hack whenever residuals are present, so I added this condition:

https://github.com/apache/hive/commit/1aa6ce800004798e78ea53c3bec2beedb5f55b6c#diff-9487d7073613adf5132783cf905ea72164eb4c19461c50e5ce3cd735bb5704a3R127

What I didn't know is that in some cases the residuals() invocation may end up returning True while the expression is still some longer construct. The residuals() invocation actually evaluates said expression against the partition information found in the base scan file task... Because of this the residuals are left untouched and will cause OOM.. 

This addendum removes aforementioned unnecessary condition