### PR TITLE
HIVE-26267: Addendum to HIVE-26107: perpared statement is not working on Postgres

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3689,9 +3689,6 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   public CompactionResponse compact(CompactionRequest rqst) throws MetaException {
     // Put a compaction request in the queue.
     try {
-      Connection dbConn = null;
-      Statement stmt = null;
-      PreparedStatement pst = null;
       TxnStore.MutexAPI.LockHandle handle = null;
       try {
         lockInternal();
@@ -3701,123 +3698,125 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
          * compactions for any resource.
          */
         handle = getMutexAPI().acquireLock(MUTEX_KEY.CompactionScheduler.name());
-        dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
-        stmt = dbConn.createStatement();
+        try (Connection dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED)) {
+          try (Statement stmt = dbConn.createStatement()) {
 
-        long id = generateCompactionQueueId(stmt);
+            long id = generateCompactionQueueId(stmt);
 
-        GetValidWriteIdsRequest request = new GetValidWriteIdsRequest(
-            Collections.singletonList(getFullTableName(rqst.getDbname(), rqst.getTablename())));
-        final ValidCompactorWriteIdList tblValidWriteIds =
-            TxnUtils.createValidCompactWriteIdList(getValidWriteIds(request).getTblValidWriteIds().get(0));
-        LOG.debug("ValidCompactWriteIdList: " + tblValidWriteIds.writeToString());
+            GetValidWriteIdsRequest request = new GetValidWriteIdsRequest(
+                Collections.singletonList(getFullTableName(rqst.getDbname(), rqst.getTablename())));
+            final ValidCompactorWriteIdList tblValidWriteIds =
+                TxnUtils.createValidCompactWriteIdList(getValidWriteIds(request).getTblValidWriteIds().get(0));
+            LOG.debug("ValidCompactWriteIdList: " + tblValidWriteIds.writeToString());
 
-        StringBuilder sb = new StringBuilder("SELECT \"CQ_ID\", \"CQ_STATE\" FROM \"COMPACTION_QUEUE\" WHERE").
-          append(" (\"CQ_STATE\" IN(").
-            append(quoteChar(INITIATED_STATE)).append(",").append(quoteChar(WORKING_STATE)).
-            append(") OR (\"CQ_STATE\" = ").append(quoteChar(READY_FOR_CLEANING)).
-            append(" AND \"CQ_HIGHEST_WRITE_ID\" = ?))").
-            append(" AND \"CQ_DATABASE\"=?").
-            append(" AND \"CQ_TABLE\"=?").append(" AND ");
-        if(rqst.getPartitionname() == null) {
-          sb.append("\"CQ_PARTITION\" is null");
-        } else {
-          sb.append("\"CQ_PARTITION\"=?");
-        }
+            StringBuilder sb = new StringBuilder("SELECT \"CQ_ID\", \"CQ_STATE\" FROM \"COMPACTION_QUEUE\" WHERE").
+                append(" (\"CQ_STATE\" IN(").
+                append(quoteChar(INITIATED_STATE)).append(",").append(quoteChar(WORKING_STATE)).
+                append(") OR (\"CQ_STATE\" = ").append(quoteChar(READY_FOR_CLEANING)).
+                append(" AND \"CQ_HIGHEST_WRITE_ID\" = ?))").
+                append(" AND \"CQ_DATABASE\"=?").
+                append(" AND \"CQ_TABLE\"=?").append(" AND ");
+            if(rqst.getPartitionname() == null) {
+              sb.append("\"CQ_PARTITION\" is null");
+            } else {
+              sb.append("\"CQ_PARTITION\"=?");
+            }
 
-        pst = dbConn.prepareStatement(sqlGenerator.addEscapeCharacters(sb.toString()));
-        pst.setLong(1, tblValidWriteIds.getHighWatermark());
-        pst.setString(2, rqst.getDbname());
-        pst.setString(3, rqst.getTablename());
-        if(rqst.getPartitionname() != null) {
-          pst.setString(4, rqst.getPartitionname());
+            try (PreparedStatement pst = dbConn.prepareStatement(sqlGenerator.addEscapeCharacters(sb.toString()))) {
+              pst.setLong(1, tblValidWriteIds.getHighWatermark());
+              pst.setString(2, rqst.getDbname());
+              pst.setString(3, rqst.getTablename());
+              if (rqst.getPartitionname() != null) {
+                pst.setString(4, rqst.getPartitionname());
+              }
+              LOG.debug("Going to execute query <" + sb + ">");
+              try (ResultSet rs = pst.executeQuery()) {
+                if(rs.next()) {
+                  long enqueuedId = rs.getLong(1);
+                  String state = compactorStateToResponse(rs.getString(2).charAt(0));
+                  LOG.info("Ignoring request to compact " + rqst.getDbname() + "/" + rqst.getTablename() +
+                      "/" + rqst.getPartitionname() + " since it is already " + quoteString(state) +
+                      " with id=" + enqueuedId);
+                  CompactionResponse resp = new CompactionResponse(-1, REFUSED_RESPONSE, false);
+                  resp.setErrormessage("Compaction is already scheduled with state=" + quoteString(state) +
+                      " and id=" + enqueuedId);
+                  return resp;
+                }
+              }
+            }
+            List<String> params = new ArrayList<>();
+            StringBuilder buf = new StringBuilder("INSERT INTO \"COMPACTION_QUEUE\" (\"CQ_ID\", \"CQ_DATABASE\", " +
+                "\"CQ_TABLE\", ");
+            String partName = rqst.getPartitionname();
+            if (partName != null) buf.append("\"CQ_PARTITION\", ");
+            buf.append("\"CQ_STATE\", \"CQ_TYPE\", \"CQ_ENQUEUE_TIME\"");
+            if (rqst.getProperties() != null) {
+              buf.append(", \"CQ_TBLPROPERTIES\"");
+            }
+            if (rqst.getRunas() != null) {
+              buf.append(", \"CQ_RUN_AS\"");
+            }
+            if (rqst.getInitiatorId() != null) {
+              buf.append(", \"CQ_INITIATOR_ID\"");
+            }
+            if (rqst.getInitiatorVersion() != null) {
+              buf.append(", \"CQ_INITIATOR_VERSION\"");
+            }
+            buf.append(") values (");
+            buf.append(id);
+            buf.append(", ?");
+            buf.append(", ?");
+            buf.append(", ");
+            params.add(rqst.getDbname());
+            params.add(rqst.getTablename());
+            if (partName != null) {
+              buf.append("?, '");
+              params.add(partName);
+            } else {
+              buf.append("'");
+            }
+            buf.append(INITIATED_STATE);
+            buf.append("', '");
+            buf.append(thriftCompactionType2DbType(rqst.getType()));
+            buf.append("',");
+            buf.append(getEpochFn(dbProduct));
+            if (rqst.getProperties() != null) {
+              buf.append(", ?");
+              params.add(new StringableMap(rqst.getProperties()).toString());
+            }
+            if (rqst.getRunas() != null) {
+              buf.append(", ?");
+              params.add(rqst.getRunas());
+            }
+            if (rqst.getInitiatorId() != null) {
+              buf.append(", ?");
+              params.add(rqst.getInitiatorId());
+            }
+            if (rqst.getInitiatorVersion() != null) {
+              buf.append(", ?");
+              params.add(rqst.getInitiatorVersion());
+            }
+            buf.append(")");
+            String s = buf.toString();
+            try (PreparedStatement pst = sqlGenerator.prepareStmtWithParameters(dbConn, s, params)) {
+              LOG.debug("Going to execute update <" + s + ">");
+              pst.executeUpdate();
+            }
+            LOG.debug("Going to commit");
+            dbConn.commit();
+            return new CompactionResponse(id, INITIATED_RESPONSE, true);
+          } catch (SQLException e) {
+            dbConn.rollback();
+            throw e;
+          }
         }
-        LOG.debug("Going to execute query <" + sb + ">");
-        ResultSet rs = pst.executeQuery();
-        if(rs.next()) {
-          long enqueuedId = rs.getLong(1);
-          String state = compactorStateToResponse(rs.getString(2).charAt(0));
-          LOG.info("Ignoring request to compact " + rqst.getDbname() + "/" + rqst.getTablename() +
-            "/" + rqst.getPartitionname() + " since it is already " + quoteString(state) +
-            " with id=" + enqueuedId);
-          CompactionResponse resp = new CompactionResponse(-1, REFUSED_RESPONSE, false);
-          resp.setErrormessage("Compaction is already scheduled with state=" + quoteString(state) +
-              " and id=" + enqueuedId);
-          return resp;
-        }
-        close(rs);
-        closeStmt(pst);
-        List<String> params = new ArrayList<>();
-        StringBuilder buf = new StringBuilder("INSERT INTO \"COMPACTION_QUEUE\" (\"CQ_ID\", \"CQ_DATABASE\", " +
-          "\"CQ_TABLE\", ");
-        String partName = rqst.getPartitionname();
-        if (partName != null) buf.append("\"CQ_PARTITION\", ");
-        buf.append("\"CQ_STATE\", \"CQ_TYPE\", \"CQ_ENQUEUE_TIME\"");
-        if (rqst.getProperties() != null) {
-          buf.append(", \"CQ_TBLPROPERTIES\"");
-        }
-        if (rqst.getRunas() != null) {
-          buf.append(", \"CQ_RUN_AS\"");
-        }
-        if (rqst.getInitiatorId() != null) {
-          buf.append(", \"CQ_INITIATOR_ID\"");
-        }
-        if (rqst.getInitiatorVersion() != null) {
-          buf.append(", \"CQ_INITIATOR_VERSION\"");
-        }
-        buf.append(") values (");
-        buf.append(id);
-        buf.append(", ?");
-        buf.append(", ?");
-        buf.append(", ");
-        params.add(rqst.getDbname());
-        params.add(rqst.getTablename());
-        if (partName != null) {
-          buf.append("?, '");
-          params.add(partName);
-        } else {
-          buf.append("'");
-        }
-        buf.append(INITIATED_STATE);
-        buf.append("', '");
-        buf.append(thriftCompactionType2DbType(rqst.getType()));
-        buf.append("',");
-        buf.append(getEpochFn(dbProduct));
-        if (rqst.getProperties() != null) {
-          buf.append(", ?");
-          params.add(new StringableMap(rqst.getProperties()).toString());
-        }
-        if (rqst.getRunas() != null) {
-          buf.append(", ?");
-          params.add(rqst.getRunas());
-        }
-        if (rqst.getInitiatorId() != null) {
-          buf.append(", ?");
-          params.add(rqst.getInitiatorId());
-        }
-        if (rqst.getInitiatorVersion() != null) {
-          buf.append(", ?");
-          params.add(rqst.getInitiatorVersion());
-        }
-        buf.append(")");
-        String s = buf.toString();
-        pst = sqlGenerator.prepareStmtWithParameters(dbConn, s, params);
-        LOG.debug("Going to execute update <" + s + ">");
-        pst.executeUpdate();
-        LOG.debug("Going to commit");
-        dbConn.commit();
-        return new CompactionResponse(id, INITIATED_RESPONSE, true);
       } catch (SQLException e) {
         LOG.debug("Going to rollback: ", e);
-        rollbackDBConn(dbConn);
         checkRetryable(e, "COMPACT(" + rqst + ")");
         throw new MetaException("Unable to select from transaction database " +
           StringUtils.stringifyException(e));
       } finally {
-        closeStmt(pst);
-        closeStmt(stmt);
-        closeDbConn(dbConn);
-        if(handle != null) {
+        if (handle != null) {
           handle.releaseLocks();
         }
         unlockInternal();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3698,6 +3698,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
          * compactions for any resource.
          */
         handle = getMutexAPI().acquireLock(MUTEX_KEY.CompactionScheduler.name());
+
         try (Connection dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED)) {
           try (Statement stmt = dbConn.createStatement()) {
 
@@ -3798,6 +3799,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
             }
             buf.append(")");
             String s = buf.toString();
+
             try (PreparedStatement pst = sqlGenerator.prepareStmtWithParameters(dbConn, s, params)) {
               LOG.debug("Going to execute update <" + s + ">");
               pst.executeUpdate();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3808,14 +3808,14 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
             dbConn.commit();
             return new CompactionResponse(id, INITIATED_RESPONSE, true);
           } catch (SQLException e) {
+            LOG.debug("Going to rollback: ", e);
             dbConn.rollback();
             throw e;
           }
         }
       } catch (SQLException e) {
-        LOG.debug("Going to rollback: ", e);
         checkRetryable(e, "COMPACT(" + rqst + ")");
-        throw new MetaException("Unable to select from transaction database " +
+        throw new MetaException("Unable to put the compaction request into the queue: " +
           StringUtils.stringifyException(e));
       } finally {
         if (handle != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In org.apache.hadoop.hive.metastore.txn.TxnHandler#compact() use the java.sql.PreparedStatement#setXXX methods instead of the org.apache.hadoop.hive.metastore.tools.SQLGenerator#prepareStmtWithParameters() method.

### Why are the changes needed?
The SQL statement modified by HIVE-26107 in org.apache.hadoop.hive.metastore.txn.TxnHandler#compact is not working with Postgres DB. org.apache.hadoop.hive.metastore.tools.SQLGenerator#prepareStmtWithParameters() can handle only string parameters.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually and through unit tests