### PR TITLE
HIVE-26124: Upgrade HBase from 2.0.0-alpha4 to 2.0.0

### DIFF
--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -178,6 +178,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-mapreduce</artifactId>
       <version>${hbase.version}</version>
       <classifier>tests</classifier>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -441,6 +441,12 @@
         <classifier>tests</classifier>
       </dependency>
       <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-testing-util</artifactId>
+        <version>${hbase.version}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
         <groupId>org.apache.tez</groupId>
         <artifactId>tez-tests</artifactId>
         <version>${tez.version}</version>

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -213,6 +213,11 @@
       <classifier>tests</classifier>
     </dependency>
     <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-it-druid</artifactId>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <hadoop.version>3.1.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
-    <hbase.version>2.0.0</hbase.version>
+    <hbase.version>2.4.11</hbase.version>
     <hppc.version>0.7.2</hppc.version>
     <!-- required for logging test to avoid including hbase which pulls disruptor transitively -->
     <disruptor.version>3.3.7</disruptor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <hadoop.version>3.1.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
-    <hbase.version>2.0.0-alpha4</hbase.version>
+    <hbase.version>2.0.0</hbase.version>
     <hppc.version>0.7.2</hppc.version>
     <!-- required for logging test to avoid including hbase which pulls disruptor transitively -->
     <disruptor.version>3.3.7</disruptor.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade the HBase to the 2.0.0

### Why are the changes needed?
In a release we minimally should depend on a stable version

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests