### PR TITLE
HIVE-26278: Add unit tests for Hive#getPartitionsByNames using batching

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHiveMetaStoreClientApiArgumentsChecker.java
@@ -38,10 +38,13 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.thrift.TException;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +83,8 @@ public class TestHiveMetaStoreClientApiArgumentsChecker {
     hive.getConf().set(ValidTxnList.VALID_TXNS_KEY, "1:");
     hive.getConf().set(ValidWriteIdList.VALID_WRITEIDS_KEY, TABLE_NAME + ":1:");
     hive.getConf().setVar(HiveConf.ConfVars.HIVE_TXN_MANAGER, "org.apache.hadoop.hive.ql.lockmgr.TestTxnManager");
+    // Pick a small number for the batch size to easily test code with multiple batches.
+    hive.getConf().setIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX, 2);
     SessionState.start(hive.getConf());
     SessionState.get().initTxnMgr(hive.getConf());
     Context ctx = new Context(hive.getConf());
@@ -144,6 +149,26 @@ public class TestHiveMetaStoreClientApiArgumentsChecker {
     req.setDb_name(DB_NAME);
     req.setTbl_name(TABLE_NAME);
     hive.getPartitionsByNames(t, new ArrayList<>(), true);
+  }
+
+  @Test
+  public void testGetPartitionsByNamesWithSingleBatch() throws HiveException {
+    hive.getPartitionsByNames(t, Arrays.asList("Greece", "Italy"), true);
+  }
+
+  @Test
+  public void testGetPartitionsByNamesWithMultipleEqualSizeBatches()
+      throws HiveException {
+    List<String> names = Arrays.asList("Greece", "Italy", "France", "Spain");
+    hive.getPartitionsByNames(t, names, true);
+  }
+
+  @Test
+  public void testGetPartitionsByNamesWithMultipleUnequalSizeBatches()
+      throws HiveException {
+    List<String> names =
+        Arrays.asList("Greece", "Italy", "France", "Spain", "Hungary");
+    hive.getPartitionsByNames(t, names, true);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
New tests cases for more code coverage.

### Why are the changes needed?
Ensure that ValidWriteIdList is set when batching is involved in `Hive#getPartitionByNames`.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn test -Dtest=TestHiveMetaStoreClientApiArgumentsChecker`