### PR TITLE
HIVE-26319: Iceberg integration: Perform update split early

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -298,9 +298,8 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
         SessionStateUtil.CommitInfo commitInfo = null;
         if (SessionStateUtil.getCommitInfo(jobContext.getJobConf(), output).isPresent()) {
-          commitInfo = SessionStateUtil.getCommitInfo(jobContext.getJobConf(), output).get()
-              .stream().filter(ci -> ci.getJobIdStr().equals(jobContext.getJobID().toString())).findFirst()
-              .orElse(null);
+          commitInfo = SessionStateUtil.getCommitInfo(jobContext.getJobConf(), output)
+              .get().get(jobContext.getJobID().toString());
         }
         outputs.add(new OutputTable(output, table, jobContext, commitInfo));
       }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -115,7 +115,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
     TaskAttemptID attemptID = context.getTaskAttemptID();
     JobConf jobConf = context.getJobConf();
-    Set<String> outputs = Sets.newHashSet(HiveIcebergStorageHandler.outputTables(context.getJobConf()));
+    Set<String> outputs = HiveIcebergStorageHandler.outputTables(context.getJobConf());
     Map<String, List<HiveIcebergWriter>> writers = Optional.ofNullable(WriterRegistry.writers(attemptID))
         .orElseGet(() -> {
           LOG.info("CommitTask found no writers for output tables: {}, attemptID: {}", outputs, attemptID);
@@ -285,7 +285,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
   private Set<OutputTable> collectOutputs(List<JobContext> jobContextList) {
     Set<OutputTable> outputs = Sets.newHashSet();
     for (JobContext jobContext : jobContextList) {
-      Set<String> outputNames = Sets.newHashSet(HiveIcebergStorageHandler.outputTables(jobContext.getJobConf()));
+      Set<String> outputNames = HiveIcebergStorageHandler.outputTables(jobContext.getJobConf());
       for (String output : outputNames) {
         Table table = SessionStateUtil.getResource(jobContext.getJobConf(), output)
             .filter(o -> o instanceof Table).map(o -> (Table) o)

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandler
 import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobContext;
-import org.apache.hadoop.mapred.JobStatus;
 import org.apache.hadoop.mapred.OutputCommitter;
 import org.apache.hadoop.mapred.TaskAttemptContext;
 import org.apache.hadoop.mapred.TaskAttemptID;
@@ -311,15 +310,6 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
   @Override
   public void abortJob(JobContext originalContext, int status) throws IOException {
     abortJobs(Collections.singletonList(originalContext));
-  }
-
-  public void abortJobs(List<JobContext> jobContexts, JobStatus.State runState) throws IOException {
-    int state = runState.getValue();
-    if (state != JobStatus.FAILED && state != JobStatus.KILLED) {
-      throw new IOException("Invalid job run state : " + runState.name());
-    } else {
-      this.abortJobs(jobContexts);
-    }
   }
 
   public void abortJobs(List<JobContext> originalContextList) throws IOException {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -131,16 +131,16 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
           .executeWith(tableExecutor)
           .run(output -> {
             Table table = HiveIcebergStorageHandler.table(context.getJobConf(), output);
-            if (table != null && writers.get(output) != null) {
-              for (HiveIcebergWriter writer : writers.get(output)) {
-                String fileForCommitLocation = generateFileForCommitLocation(table.location(), jobConf,
-                        attemptID.getJobID(), attemptID.getTaskID().getId());
-                if (writer != null) {
+            if (table != null) {
+              String fileForCommitLocation = generateFileForCommitLocation(table.location(), jobConf,
+                  attemptID.getJobID(), attemptID.getTaskID().getId());
+              if (writers.get(output) != null) {
+                for (HiveIcebergWriter writer : writers.get(output)) {
                   createFileForCommit(writer.files(), fileForCommitLocation, table.io());
-                } else {
-                  LOG.info("CommitTask found no writer for specific table: {}, attemptID: {}", output, attemptID);
-                  createFileForCommit(FilesForCommit.empty(), fileForCommitLocation, table.io());
                 }
+              } else {
+                LOG.info("CommitTask found no writer for specific table: {}, attemptID: {}", output, attemptID);
+                createFileForCommit(FilesForCommit.empty(), fileForCommitLocation, table.io());
               }
             } else {
               // When using Tez multi-table inserts, we could have more output tables in config than

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -71,7 +71,6 @@ import org.apache.iceberg.mr.hive.writer.WriterRegistry;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.util.Tasks;
@@ -132,24 +131,16 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
           .executeWith(tableExecutor)
           .run(output -> {
             Table table = HiveIcebergStorageHandler.table(context.getJobConf(), output);
-            if (table != null) {
-              Collection<DataFile> dataFiles = Lists.newArrayList();
-              Collection<DeleteFile> deleteFiles = Lists.newArrayList();
-              String fileForCommitLocation = generateFileForCommitLocation(table.location(), jobConf,
-                      attemptID.getJobID(), attemptID.getTaskID().getId());
-              if (writers.get(output) != null) {
-                for (HiveIcebergWriter writer : writers.get(output)) {
-                  if (writer != null) {
-                    dataFiles.addAll(writer.files().dataFiles());
-                    deleteFiles.addAll(writer.files().deleteFiles());
-                  }
+            if (table != null && writers.get(output) != null) {
+              for (HiveIcebergWriter writer : writers.get(output)) {
+                String fileForCommitLocation = generateFileForCommitLocation(table.location(), jobConf,
+                        attemptID.getJobID(), attemptID.getTaskID().getId());
+                if (writer != null) {
+                  createFileForCommit(writer.files(), fileForCommitLocation, table.io());
+                } else {
+                  LOG.info("CommitTask found no writer for specific table: {}, attemptID: {}", output, attemptID);
+                  createFileForCommit(FilesForCommit.empty(), fileForCommitLocation, table.io());
                 }
-              }
-              if (dataFiles.isEmpty() && deleteFiles.isEmpty()) {
-                LOG.info("CommitTask found no writer for specific table: {}, attemptID: {}", output, attemptID);
-                createFileForCommit(FilesForCommit.empty(), fileForCommitLocation, table.io());
-              } else {
-                createFileForCommit(new FilesForCommit(dataFiles, deleteFiles), fileForCommitLocation, table.io());
               }
             } else {
               // When using Tez multi-table inserts, we could have more output tables in config than

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -235,18 +235,14 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
    * @throws IOException if there is a failure accessing the files
    */
   public void commitJobs(List<JobContext> originalContextList) throws IOException {
-    if (originalContextList.isEmpty()) {
-      return;
-    }
-
     List<JobContext> jobContextList = originalContextList.stream()
         .map(TezUtil::enrichContextWithVertexId)
         .collect(Collectors.toList());
-    String ids = jobContextList.stream()
-        .map(jobContext -> jobContext.getJobID().toString()).collect(Collectors.joining(","));
     Set<OutputTable> outputs = collectOutputs(jobContextList);
     long startTime = System.currentTimeMillis();
 
+    String ids = jobContextList.stream()
+        .map(jobContext -> jobContext.getJobID().toString()).collect(Collectors.joining(","));
     LOG.info("Committing job(s) {} has started", ids);
 
     Collection<String> jobLocations = new ConcurrentLinkedQueue<>();
@@ -327,18 +323,15 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
   }
 
   public void abortJobs(List<JobContext> originalContextList) throws IOException {
-    if (originalContextList.isEmpty()) {
-      return;
-    }
-
     List<JobContext> jobContextList = originalContextList.stream()
         .map(TezUtil::enrichContextWithVertexId)
         .collect(Collectors.toList());
-    String ids = jobContextList.stream()
-        .map(jobContext -> jobContext.getJobID().toString()).collect(Collectors.joining(","));
     Set<OutputTable> outputs = collectOutputs(jobContextList);
 
+    String ids = jobContextList.stream()
+        .map(jobContext -> jobContext.getJobID().toString()).collect(Collectors.joining(","));
     LOG.info("Job(s) {} are aborted. Data file cleaning started", ids);
+
     Collection<String> jobLocations = new ConcurrentLinkedQueue<>();
 
     ExecutorService fileExecutor = fileExecutor(jobContextList.get(0).getJobConf());
@@ -351,7 +344,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
           .onFailure((output, exc) -> LOG.warn("Failed cleanup table {} on abort job", output, exc))
           .run(output -> {
             JobContext jobContext = output.jobContext;
-            JobConf jobConf = output.jobContext.getJobConf();
+            JobConf jobConf = jobContext.getJobConf();
             LOG.info("Cleaning job for jobID: {}, table: {}", jobContext.getJobID(), output);
 
             Table table = output.table;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -129,15 +129,17 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
           .executeWith(tableExecutor)
           .run(output -> {
             Table table = HiveIcebergStorageHandler.table(context.getJobConf(), output);
-            if (table != null && writers.get(output) != null) {
+            if (table != null) {
               Collection<DataFile> dataFiles = Lists.newArrayList();
               Collection<DeleteFile> deleteFiles = Lists.newArrayList();
               String fileForCommitLocation = generateFileForCommitLocation(table.location(), jobConf,
                       attemptID.getJobID(), attemptID.getTaskID().getId());
-              for (HiveIcebergWriter writer : writers.get(output)) {
-                if (writer != null) {
-                  dataFiles.addAll(writer.files().dataFiles());
-                  deleteFiles.addAll(writer.files().deleteFiles());
+              if (writers.get(output) != null) {
+                for (HiveIcebergWriter writer : writers.get(output)) {
+                  if (writer != null) {
+                    dataFiles.addAll(writer.files().dataFiles());
+                    deleteFiles.addAll(writer.files().deleteFiles());
+                  }
                 }
               }
               if (dataFiles.isEmpty() && deleteFiles.isEmpty()) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -30,6 +30,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -100,6 +101,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Throwables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializationUtil;
 import org.slf4j.Logger;
@@ -657,8 +659,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param config The configuration used to get the data from
    * @return The collection of the table names as returned by TableDesc.getTableName()
    */
-  public static Collection<String> outputTables(Configuration config) {
-    return TABLE_NAME_SPLITTER.splitToList(config.get(InputFormatConfig.OUTPUT_TABLES));
+  public static Set<String> outputTables(Configuration config) {
+    return Sets.newHashSet(TABLE_NAME_SPLITTER.split(config.get(InputFormatConfig.OUTPUT_TABLES)));
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -423,7 +423,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       } catch (Throwable e) {
         // Aborting the job if the commit has failed
         LOG.error("Error while trying to commit job: {}, starting rollback changes for table: {}",
-                jobContext.getJobID(), tableName, e);
+            jobContext.getJobID(), tableName, e);
         try {
           committer.abortJob(jobContext, JobStatus.State.FAILED);
         } catch (IOException ioe) {
@@ -431,7 +431,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           // no throwing here because the original exception should be propagated
         }
         throw new HiveException(
-                "Error committing job: " + jobContext.getJobID() + " for table: " + tableName, e);
+            "Error committing job: " + jobContext.getJobID() + " for table: " + tableName, e);
       }
     }
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapred.JobContextImpl;
 import org.apache.hadoop.mapred.JobID;
-import org.apache.hadoop.mapred.JobStatus;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
@@ -428,7 +427,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       LOG.error("Error while trying to commit job: {}, starting rollback changes for table: {}",
           ids, tableName, e);
       try {
-        committer.abortJobs(jobContextList, JobStatus.State.FAILED);
+        committer.abortJobs(jobContextList);
       } catch (IOException ioe) {
         LOG.error("Error while trying to abort failed job. There might be uncleaned data files.", ioe);
         // no throwing here because the original exception should be propagated

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -868,8 +868,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param overwrite If we have to overwrite the existing table or just add the new data
    * @return The generated JobContext
    */
-  private Optional<List<JobContext>> generateJobContext(
-          Configuration configuration, String tableName, boolean overwrite) {
+  private Optional<List<JobContext>> generateJobContext(Configuration configuration, String tableName,
+      boolean overwrite) {
     JobConf jobConf = new JobConf(configuration);
     Optional<List<SessionStateUtil.CommitInfo>> commitInfoList = SessionStateUtil.getCommitInfo(jobConf, tableName);
     if (commitInfoList.isPresent()) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -871,10 +871,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   private Optional<List<JobContext>> generateJobContext(Configuration configuration, String tableName,
       boolean overwrite) {
     JobConf jobConf = new JobConf(configuration);
-    Optional<List<SessionStateUtil.CommitInfo>> commitInfoList = SessionStateUtil.getCommitInfo(jobConf, tableName);
-    if (commitInfoList.isPresent()) {
+    Optional<Map<String, SessionStateUtil.CommitInfo>> commitInfoMap =
+        SessionStateUtil.getCommitInfo(jobConf, tableName);
+    if (commitInfoMap.isPresent()) {
       List<JobContext> jobContextList = Lists.newLinkedList();
-      for (SessionStateUtil.CommitInfo commitInfo : commitInfoList.get()) {
+      for (SessionStateUtil.CommitInfo commitInfo : commitInfoMap.get().values()) {
         JobID jobID = JobID.forName(commitInfo.getJobIdStr());
         commitInfo.getProps().forEach(jobConf::set);
         jobConf.setBoolean(InputFormatConfig.IS_OVERWRITE, overwrite);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
@@ -19,26 +19,29 @@
 
 package org.apache.iceberg.mr.hive.writer;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class WriterRegistry {
-  private static final Map<TaskAttemptID, Map<String, HiveIcebergWriter>> writers = Maps.newConcurrentMap();
+  private static final Map<TaskAttemptID, Map<String, List<HiveIcebergWriter>>> writers = Maps.newConcurrentMap();
 
   private WriterRegistry() {
   }
 
-  public static Map<String, HiveIcebergWriter> removeWriters(TaskAttemptID taskAttemptID) {
+  public static Map<String, List<HiveIcebergWriter>> removeWriters(TaskAttemptID taskAttemptID) {
     return writers.remove(taskAttemptID);
   }
 
   public static void registerWriter(TaskAttemptID taskAttemptID, String tableName, HiveIcebergWriter writer) {
     writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());
-    writers.get(taskAttemptID).put(tableName, writer);
+    writers.get(taskAttemptID).putIfAbsent(tableName, Lists.newArrayList());
+    writers.get(taskAttemptID).get(tableName).add(writer);
   }
 
-  public static Map<String, HiveIcebergWriter> writers(TaskAttemptID taskAttemptID) {
+  public static Map<String, List<HiveIcebergWriter>> writers(TaskAttemptID taskAttemptID) {
     return writers.get(taskAttemptID);
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
@@ -37,8 +37,12 @@ public class WriterRegistry {
 
   public static void registerWriter(TaskAttemptID taskAttemptID, String tableName, HiveIcebergWriter writer) {
     writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());
-    writers.get(taskAttemptID).putIfAbsent(tableName, Lists.newArrayList());
-    writers.get(taskAttemptID).get(tableName).add(writer);
+
+    Map<String, List<HiveIcebergWriter>> writersOfTableMap = writers.get(taskAttemptID);
+    writersOfTableMap.putIfAbsent(tableName, Lists.newArrayList());
+
+    List<HiveIcebergWriter> writerList = writersOfTableMap.get(tableName);
+    writerList.add(writer);
   }
 
   public static Map<String, List<HiveIcebergWriter>> writers(TaskAttemptID taskAttemptID) {

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_avro.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_avro.q.out
@@ -22,9 +22,11 @@ PREHOOK: query: update tbl_ice set b='Changes' where b in ('one', 'four') or a =
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changes' where b in ('one', 'four') or a = 22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -49,15 +51,17 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -101,10 +105,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed forever' where a in (select t1.a from tbl_ice t1 join tbl_ice_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_ice_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -150,10 +156,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_standard_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='The last one' where a in (select t1.a from tbl_ice t1 join tbl_standard_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_standard_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_avro.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_avro.q.out
@@ -51,8 +51,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[60][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_orc.q.out
@@ -51,8 +51,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[60][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_orc.q.out
@@ -22,9 +22,11 @@ PREHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a =
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a = 22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -49,15 +51,17 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -101,10 +105,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed forever' where a in (select t1.a from tbl_ice t1 join tbl_ice_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_ice_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -150,10 +156,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_standard_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='The last one' where a in (select t1.a from tbl_ice t1 join tbl_standard_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_standard_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_parquet.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_parquet.q.out
@@ -51,8 +51,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[60][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_parquet.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_partitioned_parquet.q.out
@@ -22,9 +22,11 @@ PREHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a =
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a = 22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -49,15 +51,17 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -101,10 +105,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed forever' where a in (select t1.a from tbl_ice t1 join tbl_ice_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_ice_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -150,10 +156,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_standard_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='The last one' where a in (select t1.a from tbl_ice t1 join tbl_standard_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_standard_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_unpartitioned_parquet.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_unpartitioned_parquet.q.out
@@ -51,8 +51,8 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[54][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[58][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_unpartitioned_parquet.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_unpartitioned_parquet.q.out
@@ -22,9 +22,11 @@ PREHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a =
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed' where b in ('one', 'four') or a = 22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -49,15 +51,17 @@ POSTHOOK: query: insert into tbl_ice values (444, 'hola', 800), (555, 'schola', 
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice
-Warning: Shuffle Join MERGEJOIN[51][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[54][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[56][tables = [$hdt$_0, $hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed again' where a in (select a from tbl_ice where a <= 5) or c in (select c from tbl_ice where c > 800)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -101,10 +105,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='Changed forever' where a in (select t1.a from tbl_ice t1 join tbl_ice_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_ice_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY
@@ -150,10 +156,12 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_standard_other
 PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
 POSTHOOK: query: update tbl_ice set b='The last one' where a in (select t1.a from tbl_ice t1 join tbl_standard_other t2 on t1.a = t2.a)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_ice
 POSTHOOK: Input: default@tbl_standard_other
+POSTHOOK: Output: default@tbl_ice
 POSTHOOK: Output: default@tbl_ice
 PREHOOK: query: select * from tbl_ice order by a, b, c
 PREHOOK: type: QUERY

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -617,18 +617,13 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
       initializeSpecPath();
       fs = specPath.getFileSystem(hconf);
 
-      setWriteOperation(hconf, getConf().getTableInfo().getTableName(), getConf().getWriteOperation());
-      if (hconf instanceof JobConf) {
-        jc = (JobConf) hconf;
-      } else {
-        // test code path
-        jc = new JobConf(hconf);
-      }
+      jc = new JobConf(hconf);
+      setWriteOperation(jc, getConf().getTableInfo().getTableName(), getConf().getWriteOperation());
 
       try {
         createHiveOutputFormat(jc);
       } catch (HiveException ex) {
-        logOutputFormatError(hconf, ex);
+        logOutputFormatError(jc, ex);
         throw ex;
       }
       isCompressed = conf.getCompressed();
@@ -639,7 +634,7 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
       }
       statsFromRecordWriter = new boolean[numFiles];
       AbstractSerDe serde = conf.getTableInfo().getSerDeClass().newInstance();
-      serde.initialize(unsetNestedColumnPaths(hconf), conf.getTableInfo().getProperties(), null);
+      serde.initialize(unsetNestedColumnPaths(jc), conf.getTableInfo().getProperties(), null);
 
       serializer = serde;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
@@ -555,6 +555,9 @@ public abstract class RewriteSemanticAnalyzer extends CalcitePlanner {
   }
 
   protected void appendSortBy(StringBuilder rewrittenQueryStr, List<String> keys) {
+    if (keys.isEmpty()) {
+      return;
+    }
     rewrittenQueryStr.append(INDENT).append("SORT BY ");
     rewrittenQueryStr.append(StringUtils.join(keys, ","));
     rewrittenQueryStr.append("\n");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.parse;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -30,13 +29,13 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.Context;
-import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Table;
-import org.apache.hadoop.hive.ql.session.SessionStateUtil;
+
+import static java.util.Collections.singletonList;
 
 /**
  * A subclass of the {@link org.apache.hadoop.hive.ql.parse.SemanticAnalyzer} that just handles
@@ -79,7 +78,7 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
     operation = Context.Operation.UPDATE;
     boolean nonNativeAcid = AcidUtils.isNonNativeAcidTable(mTable);
 
-    if (HiveConf.getBoolVar(queryState.getConf(), HiveConf.ConfVars.SPLIT_UPDATE) && !nonNativeAcid) {
+    if (HiveConf.getBoolVar(queryState.getConf(), HiveConf.ConfVars.SPLIT_UPDATE)) {
       analyzeSplitUpdate(tree, mTable, tabNameNode);
     } else {
       reparseAndSuperAnalyze(tree, mTable, tabNameNode);
@@ -112,9 +111,6 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
    */
   private void reparseAndSuperAnalyze(ASTNode tree, Table mTable, ASTNode tabNameNode) throws SemanticException {
     List<? extends Node> children = tree.getChildren();
-
-    // save the operation type into the query state
-    SessionStateUtil.addResource(conf, Context.Operation.class.getSimpleName(), operation.name());
 
     StringBuilder rewrittenQueryStr = new StringBuilder();
     rewrittenQueryStr.append("insert into table ");
@@ -257,6 +253,9 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
     }
   }
 
+  public static final String DELETE_PREFIX = "__d__";
+  public static final String SUB_QUERY_ALIAS = "s";
+
   private void analyzeSplitUpdate(ASTNode tree, Table mTable, ASTNode tabNameNode) throws SemanticException {
     operation = Context.Operation.UPDATE;
 
@@ -282,11 +281,45 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
 
     List<FieldSchema> nonPartCols = mTable.getCols();
     Map<String, String> colNameToDefaultConstraint = getColNameToDefaultValueMap(mTable);
-    List<String> values = new ArrayList<>(mTable.getCols().size());
     StringBuilder rewrittenQueryStr = createRewrittenQueryStrBuilder();
-    rewrittenQueryStr.append("(SELECT ROW__ID");
+    rewrittenQueryStr.append("(SELECT ");
+
+    boolean nonNativeAcid = AcidUtils.isNonNativeAcidTable(mTable);
+    int columnOffset;
+    List<String> deleteValues;
+    if (nonNativeAcid) {
+      List<FieldSchema> acidSelectColumns = mTable.getStorageHandler().acidSelectColumns(mTable, operation);
+      deleteValues = new ArrayList<>(acidSelectColumns.size());
+      for (FieldSchema fieldSchema : acidSelectColumns) {
+        String identifier = HiveUtils.unparseIdentifier(fieldSchema.getName(), this.conf);
+        rewrittenQueryStr.append(identifier).append(" AS ");
+        String prefixedIdentifier = HiveUtils.unparseIdentifier(DELETE_PREFIX + fieldSchema.getName(), this.conf);
+        rewrittenQueryStr.append(prefixedIdentifier);
+        rewrittenQueryStr.append(",");
+        deleteValues.add(String.format("%s.%s", SUB_QUERY_ALIAS, prefixedIdentifier));
+      }
+
+      columnOffset = acidSelectColumns.size();
+    } else {
+      rewrittenQueryStr.append("ROW__ID,");
+      deleteValues = new ArrayList<>(1 + mTable.getPartCols().size());
+      deleteValues.add(SUB_QUERY_ALIAS + ".ROW__ID");
+      for (FieldSchema fieldSchema : mTable.getPartCols()) {
+        deleteValues.add(SUB_QUERY_ALIAS + "." + HiveUtils.unparseIdentifier(fieldSchema.getName(), conf));
+      }
+      columnOffset = 1;
+    }
+
+    List<String> insertValues = new ArrayList<>(mTable.getCols().size());
+    boolean first = true;
+
     for (int i = 0; i < nonPartCols.size(); i++) {
-      rewrittenQueryStr.append(',');
+      if (first) {
+        first = false;
+      } else {
+        rewrittenQueryStr.append(",");
+      }
+
       String name = nonPartCols.get(i).getName();
       ASTNode setCol = setCols.get(name);
       String identifier = HiveUtils.unparseIdentifier(name, this.conf);
@@ -299,7 +332,7 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
           rewrittenQueryStr.append(identifier);
           // This is one of the columns we're setting, record it's position so we can come back
           // later and patch it up. 0th is ROW_ID
-          setColExprs.put(i + 1, setCol);
+          setColExprs.put(i + columnOffset, setCol);
         }
       } else {
         rewrittenQueryStr.append(identifier);
@@ -307,16 +340,28 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
       rewrittenQueryStr.append(" AS ");
       rewrittenQueryStr.append(identifier);
 
-      values.add("s." + identifier);
+      insertValues.add(SUB_QUERY_ALIAS + "." + identifier);
     }
     addPartitionColsToSelect(mTable.getPartCols(), rewrittenQueryStr);
-    addPartitionColsAsValues(mTable.getPartCols(), "s", values);
-    rewrittenQueryStr.append(" FROM ").append(getFullTableNameForSQL(tabNameNode)).append(") s\n");
+    addPartitionColsAsValues(mTable.getPartCols(), SUB_QUERY_ALIAS, insertValues);
+    rewrittenQueryStr.append(" FROM ").append(getFullTableNameForSQL(tabNameNode)).append(") ");
+    rewrittenQueryStr.append(SUB_QUERY_ALIAS).append("\n");
 
-    appendInsertBranch(rewrittenQueryStr, null, values);
-    appendDeleteBranch(rewrittenQueryStr, null, "s", Collections.singletonList("s.ROW__ID "));
+    appendInsertBranch(rewrittenQueryStr, null, insertValues);
+    appendInsertBranch(rewrittenQueryStr, null, deleteValues);
 
-    appendSortBy(rewrittenQueryStr, Collections.singletonList("s.ROW__ID "));
+    List<String> sortKeys;
+    if (nonNativeAcid) {
+      sortKeys = mTable.getStorageHandler().acidSortColumns(mTable, operation).stream()
+              .map(fieldSchema -> String.format(
+                      "%s.%s",
+                      SUB_QUERY_ALIAS,
+                      HiveUtils.unparseIdentifier(DELETE_PREFIX + fieldSchema.getName(), this.conf)))
+              .collect(Collectors.toList());
+    } else {
+      sortKeys = singletonList(SUB_QUERY_ALIAS + ".ROW__ID ");
+    }
+    appendSortBy(rewrittenQueryStr, sortKeys);
 
     ReparseResult rr = parseRewrittenQuery(rewrittenQueryStr, ctx.getCmd());
     Context rewrittenCtx = rr.rewrittenCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
@@ -380,14 +380,9 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
 
     patchProjectionForUpdate(rewrittenInsert, setColExprs);
 
-    try {
-      useSuper = true;
-      // Note: this will overwrite this.ctx with rewrittenCtx
-      rewrittenCtx.setEnableUnparse(false);
-      super.analyze(rewrittenTree, rewrittenCtx);
-    } finally {
-      useSuper = false;
-    }
+    // Note: this will overwrite this.ctx with rewrittenCtx
+    rewrittenCtx.setEnableUnparse(false);
+    analyzeRewrittenTree(rewrittenTree, rewrittenCtx);
 
     updateOutputs(mTable);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/UpdateDeleteSemanticAnalyzer.java
@@ -352,7 +352,7 @@ public class UpdateDeleteSemanticAnalyzer extends RewriteSemanticAnalyzer {
 
     List<String> sortKeys;
     if (nonNativeAcid) {
-      sortKeys = mTable.getStorageHandler().acidSortColumns(mTable, operation).stream()
+      sortKeys = mTable.getStorageHandler().acidSortColumns(mTable, Context.Operation.DELETE).stream()
               .map(fieldSchema -> String.format(
                       "%s.%s",
                       SUB_QUERY_ALIAS,

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
@@ -18,8 +18,7 @@
 
 package org.apache.hadoop.hive.ql.session;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -76,10 +75,10 @@ public class SessionStateUtil {
   /**
    * @param conf Configuration object used for getting the query state, should contain the query id
    * @param tableName Name of the table for which the commit info should be retrieved
-   * @return the CommitInfo, or empty Optional if not present
+   * @return the CommitInfo map. Key: jobId, Value: {@link CommitInfo}, or empty Optional if not present
    */
-  public static Optional<List<CommitInfo>> getCommitInfo(Configuration conf, String tableName) {
-    return getResource(conf, COMMIT_INFO_PREFIX + tableName).map(o -> (List<CommitInfo>)o);
+  public static Optional<Map<String, CommitInfo>> getCommitInfo(Configuration conf, String tableName) {
+    return getResource(conf, COMMIT_INFO_PREFIX + tableName).map(o -> (Map<String, CommitInfo>)o);
   }
 
   /**
@@ -98,16 +97,16 @@ public class SessionStateUtil {
             .withTaskNum(taskNum)
             .withProps(additionalProps);
 
-    Optional<List<CommitInfo>> commitInfoList = getCommitInfo(conf, tableName);
-    if (commitInfoList.isPresent()) {
-      commitInfoList.get().add(commitInfo);
+    Optional<Map<String, CommitInfo>> commitInfoMap = getCommitInfo(conf, tableName);
+    if (commitInfoMap.isPresent()) {
+      commitInfoMap.get().put(jobId, commitInfo);
       return true;
     }
 
-    List<CommitInfo> newCommitInfoList = new ArrayList<>();
-    newCommitInfoList.add(commitInfo);
+    Map<String, CommitInfo> newCommitInfoMap = new HashMap<>();
+    newCommitInfoMap.put(jobId, commitInfo);
 
-    return addResource(conf, COMMIT_INFO_PREFIX + tableName, newCommitInfoList);
+    return addResource(conf, COMMIT_INFO_PREFIX + tableName, newCommitInfoMap);
   }
 
   private static Optional<QueryState> getQueryState(Configuration conf) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rewrite update statements of iceberg tables to multi insert statement similarly in case of native acid tables.

When generating the rewritten statement:
* Get the virtual columns from the table's storage handler in case of non native acid tables
* Include the old values to the select clause of the delete branch of the multi insert statement.

When executing the multi insert:
* Two iceberg writers are used which produce a data delta file and a delete delta file. The result of these writers should be merged into one `FilesForCommit` if both writers are run in the same task.
* In case of more complex statements (ex. partitioned and/or bucketed) more than one Tez task produces commit info so this patch enables storing all of them.
* Every `FileSinkOperator` creates its own jobConf instance because the iceberg write operation is stored in it and it is different in both instance.


### Why are the changes needed?
See #2855
+ Preparation for iceberg Merge implementation.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=update_iceberg_partitioned_orc.q -pl itests/qtest-iceberg -Piceberg -Pitests
mvn test "-Dtest=TestHiveIcebergV2#testUpdateStatementWithPartitionAndSchemaEvolution[*AVRO*tez*HIVE_CATALOG*false]" -pl iceberg/iceberg-handler -Drat.skip -Piceberg
mvn test -Dtest=TestHiveIcebergInserts#testInsertOverwriteNonPartitionedTable[*ORC*tez*HIVE_CATALOG*false] -pl iceberg/iceberg-handler -Piceberg -Drat.skip
```