### PR TITLE
HIVE-26189: Iceberg metadata query throws exceptions after partition evolution (addendum)

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_partitioned_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/query_iceberg_metadata_of_partitioned_table.q
@@ -78,11 +78,11 @@ drop table ice_meta_3;
 CREATE EXTERNAL TABLE `partevv`( `id` int, `ts` timestamp, `ts2` timestamp)  STORED BY ICEBERG STORED AS ORC TBLPROPERTIES  ('format-version'='1');
 
 ALTER TABLE partevv SET PARTITION SPEC (id);
-INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp());
-INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp());
+INSERT INTO partevv VALUES (1, '2022-04-29 16:32:01', '2022-04-29 16:32:01');
+INSERT INTO partevv VALUES (2, '2022-04-29 16:32:02', '2022-04-29 16:32:02');
 
 
 ALTER TABLE partevv SET PARTITION SPEC (day(ts));
-INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp());
+INSERT INTO partevv VALUES (100, '2022-04-29 16:32:03', '2022-04-29 16:32:03');
 
 select * from default.partevv.partitions;

--- a/iceberg/iceberg-handler/src/test/results/positive/query_iceberg_metadata_of_partitioned_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/query_iceberg_metadata_of_partitioned_table.q.out
@@ -541,19 +541,19 @@ POSTHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (id)
 POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@partevv
 POSTHOOK: Output: default@partevv
-PREHOOK: query: INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp())
+PREHOOK: query: INSERT INTO partevv VALUES (1, '2022-04-29 16:32:01', '2022-04-29 16:32:01')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@partevv
-POSTHOOK: query: INSERT INTO partevv VALUES (1, current_timestamp(), current_timestamp())
+POSTHOOK: query: INSERT INTO partevv VALUES (1, '2022-04-29 16:32:01', '2022-04-29 16:32:01')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@partevv
-PREHOOK: query: INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp())
+PREHOOK: query: INSERT INTO partevv VALUES (2, '2022-04-29 16:32:02', '2022-04-29 16:32:02')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@partevv
-POSTHOOK: query: INSERT INTO partevv VALUES (2, current_timestamp(), current_timestamp())
+POSTHOOK: query: INSERT INTO partevv VALUES (2, '2022-04-29 16:32:02', '2022-04-29 16:32:02')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@partevv
@@ -564,11 +564,11 @@ POSTHOOK: query: ALTER TABLE partevv SET PARTITION SPEC (day(ts))
 POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@partevv
 POSTHOOK: Output: default@partevv
-PREHOOK: query: INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp())
+PREHOOK: query: INSERT INTO partevv VALUES (100, '2022-04-29 16:32:03', '2022-04-29 16:32:03')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@partevv
-POSTHOOK: query: INSERT INTO partevv VALUES (100, current_timestamp(), current_timestamp())
+POSTHOOK: query: INSERT INTO partevv VALUES (100, '2022-04-29 16:32:03', '2022-04-29 16:32:03')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@partevv


### PR DESCRIPTION
Fixing unit test