### PR TITLE
HIVE-26200: Add tests for Iceberg DELETE statements for every supported type

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
@@ -70,14 +70,17 @@ public class TestHiveIcebergInserts extends HiveIcebergStorageHandlerWithEngineB
   public void testInsertSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+
       // TODO: remove this filter when issue #1881 is resolved
       if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
         continue;
       }
+
       // TODO: remove this filter when we figure out how we could test binary types
-      if (type == Types.BinaryType.get() || type == Types.FixedType.ofLength(5)) {
+      if (type == Types.BinaryType.get() || type.equals(Types.FixedType.ofLength(5))) {
         continue;
       }
+
       String columnName = type.typeId().toString().toLowerCase() + "_column";
 
       Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
@@ -75,7 +75,7 @@ public class TestHiveIcebergInserts extends HiveIcebergStorageHandlerWithEngineB
         continue;
       }
       // TODO: remove this filter when we figure out how we could test binary types
-      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
+      if (type == Types.BinaryType.get() || type == Types.FixedType.ofLength(5)) {
         continue;
       }
       String columnName = type.typeId().toString().toLowerCase() + "_column";

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -360,14 +360,17 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
   public void testDeleteForSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+
       // TODO: remove this filter when issue #1881 is resolved
       if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
         continue;
       }
+
       // TODO: remove this filter when we figure out how we could test binary types
-      if (type == Types.BinaryType.get() || type == Types.FixedType.ofLength(5)) {
+      if (type == Types.BinaryType.get() || type.equals(Types.FixedType.ofLength(5))) {
         continue;
       }
+
       String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
       String columnName = type.typeId().toString().toLowerCase() + "_column";
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -365,7 +365,7 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
         continue;
       }
       // TODO: remove this filter when we figure out how we could test binary types
-      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
+      if (type == Types.BinaryType.get() || type == Types.FixedType.ofLength(5)) {
         continue;
       }
       String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a new test

### Why are the changes needed?
To make sure that the delete is working for every type of fields, and it keeps working 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a unit test