### PR TITLE
HIVE-26189: Iceberg metadata query throws exceptions after partition evolution

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInternalRecordWrapper.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInternalRecordWrapper.java
@@ -66,7 +66,7 @@ public class IcebergInternalRecordWrapper implements Record, StructLike {
 
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
-    if (transforms[pos] != null) {
+    if (transforms[pos] != null && values[pos] != null) {
       return javaClass.cast(transforms[pos].apply(values[pos]));
     }
     return javaClass.cast(values[pos]);
@@ -143,6 +143,8 @@ public class IcebergInternalRecordWrapper implements Record, StructLike {
     switch (type.typeId()) {
       case TIMESTAMP:
         return timestamp -> DateTimeUtil.timestamptzFromMicros((Long) timestamp);
+      case DATE:
+        return date -> DateTimeUtil.dateFromDays((Integer) date);
       case STRUCT:
         IcebergInternalRecordWrapper wrapper =
             new IcebergInternalRecordWrapper(type.asStructType(), type.asStructType());

--- a/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_partitioned_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_partitioned_table.q
@@ -73,3 +73,16 @@ select partition_summaries from default.ice_meta_3.manifests where partition_sum
 
 drop table ice_meta_2;
 drop table ice_meta_3;
+
+
+CREATE EXTERNAL TABLE `partevv`( `id` int, `ts` timestamp, `ts2` timestamp)  STORED BY ICEBERG STORED AS ORC TBLPROPERTIES  ('format-version'='1');
+
+ALTER TABLE partevv SET PARTITION SPEC (id);
+INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp());
+INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp());
+
+
+ALTER TABLE partevv SET PARTITION SPEC (day(ts));
+INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp());
+
+select * from default.partevv.partitions;

--- a/iceberg/iceberg-handler/src/test/results/positive/query_iceberg_metadata_of_partitioned_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/query_iceberg_metadata_of_partitioned_table.q.out
@@ -526,3 +526,60 @@ POSTHOOK: query: drop table ice_meta_3
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@ice_meta_3
 POSTHOOK: Output: default@ice_meta_3
+PREHOOK: query: CREATE EXTERNAL TABLE `partevv`( `id` int, `ts` timestamp, `ts2` timestamp)  STORED BY ICEBERG STORED AS ORC TBLPROPERTIES  ('format-version'='1')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@partevv
+POSTHOOK: query: CREATE EXTERNAL TABLE `partevv`( `id` int, `ts` timestamp, `ts2` timestamp)  STORED BY ICEBERG STORED AS ORC TBLPROPERTIES  ('format-version'='1')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@partevv
+PREHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (id)
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@partevv
+POSTHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (id)
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@partevv
+POSTHOOK: Output: default@partevv
+PREHOOK: query: INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp())
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@partevv
+POSTHOOK: query: INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp())
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@partevv
+PREHOOK: query: INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp())
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@partevv
+POSTHOOK: query: INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp())
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@partevv
+PREHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (day(ts))
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@partevv
+POSTHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (day(ts))
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@partevv
+POSTHOOK: Output: default@partevv
+PREHOOK: query: INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp())
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@partevv
+POSTHOOK: query: INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp())
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@partevv
+PREHOOK: query: select * from default.partevv.partitions
+PREHOOK: type: QUERY
+PREHOOK: Input: default@partevv
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.partevv.partitions
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@partevv
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"id":1,"ts_day":null}	1	1
+{"id":2,"ts_day":null}	1	1
+{"id":null,"ts_day":"2022-04-29"}	1	1


### PR DESCRIPTION
The following test case surfaced two issues with metadata table queries:
```
CREATE EXTERNAL TABLE `partevv`( `id` int, `ts` timestamp, `ts2` timestamp)  STORED BY ICEBERG STORED AS ORC TBLPROPERTIES  ('format-version'='1');
ALTER TABLE partevv SET PARTITION SPEC (id);

INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp());
INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp());

ALTER TABLE partevv SET PARTITION SPEC (day(ts));
INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp());

select * from default.partevv.partitions;  
```
- NPE for removed partition columns from new specs:
```
Caused by: java.lang.NullPointerException
        at org.apache.iceberg.mr.mapreduce.IcebergInternalRecordWrapper.lambda$converter$5(IcebergInternalRecordWrapper.java:147)
```
- ClassCastException for day partition transforms
```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.time.LocalDate 
```
