### PR TITLE
HIVE-26234 Update guava to 30.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
     <druid.version>0.17.1</druid.version>
     <flatbuffers.version>1.6.0.1</flatbuffers.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <groovy.version>2.4.21</groovy.version>
     <h2database.version>2.1.210</h2database.version>
     <hadoop.version>3.1.0</hadoop.version>

--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
@@ -549,9 +549,9 @@ public final class Util {
     HostAndPort hp = HostAndPort.fromString(host)
             .withDefaultPort(port);
 
-    LOG.info("Connecting to {}:{}", hp.getHostText(), hp.getPort());
+    LOG.info("Connecting to {}:{}", hp.getHost(), hp.getPort());
 
-    return new URI(THRIFT_SCHEMA, null, hp.getHostText(), hp.getPort(),
+    return new URI(THRIFT_SCHEMA, null, hp.getHost(), hp.getPort(),
             null, null, null);
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -74,7 +74,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.12.0</jackson.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <hadoop.version>3.1.0</hadoop.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>


### PR DESCRIPTION
What changes were proposed in this pull request?
Upgrading guava version to the latest

Why are the changes needed?
hive code uses the latest version of guava which fixes many bugs 

Does this PR introduce any user-facing change?
No

How was this patch tested?
Built hive locally