### PR TITLE
refactor: Use `Collections#isEmpty()` instead of comparing `size()`

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/cli/SemanticAnalysis/CreateTableHook.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/cli/SemanticAnalysis/CreateTableHook.java
@@ -134,7 +134,7 @@ final class CreateTableHook extends HCatSemanticAnalyzerBase {
               List<Task<?>> rootTasks)
     throws SemanticException {
 
-    if (rootTasks.size() == 0) {
+    if (rootTasks.isEmpty()) {
       // There will be no DDL task created in case if its CREATE TABLE IF NOT EXISTS
       return;
     }

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -455,7 +455,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
 
     List<FieldSchema> newColumns = HCatUtil.validatePartitionSchema(table, partitionSchema);
 
-    if (newColumns.size() != 0) {
+    if (!newColumns.isEmpty()) {
       List<FieldSchema> tableColumns = new ArrayList<FieldSchema>(table.getTTable().getSd().getCols());
       tableColumns.addAll(newColumns);
 

--- a/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
+++ b/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
@@ -1200,7 +1200,7 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
       close(rs);
     }
 
-    if (insertList.size() != 0) {
+    if (!insertList.isEmpty()) {
       // if rs is empty then no lock is taken and thus it can not cause deadlock.
       long nextNLId = getNextNLId(dbConn, sqlGenerator,
               "org.apache.hadoop.hive.metastore.model.MTxnWriteNotificationLog", insertList.size());

--- a/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
+++ b/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
@@ -907,7 +907,7 @@ public class HCatClientHMSImpl extends HCatClient {
   public int addPartitions(List<HCatAddPartitionDesc> partInfoList)
     throws HCatException {
     int numPartitions = -1;
-    if ((partInfoList == null) || (partInfoList.size() == 0)) {
+    if ((partInfoList == null) || (partInfoList.isEmpty())) {
       throw new HCatException("The partition list is null or empty.");
     }
 

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/LaunchMapper.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/LaunchMapper.java
@@ -338,7 +338,7 @@ public class LaunchMapper extends Mapper<NullWritable, NullWritable, Text, Text>
     WebHCatJTShim tracker = ShimLoader.getHadoopShims().getWebHCatShim(conf, ugi);
     try {
       Set<String> childJobs = tracker.getJobs(context.getJobID().toString(), startTime);
-      if (childJobs.size() == 0) {
+      if (childJobs.isEmpty()) {
         LOG.info("No child jobs found to reconnect with");
         return false;
       }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -4838,7 +4838,7 @@ public class TestReplicationScenarios {
       ReplicationMetric elem = itr.next();
       assertEquals(Metadata.ReplicationType.INCREMENTAL, elem.getMetadata().getReplicationType());
       List<Stage> stages = elem.getProgress().getStages();
-      assertTrue(stages.size() != 0);
+      assertTrue(!stages.isEmpty());
       for (Stage stage : stages) {
         if (stage.getReplStats() == null) {
           continue;
@@ -4884,7 +4884,7 @@ public class TestReplicationScenarios {
       ReplicationMetric elem = itr.next();
       assertEquals(Metadata.ReplicationType.INCREMENTAL, elem.getMetadata().getReplicationType());
       List<Stage> stages = elem.getProgress().getStages();
-      assertTrue(stages.size() != 0);
+      assertTrue(!stages.isEmpty());
       for (Stage stage : stages) {
         if (stage.getReplStats() == null) {
           continue;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerShowFilters.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerShowFilters.java
@@ -84,7 +84,7 @@ public class TestHiveAuthorizerShowFilters {
         // return static variable with results, if it is set to some set of
         // values
         // otherwise return the arguments
-        if (filteredResults.size() == 0) {
+        if (filteredResults.isEmpty()) {
           return filterArguments;
         }
         return filteredResults;

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
@@ -2957,7 +2957,7 @@ public class TestJdbcDriver2 {
     stmt.executeQuery(sql);
     List<String> logs = stmt.getQueryLog(false, 10);
     stmt.close();
-    assertTrue(logs.size() == 0);
+    assertTrue(logs.isEmpty());
     setStmt.execute("set hive.server2.logging.operation.enabled = true");
     setStmt.close();
   }

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/cbo_rp_TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/cbo_rp_TestJdbcDriver2.java
@@ -2371,7 +2371,7 @@ public void testParseUrlHttpMode() throws SQLException, JdbcUriParseException,
     stmt.executeQuery(sql);
     List<String> logs = stmt.getQueryLog(false, 10);
     stmt.close();
-    assertTrue(logs.size() == 0);
+    assertTrue(logs.isEmpty());
     setStmt.execute("set hive.server2.logging.operation.enabled = true");
     setStmt.close();
   }

--- a/jdbc-handler/src/main/java/org/apache/hive/storage/jdbc/JdbcSerDe.java
+++ b/jdbc-handler/src/main/java/org/apache/hive/storage/jdbc/JdbcSerDe.java
@@ -108,7 +108,7 @@ public class JdbcSerDe extends AbstractSerDe {
         if (hiveColumnNames.length == 0) {
           throw new SerDeException("Received an empty Hive column name definition");
         }
-        if (hiveColumnTypesList.size() == 0) {
+        if (hiveColumnTypesList.isEmpty()) {
           throw new SerDeException("Received an empty Hive column type definition");
         }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -894,7 +894,7 @@ public class Warehouse {
    */
   public static String makePartName(List<FieldSchema> partCols,
       List<String> vals, String defaultStr) throws MetaException {
-    if ((partCols.size() != vals.size()) || (partCols.size() == 0)) {
+    if ((partCols.size() != vals.size()) || (partCols.isEmpty())) {
       StringBuilder errorStrBuilder = new StringBuilder("Invalid partition key & values; keys [");
       for (FieldSchema fs : partCols) {
         errorStrBuilder.append(fs.getName()).append(", ");

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/HdfsUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/HdfsUtils.java
@@ -194,7 +194,7 @@ public class HdfsUtils {
   private static List<String> constructDistCpParams(List<Path> srcPaths, Path dst,
                                                     Configuration conf) {
     List<String> params = constructDistCpOptions(conf);
-    if (params.size() == 0){
+    if (params.isEmpty()){
       // if no entries were added via conf, we initiate our defaults
       params.add("-update");
       params.add("-pbx");

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AggregateStatsCache.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AggregateStatsCache.java
@@ -164,7 +164,7 @@ public class AggregateStatsCache {
     Key key = new Key(catName, dbName, tblName, colName);
     AggrColStatsList candidateList = cacheStore.get(key);
     // No key, or no nodes in candidate list
-    if ((candidateList == null) || (candidateList.nodes.size() == 0)) {
+    if ((candidateList == null) || (candidateList.nodes.isEmpty())) {
       LOG.debug("No aggregate stats cached for " + key.toString());
       return null;
     }
@@ -341,7 +341,7 @@ public class AggregateStatsCache {
             AggrColStats node;
             AggrColStatsList candidateList = pair.getValue();
             List<AggrColStats> nodes = candidateList.nodes;
-            if (nodes.size() == 0) {
+            if (nodes.isEmpty()) {
               mapIterator.remove();
               continue;
             }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -541,7 +541,7 @@ public class HiveAlterHandler implements AlterHandler {
     }
 
     //alter partition
-    if (part_vals == null || part_vals.size() == 0) {
+    if (part_vals == null || part_vals.isEmpty()) {
       try {
         msdb.openTransaction();
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -1825,7 +1825,7 @@ class MetaStoreDirectSql {
       }
       // Extrapolation is not needed for columns noExtraColumnNames
       List<Object[]> list;
-      if (noExtraColumnNames.size() != 0) {
+      if (!noExtraColumnNames.isEmpty()) {
         queryText = commonPrefix + " and \"COLUMN_NAME\" in ("
             + makeParams(noExtraColumnNames.size()) + ")" + " and \"PARTITION_NAME\" in ("
             + makeParams(partNames.size()) + ")"

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -316,7 +316,7 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
           ret.put(newTable, requiredCapabilities);
           break;
         case "MANAGED_TABLE":
-          if (processorCapabilities.size() == 0) { // processor has no capabilities
+          if (processorCapabilities.isEmpty()) { // processor has no capabilities
             LOG.info("Client has no capabilities for type " + tableType + ",accesstype is NONE");
             table.setAccessType(ACCESSTYPE_NONE);
             table.setRequiredReadCapabilities(getReads(requiredCapabilities));
@@ -839,11 +839,11 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
   private List<String> diff(final List<String> list1, final List<String> list2) {
     List<String> diffList = new ArrayList<>();
 
-    if (list2 == null || list2.size() == 0) {
+    if (list2 == null || list2.isEmpty()) {
       return list1;
     }
 
-    if (list1 == null || list1.size() == 0) {
+    if (list1 == null || list1.isEmpty()) {
       return Collections.emptyList();
     }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
@@ -227,7 +227,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
         cols.add(fs);
       }
 
-      if (cols.size() == 0) {
+      if (cols.isEmpty()) {
         // table does not exists or could not be fetched
         return null;
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/SQLGenerator.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/SQLGenerator.java
@@ -59,7 +59,7 @@ public final class SQLGenerator {
                                                                 String tblColumns, List<String> rows,
                                                                 List<List<String>> paramsList)
           throws SQLException {
-    if (rows == null || rows.size() == 0) {
+    if (rows == null || rows.isEmpty()) {
       return Collections.emptyList();
     }
     assert((paramsList == null) || (rows.size() == paramsList.size()));
@@ -116,7 +116,7 @@ public final class SQLGenerator {
    * @return fully formed INSERT INTO ... statements
    */
   private List<String> createInsertValuesStmt(String tblColumns, List<String> rows, List<Integer> rowsCountInStmts) {
-    if (rows == null || rows.size() == 0) {
+    if (rows == null || rows.isEmpty()) {
       return Collections.emptyList();
     }
     return dbProduct.createInsertValuesStmt(tblColumns, rows, rowsCountInStmts, conf);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -841,7 +841,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   }
 
   private void deleteInvalidOpenTransactions(Connection dbConn, List<Long> txnIds) throws MetaException {
-    if (txnIds.size() == 0) {
+    if (txnIds.isEmpty()) {
       return;
     }
     try {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
@@ -275,7 +275,7 @@ public class TxnUtils {
     int maxParameters = MetastoreConf.getIntVar(conf, ConfVars.DIRECT_SQL_MAX_PARAMETERS);
 
     // Check parameter set validity as a public method.
-    if (inList == null || inList.size() == 0 || maxQueryLength <= 0 || batchSize <= 0) {
+    if (inList == null || inList.isEmpty() || maxQueryLength <= 0 || batchSize <= 0) {
       throw new IllegalArgumentException("The IN list is empty!");
     }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -174,7 +174,7 @@ public abstract class TestHiveMetaStore {
       assertTrue("Spec from name is incorrect", spec.equals(testSpec));
 
       List<String> emptyVals = client.partitionNameToVals("");
-      assertTrue("Values should be empty", emptyVals.size() == 0);
+      assertTrue("Values should be empty", emptyVals.isEmpty());
 
       Map<String, String> emptySpec =  client.partitionNameToSpec("");
       assertTrue("Spec should be empty", emptySpec.size() == 0);
@@ -2889,7 +2889,7 @@ public abstract class TestHiveMetaStore {
       assertEquals("function owner type", PrincipalType.USER, func.getOwnerType());
       assertEquals("function type", funcType, func.getFunctionType());
       List<ResourceUri> resources = func.getResourceUris();
-      assertTrue("function resources", resources == null || resources.size() == 0);
+      assertTrue("function resources", resources == null || resources.isEmpty());
 
       boolean gotException = false;
       try {


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections



Created with: [Moderne](https://app.moderne.io)