### PR TITLE
HIVE-26349: TestOperatorCmp/TestReOptimization fail silently due to incompatible configuration

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/plan/mapping/TestOperatorCmp.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/plan/mapping/TestOperatorCmp.java
@@ -194,6 +194,7 @@ public class TestOperatorCmp {
     conf.setBoolVar(ConfVars.HIVE_QUERY_REEXECUTION_ENABLED, true);
     conf.setBoolVar(ConfVars.HIVE_VECTORIZATION_ENABLED, false);
     conf.setBoolVar(ConfVars.HIVE_QUERY_REEXECUTION_ALWAYS_COLLECT_OPERATOR_STATS, true);
+    conf.setVar(ConfVars.HIVE_CBO_FALLBACK_STRATEGY, "NEVER");
     conf.setVar(ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES, "reoptimize");
     conf.set("zzz", "1");
     conf.set("reexec.overlay.zzz", "2000");

--- a/ql/src/test/org/apache/hadoop/hive/ql/plan/mapping/TestReOptimization.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/plan/mapping/TestReOptimization.java
@@ -294,6 +294,7 @@ public class TestReOptimization {
 
     conf.setBoolVar(ConfVars.HIVE_QUERY_REEXECUTION_ENABLED, true);
     conf.setBoolVar(ConfVars.HIVE_VECTORIZATION_ENABLED, false);
+    conf.setVar(ConfVars.HIVE_CBO_FALLBACK_STRATEGY, "NEVER");
     conf.setVar(ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES, strategies);
     conf.setBoolVar(ConfVars.HIVE_EXPLAIN_USER, true);
     conf.set("zzz", "1");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the value of HIVE_CBO_FALLBACK_STRATEGY to NEVER for these tests.

### Why are the changes needed?
Avoid test failures due to incompatible behavior in HIVE_QUERY_REEXECUTION_STRATEGIES

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn test -Dtest=TestOperatorCmp
mvn test -Dtest=TestReOptimization
```