### PR TITLE
HIVE-25335: Unreasonable setting reduce number, when join big size ta…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -2091,6 +2091,8 @@ public class StatsRulesProcFactory {
           // Update largest relation
           if (rowCount > maxRowCount) {
             maxRowCount = rowCount;
+          }
+          if (dataSize > maxDataSize) {
             maxDataSize = dataSize;
           }
         }


### PR DESCRIPTION
I found an application which is slow in our cluster, because the proccess bytes of one reduce is very huge, but only two reduce.
when I debug, I found the reason. Because in this sql, one big size table (about 30G) with few row count(about 3.5M), another small size table (about 100M) have more row count (about 3.6M). So JoinStatsRule.process only use 100M to estimate reducer's number. But we need to process 30G byte in fact.

https://issues.apache.org/jira/browse/HIVE-25335