### PR TITLE
HIVE-26260: Use `Reader.getSchema` instead of deprecated `Reader.getTypes`

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -252,9 +252,8 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
 
     OrcRecordReader(Reader file, Configuration conf,
                     FileSplit split) throws IOException {
-      List<OrcProto.Type> types = file.getTypes();
       this.file = file;
-      numColumns = (types.size() == 0) ? 0 : types.get(0).getSubtypesCount();
+      numColumns = file.getSchema().getChildren().size();
       this.offset = split.getStart();
       this.length = split.getLength();
       this.reader = createReaderFromFile(file, conf, offset, length);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcNewInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcNewInputFormat.java
@@ -66,8 +66,7 @@ public class OrcNewInputFormat extends InputFormat<NullWritable, OrcStruct>{
 
     OrcRecordReader(Reader file, Configuration conf,
                     long offset, long length) throws IOException {
-      List<OrcProto.Type> types = file.getTypes();
-      numColumns = (types.size() == 0) ? 0 : types.get(0).getSubtypesCount();
+      numColumns = file.getSchema().getChildren().size();
       value = new OrcStruct(numColumns);
       this.reader = OrcInputFormat.createReaderFromFile(file, conf, offset,
           length);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `org.apache.orc.Reader.getSchema` instead of the deprecated `org.apache.orc.Reader.getTypes` API.

### Why are the changes needed?

`getTypes` was deprecated.

- https://github.com/apache/orc/blob/main/java/core/src/java/org/apache/orc/Reader.java#L144
```java
  /**
   * Get the list of types contained in the file. The root type is the first
   * type in the list.
   * @return the list of flattened types
   * @deprecated use getSchema instead
   * @since 1.1.0
   */
  List<OrcProto.Type> getTypes();
```

In addition, AS-IS implementation is only a slow-wrapper.
- https://github.com/apache/orc/blob/1e2962064b209f1b00188877f08d4226da85c640/java/core/src/java/org/apache/orc/impl/ReaderImpl.java#L259-L262
```java
  @Override
  public List<OrcProto.Type> getTypes() {
    return OrcUtils.getOrcTypes(schema);
  }
```

- https://github.com/apache/orc/blob/1e2962064b209f1b00188877f08d4226da85c640/java/core/src/java/org/apache/orc/OrcUtils.java#L108-L112
```java
  public static List<OrcProto.Type> getOrcTypes(TypeDescription typeDescr) {
    List<OrcProto.Type> result = new ArrayList<>();
    appendOrcTypes(result, typeDescr);
    return result;
  }
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs