### PR TITLE
HIVE-26205: Remove the incorrect org.slf4j dependency in kafka-handler

### DIFF
--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -128,11 +128,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
       <version>5.4.0</version>


### PR DESCRIPTION


### What changes were proposed in this pull request?
Remove the redundant slf4j dependency in kafka-handler module.


### Why are the changes needed?
Currently the scope of this dependency is test, which caused the compile errors.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No any more tests.
