### PR TITLE
HIVE-26108: Exception in Vectorization with Decimal64 to Decimal casting

### DIFF
--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64Column.txt
@@ -177,4 +177,9 @@ public class <ClassName> extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64Scalar.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64Scalar.txt
@@ -209,4 +209,9 @@ public class <ClassName> extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64ScalarUnscaled.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnArithmeticDecimal64ScalarUnscaled.txt
@@ -61,4 +61,8 @@ public class <ClassName> extends <ParentClassName> {
         .setUnscaled(true).build();
   }
 
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnBetween.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnBetween.txt
@@ -47,4 +47,9 @@ public class <ClassName> extends <BaseClassName> {
         ", decimal64Left " + leftValue + ", decimalLeft " + writable1.toString() +
         ", decimal64Right " + rightValue + ", decimalRight " + writable2.toString();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnCompareDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnCompareDecimal64Column.txt
@@ -51,4 +51,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnCompareDecimal64Scalar.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnCompareDecimal64Scalar.txt
@@ -63,4 +63,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnDivideDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnDivideDecimal64Column.txt
@@ -265,4 +265,9 @@ public class <ClassName> extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnDivideDecimal64Scalar.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnDivideDecimal64Scalar.txt
@@ -263,4 +263,9 @@ public class <ClassName> extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnScaleUp.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ColumnScaleUp.txt
@@ -61,4 +61,8 @@ public class <ClassName> extends <ParentClassName> {
         .setUnscaled(true).build();
   }
 
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarArithmeticDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarArithmeticDecimal64Column.txt
@@ -208,4 +208,9 @@ public class <ClassName> extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarArithmeticDecimal64ColumnUnscaled.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarArithmeticDecimal64ColumnUnscaled.txt
@@ -62,4 +62,9 @@ public class <ClassName> extends <ParentClassName> {
             VectorExpressionDescriptor.InputExpressionType.COLUMN)
         .setUnscaled(true).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarCompareDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/Decimal64ScalarCompareDecimal64Column.txt
@@ -63,4 +63,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ColumnCompareDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ColumnCompareDecimal64Column.txt
@@ -51,4 +51,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ColumnCompareDecimal64Scalar.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ColumnCompareDecimal64Scalar.txt
@@ -51,4 +51,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ScalarCompareDecimal64Column.txt
+++ b/ql/src/gen/vectorization/ExpressionTemplates/FilterDecimal64ScalarCompareDecimal64Column.txt
@@ -51,4 +51,9 @@ public class <ClassName> extends <BaseClassName> {
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/CastLongToDecimal64.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/CastLongToDecimal64.java
@@ -180,4 +180,9 @@ public class CastLongToDecimal64 extends VectorExpression {
             VectorExpressionDescriptor.InputExpressionType.COLUMN);
     return b.build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/ConvertDecimal64ToDecimal.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/ConvertDecimal64ToDecimal.java
@@ -41,4 +41,9 @@ public class ConvertDecimal64ToDecimal extends FuncLongToDecimal {
   protected void func(DecimalColumnVector outV, LongColumnVector inV, int i) {
     outV.vector[i].deserialize64(inV.vector[i], ((Decimal64ColumnVector) inV).scale);
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/Decimal64ColumnInList.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/Decimal64ColumnInList.java
@@ -62,4 +62,9 @@ public class Decimal64ColumnInList extends LongColumnInList {
     // return null since this will be handled as a special case in VectorizationContext
     return null;
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnBetween.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnBetween.java
@@ -65,4 +65,9 @@ public class FilterDecimal64ColumnBetween extends FilterLongColumnBetween {
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnInList.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnInList.java
@@ -65,4 +65,9 @@ public class FilterDecimal64ColumnInList extends FilterLongColumnInList {
     sb.append("]");
     return sb.toString();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnNotBetween.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/FilterDecimal64ColumnNotBetween.java
@@ -65,4 +65,9 @@ public class FilterDecimal64ColumnNotBetween extends FilterLongColumnNotBetween 
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ColumnDecimal64Column.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ColumnDecimal64Column.java
@@ -52,4 +52,9 @@ public class IfExprDecimal64ColumnDecimal64Column extends IfExprLongColumnLongCo
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ColumnDecimal64Scalar.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ColumnDecimal64Scalar.java
@@ -67,4 +67,9 @@ public class IfExprDecimal64ColumnDecimal64Scalar extends IfExprLongColumnLongSc
             VectorExpressionDescriptor.InputExpressionType.COLUMN,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ScalarDecimal64Column.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ScalarDecimal64Column.java
@@ -68,4 +68,9 @@ public class IfExprDecimal64ScalarDecimal64Column extends IfExprLongScalarLongCo
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.COLUMN).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ScalarDecimal64Scalar.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/IfExprDecimal64ScalarDecimal64Scalar.java
@@ -72,4 +72,9 @@ public class IfExprDecimal64ScalarDecimal64Scalar extends IfExprLongScalarLongSc
             VectorExpressionDescriptor.InputExpressionType.SCALAR,
             VectorExpressionDescriptor.InputExpressionType.SCALAR).build();
   }
+
+  @Override
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorExpression.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorExpression.java
@@ -436,4 +436,14 @@ public abstract class VectorExpression implements Serializable {
     }
     return sb.toString();
   }
+
+  /**
+   * By default vector expressions do not handle decimal64 types and should be
+   * converted into Decimal types if its output cannot handle Decimal64. Decimal64
+   * that only deal with Decimal64 types cannot handle conversions so they should
+   * override this method and return false.
+   */
+  public boolean shouldConvertDecimal64ToDecimal() {
+    return getOutputDataTypePhysicalVariation() == DataTypePhysicalVariation.NONE;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -4364,6 +4364,10 @@ public class Vectorizer implements PhysicalPlanResolver {
     ExprNodeDesc predicateExpr = filterDesc.getPredicate();
     VectorExpression vectorPredicateExpr =
         vContext.getVectorExpression(predicateExpr, VectorExpressionDescriptor.Mode.FILTER);
+    if (vectorPredicateExpr != null) {
+      vectorPredicateExpr = fixDecimalDataTypePhysicalVariations(vectorPredicateExpr,
+          vectorPredicateExpr.getChildExpressions(), vContext);
+    }
     vectorFilterDesc.setPredicateExpression(vectorPredicateExpr);
     return OperatorFactory.getVectorOperator(
         filterOp.getCompilationOpContext(), filterDesc,
@@ -4761,8 +4765,7 @@ public class Vectorizer implements PhysicalPlanResolver {
         children[i] = newChild;
       }
     }
-    if (parent.getOutputDataTypePhysicalVariation() == DataTypePhysicalVariation.NONE &&
-      !(parent instanceof ConvertDecimal64ToDecimal)) {
+    if (parent.shouldConvertDecimal64ToDecimal()) {
       boolean inputArgsChanged = false;
       DataTypePhysicalVariation[] dataTypePhysicalVariations = parent.getInputDataTypePhysicalVariations();
       for (int i = 0; i < children.length; i++) {

--- a/ql/src/test/queries/clientpositive/vector_decimal_7.q
+++ b/ql/src/test/queries/clientpositive/vector_decimal_7.q
@@ -1,0 +1,18 @@
+set hive.mapred.mode=nonstrict;
+set hive.explain.user=false;
+SET hive.vectorized.execution.enabled=true;
+set hive.fetch.task.conversion=none;
+
+DROP TABLE IF EXISTS int_txt;
+
+CREATE TABLE int_txt (`i` int);
+
+LOAD DATA LOCAL INPATH '../../data/files/decimal_10_0.txt' OVERWRITE INTO TABLE int_txt;
+
+select count(*)
+from
+  int_txt
+  where
+         (( 1.0 * i) / ( 1.0 * i)) > 1.2;
+
+DROP TABLE IF EXISTS int_txt;

--- a/ql/src/test/results/clientpositive/llap/vector_decimal_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_decimal_7.q.out
@@ -1,0 +1,45 @@
+PREHOOK: query: DROP TABLE IF EXISTS int_txt
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS int_txt
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE int_txt (`i` int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@int_txt
+POSTHOOK: query: CREATE TABLE int_txt (`i` int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@int_txt
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/decimal_10_0.txt' OVERWRITE INTO TABLE int_txt
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@int_txt
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/decimal_10_0.txt' OVERWRITE INTO TABLE int_txt
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@int_txt
+PREHOOK: query: select count(*)
+from
+  int_txt
+  where
+         (( 1.0 * i) / ( 1.0 * i)) > 1.2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@int_txt
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*)
+from
+  int_txt
+  where
+         (( 1.0 * i) / ( 1.0 * i)) > 1.2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@int_txt
+#### A masked pattern was here ####
+0
+PREHOOK: query: DROP TABLE IF EXISTS int_txt
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@int_txt
+PREHOOK: Output: default@int_txt
+POSTHOOK: query: DROP TABLE IF EXISTS int_txt
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@int_txt
+POSTHOOK: Output: default@int_txt


### PR DESCRIPTION
The exception was happening because the code that casts the Decimal64 to
Decimal was not being added in filtered expressions.

Once this code was added, it caused a regression in check_constraint.q. The
reason for this was because we do not want to convert Decimal64 to Decimal
if the expression explicitly handles decimal64 types. A method was added
to these classes that will prevent the conversion in these cases.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The exception was happening because the code that casts the Decimal64 to
Decimal was not being added in filtered expressions.

Once this code was added, it caused a regression in check_constraint.q. The
reason for this was because we do not want to convert Decimal64 to Decimal
if the expression explicitly handles decimal64 types. A method was added
to these classes that will prevent the conversion in these cases.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a unit test which contained the bug.