### PR TITLE
store expressions in column info

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnInfo.java
@@ -40,6 +40,9 @@ public class ColumnInfo implements Serializable {
 
   private String alias = null; // [optional] alias of the column (external name
   // as seen by the users)
+
+  private String expression;
+
   /**
    * Indicates whether the column is a skewed column.
    */
@@ -129,6 +132,7 @@ public class ColumnInfo implements Serializable {
     this.isHiddenVirtualCol = columnInfo.isHiddenVirtualCol();
     this.nullable = columnInfo.nullable;
     this.setType(columnInfo.getType());
+    this.expression = columnInfo.expression;
   }
 
   public String getTypeName() {
@@ -278,5 +282,13 @@ public class ColumnInfo implements Serializable {
 
   public boolean isNullable() {
     return nullable;
+  }
+
+  public String getExpression() {
+    return expression;
+  }
+
+  public void setExpression(String expression) {
+    this.expression = expression;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4082,10 +4082,16 @@ public class CalcitePlanner extends SemanticAnalyzer {
               + ex.getMessage());
         }
       }
+
       // then try to get it from all
       if (orderByExpression == null) {
-        Map<ASTNode, RexNode> astToExprNDescMap = genAllRexNode(ref, inputRR, cluster.getRexBuilder());
-        orderByExpression = astToExprNDescMap.get(ref);
+        try {
+          Map<ASTNode, RexNode> astToExprNDescMap = genAllRexNode(ref, inputRR, cluster.getRexBuilder());
+          orderByExpression = astToExprNDescMap.get(ref);
+        } catch (SemanticException ex) {
+          LOG.debug("Can not find column in " + ref.getText() + ". The error msg is "
+                  + ex.getMessage());
+        }
       }
 
       if (orderByExpression == null && selectOutputRR != null) {
@@ -4093,7 +4099,6 @@ public class CalcitePlanner extends SemanticAnalyzer {
           Map<ASTNode, RexNode> astToExprNDescMap = genAllRexNode(ref, selectOutputRR, cluster.getRexBuilder(), true);
           orderByExpression = astToExprNDescMap.get(ref);
         } catch (SemanticException ex) {
-          // we can tolerate this as this is the previous behavior
           LOG.debug("Can not find column in " + ref.getText() + ". The error msg is "
                   + ex.getMessage());
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4079,12 +4079,18 @@ public class CalcitePlanner extends SemanticAnalyzer {
         } catch (SemanticException ex) {
           // we can tolerate this as this is the previous behavior
           LOG.debug("Can not find column in " + ref.getText() + ". The error msg is "
-                  + ex.getMessage());
+              + ex.getMessage());
         }
 
-        if (orderByExpression == null) {
-          Map<ASTNode, RexNode> astToExprNDescMap = genAllRexNode(ref, selectOutputRR, cluster.getRexBuilder(), true);
-          orderByExpression = astToExprNDescMap.get(ref);
+        try {
+          if (orderByExpression == null) {
+            Map<ASTNode, RexNode> astToExprNDescMap = genAllRexNode(ref, selectOutputRR, cluster.getRexBuilder(), true);
+            orderByExpression = astToExprNDescMap.get(ref);
+          }
+        } catch (SemanticException ex) {
+          // we can tolerate this as this is the previous behavior
+          LOG.debug("Can not find column in " + ref.getText() + ". The error msg is "
+              + ex.getMessage());
         }
       }
       // then try to get it from all

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RowResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RowResolver.java
@@ -92,6 +92,17 @@ public class RowResolver implements Serializable{
     return get("", node.toStringTree());
   }
 
+  public ColumnInfo getByExpression(ASTNode node) {
+    String key = node.toStringTree();
+    for (ColumnInfo columnInfo : rowSchema.getSignature()) {
+      if (key.equals(columnInfo.getExpression())) {
+        return columnInfo;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * Retrieves the source expression matching a given ASTNode's
    * string rendering exactly.

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckCtx.java
@@ -61,6 +61,8 @@ public class TypeCheckCtx implements NodeProcessorCtx {
 
   private final boolean foldExpr;
 
+  private boolean allowExprLookup = false;
+
   /**
    * Receives translations which will need to be applied during unparse.
    */
@@ -307,5 +309,13 @@ public class TypeCheckCtx implements NodeProcessorCtx {
 
   public List<String> getColumnAliases() {
     return columnAliases;
+  }
+
+  public void setAllowExprLookup(boolean allowExprLookup) {
+    this.allowExprLookup = allowExprLookup;
+  }
+
+  public boolean isAllowExprLookup() {
+    return allowExprLookup;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -1608,6 +1608,10 @@ public class TypeCheckProcFactory<T> {
 
     // If the current subExpression is pre-calculated, as in Group-By etc.
     ColumnInfo colInfo = input.getExpression(expr);
+    if (colInfo == null && ctx.isAllowExprLookup()) {
+      colInfo = input.getByExpression(expr);
+    }
+
     RowResolver usedRR = input;
     int offset = 0;
 

--- a/ql/src/test/queries/clientpositive/col_ref_const_expr.q
+++ b/ql/src/test/queries/clientpositive/col_ref_const_expr.q
@@ -1,0 +1,27 @@
+create table store(store_name string, store_sqft int);
+
+insert into store values ('f', 10), ('a', 42), ('a', 12);
+
+-- order by expression having upper case string literal
+select 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name;
+
+select distinct 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name;
+
+select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name
+order by 'HQ' || store_name;
+
+select 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name;
+
+select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name;

--- a/ql/src/test/queries/clientpositive/col_ref_distinct.q
+++ b/ql/src/test/queries/clientpositive/col_ref_distinct.q
@@ -1,0 +1,23 @@
+create table t1 (a bigint, b int);
+
+insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2);
+
+-- column referenced by its name
+explain cbo
+select distinct b as c1 from t1 order by b;
+select distinct b as c1 from t1 order by b;
+
+-- column referenced by its name upper case
+explain cbo
+select distinct b as c1 from t1 order by B;
+
+-- column referenced by its alias
+explain cbo
+select distinct b as c1 from t1 order by c1;
+
+-- column referenced by its alias upper case
+explain cbo
+select distinct b as c1 from t1 order by C1;
+
+-- order by expression
+select distinct b + a as c1 from t1 order by b + a;

--- a/ql/src/test/queries/clientpositive/col_ref_windowing.q
+++ b/ql/src/test/queries/clientpositive/col_ref_windowing.q
@@ -1,0 +1,14 @@
+create table t1 (a bigint, b int);
+
+insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2);
+
+-- order by window func
+select a as c1, rank() over(order by b) c2
+from t1
+order by a;
+
+-- gby, order by and window func
+select a as c1, count(*) c2, rank() over(order by count(*)) c3
+from t1
+group by a
+order by a;

--- a/ql/src/test/results/clientpositive/llap/col_ref_const_expr.q.out
+++ b/ql/src/test/results/clientpositive/llap/col_ref_const_expr.q.out
@@ -1,0 +1,96 @@
+PREHOOK: query: create table store(store_name string, store_sqft int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@store
+POSTHOOK: query: create table store(store_name string, store_sqft int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@store
+PREHOOK: query: insert into store values ('f', 10), ('a', 42), ('a', 12)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@store
+POSTHOOK: query: insert into store values ('f', 10), ('a', 42), ('a', 12)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@store
+POSTHOOK: Lineage: store.store_name SCRIPT []
+POSTHOOK: Lineage: store.store_sqft SCRIPT []
+PREHOOK: query: select 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store
+#### A masked pattern was here ####
+POSTHOOK: query: select 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store
+#### A masked pattern was here ####
+HQa
+HQa
+HQf
+PREHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+order by 'HQ' || store_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store
+#### A masked pattern was here ####
+HQa
+HQf
+PREHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name
+order by 'HQ' || store_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name
+order by 'HQ' || store_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store
+#### A masked pattern was here ####
+HQa
+HQf
+PREHOOK: query: select 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store
+#### A masked pattern was here ####
+POSTHOOK: query: select 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store
+#### A masked pattern was here ####
+HQa
+HQa
+HQf
+PREHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct 'HQ' || store_name as c1
+from store as store
+group by 'HQ' || store_name, store_sqft
+order by 'HQ' || store_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store
+#### A masked pattern was here ####
+HQa
+HQf

--- a/ql/src/test/results/clientpositive/llap/col_ref_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/col_ref_distinct.q.out
@@ -1,0 +1,104 @@
+PREHOOK: query: create table t1 (a bigint, b int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (a bigint, b int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+PREHOOK: query: explain cbo
+select distinct b as c1 from t1 order by b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select distinct b as c1 from t1 order by b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSortLimit(sort0=[$0], dir0=[ASC])
+  HiveProject(b=[$0])
+    HiveAggregate(group=[{1}])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: select distinct b as c1 from t1 order by b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct b as c1 from t1 order by b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1
+2
+NULL
+PREHOOK: query: explain cbo
+select distinct b as c1 from t1 order by B
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select distinct b as c1 from t1 order by B
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSortLimit(sort0=[$0], dir0=[ASC])
+  HiveProject(b=[$0])
+    HiveAggregate(group=[{1}])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain cbo
+select distinct b as c1 from t1 order by c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select distinct b as c1 from t1 order by c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSortLimit(sort0=[$0], dir0=[ASC])
+  HiveProject(b=[$0])
+    HiveAggregate(group=[{1}])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain cbo
+select distinct b as c1 from t1 order by C1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select distinct b as c1 from t1 order by C1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSortLimit(sort0=[$0], dir0=[ASC])
+  HiveProject(b=[$0])
+    HiveAggregate(group=[{1}])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: select distinct b + a as c1 from t1 order by b + a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select distinct b + a as c1 from t1 order by b + a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+2
+4
+NULL

--- a/ql/src/test/results/clientpositive/llap/col_ref_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/col_ref_windowing.q.out
@@ -1,0 +1,50 @@
+PREHOOK: query: create table t1 (a bigint, b int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (a bigint, b int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(a, b) values (1, 1), (1, 1), (1, NULL), (2, 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+PREHOOK: query: select a as c1, rank() over(order by b) c2
+from t1
+order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select a as c1, rank() over(order by b) c2
+from t1
+order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	1
+1	1
+1	4
+2	3
+PREHOOK: query: select a as c1, count(*) c2, rank() over(order by count(*)) c3
+from t1
+group by a
+order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select a as c1, count(*) c2, rank() over(order by count(*)) c3
+from t1
+group by a
+order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	3	2
+2	1	1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. Store the AST string representation of the expressions in ColumnInfo.
2. When generating Order by key expressions try to lookup by expressions stored in the ColumnInfo if alias based fails.
3. Add GBY key expressions from QueryParserInfo to output RR when select clause has distinct and window function. This enables to use these expressions as Order by key too.

### Why are the changes needed?
1. Expression based lookup from RowResolver fails if expression contains a string literal with upper case letters because the expression string is stored as a column alias which is case insensitive.

### Does this PR introduce _any_ user-facing change?
Yes. This patch enables writing queries which has column names and expressions as order by keys even if an alias is also defined for the column or expression in the select clause.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=col_ref_const_expr.q,col_ref_distinct.q,col_ref_windowing.q -pl itests/qtest -Pitests
```