### PR TITLE
HIVE-26021: Change integration tests under DBInstallBase to Checkin tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ OPTS+=" -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugin.surefire.SurefirePl
 OPTS+=" -Dmaven.repo.local=$PWD/.git/m2"
 git config extra.mavenOpts "$OPTS"
 OPTS=" $M_OPTS -Dmaven.test.failure.ignore "
-if [ -s inclusions.txt ]; then OPTS+=" -Dsurefire.includesFile=$PWD/inclusions.txt"; sed -i '/\\/ITest/d' $PWD/inclusions.txt;fi
+if [ -s inclusions.txt ]; then OPTS+=" -Dsurefire.includesFile=$PWD/inclusions.txt";fi
 if [ -s exclusions.txt ]; then OPTS+=" -Dsurefire.excludesFile=$PWD/exclusions.txt";fi
 mvn $OPTS '''+args+'''
 du -h --max-depth=1
@@ -278,15 +278,6 @@ export DBNAME=metastore
 reinit_metastore $dbType
 time docker rm -f dev_$dbType || true
 '''
-          }
-          stage('verify') {
-            try {
-              sh """#!/bin/bash -e
-mvn verify -DskipITests=false -Dit.test=ITest${dbType.capitalize()} -Dtest=nosuch -pl standalone-metastore/metastore-server -Dmaven.test.failure.ignore -B
-"""
-            } finally {
-              junit '**/TEST-*.xml'
-            }
           }
         }
       }

--- a/standalone-metastore/DEV-README
+++ b/standalone-metastore/DEV-README
@@ -10,7 +10,7 @@ checkin tests before loading a patch.
 To run just the checkin tests:
 'mvn test -Dtest.groups=org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest'
 
-To run all of the tests (exclusive of the databases tests, see below):
+To run all the tests:
 'mvn test -Dtest.groups=""'.  At the moment this takes around 25 minutes.
 
 When adding a test, if you want it to run as part of the unit tests annotate it
@@ -23,47 +23,34 @@ quick test can be done for the unit tests and more in depth testing as part
 of the checkin tests.
 
 --------------------------------------------------------------------------------
-There are integration tests for testing installation and upgrade of the
+There are checkin tests for testing installation and upgrade of the
 metastore on Derby, MySQL (actually MariaDB is used), Oracle, Postgres, and SQLServer.
 
-Each ITest runs two tests, one that installs the latest version of the
+For each DB type we runs two tests, one that installs the latest version of the
 database and one that installs the latest version minus one and then upgrades
 the database.
 
-To run the tests you will need to explicitly turn on integration testing by
-setting skipITests variable to false. The tests rely on Docker so the latter
-needs to be installed and configured properly (e.g., memory more than 3.5GB).
-
-Run all tests:
-
-mvn verify -DskipITests=false -Dtest=nosuch
+The tests (except Derby) rely on Docker so the latter needs to be installed and configured
+properly (e.g., memory more than 3.5GB).
 
 Run a single test:
 
-mvn verify -DskipITests=false -Dit.test=ITestMysql -Dtest=nosuch
+mvn test -Dtest.groups=MetastoreCheckinTest -Dtest=ITestDerby
 
 Supported databases for testing:
--Dit.test=ITestDerby
--Dit.test=ITestMysql
--Dit.test=ITestOracle
--Dit.test=ITestPostgres
--Dit.test=ITestMssql
+ITestDerby
+ITestMysql
+ITestOracle
+ITestPostgres
+ITestMssql
 
 By adding -Dverbose.schematool the Schema Tool output becomes more detailed.
 
-Logs for tests are located under standalone-metastore/metastore-common/target/failsafe-reports
-
 If you wish to use one of these containers to run your own tests against a
 non-Derby version of the metastore, you can do that as well.  You must specify
-that only the install test be run (change -Dit.test=ITestMysql in the example
-above to -Dit.test=ITestMysql#install) and tell it to leave the docker container
+that only the install test be run (-Dtest=ITestMysql#install) and tell it to leave the docker container
 running by adding -Dmetastore.itest.no.stop.container=true.  You will then need
 to stop and remove the container yourself once you have finished.  The container
 is recreated for each run of the test, so you cannot rerun the test until you
 have stopped and removed it.  You can construct the connection values to put in
-metastore-site.xml from the information in the appropriate ITest file (e.g.,
-from ITestMysql you can find that the JDBC URL is
-"jdbc:mysql://localhost:3306/hivedb", the JDBC driver is
-"org.mariadb.jdbc.Driver", and the password is "hivepassword".  The user is
-always "hiveuser".
-
+metastore-site.xml from the information in the DatabaseRule and its subclasses.

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -548,37 +548,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <reuseForks>false</reuseForks>
-          <argLine>-Xmx2048m</argLine>
-          <failIfNoTests>false</failIfNoTests>
-          <systemPropertyVariables>
-            <log4j.debug>true</log4j.debug>
-            <java.io.tmpdir>${test.tmp.dir}</java.io.tmpdir>
-            <test.tmp.dir>${test.tmp.dir}</test.tmp.dir>
-            <hive.in.test>true</hive.in.test>
-            <derby.version>${derby.version}</derby.version>
-            <derby.stream.error.file>${test.tmp.dir}/derby.log</derby.stream.error.file>
-          </systemPropertyVariables>
-          <additionalClasspathElements>
-            <additionalClasspathElement>${log4j.conf.dir}</additionalClasspathElement>
-          </additionalClasspathElements>
-          <skipITs>${skipITests}</skipITs>
-          <!-- set this to false to run these tests -->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/DbInstallBase.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/DbInstallBase.java
@@ -18,10 +18,13 @@
 package org.apache.hadoop.hive.metastore.dbinstall;
 
 import org.apache.hadoop.hive.metastore.HiveMetaException;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.dbinstall.rules.DatabaseRule;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(MetastoreCheckinTest.class)
 public abstract class DbInstallBase {
   private static final String FIRST_VERSION = "1.2.0";
 


### PR DESCRIPTION
### Why are the changes needed?
- Simplify execution of tests by developers and CI
- Extend test coverage to include `mysql` and `mssql` install upgrade tests

### Does this PR introduce _any_ user-facing change?
Only developers are affected since tests are now run differently.

### How was this patch tested?
```
mvn test -Dtest.groups=MetastoreCheckinTest -pl standalone-metastore/metastore-server -Dtest=ITestDerby,ITestOracle,ITestPostgres,ITestMssql,ITestMysql
```