### PR TITLE
HIVE-26156: Iceberg delete writer should handle deleting from old partition specs

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
@@ -54,7 +54,7 @@ public class HiveIcebergDeleteWriter extends HiveIcebergWriter {
   public void write(Writable row) throws IOException {
     Record rec = ((Container<Record>) row).get();
     PositionDelete<Record> positionDelete = IcebergAcidUtil.getPositionDelete(rec, rowDataTemplate);
-    Integer specId = rec.get(0, Integer.class);
+    int specId = IcebergAcidUtil.parseSpecId(rec);
     writer.write(positionDelete, specs.get(specId), partition(positionDelete.row(), specId));
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -87,8 +87,8 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
       return new HiveIcebergDeleteWriter(schema, table.specs(), fileFormat, writerFactory, outputFileFactory, io,
           targetFileSize, taskAttemptID, tableName);
     } else {
-      return new HiveIcebergRecordWriter(schema, table.specs(), fileFormat, writerFactory, outputFileFactory, io,
-          targetFileSize, taskAttemptID, tableName);
+      return new HiveIcebergRecordWriter(schema, table.specs(), table.spec().specId(), fileFormat, writerFactory,
+          outputFileFactory, io, targetFileSize, taskAttemptID, tableName);
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.util.Progressable;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -69,7 +68,6 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     // It gets the config from the FileSinkOperator which has its own config for every target table
     Table table = HiveIcebergStorageHandler.table(jc, jc.get(hive_metastoreConstants.META_TABLE_NAME));
     Schema schema = HiveIcebergStorageHandler.schema(jc);
-    PartitionSpec spec = table.spec();
     FileFormat fileFormat = FileFormat.valueOf(PropertyUtil.propertyAsString(table.properties(),
         TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH));
     long targetFileSize = PropertyUtil.propertyAsLong(table.properties(), TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
@@ -86,11 +84,11 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     HiveFileWriterFactory writerFactory = new HiveFileWriterFactory(table, fileFormat, schema, null, fileFormat,
         null, null, null, schema);
     if (HiveIcebergStorageHandler.isDelete(jc, tableName)) {
-      return new HiveIcebergDeleteWriter(schema, spec, fileFormat, writerFactory, outputFileFactory, io, targetFileSize,
-          taskAttemptID, tableName);
+      return new HiveIcebergDeleteWriter(schema, table.specs(), fileFormat, writerFactory, outputFileFactory, io,
+          targetFileSize, taskAttemptID, tableName);
     } else {
-      return new HiveIcebergRecordWriter(schema, spec, fileFormat, writerFactory, outputFileFactory, io, targetFileSize,
-          taskAttemptID, tableName);
+      return new HiveIcebergRecordWriter(schema, table.specs(), fileFormat, writerFactory, outputFileFactory, io,
+          targetFileSize, taskAttemptID, tableName);
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.iceberg.DataFile;
@@ -37,17 +38,17 @@ import org.apache.iceberg.mr.mapred.Container;
 
 class HiveIcebergRecordWriter extends HiveIcebergWriter {
 
-  HiveIcebergRecordWriter(Schema schema, PartitionSpec spec, FileFormat format,
+  HiveIcebergRecordWriter(Schema schema, Map<Integer, PartitionSpec> specs, FileFormat format,
       FileWriterFactory<Record> fileWriterFactory, OutputFileFactory fileFactory, FileIO io, long targetFileSize,
       TaskAttemptID taskAttemptID, String tableName) {
-    super(schema, spec, io, taskAttemptID, tableName,
+    super(schema, specs, io, taskAttemptID, tableName,
         new ClusteredDataWriter<>(fileWriterFactory, fileFactory, io, format, targetFileSize));
   }
 
   @Override
   public void write(Writable row) throws IOException {
     Record record = ((Container<Record>) row).get();
-    writer.write(record, spec, partition(record));
+    writer.write(record, specs.get(specs.size() - 1), partition(record));
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -38,17 +38,21 @@ import org.apache.iceberg.mr.mapred.Container;
 
 class HiveIcebergRecordWriter extends HiveIcebergWriter {
 
-  HiveIcebergRecordWriter(Schema schema, Map<Integer, PartitionSpec> specs, FileFormat format,
+  private final int currentSpecId;
+
+  HiveIcebergRecordWriter(
+      Schema schema, Map<Integer, PartitionSpec> specs, int currentSpecId, FileFormat format,
       FileWriterFactory<Record> fileWriterFactory, OutputFileFactory fileFactory, FileIO io, long targetFileSize,
       TaskAttemptID taskAttemptID, String tableName) {
     super(schema, specs, io, taskAttemptID, tableName,
         new ClusteredDataWriter<>(fileWriterFactory, fileFactory, io, format, targetFileSize));
+    this.currentSpecId = currentSpecId;
   }
 
   @Override
   public void write(Writable row) throws IOException {
     Record record = ((Container<Record>) row).get();
-    writer.write(record, specs.get(specs.size() - 1), partition(record));
+    writer.write(record, specs.get(currentSpecId), partition(record, currentSpecId));
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
@@ -100,11 +100,6 @@ public abstract class HiveIcebergWriter implements FileSinkOperator.RecordWriter
         result.dataFiles().size(), result.deleteFiles().size());
   }
 
-  protected PartitionKey partition(Record row) {
-    // get partition key for the latest spec
-    return partition(row, specs.size() - 1);
-  }
-
   protected PartitionKey partition(Record row, int specId) {
     PartitionKey partitionKey = partitionKeys.computeIfAbsent(specId,
         id -> new PartitionKey(specs.get(id), specs.get(id).schema()));

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
@@ -53,18 +53,18 @@ public abstract class HiveIcebergWriter implements FileSinkOperator.RecordWriter
     return writers.get(taskAttemptID);
   }
 
-  protected final PartitionKey currentKey;
   protected final FileIO io;
   protected final InternalRecordWrapper wrapper;
-  protected final PartitionSpec spec;
+  protected final Map<Integer, PartitionSpec> specs;
+  protected final Map<Integer, PartitionKey> partitionKeys;
   protected final PartitioningWriter writer;
 
-  protected HiveIcebergWriter(Schema schema, PartitionSpec spec, FileIO io, TaskAttemptID attemptID, String tableName,
-      PartitioningWriter writer) {
+  protected HiveIcebergWriter(Schema schema, Map<Integer, PartitionSpec> specs, FileIO io, TaskAttemptID attemptID,
+      String tableName, PartitioningWriter writer) {
     this.io = io;
-    this.currentKey = new PartitionKey(spec, schema);
     this.wrapper = new InternalRecordWrapper(schema.asStruct());
-    this.spec = spec;
+    this.specs = specs;
+    this.partitionKeys = Maps.newHashMapWithExpectedSize(specs.size());
     this.writer = writer;
     writers.putIfAbsent(attemptID, Maps.newConcurrentMap());
     writers.get(attemptID).put(tableName, this);
@@ -101,7 +101,14 @@ public abstract class HiveIcebergWriter implements FileSinkOperator.RecordWriter
   }
 
   protected PartitionKey partition(Record row) {
-    currentKey.partition(wrapper.wrap(row));
-    return currentKey;
+    // get partition key for the latest spec
+    return partition(row, specs.size() - 1);
+  }
+
+  protected PartitionKey partition(Record row, int specId) {
+    PartitionKey partitionKey = partitionKeys.computeIfAbsent(specId,
+        id -> new PartitionKey(specs.get(id), specs.get(id).schema()));
+    partitionKey.partition(wrapper.wrap(row));
+    return partitionKey;
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -93,7 +92,7 @@ public class IcebergAcidUtil {
    * @param rowData The record object to populate with the rowData fields only
    * @return The position delete object
    */
-  public static PositionDelete<Record> getPositionDelete(Record rec, GenericRecord rowData) {
+  public static PositionDelete<Record> getPositionDelete(Record rec, Record rowData) {
     PositionDelete<Record> positionDelete = PositionDelete.create();
     String filePath = rec.get(DELETE_SERDE_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
     long filePosition = rec.get(DELETE_SERDE_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
@@ -107,21 +106,21 @@ public class IcebergAcidUtil {
     return positionDelete;
   }
 
-  public static int parseSpecId(GenericRecord rec) {
+  public static int parseSpecId(Record rec) {
     return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.SPEC_ID), Integer.class);
   }
 
-  public static long computePartitionHash(GenericRecord rec) {
+  public static long computePartitionHash(Record rec) {
     StructProjection part = rec.get(DELETE_FILE_READ_META_COLS.get(PARTITION_STRUCT_META_COL), StructProjection.class);
     // we need to compute a hash value for the partition struct so that it can be used as a sorting key
     return computeHash(part);
   }
 
-  public static String parseFilePath(GenericRecord rec) {
+  public static String parseFilePath(Record rec) {
     return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
   }
 
-  public static long parseFilePosition(GenericRecord rec) {
+  public static long parseFilePosition(Record rec) {
     return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
   }
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -266,7 +266,6 @@ public class TestHiveIcebergOutputCommitter {
     Table table = HiveIcebergStorageHandler.table(conf, name);
     FileIO io = table.io();
     Schema schema = HiveIcebergStorageHandler.schema(conf);
-    PartitionSpec spec = table.spec();
 
     for (int i = 0; i < taskNum; ++i) {
       List<Record> records = TestHelper.generateRandomRecords(schema, RECORD_NUM, i + attemptNum);
@@ -287,9 +286,8 @@ public class TestHiveIcebergOutputCommitter {
           null, fileFormat, null, null, null, null);
 
 
-      HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, spec, fileFormat,
-          hfwf, outputFileFactory, io, TARGET_FILE_SIZE,
-          TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
+      HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, table.specs(), fileFormat,
+          hfwf, outputFileFactory, io, TARGET_FILE_SIZE, TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
 
       Container<Record> container = new Container<>();
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -286,8 +286,9 @@ public class TestHiveIcebergOutputCommitter {
           null, fileFormat, null, null, null, null);
 
 
-      HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, table.specs(), fileFormat,
-          hfwf, outputFileFactory, io, TARGET_FILE_SIZE, TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
+      HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, table.specs(),
+          table.spec().specId(), fileFormat, hfwf, outputFileFactory, io, TARGET_FILE_SIZE,
+          TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
 
       Container<Record> container = new Container<>();
 

--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_avro.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_avro.q.out
@@ -46,8 +46,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[59][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: delete from tbl_ice where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_orc.q.out
@@ -46,8 +46,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[59][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: delete from tbl_ice where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_parquet.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_partitioned_parquet.q.out
@@ -46,8 +46,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[59][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[57][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: delete from tbl_ice where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice


### PR DESCRIPTION
While `HiveIcebergRecordWriter` always writes data out according to the latest spec, the `HiveIcebergDeleteWriter` might have to write delete files into partitions that correspond to a variety of specs, both old and new. Therefore we should pass the `table.specs()`map into the `HiveIcebergWriter` so that the delete writer can choose the appropriate spec on a per-record basis.

This PR also fixes the issue that we shouldn't sort by the bucket value for delete queries (as we do for regular writes), as it can mess up the ordering of the incoming records to the delete writer. In case of deletes, the records are already clustered together using the hash of the partition struct.