### PR TITLE
HIVE-26345: SQLOperation class output real exception message to jdbc client

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -511,13 +511,17 @@ public class Driver implements IDriver {
   }
 
   private void prepareForCompile(boolean resetTaskIds) throws CommandProcessorException {
-    driverTxnHandler.createTxnManager();
-    DriverState.setDriverState(driverState);
-    prepareContext();
-    setQueryId();
+    try {
+      driverTxnHandler.createTxnManager();
+      DriverState.setDriverState(driverState);
+      prepareContext();
+      setQueryId();
 
-    if (resetTaskIds) {
-      TaskFactory.resetId();
+      if (resetTaskIds) {
+        TaskFactory.resetId();
+      }
+    } catch (Exception e) {
+      DriverUtils.handleException(driverContext, e);
     }
   }
 

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -214,7 +214,7 @@ public class SQLOperation extends ExecuteStatementOperation {
       if (e instanceof OutOfMemoryError) {
         throw e;
       }
-      throw new HiveSQLException("Error running query", e);
+      throw new HiveSQLException("Error running query: " + e.toString(), e);
     }
   }
 
@@ -249,7 +249,7 @@ public class SQLOperation extends ExecuteStatementOperation {
       } else if (e instanceof OutOfMemoryError) {
         throw (OutOfMemoryError) e;
       } else {
-        throw new HiveSQLException("Error running query", e);
+        throw new HiveSQLException("Error running query: " + e.toString(), e);
       }
     }
     setState(OperationState.FINISHED);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See details from  https://issues.apache.org/jira/browse/HIVE-26345
SQLOperation class output real exception message to jdbc client and user can amend the query based on real exception.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Local cluster test.

Before the PR, beeline dispaly exception:
`Error: Error running query (state=,code=0) `

With the PR, beeline dispaly exception:
`Error: Error running query: java.lang.RuntimeException: To use DbTxnManager you must set hive.support.concurrency=true (state=,code=0)`
