### PR TITLE
HIVE-26292 GroupByOperator initialization does not clean state

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
@@ -204,6 +204,7 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
     super.initializeOp(hconf);
     numRowsInput = 0;
     numRowsHashTbl = 0;
+    currentKeys = null;
 
     heartbeatInterval = HiveConf.getIntVar(hconf,
         HiveConf.ConfVars.HIVESENDHEARTBEAT);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Issue identified in [HIVE-14222](https://issues.apache.org/jira/browse/HIVE-14222). 
GroupByOperator::initializeOp() does not reset currentKeys to null. This leads to incorrect result.

