### PR TITLE
HIVE-26174 disable rename table across dbs when on different filesystem

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -266,16 +266,18 @@ public class HiveAlterHandler implements AlterHandler {
 
             newt.getSd().setLocation(destPath.toString());
 
-            // check that destination does not exist otherwise we will be
-            // overwriting data
             // check that src and dest are on the same file system
-            if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-              throw new InvalidOperationException("table new location " + destPath
+            Path dbLocation = wh.getDatabaseManagedPath(db);
+            FileSystem dbFs = wh.getFs(dbLocation);
+            if (!FileUtils.equalsFileSystem(srcFs, dbFs)) {
+              throw new InvalidOperationException("table new db location " + dbLocation
                       + " is on a different file system than the old location "
                       + srcPath + ". This operation is not supported");
             }
 
             try {
+              // check that destination does not exist otherwise we will be
+              // overwriting data
               if (destFs.exists(destPath)) {
                 throw new InvalidOperationException("New location for this table " +
                         TableName.getQualified(catName, newDbName, newTblName) +


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Disable rename table across dbs when dbs on different filesystem.
2. Adjust the place of comment so it matches code better.


### Why are the changes needed?

Currently, if we run `ALTER TABLE db1.table1 RENAME TO db2.table2;` with `db1` and `db2` on different filesystem, for example `db1` as `"hdfs:/user/hive/warehouse/db1.db"`, and `db2` as `"s3://bucket/s3warehouse/db2.db"`, the new `db2.table2` will be under location `hdfs:/s3warehouse/db2.db/table2`, which looks quite strange.


### Does this PR introduce _any_ user-facing change?

Yes.
Before this patch, if we run
```
CREATE DATABASE db1 LOCATION '/user/hive/warehouse/db1.db';
CREATE DATABASE db2 LOCATION 's3://bucket/s3warehouse/db2.db';
CREATE TABLE db1.table1 (...);
-- write some data to db1.table1
ALTER TABLE db1.table1 RENAME TO db2.table2;
```
The `ALTER TABLE RENAME TO` command will success and, table location is under `/s3warehouse/db2.db/table2`(s3), which is like undefined behavior of the language manual.

After this fix, the `ALTER TABLE RENAME TO` command will fail with message telling user that Hive cannot rename tables because they are on different filesystem.

### How was this patch tested?

Manually tested.
