### PR TITLE
HIVE-26130: Incorrect matching of external table when validating NOT NULL constraints

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/properties/AbstractAlterTablePropertiesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/properties/AbstractAlterTablePropertiesAnalyzer.java
@@ -99,7 +99,7 @@ public abstract class AbstractAlterTablePropertiesAnalyzer extends AbstractAlter
         } catch (Exception e) {
           throw new SemanticException("AlterTable " + entry.getKey() + " failed with value " + entry.getValue());
         }
-      } else if (entry.getKey().equals("external") && entry.getValue().equals("true")) {
+      } else if (entry.getKey().equals("EXTERNAL") && entry.getValue().equalsIgnoreCase("true")) {
         // if table is being modified to be external we need to make sure existing table
         // doesn't have enabled constraint since constraints are disallowed with such tables
         if (hasConstraintsEnabled(tableName.getTable())) {

--- a/ql/src/test/queries/clientnegative/alter_tableprops_external_with_default_constraint.q
+++ b/ql/src/test/queries/clientnegative/alter_tableprops_external_with_default_constraint.q
@@ -1,3 +1,3 @@
 CREATE TABLE table1 (a STRING DEFAULT 'hive', b STRING);
-Alter table table1 set TBLPROPERTIES('external'='true');
+Alter table table1 set TBLPROPERTIES('EXTERNAL'='true');
 

--- a/ql/src/test/queries/clientnegative/alter_tableprops_external_with_notnull_constraint.q
+++ b/ql/src/test/queries/clientnegative/alter_tableprops_external_with_notnull_constraint.q
@@ -1,3 +1,3 @@
 CREATE TABLE table1 (a STRING NOT NULL enforced, b STRING); 
-Alter table table1 set TBLPROPERTIES('external'='true');
+Alter table table1 set TBLPROPERTIES('EXTERNAL'='true');
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix incorrect  external table judgment statement in _AbstractAlterTablePropertiesAnalyzer.validate_ 
https://github.com/apache/hive/blob/d06f8913533d7a003f85e03a359e3ad50409745e/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/properties/AbstractAlterTablePropertiesAnalyzer.java#L102
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In current hive code, we use hive tblproperties('EXTERNAL'='true' or 'EXTERNAL'='TRUE) to validate external table. For example:
https://github.com/apache/hive/blob/d06f8913533d7a003f85e03a359e3ad50409745e/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java#L315

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
qfile test