### PR TITLE
HIVE-26046: MySQL's bit datatype is default to void datatype in hive

### DIFF
--- a/data/scripts/q_test_mysql_datatype_mapping.sql
+++ b/data/scripts/q_test_mysql_datatype_mapping.sql
@@ -1,0 +1,21 @@
+CREATE TABLE work_calendar
+(
+    year  INT    NOT NULL,
+    month INT    NOT NULL,
+    week  INT    NOT NULL,
+    days  BIT(7) NOT NULL
+);
+INSERT INTO work_calendar
+VALUES (2022, 4, 1, b'1111100'),
+       (2022, 5, 3, b'0011100'),
+       (2022, 6, 2, b'0000110');
+
+
+CREATE TABLE work_attendance
+(
+    name       CHAR(10) NOT NULL,
+    ATTENDANCE BIT(1)   NOT NULL
+);
+INSERT INTO work_attendance
+VALUES ('JACK', 1),
+       ('TOM', 0);

--- a/ql/src/test/queries/clientpositive/dataconnector_mysql_bit_datatype.q
+++ b/ql/src/test/queries/clientpositive/dataconnector_mysql_bit_datatype.q
@@ -1,0 +1,24 @@
+--!qt:database:mysql:q_test_mysql_datatype_mapping.sql
+-- CREATE with comment
+CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="root",
+"hive.sql.dbcp.password"="qtestpassword");
+
+CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB");
+
+USE db_mysql;
+SHOW TABLES;
+
+SHOW CREATE TABLE work_calendar;
+-- SELECT * FROM work_calendar;  //Wait for HIVE-26192 to be fixed
+
+SHOW CREATE TABLE work_attendance;
+-- SELECT * FROM work_attendance;  //Wait for HIVE-26192 to be fixed
+
+-- clean up so it won't affect other tests
+DROP DATABASE db_mysql;
+DROP CONNECTOR mysql_qtest;

--- a/ql/src/test/queries/clientpositive/dataconnector_mysql_bit_datatype.q
+++ b/ql/src/test/queries/clientpositive/dataconnector_mysql_bit_datatype.q
@@ -1,6 +1,6 @@
 --!qt:database:mysql:q_test_mysql_datatype_mapping.sql
 -- CREATE with comment
-CREATE CONNECTOR mysql_qtest
+CREATE CONNECTOR mysql_data_type_dc
 TYPE 'mysql'
 URL 'jdbc:mysql://localhost:3306/qtestDB'
 COMMENT 'test connector'
@@ -8,9 +8,9 @@ WITH DCPROPERTIES (
 "hive.sql.dbcp.username"="root",
 "hive.sql.dbcp.password"="qtestpassword");
 
-CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB");
+CREATE REMOTE DATABASE mysql_data_type_db USING mysql_data_type_dc with DBPROPERTIES("connector.remoteDbName"="qtestDB");
 
-USE db_mysql;
+USE mysql_data_type_db;
 SHOW TABLES;
 
 SHOW CREATE TABLE work_calendar;
@@ -20,5 +20,5 @@ SHOW CREATE TABLE work_attendance;
 -- SELECT * FROM work_attendance;  //Wait for HIVE-26192 to be fixed
 
 -- clean up so it won't affect other tests
-DROP DATABASE db_mysql;
-DROP CONNECTOR mysql_qtest;
+DROP DATABASE mysql_data_type_db;
+DROP CONNECTOR mysql_data_type_dc;

--- a/ql/src/test/results/clientpositive/llap/dataconnector_mysql_bit_datatype.q.out
+++ b/ql/src/test/results/clientpositive/llap/dataconnector_mysql_bit_datatype.q.out
@@ -1,4 +1,4 @@
-PREHOOK: query: CREATE CONNECTOR mysql_qtest
+PREHOOK: query: CREATE CONNECTOR mysql_data_type_dc
 TYPE 'mysql'
 URL 'jdbc:mysql://localhost:3306/qtestDB'
 COMMENT 'test connector'
@@ -6,8 +6,8 @@ WITH DCPROPERTIES (
 "hive.sql.dbcp.username"="root",
 "hive.sql.dbcp.password"="qtestpassword")
 PREHOOK: type: CREATEDATACONNECTOR
-PREHOOK: Output: connector:mysql_qtest
-POSTHOOK: query: CREATE CONNECTOR mysql_qtest
+PREHOOK: Output: connector:mysql_data_type_dc
+POSTHOOK: query: CREATE CONNECTOR mysql_data_type_dc
 TYPE 'mysql'
 URL 'jdbc:mysql://localhost:3306/qtestDB'
 COMMENT 'test connector'
@@ -15,35 +15,35 @@ WITH DCPROPERTIES (
 "hive.sql.dbcp.username"="root",
 "hive.sql.dbcp.password"="qtestpassword")
 POSTHOOK: type: CREATEDATACONNECTOR
-POSTHOOK: Output: connector:mysql_qtest
-PREHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+POSTHOOK: Output: connector:mysql_data_type_dc
+PREHOOK: query: CREATE REMOTE DATABASE mysql_data_type_db USING mysql_data_type_dc with DBPROPERTIES("connector.remoteDbName"="qtestDB")
 PREHOOK: type: CREATEDATABASE
-PREHOOK: Input: connector:mysql_qtest
-PREHOOK: Output: database:db_mysql
-POSTHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+PREHOOK: Input: connector:mysql_data_type_dc
+PREHOOK: Output: database:mysql_data_type_db
+POSTHOOK: query: CREATE REMOTE DATABASE mysql_data_type_db USING mysql_data_type_dc with DBPROPERTIES("connector.remoteDbName"="qtestDB")
 POSTHOOK: type: CREATEDATABASE
-POSTHOOK: Input: connector:mysql_qtest
-POSTHOOK: Output: database:db_mysql
-PREHOOK: query: USE db_mysql
+POSTHOOK: Input: connector:mysql_data_type_dc
+POSTHOOK: Output: database:mysql_data_type_db
+PREHOOK: query: USE mysql_data_type_db
 PREHOOK: type: SWITCHDATABASE
-PREHOOK: Input: database:db_mysql
-POSTHOOK: query: USE db_mysql
+PREHOOK: Input: database:mysql_data_type_db
+POSTHOOK: query: USE mysql_data_type_db
 POSTHOOK: type: SWITCHDATABASE
-POSTHOOK: Input: database:db_mysql
+POSTHOOK: Input: database:mysql_data_type_db
 PREHOOK: query: SHOW TABLES
 PREHOOK: type: SHOWTABLES
-PREHOOK: Input: database:db_mysql
+PREHOOK: Input: database:mysql_data_type_db
 POSTHOOK: query: SHOW TABLES
 POSTHOOK: type: SHOWTABLES
-POSTHOOK: Input: database:db_mysql
+POSTHOOK: Input: database:mysql_data_type_db
 work_attendance
 work_calendar
 PREHOOK: query: SHOW CREATE TABLE work_calendar
 PREHOOK: type: SHOW_CREATETABLE
-PREHOOK: Input: db_mysql@work_calendar
+PREHOOK: Input: mysql_data_type_db@work_calendar
 POSTHOOK: query: SHOW CREATE TABLE work_calendar
 POSTHOOK: type: SHOW_CREATETABLE
-POSTHOOK: Input: db_mysql@work_calendar
+POSTHOOK: Input: mysql_data_type_db@work_calendar
 CREATE EXTERNAL TABLE `work_calendar`(
   `year` int COMMENT 'from deserializer', 
   `month` int COMMENT 'from deserializer', 
@@ -64,10 +64,10 @@ TBLPROPERTIES (
   'hive.sql.table'='qtestDB.work_calendar')
 PREHOOK: query: SHOW CREATE TABLE work_attendance
 PREHOOK: type: SHOW_CREATETABLE
-PREHOOK: Input: db_mysql@work_attendance
+PREHOOK: Input: mysql_data_type_db@work_attendance
 POSTHOOK: query: SHOW CREATE TABLE work_attendance
 POSTHOOK: type: SHOW_CREATETABLE
-POSTHOOK: Input: db_mysql@work_attendance
+POSTHOOK: Input: mysql_data_type_db@work_attendance
 CREATE EXTERNAL TABLE `work_attendance`(
   `name` char(10) COMMENT 'from deserializer', 
   `attendance` boolean COMMENT 'from deserializer')
@@ -84,19 +84,19 @@ TBLPROPERTIES (
   'hive.sql.jdbc.driver'='com.mysql.jdbc.Driver', 
   'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qtestDB', 
   'hive.sql.table'='qtestDB.work_attendance')
-PREHOOK: query: DROP DATABASE db_mysql
+PREHOOK: query: DROP DATABASE mysql_data_type_db
 PREHOOK: type: DROPDATABASE
-PREHOOK: Input: database:db_mysql
-PREHOOK: Output: database:db_mysql
-POSTHOOK: query: DROP DATABASE db_mysql
+PREHOOK: Input: database:mysql_data_type_db
+PREHOOK: Output: database:mysql_data_type_db
+POSTHOOK: query: DROP DATABASE mysql_data_type_db
 POSTHOOK: type: DROPDATABASE
-POSTHOOK: Input: database:db_mysql
-POSTHOOK: Output: database:db_mysql
-PREHOOK: query: DROP CONNECTOR mysql_qtest
+POSTHOOK: Input: database:mysql_data_type_db
+POSTHOOK: Output: database:mysql_data_type_db
+PREHOOK: query: DROP CONNECTOR mysql_data_type_dc
 PREHOOK: type: DROPDATACONNECTOR
-PREHOOK: Input: connector:mysql_qtest
-PREHOOK: Output: connector:mysql_qtest
-POSTHOOK: query: DROP CONNECTOR mysql_qtest
+PREHOOK: Input: connector:mysql_data_type_dc
+PREHOOK: Output: connector:mysql_data_type_dc
+POSTHOOK: query: DROP CONNECTOR mysql_data_type_dc
 POSTHOOK: type: DROPDATACONNECTOR
-POSTHOOK: Input: connector:mysql_qtest
-POSTHOOK: Output: connector:mysql_qtest
+POSTHOOK: Input: connector:mysql_data_type_dc
+POSTHOOK: Output: connector:mysql_data_type_dc

--- a/ql/src/test/results/clientpositive/llap/dataconnector_mysql_bit_datatype.q.out
+++ b/ql/src/test/results/clientpositive/llap/dataconnector_mysql_bit_datatype.q.out
@@ -1,0 +1,102 @@
+PREHOOK: query: CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="root",
+"hive.sql.dbcp.password"="qtestpassword")
+PREHOOK: type: CREATEDATACONNECTOR
+PREHOOK: Output: connector:mysql_qtest
+POSTHOOK: query: CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="root",
+"hive.sql.dbcp.password"="qtestpassword")
+POSTHOOK: type: CREATEDATACONNECTOR
+POSTHOOK: Output: connector:mysql_qtest
+PREHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Input: connector:mysql_qtest
+PREHOOK: Output: database:db_mysql
+POSTHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Input: connector:mysql_qtest
+POSTHOOK: Output: database:db_mysql
+PREHOOK: query: USE db_mysql
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:db_mysql
+POSTHOOK: query: USE db_mysql
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:db_mysql
+PREHOOK: query: SHOW TABLES
+PREHOOK: type: SHOWTABLES
+PREHOOK: Input: database:db_mysql
+POSTHOOK: query: SHOW TABLES
+POSTHOOK: type: SHOWTABLES
+POSTHOOK: Input: database:db_mysql
+work_attendance
+work_calendar
+PREHOOK: query: SHOW CREATE TABLE work_calendar
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: db_mysql@work_calendar
+POSTHOOK: query: SHOW CREATE TABLE work_calendar
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: db_mysql@work_calendar
+CREATE EXTERNAL TABLE `work_calendar`(
+  `year` int COMMENT 'from deserializer', 
+  `month` int COMMENT 'from deserializer', 
+  `week` int COMMENT 'from deserializer', 
+  `days` bigint COMMENT 'from deserializer')
+ROW FORMAT SERDE 
+  'org.apache.hive.storage.jdbc.JdbcSerDe' 
+STORED BY 
+  'org.apache.hive.storage.jdbc.JdbcStorageHandler' 
+WITH SERDEPROPERTIES ( 
+  'serialization.format'='1')
+TBLPROPERTIES (
+  'hive.sql.database.type'='MYSQL', 
+  'hive.sql.dbcp.password'='qtestpassword', 
+  'hive.sql.dbcp.username'='root', 
+  'hive.sql.jdbc.driver'='com.mysql.jdbc.Driver', 
+  'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qtestDB', 
+  'hive.sql.table'='qtestDB.work_calendar')
+PREHOOK: query: SHOW CREATE TABLE work_attendance
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: db_mysql@work_attendance
+POSTHOOK: query: SHOW CREATE TABLE work_attendance
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: db_mysql@work_attendance
+CREATE EXTERNAL TABLE `work_attendance`(
+  `name` char(10) COMMENT 'from deserializer', 
+  `attendance` boolean COMMENT 'from deserializer')
+ROW FORMAT SERDE 
+  'org.apache.hive.storage.jdbc.JdbcSerDe' 
+STORED BY 
+  'org.apache.hive.storage.jdbc.JdbcStorageHandler' 
+WITH SERDEPROPERTIES ( 
+  'serialization.format'='1')
+TBLPROPERTIES (
+  'hive.sql.database.type'='MYSQL', 
+  'hive.sql.dbcp.password'='qtestpassword', 
+  'hive.sql.dbcp.username'='root', 
+  'hive.sql.jdbc.driver'='com.mysql.jdbc.Driver', 
+  'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qtestDB', 
+  'hive.sql.table'='qtestDB.work_attendance')
+PREHOOK: query: DROP DATABASE db_mysql
+PREHOOK: type: DROPDATABASE
+PREHOOK: Input: database:db_mysql
+PREHOOK: Output: database:db_mysql
+POSTHOOK: query: DROP DATABASE db_mysql
+POSTHOOK: type: DROPDATABASE
+POSTHOOK: Input: database:db_mysql
+POSTHOOK: Output: database:db_mysql
+PREHOOK: query: DROP CONNECTOR mysql_qtest
+PREHOOK: type: DROPDATACONNECTOR
+PREHOOK: Input: connector:mysql_qtest
+PREHOOK: Output: connector:mysql_qtest
+POSTHOOK: query: DROP CONNECTOR mysql_qtest
+POSTHOOK: type: DROPDATACONNECTOR
+POSTHOOK: Input: connector:mysql_qtest
+POSTHOOK: Output: connector:mysql_qtest

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
@@ -90,10 +90,20 @@ public class MySQLConnectorProvider extends AbstractJDBCConnectorProvider {
     // map any db specific types here.
     switch (dbDataType.toLowerCase())
     {
+    case "bit":
+      return toHiveBitType(size);
     default:
       mappedType = ColumnType.VOID_TYPE_NAME;
       break;
     }
     return mappedType;
+  }
+
+  private String toHiveBitType(int size) {
+    if (size <= 1) {
+      return ColumnType.BOOLEAN_TYPE_NAME;
+    } else {
+      return ColumnType.BIGINT_TYPE_NAME;
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
MySQl'bit type should be mapped to a suitable datatype in hive.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=dataconnector_mysql_bit_datatype.q