### PR TITLE
HIVE-25879: MetaStoreDirectSql test query should not query the whole DBS table

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -324,7 +324,7 @@ class MetaStoreDirectSql {
       doCommit = true;
     }
     // Run a self-test query. If it doesn't work, we will self-disable. What a PITA...
-    String selfTestQuery = "select \"DB_ID\" from " + DBS + " WHERE DB_ID=1";
+    String selfTestQuery = "select \"DB_ID\" from " + DBS + " WHERE \"DB_ID\"=1";
     try (QueryWrapper query = new QueryWrapper(pm.newQuery("javax.jdo.query.SQL", selfTestQuery))) {
       prepareTxn();
       long start = doTrace ? System.nanoTime() : 0;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -316,6 +316,7 @@ class MetaStoreDirectSql {
   }
 
   private boolean runTestQuery() {
+    boolean doTrace = LOG.isDebugEnabled();
     Transaction tx = pm.currentTransaction();
     boolean doCommit = false;
     if (!tx.isActive()) {
@@ -323,10 +324,12 @@ class MetaStoreDirectSql {
       doCommit = true;
     }
     // Run a self-test query. If it doesn't work, we will self-disable. What a PITA...
-    String selfTestQuery = "select \"DB_ID\" from " + DBS + "";
+    String selfTestQuery = "select \"DB_ID\" from " + DBS + " WHERE DB_ID=1";
     try (QueryWrapper query = new QueryWrapper(pm.newQuery("javax.jdo.query.SQL", selfTestQuery))) {
       prepareTxn();
+      long start = doTrace ? System.nanoTime() : 0;
       query.execute();
+      MetastoreDirectSqlUtils.timingTrace(doTrace, selfTestQuery, start, doTrace ? System.nanoTime() : 0);
       return true;
     } catch (Throwable t) {
       doCommit = false;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Performance optimization: the MetaStoreDirectSql#runTestQuery determines whether the direct SQL can be used. Before the fix the code queries the whole DBS table without any filters. The proposed change is to add a filter "WHERE DB_ID=1" which should be fast as it is the primary key for that table.


### Why are the changes needed?
Performance improvement. With bigger deployments the test query can run 10x faster (~3 ms instead of 30 ms), and this test query runs for every ObjectStore initialization.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
In my local dev env I've run the "mvn test" successfully in the "standalone-metastore".