### PR TITLE
HIVE-26235: OR Condition on binary column is returning empty result

### DIFF
--- a/ql/src/test/queries/clientpositive/udf_in_binary.q
+++ b/ql/src/test/queries/clientpositive/udf_in_binary.q
@@ -1,0 +1,6 @@
+create table test_binary(data_col timestamp, binary_col binary) partitioned by (ts string);
+insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c');
+select * from test_binary where ts='202204200000' and binary_col = unhex('61');
+select * from test_binary where ts='202204200000' and binary_col between unhex('61') and unhex('62');
+select * from test_binary where binary_col = unhex('61') or binary_col = unhex('62');
+select * from test_binary where ts='202204200000' and (binary_col = unhex('61') or binary_col = unhex('62'));

--- a/ql/src/test/queries/clientpositive/udf_in_binary.q
+++ b/ql/src/test/queries/clientpositive/udf_in_binary.q
@@ -1,6 +1,8 @@
 create table test_binary(data_col timestamp, binary_col binary) partitioned by (ts string);
-insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c');
+insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),
+('2022-04-20 00:00:00.0', 'b'),('2022-04-20 00:00:00.0', 'c'),('2022-04-20 00:00:00.0', NULL);
 select * from test_binary where ts='202204200000' and binary_col = unhex('61');
 select * from test_binary where ts='202204200000' and binary_col between unhex('61') and unhex('62');
 select * from test_binary where binary_col = unhex('61') or binary_col = unhex('62');
 select * from test_binary where ts='202204200000' and (binary_col = unhex('61') or binary_col = unhex('62'));
+select * from test_binary where binary_col in (unhex('61'), unhex('62'));

--- a/ql/src/test/results/clientpositive/llap/udf_in_binary.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_in_binary.q.out
@@ -1,0 +1,65 @@
+PREHOOK: query: create table test_binary(data_col timestamp, binary_col binary) partitioned by (ts string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_binary
+POSTHOOK: query: create table test_binary(data_col timestamp, binary_col binary) partitioned by (ts string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_binary
+PREHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_binary@ts=202204200000
+POSTHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_binary@ts=202204200000
+POSTHOOK: Lineage: test_binary PARTITION(ts=202204200000).binary_col SCRIPT []
+POSTHOOK: Lineage: test_binary PARTITION(ts=202204200000).data_col SCRIPT []
+PREHOOK: query: select * from test_binary where ts='202204200000' and binary_col = unhex('61')
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_binary
+PREHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_binary where ts='202204200000' and binary_col = unhex('61')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_binary
+POSTHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+2022-04-20 00:00:00	a	202204200000
+PREHOOK: query: select * from test_binary where ts='202204200000' and binary_col between unhex('61') and unhex('62')
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_binary
+PREHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_binary where ts='202204200000' and binary_col between unhex('61') and unhex('62')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_binary
+POSTHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+2022-04-20 00:00:00	a	202204200000
+2022-04-20 00:00:00	b	202204200000
+PREHOOK: query: select * from test_binary where binary_col = unhex('61') or binary_col = unhex('62')
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_binary
+PREHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_binary where binary_col = unhex('61') or binary_col = unhex('62')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_binary
+POSTHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+2022-04-20 00:00:00	a	202204200000
+2022-04-20 00:00:00	b	202204200000
+PREHOOK: query: select * from test_binary where ts='202204200000' and (binary_col = unhex('61') or binary_col = unhex('62'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_binary
+PREHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_binary where ts='202204200000' and (binary_col = unhex('61') or binary_col = unhex('62'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_binary
+POSTHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+2022-04-20 00:00:00	a	202204200000
+2022-04-20 00:00:00	b	202204200000

--- a/ql/src/test/results/clientpositive/llap/udf_in_binary.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_in_binary.q.out
@@ -6,11 +6,13 @@ POSTHOOK: query: create table test_binary(data_col timestamp, binary_col binary)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@test_binary
-PREHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c')
+PREHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),
+('2022-04-20 00:00:00.0', 'b'),('2022-04-20 00:00:00.0', 'c'),('2022-04-20 00:00:00.0', NULL)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@test_binary@ts=202204200000
-POSTHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),('2022-04-20 00:00:00.0', 'b'), ('2022-04-20 00:00:00.0', 'c')
+POSTHOOK: query: insert into test_binary partition(ts='202204200000') values ('2022-04-20 00:00:00.0', 'a'),
+('2022-04-20 00:00:00.0', 'b'),('2022-04-20 00:00:00.0', 'c'),('2022-04-20 00:00:00.0', NULL)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@test_binary@ts=202204200000
@@ -57,6 +59,18 @@ PREHOOK: Input: default@test_binary
 PREHOOK: Input: default@test_binary@ts=202204200000
 #### A masked pattern was here ####
 POSTHOOK: query: select * from test_binary where ts='202204200000' and (binary_col = unhex('61') or binary_col = unhex('62'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_binary
+POSTHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+2022-04-20 00:00:00	a	202204200000
+2022-04-20 00:00:00	b	202204200000
+PREHOOK: query: select * from test_binary where binary_col in (unhex('61'), unhex('62'))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_binary
+PREHOOK: Input: default@test_binary@ts=202204200000
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_binary where binary_col in (unhex('61'), unhex('62'))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_binary
 POSTHOOK: Input: default@test_binary@ts=202204200000


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixing the OR condition evaluation for binary types

### Why are the changes needed?
Fix the wrong query results

### Does this PR introduce _any_ user-facing change?
Just the fix

### How was this patch tested?
Added query test
