### PR TITLE
HIVE-26233: Problems reading back PARQUET timestamps above 10000 years

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
@@ -389,30 +389,6 @@ public class TestParquetTimestampUtils {
     verifyInt64TimestampValue("2262-04-11 23:47:16.854775808", LogicalTypeAnnotation.TimeUnit.NANOS, false);
   }
 
-  /**
-   * Timestamps for 9999-12-31 might go over 10000 with certain TimeZones.
-   * Test that the legacy conversion is working for these too.
-   */
-  @Test
-  public void testTimestamp9999() {
-  TimeZone oldTz = TimeZone.getDefault();
-    try {
-      // With the old writer and TZ we might end up writing out timestamps outside the allowed -9999/9999 range
-      // Simulate these timestamps
-      TimeZone.setDefault(TimeZone.getTimeZone("EST"));
-      String originalString = "9999-12-31 23:59:59.999";
-      // Hive 2.1.1 written this out with the following NanoTime
-      // We should be able to handle these with or without the legacy conversion
-      NanoTime nanoTime = new NanoTime(5373485, 17999999000000L);
-      Timestamp nonLegacy = NanoTimeUtils.getTimestamp(nanoTime, TimeZone.getTimeZone("EST").toZoneId(), false);
-      Assert.assertEquals(originalString, nonLegacy.toString());
-      Timestamp withLegacy = NanoTimeUtils.getTimestamp(nanoTime, TimeZone.getTimeZone("EST").toZoneId(), true);
-      Assert.assertEquals(originalString, withLegacy.toString());
-    } finally {
-      TimeZone.setDefault(oldTz);
-    }
-  }
-
   private void verifyInt64TimestampValue(String tsString, boolean legal) {
     verifyInt64TimestampValue(tsString, LogicalTypeAnnotation.TimeUnit.MILLIS, legal);
     verifyInt64TimestampValue(tsString, LogicalTypeAnnotation.TimeUnit.MICROS, legal);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
@@ -389,6 +389,30 @@ public class TestParquetTimestampUtils {
     verifyInt64TimestampValue("2262-04-11 23:47:16.854775808", LogicalTypeAnnotation.TimeUnit.NANOS, false);
   }
 
+  /**
+   * Timestamps for 9999-12-31 might go over 10000 with certain TimeZones.
+   * Test that the legacy conversion is working for these too.
+   */
+  @Test
+  public void testTimestamp9999() {
+  TimeZone oldTz = TimeZone.getDefault();
+    try {
+      // With the old writer and TZ we might end up writing out timestamps outside the allowed -9999/9999 range
+      // Simulate these timestamps
+      TimeZone.setDefault(TimeZone.getTimeZone("EST"));
+      String originalString = "9999-12-31 23:59:59.999";
+      // Hive 2.1.1 written this out with the following NanoTime
+      // We should be able to handle these with or without the legacy conversion
+      NanoTime nanoTime = new NanoTime(5373485, 17999999000000L);
+      Timestamp nonLegacy = NanoTimeUtils.getTimestamp(nanoTime, TimeZone.getTimeZone("EST").toZoneId(), false);
+      Assert.assertEquals(originalString, nonLegacy.toString());
+      Timestamp withLegacy = NanoTimeUtils.getTimestamp(nanoTime, TimeZone.getTimeZone("EST").toZoneId(), true);
+      Assert.assertEquals(originalString, withLegacy.toString());
+    } finally {
+      TimeZone.setDefault(oldTz);
+    }
+  }
+
   private void verifyInt64TimestampValue(String tsString, boolean legal) {
     verifyInt64TimestampValue(tsString, LogicalTypeAnnotation.TimeUnit.MILLIS, legal);
     verifyInt64TimestampValue(tsString, LogicalTypeAnnotation.TimeUnit.MICROS, legal);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
@@ -80,6 +80,18 @@ class TestParquetTimestampsHive2Compatibility {
   }
 
   /**
+   * Tests that timestamps written using Hive2 APIs are read correctly by Hive4 APIs when legacy conversion is on.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive2ReadHive4UsingLegacyConversionWithZone(String timestampString) {
+    String zoneId = "US/Pacific";
+    NanoTime nt = writeHive2(timestampString);
+    Timestamp ts = readHive4(nt, zoneId, true);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  /**
    * Tests that timestamps written using Hive4 APIs are read correctly by Hive4 APIs when legacy conversion is on. 
    */
   @ParameterizedTest(name = "{0}")
@@ -116,7 +128,7 @@ class TestParquetTimestampsHive2Compatibility {
   }
 
   private static Stream<String> generateTimestamps() {
-    return Stream.generate(new Supplier<String>() {
+    return Stream.concat(Stream.generate(new Supplier<String>() {
       int i = 0;
 
       @Override
@@ -157,7 +169,7 @@ class TestParquetTimestampsHive2Compatibility {
     // Exclude dates falling in the default Gregorian change date since legacy code does not handle that interval
     // gracefully. It is expected that these do not work well when legacy APIs are in use. 
     .filter(s -> !s.startsWith("1582-10"))
-    .limit(3000);
+    .limit(3000), Stream.of("9999-12-31 23:59:59.999"));
   }
 
   private static int digits(int number) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
@@ -85,10 +85,16 @@ class TestParquetTimestampsHive2Compatibility {
   @ParameterizedTest(name = "{0}")
   @MethodSource("generateTimestamps")
   void testWriteHive2ReadHive4UsingLegacyConversionWithZone(String timestampString) {
-    String zoneId = "US/Pacific";
-    NanoTime nt = writeHive2(timestampString);
-    Timestamp ts = readHive4(nt, zoneId, true);
-    assertEquals(timestampString, ts.toString());
+    TimeZone original = TimeZone.getDefault();
+    try {
+      String zoneId = "US/Pacific";
+      TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+      NanoTime nt = writeHive2(timestampString);
+      Timestamp ts = readHive4(nt, zoneId, true);
+      assertEquals(timestampString, ts.toString());
+    } finally {
+      TimeZone.setDefault(original);
+    }
   }
 
   /**
@@ -169,7 +175,7 @@ class TestParquetTimestampsHive2Compatibility {
     // Exclude dates falling in the default Gregorian change date since legacy code does not handle that interval
     // gracefully. It is expected that these do not work well when legacy APIs are in use. 
     .filter(s -> !s.startsWith("1582-10"))
-    .limit(3000), Stream.of("9999-12-31 23:59:59.999"));
+    .limit(3), Stream.of("9999-12-31 23:59:59.999"));
   }
 
   private static int digits(int number) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Timestamps where the year is more than 4 digits will not have an extra + sign in front of them

### Why are the changes needed?
So these big timestamps could be read and rewritten so they can conform the original 9999 year limit.

### Does this PR introduce _any_ user-facing change?
Timestamps where the year is more than 4 digits will not have an extra + sign in front of them. Since it was not supported even before this change, I think it is ok to have this in.

### How was this patch tested?
Added unit test
