### PR TITLE
HIVE-26231: Generate insert notification events when dynamic partitio…

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -83,6 +83,7 @@ minillap.query.files=\
   input36.q,\
   input38.q,\
   input5.q,\
+  insert_dynamic_partitions_notification_log.q,\
   insert_into1.q,\
   insert_into2.q,\
   insert_into3.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -3156,7 +3156,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
           if (partitionDetails.newFiles != null) {
             // If we already know the files from the direct insert manifest, use them
             newFiles = partitionDetails.newFiles;
-          } else if (conf.getBoolVar(ConfVars.FIRE_EVENTS_FOR_DML) && !tbl.isTemporary() && oldPartition == null) {
+          } else if (conf.getBoolVar(ConfVars.FIRE_EVENTS_FOR_DML) && !tbl.isTemporary()) {
             // Otherwise only collect them, if we are going to fire write notifications
             newFiles = Collections.synchronizedList(new ArrayList<>());
           }

--- a/ql/src/test/queries/clientpositive/insert_dynamic_partitions_notification_log.q
+++ b/ql/src/test/queries/clientpositive/insert_dynamic_partitions_notification_log.q
@@ -1,0 +1,15 @@
+--! qt:sysdb
+set hive.metastore.event.listeners=org.apache.hive.hcatalog.listener.DbNotificationListener;
+set hive.metastore.dml.events=true;
+
+CREATE EXTERNAL TABLE exttable (b INT) PARTITIONED BY (a INT) STORED AS ORC;
+
+INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6);
+
+SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT';
+
+INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6);
+
+SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT';
+
+DROP TABLE exttable;

--- a/ql/src/test/results/clientpositive/llap/insert_dynamic_partitions_notification_log.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_dynamic_partitions_notification_log.q.out
@@ -1,0 +1,70 @@
+PREHOOK: query: CREATE EXTERNAL TABLE exttable (b INT) PARTITIONED BY (a INT) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@exttable
+POSTHOOK: query: CREATE EXTERNAL TABLE exttable (b INT) PARTITIONED BY (a INT) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@exttable
+PREHOOK: query: INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@exttable
+POSTHOOK: query: INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@exttable
+POSTHOOK: Output: default@exttable@a=2
+POSTHOOK: Output: default@exttable@a=3
+POSTHOOK: Output: default@exttable@a=4
+POSTHOOK: Output: default@exttable@a=5
+POSTHOOK: Output: default@exttable@a=6
+POSTHOOK: Lineage: exttable PARTITION(a=2).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=3).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=4).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=5).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=6).b SCRIPT []
+PREHOOK: query: SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT'
+PREHOOK: type: QUERY
+PREHOOK: Input: sys@notification_log
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: sys@notification_log
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@exttable
+POSTHOOK: query: INSERT INTO TABLE exttable PARTITION (a) VALUES (1,2), (2,3), (3,4), (4,5), (5,6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@exttable
+POSTHOOK: Output: default@exttable@a=2
+POSTHOOK: Output: default@exttable@a=3
+POSTHOOK: Output: default@exttable@a=4
+POSTHOOK: Output: default@exttable@a=5
+POSTHOOK: Output: default@exttable@a=6
+POSTHOOK: Lineage: exttable PARTITION(a=2).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=3).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=4).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=5).b SCRIPT []
+POSTHOOK: Lineage: exttable PARTITION(a=6).b SCRIPT []
+PREHOOK: query: SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT'
+PREHOOK: type: QUERY
+PREHOOK: Input: sys@notification_log
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: SELECT COUNT(*) FROM sys.notification_log WHERE tbl_name='exttable' AND event_type='INSERT'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: sys@notification_log
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+5
+PREHOOK: query: DROP TABLE exttable
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@exttable
+PREHOOK: Output: default@exttable
+POSTHOOK: query: DROP TABLE exttable
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@exttable
+POSTHOOK: Output: default@exttable


### PR DESCRIPTION
…n insert is done on existing partitions

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
[HIVE-24738](https://issues.apache.org/jira/browse/HIVE-24738) introduced a bug which wont allow generation of insert events when dynamic partition insert is done on existing partitions.

The newFiles list used is null because of the following condition - 
https://github.com/apache/hive/blob/8077bb118cb418cae24a46f7155c481bf893da99/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L3159

The newFiles is assigned to empty list only when new partitions are created and is not assigned when insert is done on existing partitions. This affects insert events generation for external tables.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a bug since it does not generate the insert events for existing partitions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
QTest