### PR TITLE
HIVE-26183: Create delete writer for the UPDATE statements

### DIFF
--- a/iceberg/iceberg-handler/pom.xml
+++ b/iceberg/iceberg-handler/pom.xml
@@ -101,10 +101,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
       <version>0.9.22</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/FilesForCommit.java
@@ -20,8 +20,8 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.ContentFile;
@@ -30,19 +30,19 @@ import org.apache.iceberg.DeleteFile;
 
 public class FilesForCommit implements Serializable {
 
-  private final List<DataFile> dataFiles;
-  private final List<DeleteFile> deleteFiles;
+  private final Collection<DataFile> dataFiles;
+  private final Collection<DeleteFile> deleteFiles;
 
-  public FilesForCommit(List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
+  public FilesForCommit(Collection<DataFile> dataFiles, Collection<DeleteFile> deleteFiles) {
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
   }
 
-  public static FilesForCommit onlyDelete(List<DeleteFile> deleteFiles) {
+  public static FilesForCommit onlyDelete(Collection<DeleteFile> deleteFiles) {
     return new FilesForCommit(Collections.emptyList(), deleteFiles);
   }
 
-  public static FilesForCommit onlyData(List<DataFile> dataFiles) {
+  public static FilesForCommit onlyData(Collection<DataFile> dataFiles) {
     return new FilesForCommit(dataFiles, Collections.emptyList());
   }
 
@@ -50,15 +50,15 @@ public class FilesForCommit implements Serializable {
     return new FilesForCommit(Collections.emptyList(), Collections.emptyList());
   }
 
-  public List<DataFile> dataFiles() {
+  public Collection<DataFile> dataFiles() {
     return dataFiles;
   }
 
-  public List<DeleteFile> deleteFiles() {
+  public Collection<DeleteFile> deleteFiles() {
     return deleteFiles;
   }
 
-  public List<? extends ContentFile> allFiles() {
+  public Collection<? extends ContentFile> allFiles() {
     return Stream.concat(dataFiles.stream(), deleteFiles.stream()).collect(Collectors.toList());
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -97,7 +96,7 @@ public class HiveIcebergBufferedDeleteWriter implements HiveIcebergWriter {
   public void write(Writable row) throws IOException {
     Record rec = ((Container<Record>) row).get();
     IcebergAcidUtil.populateWithOriginalValues(rec, record);
-    String filePath = (String) rec.getField(MetadataColumns.FILE_PATH.name());
+    String filePath = IcebergAcidUtil.parseFilePath(rec);
     int specId = IcebergAcidUtil.parseSpecId(rec);
 
     Map<String, Roaring64Bitmap> deleteMap =
@@ -106,7 +105,7 @@ public class HiveIcebergBufferedDeleteWriter implements HiveIcebergWriter {
           return Maps.newHashMap();
         });
     Roaring64Bitmap deletes = deleteMap.computeIfAbsent(filePath, unused -> new Roaring64Bitmap());
-    deletes.add((Long) rec.getField(MetadataColumns.ROW_POSITION.name()));
+    deletes.add(IcebergAcidUtil.parseFilePosition(rec));
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Writable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.io.ClusteredPositionDeleteWriter;
+import org.apache.iceberg.io.DeleteWriteResult;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileWriterFactory;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.PartitioningWriter;
+import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.util.Tasks;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HiveIcebergBufferedDeleteWriter implements HiveIcebergWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergBufferedDeleteWriter.class);
+
+  private static final String DELETE_FILE_THREAD_POOL_SIZE = "iceberg.delete.file.thread.pool.size";
+  private static final int DELETE_FILE_THREAD_POOL_SIZE_DEFAULT = 10;
+
+  // Storing deleted data in a map Partition -> FileName -> BitMap
+  private final Map<PartitionKey, Map<String, Roaring64Bitmap>> buffer = Maps.newHashMap();
+  private final Map<Integer, PartitionSpec> specs;
+  private final Map<PartitionKey, PartitionSpec> keyToSpec = Maps.newHashMap();
+  private final FileFormat format;
+  private final FileWriterFactory<Record> writerFactory;
+  private final OutputFileFactory fileFactory;
+  private final FileIO io;
+  private final long targetFileSize;
+  private final Configuration configuration;
+  private final Record record;
+  private final InternalRecordWrapper wrapper;
+  private FilesForCommit filesForCommit;
+
+  HiveIcebergBufferedDeleteWriter(Schema schema, Map<Integer, PartitionSpec> specs, FileFormat format,
+      FileWriterFactory<Record> writerFactory, OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+      Configuration configuration) {
+    this.specs = specs;
+    this.format = format;
+    this.writerFactory = writerFactory;
+    this.fileFactory = fileFactory;
+    this.io = io;
+    this.targetFileSize = targetFileSize;
+    this.configuration = configuration;
+    this.wrapper = new InternalRecordWrapper(schema.asStruct());
+    this.record = GenericRecord.create(schema);
+  }
+
+  @Override
+  public void write(Writable row) throws IOException {
+    Record rec = ((Container<Record>) row).get();
+    IcebergAcidUtil.getUpdatedRecord(rec, record);
+    String filePath = (String) rec.getField(MetadataColumns.FILE_PATH.name());
+    int specId = IcebergAcidUtil.parseSpecId(rec);
+
+    Map<String, Roaring64Bitmap> deleteMap =
+        buffer.computeIfAbsent(partition(record, specId), key -> {
+          keyToSpec.put(key, specs.get(specId));
+          return Maps.newHashMap();
+        });
+    Roaring64Bitmap deletes = deleteMap.computeIfAbsent(filePath, unused -> new Roaring64Bitmap());
+    deletes.add((Long) rec.getField(MetadataColumns.ROW_POSITION.name()));
+  }
+
+  @Override
+  public void close(boolean abort) throws IOException {
+    long startTime = System.currentTimeMillis();
+    Collection<DeleteFile> deleteFiles = new ConcurrentLinkedQueue<>();
+    if (!abort) {
+      LOG.info("Delete file flush is started");
+      Tasks.foreach(buffer.keySet())
+          .retry(3)
+          .executeWith(fileExecutor(configuration))
+          .onFailure((partition, exception) -> LOG.debug("Failed to write delete file {}", partition, exception))
+          .run(partition -> {
+            PositionDelete<Record> positionDelete = PositionDelete.create();
+            PartitioningWriter writerForData =
+                new ClusteredPositionDeleteWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+            try (PartitioningWriter writer = writerForData) {
+              writerForData = writer;
+              for (String filePath : new TreeSet<>(buffer.get(partition).keySet())) {
+                Roaring64Bitmap deletes = buffer.get(partition).get(filePath);
+                deletes.forEach(position -> {
+                  positionDelete.set(filePath, position, null);
+                  writer.write(positionDelete, keyToSpec.get(partition), partition);
+                });
+              }
+            }
+            deleteFiles.addAll(((DeleteWriteResult) writerForData.result()).deleteFiles());
+          }, IOException.class);
+    }
+
+    LOG.info("HiveIcebergBufferedDeleteWriter is closed with abort={}. Created {} delete files and it took {} ns.",
+        abort, deleteFiles.size(), System.currentTimeMillis() - startTime);
+    LOG.debug("Delete files written {}", deleteFiles);
+
+    this.filesForCommit = FilesForCommit.onlyDelete(deleteFiles);
+  }
+
+  @Override
+  public FilesForCommit files() {
+    return filesForCommit;
+  }
+
+  protected PartitionKey partition(Record row, int specId) {
+    PartitionKey partitionKey = new PartitionKey(specs.get(specId), specs.get(specId).schema());
+    partitionKey.partition(wrapper.wrap(row));
+    return partitionKey;
+  }
+
+  /**
+   * Executor service for parallel writing of delete files.
+   * @param conf The configuration containing the pool size
+   * @return The generated executor service
+   */
+  private static ExecutorService fileExecutor(Configuration conf) {
+    int size = conf.getInt(DELETE_FILE_THREAD_POOL_SIZE, DELETE_FILE_THREAD_POOL_SIZE_DEFAULT);
+    return Executors.newFixedThreadPool(
+        size,
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setPriority(Thread.NORM_PRIORITY)
+            .setNameFormat("iceberg-delete-file-pool-%d")
+            .build());
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergBufferedDeleteWriter.java
@@ -89,7 +89,7 @@ public class HiveIcebergBufferedDeleteWriter implements HiveIcebergWriter {
   @Override
   public void write(Writable row) throws IOException {
     Record rec = ((Container<Record>) row).get();
-    IcebergAcidUtil.getUpdatedRecord(rec, record);
+    IcebergAcidUtil.getOriginalFromUpdatedRecord(rec, record);
     String filePath = (String) rec.getField(MetadataColumns.FILE_PATH.name());
     int specId = IcebergAcidUtil.parseSpecId(rec);
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
@@ -46,7 +46,7 @@ public class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
       FileWriterFactory<Record> writerFactory, OutputFileFactory fileFactory, FileIO io, long targetFileSize,
       TaskAttemptID taskAttemptID, String tableName) {
     super(schema, specs, io, taskAttemptID, tableName,
-        new ClusteredPositionDeleteWriter<>(writerFactory, fileFactory, io, fileFormat, targetFileSize));
+        new ClusteredPositionDeleteWriter<>(writerFactory, fileFactory, io, fileFormat, targetFileSize), false);
     rowDataTemplate = GenericRecord.create(schema);
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergDeleteWriter.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.mapred.Container;
 
-public class HiveIcebergDeleteWriter extends HiveIcebergWriter {
+public class HiveIcebergDeleteWriter extends HiveIcebergWriterBase {
 
   private final GenericRecord rowDataTemplate;
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -107,7 +107,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
     TaskAttemptID attemptID = context.getTaskAttemptID();
     JobConf jobConf = context.getJobConf();
     Collection<String> outputs = HiveIcebergStorageHandler.outputTables(context.getJobConf());
-    Map<String, HiveIcebergWriter> writers = Optional.ofNullable(HiveIcebergWriter.getWriters(attemptID))
+    Map<String, HiveIcebergWriter> writers = Optional.ofNullable(HiveIcebergWriterBase.getWriters(attemptID))
         .orElseGet(() -> {
           LOG.info("CommitTask found no writers for output tables: {}, attemptID: {}", outputs, attemptID);
           return ImmutableMap.of();
@@ -146,7 +146,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
     }
 
     // remove the writer to release the object
-    HiveIcebergWriter.removeWriters(attemptID);
+    HiveIcebergWriterBase.removeWriters(attemptID);
   }
 
   /**
@@ -159,7 +159,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
     TaskAttemptContext context = TezUtil.enrichContextWithAttemptWrapper(originalContext);
 
     // Clean up writer data from the local store
-    Map<String, HiveIcebergWriter> writers = HiveIcebergWriter.removeWriters(context.getTaskAttemptID());
+    Map<String, HiveIcebergWriter> writers = HiveIcebergWriterBase.removeWriters(context.getTaskAttemptID());
 
     // Remove files if it was not done already
     if (writers != null) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -63,7 +63,7 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     // Not doing any check.
   }
 
-  private static HiveIcebergWriter writer(JobConf jc) {
+  private static HiveIcebergWriterBase writer(JobConf jc) {
     TaskAttemptID taskAttemptID = TezUtil.taskAttemptWrapper(jc);
     // It gets the config from the FileSinkOperator which has its own config for every target table
     Table table = HiveIcebergStorageHandler.table(jc, jc.get(hive_metastoreConstants.META_TABLE_NAME));

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -88,7 +88,7 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
           targetFileSize, taskAttemptID, tableName);
     } else {
       return new HiveIcebergRecordWriter(schema, table.specs(), table.spec().specId(), fileFormat, writerFactory,
-          outputFileFactory, io, targetFileSize, taskAttemptID, tableName);
+          outputFileFactory, io, targetFileSize, taskAttemptID, tableName, false);
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.mapred.Container;
 
-class HiveIcebergRecordWriter extends HiveIcebergWriter {
+class HiveIcebergRecordWriter extends HiveIcebergWriterBase {
 
   private final int currentSpecId;
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
@@ -70,7 +70,7 @@ class HiveIcebergUpdateWriter extends HiveIcebergWriterBase {
   @Override
   public void write(Writable row) throws IOException {
     deleteWriter.write(row);
-    IcebergAcidUtil.getNewFromUpdatedRecord(((Container<Record>) row).get(), container.get());
+    IcebergAcidUtil.populateWithNewValues(((Container<Record>) row).get(), container.get());
     insertWriter.write(container);
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
@@ -30,6 +31,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.ClusteredDataWriter;
@@ -38,6 +40,12 @@ import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.mapred.Container;
 
+/**
+ * Hive update queries are converted to an insert statement where the result contains the updated rows.
+ * The schema is defined by {@link IcebergAcidUtil#createFileReadSchemaForUpdate(List, Table)}}.
+ * The rows are sorted based on the requirements of the {@link HiveIcebergRecordWriter}.
+ * The {@link HiveIcebergBufferedDeleteWriter} needs to handle out of order records.
+ */
 class HiveIcebergUpdateWriter extends HiveIcebergWriterBase {
 
   private final HiveIcebergBufferedDeleteWriter deleteWriter;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergUpdateWriter.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.TaskAttemptID;
@@ -34,10 +37,6 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.mr.mapred.Container;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
 
 class HiveIcebergUpdateWriter extends HiveIcebergWriterBase {
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriter.java
@@ -20,90 +20,22 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.util.Map;
-import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.Reporter;
-import org.apache.hadoop.mapred.TaskAttemptID;
-import org.apache.iceberg.PartitionKey;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.data.InternalRecordWrapper;
-import org.apache.iceberg.data.Record;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.mr.mapred.Container;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.util.Tasks;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("checkstyle:VisibilityModifier")
-public abstract class HiveIcebergWriter implements FileSinkOperator.RecordWriter,
-    org.apache.hadoop.mapred.RecordWriter<NullWritable, Container<Record>> {
-  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergWriter.class);
+public interface HiveIcebergWriter {
+  FilesForCommit files();
+  void close(boolean abort) throws IOException;
+  void write(Writable row) throws IOException;
 
-  private static final Map<TaskAttemptID, Map<String, HiveIcebergWriter>> writers = Maps.newConcurrentMap();
-
-  static Map<String, HiveIcebergWriter> removeWriters(TaskAttemptID taskAttemptID) {
-    return writers.remove(taskAttemptID);
-  }
-
-  static Map<String, HiveIcebergWriter> getWriters(TaskAttemptID taskAttemptID) {
-    return writers.get(taskAttemptID);
-  }
-
-  protected final FileIO io;
-  protected final InternalRecordWrapper wrapper;
-  protected final Map<Integer, PartitionSpec> specs;
-  protected final Map<Integer, PartitionKey> partitionKeys;
-  protected final PartitioningWriter writer;
-
-  protected HiveIcebergWriter(Schema schema, Map<Integer, PartitionSpec> specs, FileIO io, TaskAttemptID attemptID,
-      String tableName, PartitioningWriter writer) {
-    this.io = io;
-    this.wrapper = new InternalRecordWrapper(schema.asStruct());
-    this.specs = specs;
-    this.partitionKeys = Maps.newHashMapWithExpectedSize(specs.size());
-    this.writer = writer;
-    writers.putIfAbsent(attemptID, Maps.newConcurrentMap());
-    writers.get(attemptID).put(tableName, this);
-  }
-
-  protected abstract FilesForCommit files();
-
-  @Override
-  public void write(NullWritable key, Container value) throws IOException {
-    write(value);
-  }
-
-  @Override
-  public void close(Reporter reporter) throws IOException {
+  default void close(Reporter reporter) throws IOException {
     close(false);
   }
 
-  @Override
-  public void close(boolean abort) throws IOException {
-    writer.close();
-    FilesForCommit result = files();
-
-    // If abort then remove the unnecessary files
-    if (abort) {
-      Tasks.foreach(result.allFiles())
-          .retry(3)
-          .suppressFailureWhenFinished()
-          .onFailure((file, exception) -> LOG.debug("Failed on to remove file {} on abort", file, exception))
-          .run(file -> io.deleteFile(file.path().toString()));
-    }
-
-    LOG.info("HiveIcebergWriter is closed with abort={}. Created {} data files and {} delete files", abort,
-        result.dataFiles().size(), result.deleteFiles().size());
+  default void write(NullWritable key, Container value) throws IOException {
+    write(value);
   }
 
-  protected PartitionKey partition(Record row, int specId) {
-    PartitionKey partitionKey = partitionKeys.computeIfAbsent(specId,
-        id -> new PartitionKey(specs.get(id), specs.get(id).schema()));
-    partitionKey.partition(wrapper.wrap(row));
-    return partitionKey;
-  }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriterBase.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriterBase.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.PartitioningWriter;
+import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public abstract class HiveIcebergWriterBase implements FileSinkOperator.RecordWriter,
+    org.apache.hadoop.mapred.RecordWriter<NullWritable, Container<Record>>, HiveIcebergWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergWriterBase.class);
+
+  private static final Map<TaskAttemptID, Map<String, HiveIcebergWriter>> writers = Maps.newConcurrentMap();
+
+  static Map<String, HiveIcebergWriter> removeWriters(TaskAttemptID taskAttemptID) {
+    return writers.remove(taskAttemptID);
+  }
+
+  static Map<String, HiveIcebergWriter> getWriters(TaskAttemptID taskAttemptID) {
+    return writers.get(taskAttemptID);
+  }
+
+  protected final FileIO io;
+  protected final InternalRecordWrapper wrapper;
+  protected final Map<Integer, PartitionSpec> specs;
+  protected final Map<Integer, PartitionKey> partitionKeys;
+  protected final PartitioningWriter writer;
+
+  protected HiveIcebergWriterBase(Schema schema, Map<Integer, PartitionSpec> specs, FileIO io, TaskAttemptID attemptID,
+      String tableName, PartitioningWriter writer) {
+    this.io = io;
+    this.wrapper = new InternalRecordWrapper(schema.asStruct());
+    this.specs = specs;
+    this.partitionKeys = Maps.newHashMapWithExpectedSize(specs.size());
+    this.writer = writer;
+    writers.putIfAbsent(attemptID, Maps.newConcurrentMap());
+    writers.get(attemptID).put(tableName, this);
+  }
+
+  @Override
+  public void write(NullWritable key, Container value) throws IOException {
+    write(value);
+  }
+
+  @Override
+  public void close(Reporter reporter) throws IOException {
+    close(false);
+  }
+
+  @Override
+  public void close(boolean abort) throws IOException {
+    writer.close();
+    FilesForCommit result = files();
+
+    // If abort then remove the unnecessary files
+    if (abort) {
+      Tasks.foreach(result.allFiles())
+          .retry(3)
+          .suppressFailureWhenFinished()
+          .onFailure((file, exception) -> LOG.debug("Failed on to remove file {} on abort", file, exception))
+          .run(file -> io.deleteFile(file.path().toString()));
+    }
+
+    LOG.info("HiveIcebergWriter is closed with abort={}. Created {} data files and {} delete files", abort,
+        result.dataFiles().size(), result.deleteFiles().size());
+  }
+
+  protected PartitionKey partition(Record row, int specId) {
+    PartitionKey partitionKey = partitionKeys.computeIfAbsent(specId,
+        id -> new PartitionKey(specs.get(id), specs.get(id).schema()));
+    partitionKey.partition(wrapper.wrap(row));
+    return partitionKey;
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriterBase.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergWriterBase.java
@@ -60,14 +60,16 @@ public abstract class HiveIcebergWriterBase implements FileSinkOperator.RecordWr
   protected final PartitioningWriter writer;
 
   protected HiveIcebergWriterBase(Schema schema, Map<Integer, PartitionSpec> specs, FileIO io, TaskAttemptID attemptID,
-      String tableName, PartitioningWriter writer) {
+      String tableName, PartitioningWriter writer, boolean wrapped) {
     this.io = io;
     this.wrapper = new InternalRecordWrapper(schema.asStruct());
     this.specs = specs;
     this.partitionKeys = Maps.newHashMapWithExpectedSize(specs.size());
     this.writer = writer;
-    writers.putIfAbsent(attemptID, Maps.newConcurrentMap());
-    writers.get(attemptID).put(tableName, this);
+    if (!wrapped) {
+      writers.putIfAbsent(attemptID, Maps.newConcurrentMap());
+      writers.get(attemptID).put(tableName, this);
+    }
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -158,26 +158,26 @@ public class IcebergAcidUtil {
   }
 
   /**
-   * Get the original record from the updated record. Populate the `rowData` with the filed values from `rec`.
+   * Get the original record from the updated record. Populate the `original` with the filed values from `rec`.
    * @param rec The record read by the file scan task, which contains both the metadata fields and the row data fields
-   * @param rowData The record object to populate with the rowData fields only
+   * @param original The record object to populate. The end result is the original record before the update.
    */
-  public static void getOriginalFromUpdatedRecord(Record rec, Record rowData) {
-    int dataOffset = UPDATE_SERDE_META_COLS.size() + rowData.size();
-    for (int i = dataOffset; i < dataOffset + rowData.size(); ++i) {
-      rowData.set(i - dataOffset, rec.get(i));
+  public static void populateWithOriginalValues(Record rec, Record original) {
+    int dataOffset = UPDATE_SERDE_META_COLS.size() + original.size();
+    for (int i = dataOffset; i < dataOffset + original.size(); ++i) {
+      original.set(i - dataOffset, rec.get(i));
     }
   }
 
   /**
-   * Get the new record from the updated record. Populate the `rowData` with the filed values from `rec`.
+   * Get the new record from the updated record. Populate the `newRecord` with the filed values from `rec`.
    * @param rec The record read by the file scan task, which contains both the metadata fields and the row data fields
-   * @param rowData The record object to populate with the rowData fields only
+   * @param newRecord The record object to populate. The end result is the new record after the update.
    */
-  public static void getNewFromUpdatedRecord(Record rec, Record rowData) {
+  public static void populateWithNewValues(Record rec, Record newRecord) {
     int dataOffset = UPDATE_SERDE_META_COLS.size();
-    for (int i = dataOffset; i < dataOffset + rowData.size(); ++i) {
-      rowData.set(i - dataOffset, rec.get(i));
+    for (int i = dataOffset; i < dataOffset + newRecord.size(); ++i) {
+      newRecord.set(i - dataOffset, rec.get(i));
     }
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -158,12 +158,24 @@ public class IcebergAcidUtil {
   }
 
   /**
-   * Populate the `rowData` with the filed values from `rec`.
+   * Get the original record from the updated record. Populate the `rowData` with the filed values from `rec`.
    * @param rec The record read by the file scan task, which contains both the metadata fields and the row data fields
    * @param rowData The record object to populate with the rowData fields only
    */
-  public static void getUpdatedRecord(Record rec, Record rowData) {
+  public static void getOriginalFromUpdatedRecord(Record rec, Record rowData) {
     int dataOffset = UPDATE_SERDE_META_COLS.size() + rowData.size();
+    for (int i = dataOffset; i < dataOffset + rowData.size(); ++i) {
+      rowData.set(i - dataOffset, rec.get(i));
+    }
+  }
+
+  /**
+   * Get the new record from the updated record. Populate the `rowData` with the filed values from `rec`.
+   * @param rec The record read by the file scan task, which contains both the metadata fields and the row data fields
+   * @param rowData The record object to populate with the rowData fields only
+   */
+  public static void getNewFromUpdatedRecord(Record rec, Record rowData) {
+    int dataOffset = UPDATE_SERDE_META_COLS.size();
     for (int i = dataOffset; i < dataOffset + rowData.size(); ++i) {
       rowData.set(i - dataOffset, rec.get(i));
     }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -39,33 +39,24 @@ public class IcebergAcidUtil {
   }
 
   private static final Types.NestedField PARTITION_STRUCT_META_COL = null; // placeholder value in the map
-  private static final Map<Types.NestedField, Integer> DELETE_FILE_READ_META_COLS = Maps.newLinkedHashMap();
+  private static final Map<Types.NestedField, Integer> FILE_READ_META_COLS = Maps.newLinkedHashMap();
 
   static {
-    DELETE_FILE_READ_META_COLS.put(MetadataColumns.SPEC_ID, 0);
-    DELETE_FILE_READ_META_COLS.put(PARTITION_STRUCT_META_COL, 1);
-    DELETE_FILE_READ_META_COLS.put(MetadataColumns.FILE_PATH, 2);
-    DELETE_FILE_READ_META_COLS.put(MetadataColumns.ROW_POSITION, 3);
+    FILE_READ_META_COLS.put(MetadataColumns.SPEC_ID, 0);
+    FILE_READ_META_COLS.put(PARTITION_STRUCT_META_COL, 1);
+    FILE_READ_META_COLS.put(MetadataColumns.FILE_PATH, 2);
+    FILE_READ_META_COLS.put(MetadataColumns.ROW_POSITION, 3);
   }
 
   private static final Types.NestedField PARTITION_HASH_META_COL = Types.NestedField.required(
       MetadataColumns.PARTITION_COLUMN_ID, MetadataColumns.PARTITION_COLUMN_NAME, Types.LongType.get());
-  private static final Map<Types.NestedField, Integer> DELETE_SERDE_META_COLS = Maps.newLinkedHashMap();
+  private static final Map<Types.NestedField, Integer> SERDE_META_COLS = Maps.newLinkedHashMap();
 
   static {
-    DELETE_SERDE_META_COLS.put(MetadataColumns.SPEC_ID, 0);
-    DELETE_SERDE_META_COLS.put(PARTITION_HASH_META_COL, 1);
-    DELETE_SERDE_META_COLS.put(MetadataColumns.FILE_PATH, 2);
-    DELETE_SERDE_META_COLS.put(MetadataColumns.ROW_POSITION, 3);
-  }
-
-  private static final Map<Types.NestedField, Integer> UPDATE_SERDE_META_COLS = Maps.newLinkedHashMap();
-
-  static {
-    UPDATE_SERDE_META_COLS.put(MetadataColumns.SPEC_ID, 0);
-    UPDATE_SERDE_META_COLS.put(PARTITION_HASH_META_COL, 1);
-    UPDATE_SERDE_META_COLS.put(MetadataColumns.FILE_PATH, 2);
-    UPDATE_SERDE_META_COLS.put(MetadataColumns.ROW_POSITION, 3);
+    SERDE_META_COLS.put(MetadataColumns.SPEC_ID, 0);
+    SERDE_META_COLS.put(PARTITION_HASH_META_COL, 1);
+    SERDE_META_COLS.put(MetadataColumns.FILE_PATH, 2);
+    SERDE_META_COLS.put(MetadataColumns.ROW_POSITION, 3);
   }
 
   /**
@@ -74,8 +65,8 @@ public class IcebergAcidUtil {
    * @return The schema for reading files, extended with metadata columns needed for deletes
    */
   public static Schema createFileReadSchemaForDelete(List<Types.NestedField> dataCols, Table table) {
-    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + DELETE_FILE_READ_META_COLS.size());
-    DELETE_FILE_READ_META_COLS.forEach((metaCol, index) -> {
+    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + FILE_READ_META_COLS.size());
+    FILE_READ_META_COLS.forEach((metaCol, index) -> {
       if (metaCol == PARTITION_STRUCT_META_COL) {
         cols.add(MetadataColumns.metadataColumn(table, MetadataColumns.PARTITION_COLUMN_NAME));
       } else {
@@ -91,8 +82,8 @@ public class IcebergAcidUtil {
    * @return The schema for SerDe operations, extended with metadata columns needed for deletes
    */
   public static Schema createSerdeSchemaForDelete(List<Types.NestedField> dataCols) {
-    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + DELETE_SERDE_META_COLS.size());
-    DELETE_SERDE_META_COLS.forEach((metaCol, index) -> cols.add(metaCol));
+    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + SERDE_META_COLS.size());
+    SERDE_META_COLS.forEach((metaCol, index) -> cols.add(metaCol));
     cols.addAll(dataCols);
     return new Schema(cols);
   }
@@ -106,10 +97,10 @@ public class IcebergAcidUtil {
    */
   public static PositionDelete<Record> getPositionDelete(Record rec, Record rowData) {
     PositionDelete<Record> positionDelete = PositionDelete.create();
-    String filePath = rec.get(DELETE_SERDE_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
-    long filePosition = rec.get(DELETE_SERDE_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
+    String filePath = rec.get(SERDE_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
+    long filePosition = rec.get(SERDE_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
 
-    int dataOffset = DELETE_SERDE_META_COLS.size(); // position in the rec where the actual row data begins
+    int dataOffset = SERDE_META_COLS.size(); // position in the rec where the actual row data begins
     for (int i = dataOffset; i < rec.size(); ++i) {
       rowData.set(i - dataOffset, rec.get(i));
     }
@@ -124,8 +115,8 @@ public class IcebergAcidUtil {
    * @return The schema for reading files, extended with metadata columns needed for deletes
    */
   public static Schema createFileReadSchemaForUpdate(List<Types.NestedField> dataCols, Table table) {
-    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + UPDATE_SERDE_META_COLS.size());
-    UPDATE_SERDE_META_COLS.forEach((metaCol, index) -> {
+    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + SERDE_META_COLS.size());
+    SERDE_META_COLS.forEach((metaCol, index) -> {
       if (metaCol == PARTITION_STRUCT_META_COL) {
         cols.add(MetadataColumns.metadataColumn(table, MetadataColumns.PARTITION_COLUMN_NAME));
       } else {
@@ -146,8 +137,8 @@ public class IcebergAcidUtil {
    * @return The schema for SerDe operations, extended with metadata columns needed for deletes
    */
   public static Schema createSerdeSchemaForUpdate(List<Types.NestedField> dataCols) {
-    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + UPDATE_SERDE_META_COLS.size());
-    UPDATE_SERDE_META_COLS.forEach((metaCol, index) -> cols.add(metaCol));
+    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(dataCols.size() + SERDE_META_COLS.size());
+    SERDE_META_COLS.forEach((metaCol, index) -> cols.add(metaCol));
     // New column values
     cols.addAll(dataCols);
     // Old column values
@@ -163,7 +154,7 @@ public class IcebergAcidUtil {
    * @param original The record object to populate. The end result is the original record before the update.
    */
   public static void populateWithOriginalValues(Record rec, Record original) {
-    int dataOffset = UPDATE_SERDE_META_COLS.size() + original.size();
+    int dataOffset = SERDE_META_COLS.size() + original.size();
     for (int i = dataOffset; i < dataOffset + original.size(); ++i) {
       original.set(i - dataOffset, rec.get(i));
     }
@@ -175,28 +166,28 @@ public class IcebergAcidUtil {
    * @param newRecord The record object to populate. The end result is the new record after the update.
    */
   public static void populateWithNewValues(Record rec, Record newRecord) {
-    int dataOffset = UPDATE_SERDE_META_COLS.size();
+    int dataOffset = SERDE_META_COLS.size();
     for (int i = dataOffset; i < dataOffset + newRecord.size(); ++i) {
       newRecord.set(i - dataOffset, rec.get(i));
     }
   }
 
   public static int parseSpecId(Record rec) {
-    return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.SPEC_ID), Integer.class);
+    return rec.get(FILE_READ_META_COLS.get(MetadataColumns.SPEC_ID), Integer.class);
   }
 
   public static long computePartitionHash(Record rec) {
-    StructProjection part = rec.get(DELETE_FILE_READ_META_COLS.get(PARTITION_STRUCT_META_COL), StructProjection.class);
+    StructProjection part = rec.get(FILE_READ_META_COLS.get(PARTITION_STRUCT_META_COL), StructProjection.class);
     // we need to compute a hash value for the partition struct so that it can be used as a sorting key
     return computeHash(part);
   }
 
   public static String parseFilePath(Record rec) {
-    return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
+    return rec.get(FILE_READ_META_COLS.get(MetadataColumns.FILE_PATH), String.class);
   }
 
   public static long parseFilePosition(Record rec) {
-    return rec.get(DELETE_FILE_READ_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
+    return rec.get(FILE_READ_META_COLS.get(MetadataColumns.ROW_POSITION), Long.class);
   }
 
   private static long computeHash(StructProjection struct) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/IcebergAcidUtil.java
@@ -137,7 +137,7 @@ public class IcebergAcidUtil {
     // Old column values
     cols.addAll(dataCols.stream()
         .map(f -> Types.NestedField.optional(1147483545 + f.fieldId(), "__old_value_for" + f.name(), f.type()))
-        .collect(Collectors.toSet()));
+        .collect(Collectors.toList()));
     return new Schema(cols);
   }
 
@@ -153,7 +153,7 @@ public class IcebergAcidUtil {
     // Old column values
     cols.addAll(dataCols.stream()
         .map(f -> Types.NestedField.optional(1147483545 + f.fieldId(), "__old_value_for_" + f.name(), f.type()))
-        .collect(Collectors.toSet()));
+        .collect(Collectors.toList()));
     return new Schema(cols);
   }
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/data/IcebergGenerics2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/data/IcebergGenerics2.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+public class IcebergGenerics2 {
+  private IcebergGenerics2() {
+  }
+
+  /**
+   * Returns a builder to configure a read of the given table that produces generic records.
+   *
+   * @param table an Iceberg table
+   * @return a builder to configure the scan
+   */
+  public static ScanBuilder read(Table table) {
+    return new ScanBuilder(table);
+  }
+
+  public static class ScanBuilder {
+    private TableScan tableScan;
+    private boolean reuseContainers = false;
+
+    public ScanBuilder(Table table) {
+      this.tableScan = table.newScan();
+    }
+
+    public ScanBuilder reuseContainers() {
+      this.reuseContainers = true;
+      return this;
+    }
+
+    public ScanBuilder where(Expression rowFilter) {
+      this.tableScan = tableScan.filter(rowFilter);
+      return this;
+    }
+
+    public ScanBuilder caseInsensitive() {
+      this.tableScan = tableScan.caseSensitive(false);
+      return this;
+    }
+
+    public ScanBuilder select(String... selectedColumns) {
+      this.tableScan = tableScan.select(ImmutableList.copyOf(selectedColumns));
+      return this;
+    }
+
+    public ScanBuilder project(Schema schema) {
+      this.tableScan = tableScan.project(schema);
+      return this;
+    }
+
+    public ScanBuilder useSnapshot(long scanSnapshotId) {
+      this.tableScan = tableScan.useSnapshot(scanSnapshotId);
+      return this;
+    }
+
+    public ScanBuilder asOfTime(long scanTimestampMillis) {
+      this.tableScan = tableScan.asOfTime(scanTimestampMillis);
+      return this;
+    }
+
+    public ScanBuilder appendsBetween(long fromSnapshotId, long toSnapshotId) {
+      this.tableScan = tableScan.appendsBetween(fromSnapshotId, toSnapshotId);
+      return this;
+    }
+
+    public ScanBuilder appendsAfter(long fromSnapshotId) {
+      this.tableScan = tableScan.appendsAfter(fromSnapshotId);
+      return this;
+    }
+
+    public CloseableIterable<Record> build() {
+      return new TableScanIterable(
+          tableScan,
+          reuseContainers
+      );
+    }
+  }
+}

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergWriterTestBase.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergWriterTestBase.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IcebergGenerics2;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.Parameterized;
+
+public class HiveIcebergWriterTestBase {
+  // Schema passed to create tables
+  public static final Schema SCHEMA = new Schema(
+      Types.NestedField.required(1, "id", Types.IntegerType.get()),
+      Types.NestedField.required(2, "data", Types.StringType.get())
+  );
+
+  public static final List<Record> RECORDS = TestHelper.RecordsBuilder.newInstance(SCHEMA)
+      .add(29, "a")
+      .add(43, "b")
+      .add(61, "c")
+      .add(89, "d")
+      .add(100, "e")
+      .add(121, "f")
+      .add(122, "g")
+      .build();
+
+  private final HadoopTables tables = new HadoopTables(new HiveConf());
+  private TestHelper helper;
+  protected Table table;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Parameterized.Parameter(0)
+  public FileFormat fileFormat;
+
+  @Parameterized.Parameter(1)
+  public boolean partitioned;
+
+  @Parameterized.Parameters(name = "fileFormat={0}, partitioned={1}")
+  public static Collection<Object[]> parameters() {
+    return Lists.newArrayList(new Object[][] {
+        { FileFormat.PARQUET, true },
+        { FileFormat.ORC, true },
+        { FileFormat.AVRO, true },
+        { FileFormat.PARQUET, false },
+// Skip this until the ORC reader is fixed - test only issue
+//        { FileFormat.ORC, false },
+        { FileFormat.AVRO, false }
+    });
+  }
+
+  @Before
+  public void init() throws IOException {
+    File location = temp.newFolder(fileFormat.name());
+    Assert.assertTrue(location.delete());
+
+    PartitionSpec spec = !partitioned ? PartitionSpec.unpartitioned() :
+        PartitionSpec.builderFor(SCHEMA)
+            .bucket("data", 3)
+            .build();
+    this.helper = new TestHelper(new HiveConf(), tables, location.toString(), SCHEMA, spec, fileFormat, temp);
+    this.table = helper.createTable();
+    helper.appendToTable(RECORDS);
+
+    TableOperations ops = ((BaseTable) table).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+  }
+
+  @After
+  public void cleanUp() {
+    tables.dropTable(helper.table().location());
+  }
+
+  protected StructLikeSet rowSetWithoutIds(List<Record> records, Set<Integer> idToDelete) {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    records.stream()
+        .filter(row -> !idToDelete.contains(row.getField("id")))
+        .forEach(set::add);
+    return set;
+  }
+
+  protected static List<GenericRecord> readRecords(Table table, Schema schema) throws IOException {
+    List<GenericRecord> records = Lists.newArrayList();
+    try (CloseableIterable<Record> reader = IcebergGenerics2.read(table).project(schema).build()) {
+      // For these tests we can be sure that the records are GenericRecords, and we need it to easily access fields
+      reader.forEach(record -> records.add((GenericRecord) record));
+    }
+
+    return records;
+  }
+
+  protected static StructLikeSet actualRowSet(Table table) throws IOException {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    readRecords(table, table.schema()).forEach(set::add);
+    return set;
+  }
+
+  protected static Schema schemaWithMeta(Table table) {
+    List<Types.NestedField> cols = Lists.newArrayListWithCapacity(table.schema().columns().size() + 4);
+    cols.addAll(table.schema().columns());
+    cols.add(MetadataColumns.ROW_POSITION);
+    cols.add(MetadataColumns.FILE_PATH);
+    cols.add(MetadataColumns.SPEC_ID);
+    cols.add(MetadataColumns.metadataColumn(table, MetadataColumns.PARTITION_COLUMN_NAME));
+    return new Schema(cols);
+  }
+}

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergDeleteWriter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergDeleteWriter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestHiveIcebergDeleteWriter extends HiveIcebergWriterTestBase {
+  private static final long TARGET_FILE_SIZE = 128 * 1024 * 1024;
+  private static final JobID JOB_ID = new JobID("test", 0);
+  private static final Set<Integer> DELETED_IDS = Sets.newHashSet(29, 61, 89, 100, 122);
+
+  @Test
+  public void testDelete() throws IOException {
+    HiveIcebergDeleteWriter testWriter = deleteWriter();
+
+    List<GenericRecord> deleteRecords = deleteRecords(table, DELETED_IDS);
+
+    Collections.sort(deleteRecords,
+        Comparator.comparing(a -> a.getField(MetadataColumns.PARTITION_COLUMN_NAME).toString()));
+
+    Container<Record> container = new Container<>();
+    for (Record deleteRecord : deleteRecords) {
+      container.set(deleteRecord);
+      testWriter.write(container);
+    }
+
+    testWriter.close(false);
+
+    RowDelta rowDelta = table.newRowDelta();
+    testWriter.files().deleteFiles().forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+
+    StructLikeSet expected = rowSetWithoutIds(RECORDS, DELETED_IDS);
+    StructLikeSet actual = actualRowSet(table);
+
+    Assert.assertEquals("Table should contain expected rows", expected, actual);
+  }
+
+  private static List<GenericRecord> deleteRecords(Table table, Set<Integer> idsToRemove)
+      throws IOException {
+    List<GenericRecord> deleteRecords = Lists.newArrayListWithExpectedSize(idsToRemove.size());
+    for (GenericRecord record : readRecords(table, schemaWithMeta(table))) {
+      if (!idsToRemove.contains(record.getField("id"))) {
+        continue;
+      }
+
+      GenericRecord deleteRecord = GenericRecord.create(IcebergAcidUtil.createSerdeSchemaForDelete(SCHEMA.columns()));
+      int specId = (Integer) record.getField(MetadataColumns.SPEC_ID.name());
+      deleteRecord.setField(MetadataColumns.SPEC_ID.name(), specId);
+      PartitionKey partitionKey = new PartitionKey(table.specs().get(specId), table.schema());
+      partitionKey.partition(record);
+      deleteRecord.setField(MetadataColumns.PARTITION_COLUMN_NAME, partitionKey);
+      deleteRecord.setField(MetadataColumns.FILE_PATH.name(), record.getField(MetadataColumns.FILE_PATH.name()));
+      deleteRecord.setField(MetadataColumns.ROW_POSITION.name(), record.getField(MetadataColumns.ROW_POSITION.name()));
+
+      SCHEMA.columns().forEach(field -> deleteRecord.setField(field.name(), record.getField(field.name())));
+      deleteRecords.add(deleteRecord);
+    }
+    return deleteRecords;
+  }
+
+  private HiveIcebergDeleteWriter deleteWriter() {
+    OutputFileFactory outputFileFactory = OutputFileFactory.builderFor(table, 1, 2)
+        .format(fileFormat)
+        .operationId("3")
+        .build();
+
+    HiveFileWriterFactory hfwf = new HiveFileWriterFactory(table, fileFormat, SCHEMA, null, fileFormat, null, null,
+        null, null);
+
+    TaskAttemptID taskId = new TaskAttemptID(JOB_ID.getJtIdentifier(), JOB_ID.getId(), TaskType.MAP, 1, 0);
+
+    return new HiveIcebergDeleteWriter(table.schema(), table.specs(), fileFormat, hfwf, outputFileFactory, table.io(),
+        TARGET_FILE_SIZE, taskId, "partitioned");
+  }
+}

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -59,7 +59,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import static org.apache.iceberg.mr.hive.HiveIcebergWriter.getWriters;
+import static org.apache.iceberg.mr.hive.HiveIcebergWriterBase.getWriters;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestHiveIcebergOutputCommitter {

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -288,7 +288,7 @@ public class TestHiveIcebergOutputCommitter {
 
       HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, table.specs(),
           table.spec().specId(), fileFormat, hfwf, outputFileFactory, io, TARGET_FILE_SIZE,
-          TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
+          TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME), false);
 
       Container<Record> container = new Container<>();
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergUpdateWriter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergUpdateWriter.java
@@ -59,7 +59,7 @@ public class TestHiveIcebergUpdateWriter extends HiveIcebergWriterTestBase {
 
   /**
    * This test just runs sends the data through the DeleteWriter. Here we make sure that the correct rows are removed.
-   * @throws IOException It here is an error
+   * @throws IOException If here is an error
    */
   @Test
   public void testDelete() throws IOException {
@@ -75,8 +75,8 @@ public class TestHiveIcebergUpdateWriter extends HiveIcebergWriterTestBase {
   }
 
   /**
-   * This test uses the full
-   * @throws IOException
+   * This test uses the UpdateWriter to check that the values are correctly updated.
+   * @throws IOException If there is an error
    */
   @Test
   public void testUpdate() throws IOException {
@@ -105,7 +105,7 @@ public class TestHiveIcebergUpdateWriter extends HiveIcebergWriterTestBase {
         null, null);
   }
 
-  private static void update(Table table, HiveIcebergWriter testWriter) throws IOException{
+  private static void update(Table table, HiveIcebergWriter testWriter) throws IOException {
     List<GenericRecord> updateRecords = updateRecords(table, UPDATED_RECORDS);
 
     Collections.sort(updateRecords, Comparator.comparing(a -> a.getField("data").toString()));

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergUpdateWriter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergUpdateWriter.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestHiveIcebergUpdateWriter extends HiveIcebergWriterTestBase {
+  private static final long TARGET_FILE_SIZE = 128 * 1024 * 1024;
+  private static final Map<Integer, GenericRecord> UPDATED_RECORDS = ImmutableMap.of(
+      29, record(29, "d"),
+      61, record(61, "h"),
+      89, record(81, "a"),
+      100, record(132, "e"),
+      122, record(142, "k"));
+
+  @Test
+  public void testDelete() throws IOException {
+    HiveIcebergBufferedDeleteWriter testWriter = deleteWriter();
+
+    List<GenericRecord> updateRecords = updateRecords(table, UPDATED_RECORDS);
+
+    Collections.sort(updateRecords, Comparator.comparing(a -> a.getField("data").toString()));
+
+    Container<Record> container = new Container<>();
+    for (Record deleteRecord : updateRecords) {
+      container.set(deleteRecord);
+      testWriter.write(container);
+    }
+
+    testWriter.close(false);
+
+    RowDelta rowDelta = table.newRowDelta();
+    testWriter.files().deleteFiles().forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+
+    StructLikeSet expected = rowSetWithoutIds(RECORDS, UPDATED_RECORDS.keySet());
+    StructLikeSet actual = actualRowSet(table);
+
+    Assert.assertEquals("Table should contain expected rows", expected, actual);
+  }
+
+  private HiveIcebergBufferedDeleteWriter deleteWriter() {
+    OutputFileFactory outputFileFactory = OutputFileFactory.builderFor(table, 1, 2)
+        .format(fileFormat)
+        .operationId("3")
+        .build();
+
+    HiveFileWriterFactory hfwf = new HiveFileWriterFactory(table, fileFormat, SCHEMA, null, fileFormat, null, null,
+        null, null);
+
+    return new HiveIcebergBufferedDeleteWriter(table.schema(), table.specs(), fileFormat, hfwf, outputFileFactory,
+        table.io(), TARGET_FILE_SIZE, new HiveConf());
+  }
+
+  private static List<GenericRecord> updateRecords(Table table, Map<Integer, GenericRecord> updated)
+      throws IOException {
+    List<GenericRecord> updateRecords = Lists.newArrayListWithExpectedSize(updated.size());
+    for (GenericRecord record : readRecords(table, schemaWithMeta(table))) {
+      if (!updated.keySet().contains(record.getField("id"))) {
+        continue;
+      }
+
+      GenericRecord updateRecord = GenericRecord.create(IcebergAcidUtil.createSerdeSchemaForUpdate(SCHEMA.columns()));
+      int specId = (Integer) record.getField(MetadataColumns.SPEC_ID.name());
+      updateRecord.setField(MetadataColumns.SPEC_ID.name(), specId);
+      PartitionKey partitionKey = new PartitionKey(table.specs().get(specId), table.schema());
+      partitionKey.partition(record);
+      updateRecord.setField(MetadataColumns.PARTITION_COLUMN_NAME, partitionKey);
+      updateRecord.setField(MetadataColumns.FILE_PATH.name(), record.getField(MetadataColumns.FILE_PATH.name()));
+      updateRecord.setField(MetadataColumns.ROW_POSITION.name(), record.getField(MetadataColumns.ROW_POSITION.name()));
+
+      SCHEMA.columns().forEach(field -> {
+        updateRecord.setField(field.name(), updated.get(record.getField("id")).getField(field.name()));
+        updateRecord.setField("__old_value_for_" + field.name(), record.getField(field.name()));
+      });
+      updateRecords.add(updateRecord);
+    }
+    return updateRecords;
+  }
+
+  private static GenericRecord record(Integer id, String data) {
+    GenericRecord record = GenericRecord.create(SCHEMA);
+    record.setField("id", id);
+    record.setField("data", data);
+    return record;
+  }
+}

--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -183,6 +183,12 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.iceberg</groupId>
+        <artifactId>iceberg-core</artifactId>
+        <classifier>tests</classifier>
+        <version>${iceberg.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Refactor the HiveIcebergWriter-s to have a common interface
- Refactor the FilesForCommit to use Collections instead of Lists.
- Create a HiveIcebergBufferedDeleteWriter to collect the deleted row data in memory and write it out sorted when the writer is closed
- Added tests for different Delete writers

### Why are the changes needed?
First step for implementing `UPDATE`s.

### Does this PR introduce _any_ user-facing change?
Not yet

### How was this patch tested?
Added unit tests