### PR TITLE
HIVE-26274: No vectorization if query has upper case window function

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -2878,7 +2878,7 @@ public class Vectorizer implements PhysicalPlanResolver {
     List<ExprNodeDesc>[] evaluatorInputExprNodeDescLists = vectorPTFDesc.getEvaluatorInputExprNodeDescLists();
 
     for (int i = 0; i < count; i++) {
-      String functionName = evaluatorFunctionNames[i];
+      String functionName = evaluatorFunctionNames[i].toLowerCase();
       SupportedFunctionType supportedFunctionType = VectorPTFDesc.supportedFunctionsMap.get(functionName);
       if (supportedFunctionType == null) {
         setOperatorIssue(functionName + " not in supported functions " + VectorPTFDesc.supportedFunctionNames);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFDesc.java
@@ -119,18 +119,9 @@ public class VectorPTFDesc extends AbstractVectorDesc  {
   public static HashMap<String, SupportedFunctionType> supportedFunctionsMap =
       new HashMap<String, SupportedFunctionType>();
   static {
-    supportedFunctionsMap.put("row_number", SupportedFunctionType.ROW_NUMBER);
-    supportedFunctionsMap.put("rank", SupportedFunctionType.RANK);
-    supportedFunctionsMap.put("dense_rank", SupportedFunctionType.DENSE_RANK);
-    supportedFunctionsMap.put("min", SupportedFunctionType.MIN);
-    supportedFunctionsMap.put("max", SupportedFunctionType.MAX);
-    supportedFunctionsMap.put("sum", SupportedFunctionType.SUM);
-    supportedFunctionsMap.put("avg", SupportedFunctionType.AVG);
-    supportedFunctionsMap.put("first_value", SupportedFunctionType.FIRST_VALUE);
-    supportedFunctionsMap.put("last_value", SupportedFunctionType.LAST_VALUE);
-    supportedFunctionsMap.put("count", SupportedFunctionType.COUNT);
-    supportedFunctionsMap.put("lead", SupportedFunctionType.LEAD);
-    supportedFunctionsMap.put("lag", SupportedFunctionType.LAG);
+    for (SupportedFunctionType supportedFunctionType : SupportedFunctionType.values()) {
+      supportedFunctionsMap.put(supportedFunctionType.name().toLowerCase(), supportedFunctionType);
+    }
   }
   public static List<String> supportedFunctionNames = new ArrayList<String>();
   static {

--- a/ql/src/test/queries/clientpositive/vector_ptf_1.q
+++ b/ql/src/test/queries/clientpositive/vector_ptf_1.q
@@ -21,3 +21,5 @@ group by age, name;
 select age, name, avg(gpa), sum(age) over (partition by name)
 from studentnull100
 group by age, name;
+
+EXPLAIN VECTORIZATION ONLY SELECT ROW_NUMBER() OVER(order by age) AS rn FROM studentnull100;

--- a/ql/src/test/results/clientpositive/llap/llap_smb_ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_smb_ptf.q.out
@@ -593,7 +593,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string), VALUE._col6 (type: smallint), VALUE._col7 (type: smallint), VALUE._col8 (type: smallint), VALUE._col23 (type: string), VALUE._col25 (type: string), VALUE._col40 (type: string)
@@ -721,7 +721,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 0 Basic stats: PARTIAL Column stats: COMPLETE
         Reducer 9 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: int), VALUE._col2 (type: smallint), VALUE._col3 (type: smallint), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col8 (type: string)

--- a/ql/src/test/results/clientpositive/llap/semijoin2.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin2.q.out
@@ -160,7 +160,7 @@ STAGE PLANS:
                   Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col16 (type: smallint), _col21 (type: double), _col99 (type: int)
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col16 (type: smallint), VALUE._col21 (type: double), VALUE._col99 (type: int)

--- a/ql/src/test/results/clientpositive/llap/vector_ptf_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_ptf_1.q.out
@@ -296,3 +296,50 @@ NULL	sarah ovid	1.62	NULL
 26	yuri robinson	1.22	26
 69	yuri zipper	NULL	69
 56	zach robinson	0.86	56
+PREHOOK: query: EXPLAIN VECTORIZATION ONLY SELECT ROW_NUMBER() OVER(order by age) AS rn FROM studentnull100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@studentnull100
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION ONLY SELECT ROW_NUMBER() OVER(order by age) AS rn FROM studentnull100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@studentnull100
+#### A masked pattern was here ####
+Explain
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+      Vertices:
+        Map 1 
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+
+  Stage: Stage-0
+    Fetch Operator
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Convert window function names to lower case when looking up in vectorizable function registry.

### Why are the changes needed?
Support case insensitivity of window functions when vectorizing PTF operator.

### Does this PR introduce _any_ user-facing change?
No, but explain vectorization output may change if query has window functions

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=vector_ptf_1.q -pl itests/qtest -Pitests
```