### PR TITLE
HIVE-26145: Disable notification cleaner if interval is zero

### DIFF
--- a/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
+++ b/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
@@ -174,12 +174,17 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
 
   //cleaner is a static object, use static synchronized to make sure its thread-safe
   private static synchronized void init(Configuration conf) throws MetaException {
-    if (cleaner == null) {
+    long freq = MetastoreConf.getTimeVar(conf, EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL, TimeUnit.MILLISECONDS);
+    if (cleaner == null && freq > 0) {
       cleaner =
           new CleanerThread(conf, RawStoreProxy.getProxy(conf, conf,
               MetastoreConf.getVar(conf, ConfVars.RAW_STORE_IMPL)));
       cleaner.start();
-    }
+      LOG.info("Scheduling notification log cleanup service with " +
+            "frequency " + freq + "ms.");
+    } else {
+      LOG.info("NOT scheduling notification log cleanup service!");
+    } 
   }
 
   @VisibleForTesting

--- a/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
+++ b/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
@@ -174,7 +174,7 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
 
   //cleaner is a static object, use static synchronized to make sure its thread-safe
   private static synchronized void init(Configuration conf) throws MetaException {
-    long freq = MetastoreConf.getTimeVar(conf, EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL, TimeUnit.MILLISECONDS);
+    long freq = MetastoreConf.getTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL, TimeUnit.MILLISECONDS);
     if (cleaner == null && freq > 0) {
       cleaner =
           new CleanerThread(conf, RawStoreProxy.getProxy(conf, conf,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make it possible to disable the db-notification cleaner(s) in an instance by configuring interval to zero, in case if there are multiple instances running 

### Why are the changes needed?
In a highly concurrent deployment there can be multiple HMS instances running where it would be needed to run cleaner only in one instance to avoid overhead and/or conflict on the notification tables.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.ql.parse.TestReplicationScenarios
[WARNING] Tests run: 76, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1,705.922 s - in org.apache.hadoop.hive.ql.parse.TestReplicationScenarios
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 76, Failures: 0, Errors: 0, Skipped: 1
```