### PR TITLE
HIVE-26201 QueryResultsCache should add permission check after mkdir with special permission

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -558,6 +558,11 @@ public class Context {
             throw new RuntimeException("Cannot make directory: "
                 + dirPath.toString());
           }
+          if (!fs.getFileStatus(dirPath).getPermission().equals(fsPermission)) {
+              LOG.warn("Directory {} created with unexpected permissions : {}.Change permission to : ",
+                  dirPath, fs.getFileStatus(dirPath).getPermission(), fsPermission);
+              fs.setPermission(dirPath, fsPermission);
+          }
           if (isHDFSCleanup) {
             fs.deleteOnExit(dirPath);
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
@@ -371,6 +371,11 @@ public final class QueryResultsCache {
     FsPermission fsPermission = new FsPermission("700");
     fs.mkdirs(cacheDirPath, fsPermission);
 
+    if (!fs.getFileStatus(cacheDirPath).getPermission().equals(fsPermission)) {
+        LOG.warn("Directory {} created with unexpected permissions : {}.Change permission to : ",
+            cacheDirPath, fs.getFileStatus(cacheDirPath).getPermission(), fsPermission);
+        fs.setPermission(cacheDirPath, fsPermission);
+    }
     // Create non-existent path for 0-row results
     zeroRowsPath = new Path(cacheDirPath, "dummy_zero_rows");
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -796,6 +796,11 @@ public class TezSessionState {
     FileSystem fs = tezDir.getFileSystem(conf);
     FsPermission fsPermission = new FsPermission(HiveConf.getVar(conf, HiveConf.ConfVars.SCRATCHDIRPERMISSION));
     fs.mkdirs(tezDir, fsPermission);
+    if(!fs.getFileStatus(tezDir).getPermission().equals(fsPermission)){
+        LOG.warn("Directory {} created with unexpected permissions : {}.Change permission to : ",
+            tezDir, fs.getFileStatus(tezDir).getPermission(), fsPermission);
+        fs.setPermission(tezDir, fsPermission);
+    }
     // Make sure the path is normalized (we expect validation to pass since we just created it).
     tezDir = DagUtils.validateTargetDir(tezDir, conf).getPath();
 


### PR DESCRIPTION
HIVE-26201 QueryResultsCache should add permission check after mkdir with special permission
### What changes were proposed in this pull request?
TezSessionState, QueryResultsCache and Context use mkdirs(path, permission) to create directory with special permission. But If the umask is too restrictive, permissions may not work as expected. So we need to check if permission is set as expected.


### Does this PR introduce _any_ user-facing change?
no

