### PR TITLE
HIVE-26329: Upgrade protobuf-java to 3.16.1

### DIFF
--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -33,7 +33,7 @@
     <active.hadoop.version>${hadoop.version}</active.hadoop.version>
     <test.dfs.mkdir>-mkdir -p</test.dfs.mkdir>
     <!-- Required by Calcite Avatica -->
-    <protobuf.version>3.3.0</protobuf.version>
+    <protobuf.version>3.16.1</protobuf.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -27,7 +27,7 @@
     <hive.path.to.root>../..</hive.path.to.root>
     <exclude.tests>None</exclude.tests>
     <!-- Required by Calcite Avatica -->
-    <protobuf.version>3.3.0</protobuf.version>
+    <protobuf.version>3.16.1</protobuf.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <parquet.version>1.11.1</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.16.1</protobuf.version>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.30</slf4j.version>
     <ST4.version>4.0.4</ST4.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,8 +89,8 @@
     <orc.version>1.6.9</orc.version>
     <!-- com.google repo will be used except on Aarch64 platform. -->
     <protobuf.group>com.google.protobuf</protobuf.group>
-    <protobuf.version>2.6.1</protobuf.version>
-    <protobuf-exc.version>2.6.1</protobuf-exc.version>
+    <protobuf.version>3.16.1</protobuf.version>
+    <protobuf-exc.version>3.16.1</protobuf-exc.version>
     <sqlline.version>1.9.0</sqlline.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>
@@ -531,7 +531,7 @@
       <id>aarch64</id>
       <properties>
         <protobuf.group>com.github.os72</protobuf.group>
-        <protobuf-exc.version>2.6.1-build3</protobuf-exc.version>
+        <protobuf-exc.version>3.16.1-build3</protobuf-exc.version>
       </properties>
       <activation>
         <os>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade protobuf-java to 3.16.1

### Why are the changes needed?
Uptaking new releases to keep up for new features and bug fixes including CVEs.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.
