### PR TITLE
HIVE-26191: Missing catalog name in GetTableRequest results in duplicate values in query level cache

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientWithLocalCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientWithLocalCache.java
@@ -331,8 +331,8 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
       int maxParts) throws TException {
     if (isCacheEnabledAndInitialized()) {
       TableWatermark watermark = new TableWatermark(
-          getValidWriteIdList(dbName, tableName),
-          getTable(dbName, tableName).getId());
+          getValidWriteIdList(catName, dbName, tableName),
+          getTable(catName, dbName, tableName).getId());
       if (watermark.isValid()) {
         CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_ALL, watermark,
             catName, dbName, tableName, maxParts);
@@ -371,8 +371,8 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
     if (isCacheEnabledAndInitialized()) {
       // table should be transactional to get responses from the cache
       TableWatermark watermark = new TableWatermark(
-          getValidWriteIdList(req.getDbName(), req.getTblName()),
-          getTable(req.getDbName(), req.getTblName()).getId());
+          getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()),
+          getTable(req.getCatName(), req.getDbName(), req.getTblName()).getId());
       if (watermark.isValid()) {
         CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_SPEC_BY_EXPR, watermark, req);
         PartitionsSpecByExprResult r = (PartitionsSpecByExprResult) mscLocalCache.getIfPresent(cacheKey);
@@ -400,8 +400,8 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
   protected TableStatsResult getTableColumnStatisticsInternal(TableStatsRequest req) throws TException {
     if (isCacheEnabledAndInitialized()) {
       TableWatermark watermark = new TableWatermark(
-          getValidWriteIdList(req.getDbName(), req.getTblName()),
-          getTable(req.getDbName(), req.getTblName()).getId());
+          getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()),
+          getTable(req.getCatName(), req.getDbName(), req.getTblName()).getId());
       if (watermark.isValid()) {
         CacheWrapper cache = new CacheWrapper(mscLocalCache);
         // 1) Retrieve from the cache those ids present, gather the rest
@@ -438,7 +438,7 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient imple
   protected AggrStats getAggrStatsForInternal(PartitionsStatsRequest req) throws TException {
     if (isCacheEnabledAndInitialized()) {
       TableWatermark watermark = new TableWatermark(
-          req.getValidWriteIdList(), getTable(req.getDbName(), req.getTblName()).getId());
+          req.getValidWriteIdList(), getTable(req.getCatName(), req.getDbName(), req.getTblName()).getId());
       if (watermark.isValid()) {
         CacheKey cacheKey = new CacheKey(KeyType.AGGR_COL_STATS, watermark, req);
         AggrStats r = (AggrStats) mscLocalCache.getIfPresent(cacheKey);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -266,8 +266,8 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
     GetTableRequest getTableRequest = new GetTableRequest(dbName, tableName);
     getTableRequest.setGetColumnStats(getColStats);
     getTableRequest.setEngine(engine);
+    getTableRequest.setCatName(catName);
     if (!getDefaultCatalog(conf).equals(catName)) {
-      getTableRequest.setCatName(catName);
       return super.getTable(getTableRequest);
     } else {
       return getTable(getTableRequest);
@@ -2506,13 +2506,13 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
   }
 
   @Override
-  protected String getValidWriteIdList(String dbName, String tblName) {
+  protected String getValidWriteIdList(String catName, String dbName, String tblName) {
     try {
       final String validTxnsList = Hive.get().getConf().get(ValidTxnList.VALID_TXNS_KEY);
       if (validTxnsList == null) {
-        return super.getValidWriteIdList(dbName, tblName);
+        return super.getValidWriteIdList(catName, dbName, tblName);
       }
-      if (!AcidUtils.isTransactionalTable(getTable(dbName, tblName))) {
+      if (!AcidUtils.isTransactionalTable(getTable(catName, dbName, tblName))) {
         return null;
       }
       final String fullTableName = TableName.getDbTable(dbName, tblName);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2137,7 +2137,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   public GetPartitionsPsWithAuthResponse listPartitionsWithAuthInfoRequest(GetPartitionsPsWithAuthRequest req)
       throws MetaException, TException, NoSuchObjectException {
     if (req.getValidWriteIdList() == null) {
-      req.setValidWriteIdList(getValidWriteIdList(req.getDbName(), req.getTblName()));
+      req.setValidWriteIdList(getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()));
     }
     if(req.getCatName() == null) {
       req.setCatName(getDefaultCatalog(conf));
@@ -2277,7 +2277,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     if (max_parts >= 0) {
       req.setMaxParts(shrinkMaxtoShort(max_parts));
     }
-    req.setValidWriteIdList(getValidWriteIdList(db_name, tbl_name));
+    req.setValidWriteIdList(getValidWriteIdList(req.getCatName(), db_name, tbl_name));
     return req;
   }
 
@@ -2411,9 +2411,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
 
   @Override
   public GetPartitionResponse getPartitionRequest(GetPartitionRequest req)
-      throws NoSuchObjectException, MetaException, TException {
+      throws TException {
     if (req.getValidWriteIdList() == null) {
-      req.setValidWriteIdList(getValidWriteIdList(req.getDbName(), req.getTblName()));
+      req.setValidWriteIdList(getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()));
     }
     GetPartitionResponse res = client.get_partition_req(req);
     res.setPartition(deepCopy(
@@ -2436,10 +2436,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
 
   @Override
   public PartitionsResponse getPartitionsRequest(PartitionsRequest req)
-      throws NoSuchObjectException, MetaException, TException {
+      throws TException {
 
     if (req.getValidWriteIdList() == null) {
-      req.setValidWriteIdList(getValidWriteIdList(req.getDbName(), req.getTblName()));
+      req.setValidWriteIdList(getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()));
     }
     PartitionsResponse res = client.get_partitions_req(req);
     List<Partition> parts = deepCopyPartitions(
@@ -2901,9 +2901,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
 
   @Override
   public GetPartitionNamesPsResponse listPartitionNamesRequest(GetPartitionNamesPsRequest req)
-          throws NoSuchObjectException, MetaException, TException {
+          throws TException {
     if (req.getValidWriteIdList() == null) {
-      req.setValidWriteIdList(getValidWriteIdList(req.getDbName(), req.getTblName()));
+      req.setValidWriteIdList(getValidWriteIdList(req.getCatName(), req.getDbName(), req.getTblName()));
     }
     if( req.getCatName() == null ) {
       req.setCatName(getDefaultCatalog(conf));
@@ -3346,7 +3346,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     PartitionsStatsRequest rqst = new PartitionsStatsRequest(dbName, tableName, colNames,
         partNames, engine);
     rqst.setCatName(catName);
-    rqst.setValidWriteIdList(getValidWriteIdList(dbName, tableName));
+    rqst.setValidWriteIdList(getValidWriteIdList(catName, dbName, tableName));
     return client.get_partitions_statistics_req(rqst).getPartStats();
   }
 
@@ -4455,7 +4455,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       }
       PartitionsStatsRequest req = new PartitionsStatsRequest(dbName, tblName, colNames, partNames, engine);
       req.setCatName(catName);
-      req.setValidWriteIdList(getValidWriteIdList(dbName, tblName));
+      req.setValidWriteIdList(getValidWriteIdList(catName, dbName, tblName));
 
       return getAggrStatsForInternal(req);
     } finally {
@@ -4867,7 +4867,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
    * this only covers a subset of cases, where we invoke get_* APIs after query compilation,
    * if the validWriteIdList is not explicitly passed (as a method argument) to the HMS APIs.
    */
-  protected String getValidWriteIdList(String dbName, String tblName) {
+  protected String getValidWriteIdList(String catName, String dbName, String tblName) {
     if (conf.get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY) == null) {
       return null;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add catalog name as argument to `getValidWriteIdList` method

### Why are the changes needed?
Missing catalog results in query cache misses and duplicate cache entries

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Checked the cache entries manually by debugging various qtests like `cbo_query2.q`
