### PR TITLE
HIVE-25421: Fallback from vectorization when reading Iceberg's time columns

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
@@ -117,9 +117,8 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if ((type == Types.TimestampType.withZone() || type == Types.TimeType.get()) &&
-          isVectorized && fileFormat == FileFormat.ORC) {
-        // ORC/TIMESTAMP_INSTANT and time are not supported vectorized types for Hive
+      if ((type == Types.TimestampType.withZone()) && isVectorized && fileFormat == FileFormat.ORC) {
+        // ORC/TIMESTAMP_INSTANT is not supported vectorized types for Hive
         continue;
       }
       // TODO: remove this filter when issue #1881 is resolved
@@ -145,9 +144,9 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if ((type == Types.TimestampType.withZone() || type == Types.TimeType.get()) &&
+      if ((type == Types.TimestampType.withZone()) &&
           isVectorized && fileFormat == FileFormat.ORC) {
-        // ORC/TIMESTAMP_INSTANT and time are not supported vectorized types for Hive
+        // ORC/TIMESTAMP_INSTANT is not supported vectorized types for Hive
         continue;
       }
       // TODO: remove this filter when issue #1881 is resolved


### PR DESCRIPTION
As discussed in [HIVE-25420](https://issues.apache.org/jira/browse/HIVE-25420) time column is not native Hive type, reading it is more complicated, and is not supported for vectorized read when the file format is ORC. Trying this currently results in an exception, so we should make an effort to gracefully fall back to non-vectorized reads when there's such a column in the query's projection.