### PR TITLE
HIVE-26237: Check if replication cause metastore connection leakage

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -122,7 +122,10 @@ public class BaseReplicationAcrossInstances {
   public static void classLevelTearDown() throws IOException {
     primary.close();
     replica.close();
-    Hive.getThreadLocal().close(true);
+    Hive hiveDb = Hive.getThreadLocal();
+    if (hiveDb != null) {
+      hiveDb.close(true);
+    }
   }
 
   private static void setFullyQualifiedReplicaExternalTableBase(FileSystem fs) throws IOException {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.metadata.Hive;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.shims.Utils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -120,10 +119,10 @@ public class BaseReplicationAcrossInstances {
   }
 
   @AfterClass
-  public static void classLevelTearDown() throws IOException, HiveException {
+  public static void classLevelTearDown() throws IOException {
     primary.close();
     replica.close();
-    Hive.getCurrHiveDb(null, null).close(true);
+    Hive.getThreadLocal().close(true);
   }
 
   private static void setFullyQualifiedReplicaExternalTableBase(FileSystem fs) throws IOException {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -122,10 +122,7 @@ public class BaseReplicationAcrossInstances {
   public static void classLevelTearDown() throws IOException {
     primary.close();
     replica.close();
-    Hive hiveDb = Hive.getThreadLocal();
-    if (hiveDb != null) {
-      hiveDb.close(true);
-    }
+    Hive.closeCurrent();
   }
 
   private static void setFullyQualifiedReplicaExternalTableBase(FileSystem fs) throws IOException {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.shims.Utils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -118,9 +120,10 @@ public class BaseReplicationAcrossInstances {
   }
 
   @AfterClass
-  public static void classLevelTearDown() throws IOException {
+  public static void classLevelTearDown() throws IOException, HiveException {
     primary.close();
     replica.close();
+    Hive.getCurrHiveDb(null, null).close(true);
   }
 
   private static void setFullyQualifiedReplicaExternalTableBase(FileSystem fs) throws IOException {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -267,10 +267,10 @@ public class TestReplicationScenarios {
     try {
       warehousePath.getFileSystem(hconf).delete(warehousePath, true);
       warehousePathReplica.getFileSystem(hconfMirror).delete(warehousePathReplica, true);
-      Hive.getCurrHiveDb(null, null).close(true);
-    } catch (IOException | HiveException e) {
+    } catch (IOException e) {
 
     }
+    Hive.getThreadLocal().close(true);
     if (metaStoreClient != null) {
       metaStoreClient.close();
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -270,10 +270,7 @@ public class TestReplicationScenarios {
     } catch (IOException e) {
 
     }
-    Hive hiveDb = Hive.getThreadLocal();
-    if (hiveDb != null) {
-      hiveDb.close(true);
-    }
+    Hive.closeCurrent();
     if (metaStoreClient != null) {
       metaStoreClient.close();
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -270,7 +270,10 @@ public class TestReplicationScenarios {
     } catch (IOException e) {
 
     }
-    Hive.getThreadLocal().close(true);
+    Hive hiveDb = Hive.getThreadLocal();
+    if (hiveDb != null) {
+      hiveDb.close(true);
+    }
     if (metaStoreClient != null) {
       metaStoreClient.close();
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.common.repl.ReplScope;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.repl.ReplAck;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.StringAppender;
 import org.apache.hadoop.hive.ql.parse.repl.metric.MetricCollector;
 import org.apache.hadoop.hive.ql.parse.repl.metric.event.Metadata;
@@ -262,16 +263,19 @@ public class TestReplicationScenarios {
     // FIXME : should clean up TEST_PATH, but not doing it now, for debugging's sake
     //Clean up the warehouse after test run as we are restoring the warehouse path for other metastore creation
     Path warehousePath = new Path(MetastoreConf.getVar(hconf, MetastoreConf.ConfVars.WAREHOUSE));
-    try {
-      warehousePath.getFileSystem(hconf).delete(warehousePath, true);
-    } catch (IOException e) {
-
-    }
     Path warehousePathReplica = new Path(MetastoreConf.getVar(hconfMirror, MetastoreConf.ConfVars.WAREHOUSE));
     try {
+      warehousePath.getFileSystem(hconf).delete(warehousePath, true);
       warehousePathReplica.getFileSystem(hconfMirror).delete(warehousePathReplica, true);
-    } catch (IOException e) {
+      Hive.getCurrHiveDb(null, null).close(true);
+    } catch (IOException | HiveException e) {
 
+    }
+    if (metaStoreClient != null) {
+      metaStoreClient.close();
+    }
+    if (metaStoreClientMirror != null) {
+      metaStoreClientMirror.close();
     }
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -612,6 +612,9 @@ public class WarehouseInstance implements Closeable {
     if (miniDFSCluster != null && miniDFSCluster.isClusterUp()) {
       miniDFSCluster.shutdown();
     }
+    if (client != null) {
+      client.close();
+    }
   }
 
   CurrentNotificationEventId getCurrentNotificationEventId() throws Exception {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLOperationContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLOperationContext.java
@@ -51,8 +51,8 @@ public class DDLOperationContext {
     this.console = console;
   }
 
-  public Hive getDb() {
-    return db;
+  public Hive getDb() throws HiveException {
+    return Hive.getCurrHiveDb(db, conf);
   }
 
   public HiveConf getConf() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLOperationContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLOperationContext.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
  * Context for DDL operations.
  */
 public class DDLOperationContext {
-  private final Hive db;
   private final HiveConf conf;
   private final Context context;
   private final DDLTask task;
@@ -40,8 +39,7 @@ public class DDLOperationContext {
   private final LogHelper console;
 
   public DDLOperationContext(HiveConf conf, Context context, DDLTask task, DDLWork work, QueryState queryState,
-      QueryPlan queryPlan, LogHelper console) throws HiveException {
-    this.db = Hive.get(conf);
+      QueryPlan queryPlan, LogHelper console){
     this.conf = conf;
     this.context = context;
     this.task = task;
@@ -52,7 +50,7 @@ public class DDLOperationContext {
   }
 
   public Hive getDb() throws HiveException {
-    return Hive.getCurrHiveDb(db, conf);
+    return Hive.get(conf);
   }
 
   public HiveConf getConf() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -293,7 +293,7 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
     }
   }
 
-  private void handleMaterializedView(Table table) throws LockException {
+  private void handleMaterializedView(Table table) throws HiveException {
     if (table.isMaterializedView()) {
       table.setOutdatedForRewriting(context.getDb().isOutdatedMaterializedView(
               table,

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/concatenate/AlterTableConcatenateOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/concatenate/AlterTableConcatenateOperation.java
@@ -63,7 +63,7 @@ public class AlterTableConcatenateOperation extends DDLOperation<AlterTableConca
     return executeTask(generalContext, task);
   }
 
-  private MergeFileWork getMergeFileWork(CompilationOpContext opContext) {
+  private MergeFileWork getMergeFileWork(CompilationOpContext opContext) throws HiveException {
     List<Path> inputDirList = Lists.newArrayList(desc.getInputDir());
 
     // merge work only needs input and output.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.repl.ReplScope;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
@@ -547,7 +548,8 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
         @Override
         public void run() throws SemanticException {
           try {
-            long currentNotificationID = getHive().getMSC().getCurrentNotificationEventId().getEventId();
+            IMetaStoreClient client = getHive().getMSC();
+            long currentNotificationID = client.getCurrentNotificationEventId().getEventId();
             Path loadMetadataFilePath = new Path(work.dumpDirectory, LOAD_METADATA.toString());
             Utils.writeOutput(String.valueOf(currentNotificationID), loadMetadataFilePath, conf);
             LOG.info("Created LOAD Metadata file : {} with NotificationID : {}",

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.repl.ReplScope;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
@@ -96,7 +95,6 @@ import static org.apache.hadoop.hive.ql.exec.repl.OptimisedBootstrapUtils.checkF
 import static org.apache.hadoop.hive.ql.exec.repl.OptimisedBootstrapUtils.getEventIdFromFile;
 import static org.apache.hadoop.hive.ql.exec.repl.OptimisedBootstrapUtils.prepareTableDiffFile;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_METADATA;
-import static org.apache.hadoop.hive.ql.exec.repl.ReplExternalTables.getExternalTableBaseDir;
 import static org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.LoadDatabase.AlterDatabase;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_ACKNOWLEDGEMENT;
 import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.RANGER_AUTHORIZER;
@@ -549,8 +547,7 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
         @Override
         public void run() throws SemanticException {
           try {
-            HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
-            long currentNotificationID = metaStoreClient.getCurrentNotificationEventId().getEventId();
+            long currentNotificationID = getHive().getMSC().getCurrentNotificationEventId().getEventId();
             Path loadMetadataFilePath = new Path(work.dumpDirectory, LOAD_METADATA.toString());
             Utils.writeOutput(String.valueOf(currentNotificationID), loadMetadataFilePath, conf);
             LOG.info("Created LOAD Metadata file : {} with NotificationID : {}",

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -223,7 +223,6 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.hive.shims.HadoopShims;
 import org.apache.hadoop.hive.shims.ShimLoader;
-import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
@@ -253,6 +252,7 @@ public class Hive {
   private SynchronizedMetaStoreClient syncMetaStoreClient;
   private UserGroupInformation owner;
   private boolean isAllowClose = true;
+  private boolean isCurrentClosed = false;
 
   // metastore calls timing information
   private final ConcurrentHashMap<String, Long> metaCallTimeMap = new ConcurrentHashMap<>();
@@ -500,6 +500,10 @@ public class Hive {
     return hiveDB.get();
   }
 
+  public static Hive getCurrHiveDb(Hive hiveDb, HiveConf c) throws HiveException {
+    return (hiveDb == null || hiveDb.isCurrentClosed) ? get(c, false) : hiveDb;
+  }
+
   public static Hive get() throws HiveException {
     return get(true);
   }
@@ -534,6 +538,7 @@ public class Hive {
   }
 
   public static void closeCurrent() {
+    hiveDB.get().isCurrentClosed = true;
     hiveDB.remove();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -223,6 +223,7 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.hive.shims.HadoopShims;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
@@ -252,7 +253,6 @@ public class Hive {
   private SynchronizedMetaStoreClient syncMetaStoreClient;
   private UserGroupInformation owner;
   private boolean isAllowClose = true;
-  private boolean isCurrentClosed = false;
 
   // metastore calls timing information
   private final ConcurrentHashMap<String, Long> metaCallTimeMap = new ConcurrentHashMap<>();
@@ -500,10 +500,6 @@ public class Hive {
     return hiveDB.get();
   }
 
-  public static Hive getCurrHiveDb(Hive hiveDb, HiveConf c) throws HiveException {
-    return (hiveDb == null || hiveDb.isCurrentClosed) ? get(c, false) : hiveDb;
-  }
-
   public static Hive get() throws HiveException {
     return get(true);
   }
@@ -538,7 +534,6 @@ public class Hive {
   }
 
   public static void closeCurrent() {
-    hiveDB.get().isCurrentClosed = true;
     hiveDB.remove();
   }
 


### PR DESCRIPTION
Problems:
1. Some replication tests don't close the ongoing HMS connections.
2. At one place in ReplLoadTask, we initiate a fresh HMS connection but don't close it.
3. In DDLOperationContext.java, sometimes stored Hive db object is closed and a new object is instantiated. In this case, Actual ddl operations (say CreateDatabaseOperation) will make fresh HMS connection in outdated Hive obj and it will never get closed since that this connection is not accessible. This is causing connection leakage.