### PR TITLE
HIVE-26118: [Standalone beeline] Jar name mismatch in assembly (Naveen Gangam)

### DIFF
--- a/packaging/src/main/assembly/beeline.xml
+++ b/packaging/src/main/assembly/beeline.xml
@@ -79,7 +79,7 @@
             <directory>${project.parent.basedir}/beeline/target</directory>
             <outputDirectory>lib</outputDirectory>
             <includes>
-                <include>original-jar-with-dependencies.jar</include>
+                <include>jar-with-dependencies.jar</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The jar name the beeline standalone assembly build is looking for, original-jar-with-dependencies.jar, does not match the name of the jar being built by the beeline build, jar-with-dependencies.jar. So the uber jar is not being bundled into the final apache-hive-beeline.xxx.tar.gz

### Why are the changes needed?
To include the uber jar into the beeline assembly.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually