### PR TITLE
HIVE-26159: Make hive cli available from hive shell command

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -90,7 +90,6 @@ if [ "$SERVICE" = "" ] ; then
   fi
 fi
 
-USE_BEELINE_FOR_HIVE_CLI="true"
 if [[ "$SERVICE" == "cli" && "$USE_BEELINE_FOR_HIVE_CLI" == "true" ]] ; then
   CLIUSER=`whoami`
   SERVICE="beeline"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hive cli is the default service in hive script, but it can not start even if we use `--service cli` option now, I don't think this is what we expect from beeline.

### Why are the changes needed?

Hive cli is a convenient tool to connect to hive metastore service for testing or hive taste, and the hive community seems not intend to deprecate hive cli so far.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Shell script, can test on local with just `hive` command:
```bash
$ $HIVE_HOME/bin/hive
```
