### PR TITLE
HIVE-26343: Disable TestWebHCatE2e test cause it fails

### DIFF
--- a/hcatalog/webhcat/svr/src/test/java/org/apache/hive/hcatalog/templeton/TestWebHCatE2e.java
+++ b/hcatalog/webhcat/svr/src/test/java/org/apache/hive/hcatalog/templeton/TestWebHCatE2e.java
@@ -61,6 +61,7 @@ import org.junit.Assert;
  *
  * It may be possible to extend this to more than just DDL later.
  */
+@Ignore("HIVE-26343")
 public class TestWebHCatE2e {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestWebHCatE2e.class);


### PR DESCRIPTION
### Why are the changes needed?
Test fails

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
mvn test -Dtest=TestWebHCatE2e