### PR TITLE
HIVE-26184: COLLECT_SET with GROUP BY is very slow when some keys are highly skewed

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFMkCollectionEvaluator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFMkCollectionEvaluator.java
@@ -95,11 +95,27 @@ public class GenericUDAFMkCollectionEvaluator extends GenericUDAFEvaluator
         throw new RuntimeException("Buffer type unknown");
       }
     }
+
+    private void reset() {
+      if (bufferType == BufferType.LIST) {
+        container.clear();
+      } else if (bufferType == BufferType.SET) {
+        // Don't reuse a container because HashSet#clear can be very slow. The operation takes O(N)
+        // and N is the capacity of the internal hash table. The internal capacity grows based on
+        // the number of elements and it never shrinks. Thus, HashSet#clear takes O(N) every time
+        // once a skewed key appears.
+        // In order to avoid too many resizing in average cases, we set the initial capacity to the
+        // number of elements of the previous aggregation.
+        container = new LinkedHashSet<>(container.size());
+      } else {
+        throw new RuntimeException("Buffer type unknown");
+      }
+    }
   }
 
   @Override
   public void reset(AggregationBuffer agg) throws HiveException {
-    ((MkArrayAggregationBuffer) agg).container.clear();
+    ((MkArrayAggregationBuffer) agg).reset();
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
This would reduce the time complexity of `COLLECT_SET` from `O({maximum length} * {num rows})` into `O({maximum length} + {num rows})`.

https://issues.apache.org/jira/browse/HIVE-26184

### Why are the changes needed?
I'm observing some reducers take much time due to this issue.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I have run the reproduction case in HIVE-26184 with this patch and confirmed the reduce vertex finished more than 30x faster.