### PR TITLE
HIVE-25813: Create Table x Like commands based storage handlers fail …

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
@@ -163,7 +163,7 @@ public class CreateTableLikeOperation extends DDLOperation<CreateTableLikeDesc> 
     tbl.getParameters().clear();
 
     if (desc.getTblProps() != null) {
-      tbl.setParameters(params);
+      tbl.setParameters(desc.getTblProps());
     }
   }
 

--- a/ql/src/test/queries/clientpositive/create_like2.q
+++ b/ql/src/test/queries/clientpositive/create_like2.q
@@ -39,3 +39,27 @@ drop table test_external;
 drop table test_mm1;
 drop table test_external1;
 drop table test_mm2;
+
+-- Create JBDC based CTLT table, HIVE-25813
+CREATE EXTERNAL TABLE default.dbs (
+  DB_ID            bigint,
+  DB_LOCATION_URI  string,
+  NAME             string,
+  OWNER_NAME       string,
+  OWNER_TYPE       string )
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+  'hive.sql.database.type' = 'MYSQL',
+  'hive.sql.jdbc.driver'   = 'com.mysql.jdbc.Driver',
+  'hive.sql.jdbc.url'      = 'jdbc:mysql://localhost:3306/hive1',
+  'hive.sql.dbcp.username' = 'hive1',
+  'hive.sql.dbcp.password' = 'cloudera',
+  'hive.sql.query' = 'SELECT DB_ID, DB_LOCATION_URI, NAME, OWNER_NAME, OWNER_TYPE FROM DBS'
+);
+
+CREATE TABLE default.dbscopy LIKE default.dbs;
+
+desc formatted default.dbscopy;
+
+drop table default.dbs;
+drop table default.dbscopy;

--- a/ql/src/test/results/clientpositive/llap/create_like2.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_like2.q.out
@@ -40,9 +40,7 @@ Retention:          	0
 Table Type:         	MANAGED_TABLE       	 
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}
-	a                   	1                   
 	bucketing_version   	2                   
-	c                   	3                   
 	numFiles            	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
@@ -339,3 +337,100 @@ POSTHOOK: query: drop table test_mm2
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@test_mm2
 POSTHOOK: Output: default@test_mm2
+PREHOOK: query: CREATE EXTERNAL TABLE default.dbs (
+  DB_ID            bigint,
+  DB_LOCATION_URI  string,
+  NAME             string,
+  OWNER_NAME       string,
+  OWNER_TYPE       string )
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+  'hive.sql.database.type' = 'MYSQL',
+  'hive.sql.jdbc.driver'   = 'com.mysql.jdbc.Driver',
+  'hive.sql.jdbc.url'      = 'jdbc:mysql://localhost:3306/hive1',
+  'hive.sql.dbcp.username' = 'hive1',
+  'hive.sql.dbcp.password' = 'cloudera',
+  'hive.sql.query' = 'SELECT DB_ID, DB_LOCATION_URI, NAME, OWNER_NAME, OWNER_TYPE FROM DBS'
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dbs
+POSTHOOK: query: CREATE EXTERNAL TABLE default.dbs (
+  DB_ID            bigint,
+  DB_LOCATION_URI  string,
+  NAME             string,
+  OWNER_NAME       string,
+  OWNER_TYPE       string )
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+  'hive.sql.database.type' = 'MYSQL',
+  'hive.sql.jdbc.driver'   = 'com.mysql.jdbc.Driver',
+  'hive.sql.jdbc.url'      = 'jdbc:mysql://localhost:3306/hive1',
+  'hive.sql.dbcp.username' = 'hive1',
+  'hive.sql.dbcp.password' = 'cloudera',
+  'hive.sql.query' = 'SELECT DB_ID, DB_LOCATION_URI, NAME, OWNER_NAME, OWNER_TYPE FROM DBS'
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dbs
+PREHOOK: query: CREATE TABLE default.dbscopy LIKE default.dbs
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dbscopy
+POSTHOOK: query: CREATE TABLE default.dbscopy LIKE default.dbs
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dbscopy
+PREHOOK: query: desc formatted default.dbscopy
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@dbscopy
+POSTHOOK: query: desc formatted default.dbscopy
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@dbscopy
+# col_name            	data_type           	comment             
+db_id               	bigint              	                    
+db_location_uri     	string              	                    
+name                	string              	                    
+#### A masked pattern was here ####
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+#### A masked pattern was here ####
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+	transactional       	true                
+	transactional_properties	default             
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: drop table default.dbs
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@dbs
+PREHOOK: Output: default@dbs
+POSTHOOK: query: drop table default.dbs
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@dbs
+POSTHOOK: Output: default@dbs
+PREHOOK: query: drop table default.dbscopy
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@dbscopy
+PREHOOK: Output: default@dbscopy
+POSTHOOK: query: drop table default.dbscopy
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@dbscopy
+POSTHOOK: Output: default@dbscopy


### PR DESCRIPTION
…over is fixed

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
CTLT commands based on external tables will not copy over table properties of the source table.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Because it is consistent with other Query engines like MySql and Redshift.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, When users execute CREATE TABLE  x LIKE command, we'll no more copy the table properties of source table to the destination table, we'll only copy the table/column schema of the source table.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Local machine, Unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
