### PR TITLE
HIVE-26331: Use maven-surefire-plugin version consistently in standalone-metastore modules

### DIFF
--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -440,11 +440,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven.surefire.plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <dependencies>
             <dependency>

--- a/standalone-metastore/metastore-tools/pom.xml
+++ b/standalone-metastore/metastore-tools/pom.xml
@@ -27,7 +27,6 @@
     <module>tools-common</module>
   </modules>
   <properties>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <javac.errorprone.version>2.8</javac.errorprone.version>
     <errorprone.core.version>2.3.1</errorprone.core.version>
     <picocli.version>3.1.0</picocli.version>
@@ -139,15 +138,6 @@
     </dependencies>
   </dependencyManagement>
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven.surefire.plugin.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <!-- Suppress source assembly -->
       <plugin>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -443,6 +443,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.plugin.version}</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
           </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move maven-surefire-plugin management to common parent module (standalone-metastore)

### Why are the changes needed?
1. Use the same plugin version (3.0.0-M4) in all modules
2. Simplify dependency management

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn clean install -DskipTests -Pitests | grep "surefire-plugin" ` and check manually that the same version is used in all modules