### PR TITLE
HIVE-26146: Handle missing hive.acid.key.index in the fixacidkeyindex…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
@@ -157,6 +157,11 @@ public class FixAcidKeyIndex {
         RecordReader rr = reader.rows()) {
       List<StripeInformation> stripes = reader.getStripes();
       RecordIdentifier[] keyIndex = OrcRecordUpdater.parseKeyIndex(reader);
+
+      if (keyIndex == null) {
+        result.isValid = false;
+      }
+
       StructObjectInspector soi = (StructObjectInspector) reader.getObjectInspector();
       // struct<operation:int,originalTransaction:bigint,bucket:int,rowId:bigint,currentTransaction:bigint
       List<? extends StructField> structFields = soi.getAllStructFieldRefs();
@@ -180,7 +185,7 @@ public class FixAcidKeyIndex {
         RecordIdentifier recordIdentifier = new RecordIdentifier(lastTransaction, lastBucket, lastRowId);
         result.recordIdentifiers.add(recordIdentifier);
 
-        if (keyIndex == null || stripes.size() != keyIndex.length || keyIndex[i] == null
+        if (result.isValid && stripes.size() != keyIndex.length || keyIndex[i] == null
             || recordIdentifier.compareTo(keyIndex[i]) != 0) {
           result.isValid = false;
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
@@ -180,7 +180,8 @@ public class FixAcidKeyIndex {
         RecordIdentifier recordIdentifier = new RecordIdentifier(lastTransaction, lastBucket, lastRowId);
         result.recordIdentifiers.add(recordIdentifier);
 
-        if (stripes.size() != keyIndex.length || keyIndex[i] == null || recordIdentifier.compareTo(keyIndex[i]) != 0) {
+        if (keyIndex == null || stripes.size() != keyIndex.length || keyIndex[i] == null
+            || recordIdentifier.compareTo(keyIndex[i]) != 0) {
           result.isValid = false;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/FixAcidKeyIndex.java
@@ -185,8 +185,8 @@ public class FixAcidKeyIndex {
         RecordIdentifier recordIdentifier = new RecordIdentifier(lastTransaction, lastBucket, lastRowId);
         result.recordIdentifiers.add(recordIdentifier);
 
-        if (result.isValid && stripes.size() != keyIndex.length || keyIndex[i] == null
-            || recordIdentifier.compareTo(keyIndex[i]) != 0) {
+        if (result.isValid && (stripes.size() != keyIndex.length || keyIndex[i] == null
+            || recordIdentifier.compareTo(keyIndex[i]) != 0)) {
           result.isValid = false;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcOutputFormat.java
@@ -305,7 +305,7 @@ public class OrcOutputFormat extends FileOutputFormat<NullWritable, OrcSerdeRow>
       }
     }
     final OrcRecordUpdater.KeyIndexBuilder watcher =
-        new OrcRecordUpdater.KeyIndexBuilder("compactor");
+        new OrcRecordUpdater.KeyIndexBuilder();
     opts.inspector(options.getInspector())
         .callback(watcher);
     final Writer writer = OrcFile.createWriter(filename, opts);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
@@ -136,7 +136,7 @@ public class OrcRecordUpdater implements RecordUpdater {
   private long deleteCount = 0;
   // used only for insert events, this is the number of rows held in memory before flush() is invoked
   private long bufferedRows = 0;
-  private final KeyIndexBuilder indexBuilder = new KeyIndexBuilder("insert");
+  private final KeyIndexBuilder indexBuilder = new KeyIndexBuilder();
   private KeyIndexBuilder deleteEventIndexBuilder;
   private StructField recIdField = null; // field to look for the record identifier in
   private StructField rowIdField = null; // field inside recId to look for row id in
@@ -474,7 +474,7 @@ public class OrcRecordUpdater implements RecordUpdater {
       // Initialize a deleteEventWriter if not yet done. (Lazy initialization)
       if (deleteEventWriter == null) {
         // Initialize an indexBuilder for deleteEvents. (HIVE-17284)
-        deleteEventIndexBuilder = new KeyIndexBuilder("delete");
+        deleteEventIndexBuilder = new KeyIndexBuilder();
         this.deleteEventWriter = OrcFile.createWriter(deleteEventPath,
             deleteWriterOptions.callback(deleteEventIndexBuilder));
         AcidUtils.OrcAcidVersion.setAcidVersionInDataFile(deleteEventWriter);
@@ -690,7 +690,6 @@ public class OrcRecordUpdater implements RecordUpdater {
   }
 
   static class KeyIndexBuilder implements OrcFile.WriterCallback {
-    private final String builderName;
     StringBuilder lastKey = new StringBuilder();//list of last keys for each stripe
     long lastTransaction;
     int lastBucket;
@@ -706,11 +705,8 @@ public class OrcRecordUpdater implements RecordUpdater {
      *
      *  This is used to decide if we need to make preStripeWrite() call here.
      */
-    private long numKeysCurrentStripe = 0;
+    protected long numKeysCurrentStripe = 0;
 
-    KeyIndexBuilder(String name) {
-      this.builderName = name;
-    }
     @Override
     public void preStripeWrite(OrcFile.WriterContext context
     ) throws IOException {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -4113,7 +4113,7 @@ public class TestInputOutputFormat {
             "currentTransaction:bigint," +
             "row:struct<a:int,b:struct<c:int>,d:string>>");
 
-    OrcRecordUpdater.KeyIndexBuilder indexBuilder = new OrcRecordUpdater.KeyIndexBuilder("test");
+    OrcRecordUpdater.KeyIndexBuilder indexBuilder = new OrcRecordUpdater.KeyIndexBuilder();
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)
         .setSchema(fileSchema)


### PR DESCRIPTION
… utility

Minor code quality improvement:
- Removed unused private parameter builderName and associated ctor in OrcRecordUpdater.KeyIndexBuilder

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

There is a utility in hive which can validate/fix corrupted `hive.acid.key.index`: 
```
hive --service fixacidkeyindex
```

The utility throws a NPE if the hive.acid.key.index metadata entry is missing, the patch allows to keep processing the ORC file and insert the missing `hive.acid.key.index` metadata.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ORC acid files can be legally missing this property, so handling such cases is needed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a test covering the case in `TestFixAcidKeyIndex`:
```
mvn test -Dtest=TestFixAcidKeyIndex -pl ql
```