### PR TITLE
HIVE-26352: Tez queue access check fails with GSS Exception on Compaction

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
@@ -23,10 +23,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -92,6 +94,20 @@ public class YarnQueueHelper {
   }
 
   public void checkQueueAccess(
+      String queueName, String userName) throws IOException, InterruptedException {
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    ugi.doAs((PrivilegedExceptionAction<Object>) () -> {
+      checkQueueAccessInternal(queueName, userName);
+      return null;
+    });
+    try {
+      FileSystem.closeAllForUGI(ugi);
+    } catch (IOException exception) {
+      LOG.error("Could not clean up file-system handles for UGI: " + ugi, exception);
+    }
+  }
+
+  private void checkQueueAccessInternal(
       String queueName, String userName) throws IOException, HiveException {
     String urlSuffix = String.format(PERMISSION_PATH, queueName, userName);
     // TODO: if we ever use this endpoint for anything else, refactor cycling into a separate class.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
@@ -96,14 +96,17 @@ public class YarnQueueHelper {
   public void checkQueueAccess(
       String queueName, String userName) throws IOException, InterruptedException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-    ugi.doAs((PrivilegedExceptionAction<Object>) () -> {
-      checkQueueAccessInternal(queueName, userName);
-      return null;
-    });
     try {
-      FileSystem.closeAllForUGI(ugi);
-    } catch (IOException exception) {
-      LOG.error("Could not clean up file-system handles for UGI: " + ugi, exception);
+      ugi.doAs((PrivilegedExceptionAction<Void>) () -> {
+        checkQueueAccessInternal(queueName, userName);
+        return null;
+      });
+    } finally {
+      try {
+        FileSystem.closeAllForUGI(ugi);
+      } catch (IOException exception) {
+        LOG.error("Could not clean up file-system handles for UGI: " + ugi, exception);
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Yarn queue check url now called with the HIVE login user's credentials.

### Why are the changes needed?
The queue check url was called with empty credentials, and therefore failed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually