### PR TITLE
HIVE-26137 Optimized transfer of Iceberg residual expressions from AM to execution

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -41,9 +41,12 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.mapred.AbstractMapredIcebergRecordReader;
@@ -80,20 +83,49 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
     }
   }
 
-  @Override
-  public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
-    // Convert Hive filter to Iceberg filter
-    String hiveFilter = job.get(TableScanDesc.FILTER_EXPR_CONF_STR);
+  /**
+   * Converts the Hive filter found in the job conf to an Iceberg filter expression.
+   * @param conf - job conf
+   * @return - Iceberg data filter expression
+   */
+  static Expression icebergDataFilterFromHiveConf(Configuration conf) {
+    String hiveFilter = conf.get(TableScanDesc.FILTER_EXPR_CONF_STR);
     if (hiveFilter != null) {
       ExprNodeGenericFuncDesc exprNodeDesc = SerializationUtilities
-              .deserializeObject(hiveFilter, ExprNodeGenericFuncDesc.class);
-      SearchArgument sarg = ConvertAstToSearchArg.create(job, exprNodeDesc);
+          .deserializeObject(hiveFilter, ExprNodeGenericFuncDesc.class);
+      SearchArgument sarg = ConvertAstToSearchArg.create(conf, exprNodeDesc);
       try {
-        Expression filter = HiveIcebergFilterFactory.generateFilterExpression(sarg);
-        job.set(InputFormatConfig.FILTER_EXPRESSION, SerializationUtil.serializeToBase64(filter));
+        return HiveIcebergFilterFactory.generateFilterExpression(sarg);
       } catch (UnsupportedOperationException e) {
         LOG.warn("Unable to create Iceberg filter, continuing without filter (will be applied by Hive later): ", e);
       }
+    }
+    return null;
+  }
+
+  /**
+   * Converts Hive filter found in the passed job conf to an Iceberg filter expression. Then evaluates this
+   * against the task's partition value producing a residual filter expression.
+   * @param task - file scan task to evaluate the expression against
+   * @param conf - job conf
+   * @return - Iceberg residual filter expression
+   */
+  public static Expression residualForTask(FileScanTask task, Configuration conf) {
+    Expression dataFilter = icebergDataFilterFromHiveConf(conf);
+    if (dataFilter == null) {
+      return Expressions.alwaysTrue();
+    }
+    return ResidualEvaluator.of(
+        task.spec(), dataFilter,
+        conf.getBoolean(InputFormatConfig.CASE_SENSITIVE, InputFormatConfig.CASE_SENSITIVE_DEFAULT)
+    ).residualFor(task.file().partition());
+  }
+
+  @Override
+  public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+    Expression filter = icebergDataFilterFromHiveConf(job);
+    if (filter != null) {
+      job.set(InputFormatConfig.FILTER_EXPRESSION, SerializationUtil.serializeToBase64(filter));
     }
 
     job.set(InputFormatConfig.SELECTED_COLUMNS, job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, ""));

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -89,6 +89,11 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
    * @return - Iceberg data filter expression
    */
   static Expression icebergDataFilterFromHiveConf(Configuration conf) {
+    Expression icebergFilter = SerializationUtil.deserializeFromBase64(conf.get(InputFormatConfig.FILTER_EXPRESSION));
+    if (icebergFilter != null) {
+      // in case we already have it prepared..
+      return icebergFilter;
+    }
     String hiveFilter = conf.get(TableScanDesc.FILTER_EXPR_CONF_STR);
     if (hiveFilter != null) {
       ExprNodeGenericFuncDesc exprNodeDesc = SerializationUtilities

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -124,7 +124,8 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
   @Override
   public void write(DataOutput out) throws IOException {
     for (FileScanTask fileScanTask : icebergSplit().task().files()) {
-      if (fileScanTask.getClass().isAssignableFrom(SPLIT_SCAN_TASK_CLAZZ)) {
+      if (fileScanTask.residual() != Expressions.alwaysTrue() &&
+          fileScanTask.getClass().isAssignableFrom(SPLIT_SCAN_TASK_CLAZZ)) {
 
         Object residuals = RESIDUALS_FIELD.get(FILE_SCAN_TASK_FIELD.get(fileScanTask));
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSplit.java
@@ -28,10 +28,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.tez.HashableInputSplit;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.common.DynClasses;
-import org.apache.iceberg.common.DynFields;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.mr.mapreduce.IcebergSplitContainer;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
@@ -97,46 +93,8 @@ public class HiveIcebergSplit extends FileSplit implements IcebergSplitContainer
     return 0;
   }
 
-  /**
-   * This hack removes residual expressions from the file scan task just before split serialization.
-   * Residuals can sometime take up too much space in the payload causing Tez AM to OOM.
-   * Unfortunately Tez AM doesn't distribute splits in a streamed way, that is, it serializes all splits for a job
-   * before sending them out to executors. Some residuals may take ~ 1 MB in memory, multiplied with thousands of splits
-   * could kill the Tez AM JVM.
-   * Until the streamed split distribution is implemented we will kick residuals out of the split, essentially the
-   * executor side won't use it anyway (yet).
-   */
-  private static final Class<?> SPLIT_SCAN_TASK_CLAZZ;
-  private static final DynFields.UnboundField<Object> FILE_SCAN_TASK_FIELD;
-  private static final DynFields.UnboundField<Object> RESIDUALS_FIELD;
-  private static final DynFields.UnboundField<Object> EXPR_FIELD;
-  private static final DynFields.UnboundField<Object> UNPARTITIONED_EXPR_FIELD;
-
-  static {
-    SPLIT_SCAN_TASK_CLAZZ = DynClasses.builder().impl("org.apache.iceberg.BaseFileScanTask$SplitScanTask").build();
-    FILE_SCAN_TASK_FIELD = DynFields.builder().hiddenImpl(SPLIT_SCAN_TASK_CLAZZ, "fileScanTask").build();
-    RESIDUALS_FIELD = DynFields.builder().hiddenImpl("org.apache.iceberg.BaseFileScanTask", "residuals").build();
-    EXPR_FIELD = DynFields.builder().hiddenImpl(ResidualEvaluator.class, "expr").build();
-    UNPARTITIONED_EXPR_FIELD = DynFields.builder().hiddenImpl("org.apache.iceberg.expressions." +
-        "ResidualEvaluator$UnpartitionedResidualEvaluator", "expr").build();
-  }
-
   @Override
   public void write(DataOutput out) throws IOException {
-    for (FileScanTask fileScanTask : icebergSplit().task().files()) {
-      if (fileScanTask.residual() != Expressions.alwaysTrue() &&
-          fileScanTask.getClass().isAssignableFrom(SPLIT_SCAN_TASK_CLAZZ)) {
-
-        Object residuals = RESIDUALS_FIELD.get(FILE_SCAN_TASK_FIELD.get(fileScanTask));
-
-        if (fileScanTask.spec().isPartitioned()) {
-          EXPR_FIELD.set(residuals, Expressions.alwaysTrue());
-        } else {
-          UNPARTITIONED_EXPR_FIELD.set(residuals, Expressions.alwaysTrue());
-        }
-
-      }
-    }
     byte[] bytes = SerializationUtil.serializeToBytes(tableLocation);
     out.writeInt(bytes.length);
     out.write(bytes);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
@@ -162,18 +162,16 @@ public class VectorizedReadUtils {
 
     // Predicate pushdowns needs to be adjusted too in case of column renames, we let Iceberg generate this into job
     Expression residual = HiveIcebergInputFormat.residualForTask(task, job);
-    if (residual != null) {
-      Expression boundFilter = Binder.bind(currentSchema.asStruct(), residual, false);
+    Expression boundFilter = Binder.bind(currentSchema.asStruct(), residual, false);
 
-      // Note the use of the unshaded version of this class here (required for SARG deseralization later)
-      org.apache.hadoop.hive.ql.io.sarg.SearchArgument sarg =
-          ExpressionToOrcSearchArgument.convert(boundFilter, readOrcSchema);
-      if (sarg != null) {
-        job.unset(TableScanDesc.FILTER_EXPR_CONF_STR);
-        job.unset(ConvertAstToSearchArg.SARG_PUSHDOWN);
+    // Note the use of the unshaded version of this class here (required for SARG deseralization later)
+    org.apache.hadoop.hive.ql.io.sarg.SearchArgument sarg =
+        ExpressionToOrcSearchArgument.convert(boundFilter, readOrcSchema);
+    if (sarg != null) {
+      job.unset(TableScanDesc.FILTER_EXPR_CONF_STR);
+      job.unset(ConvertAstToSearchArg.SARG_PUSHDOWN);
 
-        job.set(ConvertAstToSearchArg.SARG_PUSHDOWN, ConvertAstToSearchArg.sargToKryo(sarg));
-      }
+      job.set(ConvertAstToSearchArg.SARG_PUSHDOWN, ConvertAstToSearchArg.sargToKryo(sarg));
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mr.hive.HiveIcebergInputFormat;
 import org.apache.orc.impl.BufferChunk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,8 +161,9 @@ public class VectorizedReadUtils {
     job.set(ColumnProjectionUtils.ORC_SCHEMA_STRING, readOrcSchema.toString());
 
     // Predicate pushdowns needs to be adjusted too in case of column renames, we let Iceberg generate this into job
-    if (task.residual() != null) {
-      Expression boundFilter = Binder.bind(currentSchema.asStruct(), task.residual(), false);
+    Expression residual = HiveIcebergInputFormat.residualForTask(task, job);
+    if (residual != null) {
+      Expression boundFilter = Binder.bind(currentSchema.asStruct(), residual, false);
 
       // Note the use of the unshaded version of this class here (required for SARG deseralization later)
       org.apache.hadoop.hive.ql.io.sarg.SearchArgument sarg =

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -17,12 +17,8 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.hive;
+package org.apache.iceberg.mr;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,7 +40,6 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -59,9 +54,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.iceberg.mr.Catalogs;
-import org.apache.iceberg.mr.InputFormatConfig;
-import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.mr.hive.HiveIcebergInputFormat;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.mr.mapred.MapredIcebergInputFormat;
 import org.apache.iceberg.mr.mapreduce.IcebergInputFormat;
@@ -81,9 +74,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestInputFormatReaderDeletes.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestInputFormatReaderDeletes.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.iceberg.mr.hive.TestIcebergInputFormats;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
The filter expression that goes with the file scan tasks is actually not a "residual" one, but rather the original data filter. This is good for us, as now we know that for any Hive job the expression is the same object - so we can transfer it another way to Hive execution processes:

- The expression itself is generated via https://github.com/apache/iceberg/blob/master/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java#L82-L93 before split generation within the AM. There's nothing to prevent us from reusing this same logic on the executors.
- At the same time we can ask ignoreResiduals() on the table scan, so that Iceberg only uses the filter for split generation, but won't actually attach it to the file scan tasks, and therefore their enwrapping splits.
- On the execution side we can just simply retrieve the original filter expression by the logic above and evaluate it against the current task (whose spec and partition value information are present anyway), ending up with the actual residual expression for the task. This is then passed to the underlying file formats the same way as before.