### PR TITLE
HIVE-26323: Expose real exception information to the client in JdbcSerDe.java

### DIFF
--- a/jdbc-handler/src/main/java/org/apache/hive/storage/jdbc/JdbcSerDe.java
+++ b/jdbc-handler/src/main/java/org/apache/hive/storage/jdbc/JdbcSerDe.java
@@ -131,7 +131,8 @@ public class JdbcSerDe extends AbstractSerDe {
         row = new ArrayList<>(hiveColumnNames.length);
       }
     } catch (Exception e) {
-      throw new SerDeException("Caught exception while initializing the SqlSerDe", e);
+      log.error("Caught exception while initializing the SqlSerDe", e);
+      throw new SerDeException(e);
     }
 
     if (log.isDebugEnabled()) {

--- a/ql/src/test/queries/clientnegative/jdbc_table_create_with_wrong_password.q
+++ b/ql/src/test/queries/clientnegative/jdbc_table_create_with_wrong_password.q
@@ -1,0 +1,12 @@
+--! qt:database:mariadb:q_test_country_table_with_schema.mariadb.sql
+
+-- Create jdbc table with wrong password(hive.sql.dbcp.password)
+CREATE EXTERNAL TABLE country_test1 (id int, name varchar(20))
+    STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+    TBLPROPERTIES (
+        "hive.sql.database.type" = "MYSQL",
+        "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/bob",
+        "hive.sql.dbcp.username" = "root",
+        "hive.sql.dbcp.password" = "qtestpassword_wrong",
+        "hive.sql.table" = "country");

--- a/ql/src/test/queries/clientnegative/jdbc_table_create_with_wrong_url.q
+++ b/ql/src/test/queries/clientnegative/jdbc_table_create_with_wrong_url.q
@@ -1,0 +1,12 @@
+--! qt:database:mariadb:q_test_country_table_with_schema.mariadb.sql
+
+-- Create jdbc table with wrong MySQL url(hive.sql.jdbc.url)
+CREATE EXTERNAL TABLE country_test3 (id int, name varchar(20))
+    STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+    TBLPROPERTIES (
+        "hive.sql.database.type" = "MYSQL",
+        "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost_no_exists:3309/bob",
+        "hive.sql.dbcp.username" = "root",
+        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.table" = "country");

--- a/ql/src/test/results/clientnegative/jdbc_table_create_with_wrong_password.q.out
+++ b/ql/src/test/results/clientnegative/jdbc_table_create_with_wrong_password.q.out
@@ -1,0 +1,14 @@
+PREHOOK: query: CREATE EXTERNAL TABLE country_test1 (id int, name varchar(20))
+    STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+    TBLPROPERTIES (
+        "hive.sql.database.type" = "MYSQL",
+        "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost:3309/bob",
+        "hive.sql.dbcp.username" = "root",
+        "hive.sql.dbcp.password" = "qtestpassword_wrong",
+        "hive.sql.table" = "country")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@country_test1
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException org.apache.hive.storage.jdbc.exception.HiveJdbcDatabaseAccessException: Error while trying to get column names: Cannot create PoolableConnectionFactory (Could not connect to address=(host=localhost)(port=3309)(type=master) : Access denied for user 'root'@'172.17.42.1' (using password: YES)
+Current charset is UTF-8. If password has been set using other charset, consider using option 'passwordCharacterEncoding'))

--- a/ql/src/test/results/clientnegative/jdbc_table_create_with_wrong_url.q.out
+++ b/ql/src/test/results/clientnegative/jdbc_table_create_with_wrong_url.q.out
@@ -1,0 +1,13 @@
+PREHOOK: query: CREATE EXTERNAL TABLE country_test3 (id int, name varchar(20))
+    STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+    TBLPROPERTIES (
+        "hive.sql.database.type" = "MYSQL",
+        "hive.sql.jdbc.driver" = "org.mariadb.jdbc.Driver",
+        "hive.sql.jdbc.url" = "jdbc:mariadb://localhost_no_exists:3309/bob",
+        "hive.sql.dbcp.username" = "root",
+        "hive.sql.dbcp.password" = "qtestpassword",
+        "hive.sql.table" = "country")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@country_test3
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException org.apache.hive.storage.jdbc.exception.HiveJdbcDatabaseAccessException: Error while trying to get column names: Cannot create PoolableConnectionFactory (Could not connect to address=(host=localhost_no_exists)(port=3309)(type=master) : Socket fail to connect to host:localhost_no_exists, port:3309. localhost_no_exists))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Throw real exception massage to client in method _initialize_  of JdbcSerDe.java

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Display friendly execption massage to the client user.
Please see the details in: https://issues.apache.org/jira/browse/HIVE-26323

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn test -Dtest=TestNegativeLlapLocalCliDriver -Dqfile=jdbc_table_create_with_wrong_password.q -Dtest.output.overwrite=true
mvn test -Dtest=TestNegativeLlapLocalCliDriver -Dqfile=jdbc_table_create_with_wrong_url.q -Dtest.output.overwrite=true
