### PR TITLE
HIVE-24598: handle null in trim function

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBaseTrim.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBaseTrim.java
@@ -71,6 +71,7 @@ public abstract class GenericUDFBaseTrim extends GenericUDF {
       case STRING:
       case CHAR:
       case VARCHAR:
+      case VOID:
         break;
       default:
         throw new UDFArgumentException(udfName + " takes only STRING/CHAR/VARCHAR types. Found "

--- a/ql/src/test/queries/clientpositive/udf_trim.q
+++ b/ql/src/test/queries/clientpositive/udf_trim.q
@@ -1,6 +1,18 @@
 DESCRIBE FUNCTION trim;
 DESCRIBE FUNCTION EXTENDED trim;
 
+SET hive.vectorized.execution.enabled=false;
+
+SELECT trim(null);
+
+SELECT '"' || trim(null, null) || '"';
+
+SET hive.vectorized.execution.enabled=true;
+
+SELECT trim(null);
+
+SELECT '"' || trim(null, null) || '"';
+
 SELECT '"' || trim('   tech   ') || '"';
 
 SELECT '"' || TRIM(' '  FROM  '   tech   ') || '"';

--- a/ql/src/test/results/clientpositive/llap/udf_trim.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_trim.q.out
@@ -21,6 +21,42 @@ Example:
   'facebook'
 Function class:org.apache.hadoop.hive.ql.udf.generic.GenericUDFTrim
 Function type:BUILTIN
+PREHOOK: query: SELECT trim(null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT trim(null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+NULL
+PREHOOK: query: SELECT '"' || trim(null, null) || '"'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT '"' || trim(null, null) || '"'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+NULL
+PREHOOK: query: SELECT trim(null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT trim(null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+NULL
+PREHOOK: query: SELECT '"' || trim(null, null) || '"'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT '"' || trim(null, null) || '"'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+NULL
 PREHOOK: query: SELECT '"' || trim('   tech   ') || '"'
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table


### PR DESCRIPTION
### What changes were proposed in this pull request?
NULL is a special value in SQL and therefore trim function should return NULL instead of error out. 

### Why are the changes needed?
Argument object inspector now accommodates NULL value as VOID type.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added ptest with additional cases.
