### PR TITLE
HIVE-26355: Column compare should be case insensitive for name

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -505,6 +505,16 @@ public class MetaStoreServerUtils {
     params.remove(StatsSetupConst.NUM_ERASURE_CODED_FILES);
   }
 
+  /**
+   * Compare the names, types and comments of two lists of {@link FieldSchema}.
+   * <p>
+   * The name of {@link FieldSchema} is compared in the case-insensitive mode
+   * because all names in Hive are case-insensitive.
+   *
+   * @param oldCols old columns
+   * @param newCols new columns
+   * @return true if the two columns are the same, false otherwise
+   */
   public static boolean areSameColumns(List<FieldSchema> oldCols, List<FieldSchema> newCols) {
     if (oldCols == newCols) {
       return true;
@@ -524,6 +534,8 @@ public class MetaStoreServerUtils {
 
   /**
    * Returns true if p is a prefix of s.
+   * <p>
+   * The compare of {@link FieldSchema} is the same as {@link #areSameColumns(List, List)}.
    */
   public static boolean arePrefixColumns(List<FieldSchema> p, List<FieldSchema> s) {
     if (p == s) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -506,7 +506,20 @@ public class MetaStoreServerUtils {
   }
 
   public static boolean areSameColumns(List<FieldSchema> oldCols, List<FieldSchema> newCols) {
-    return ListUtils.isEqualList(oldCols, newCols);
+    if (oldCols == newCols) {
+      return true;
+    }
+    if (oldCols == null || newCols == null || oldCols.size() != newCols.size()) {
+      return false;
+    }
+    // We should ignore the case of field names, because some computing engines are case-sensitive, such as Spark.
+    List<FieldSchema> transformedOldCols = oldCols.stream()
+        .map(col -> new FieldSchema(col.getName().toLowerCase(), col.getType(), col.getComment()))
+        .collect(Collectors.toList());
+    List<FieldSchema> transformedNewCols = newCols.stream()
+        .map(col -> new FieldSchema(col.getName().toLowerCase(), col.getType(), col.getComment()))
+        .collect(Collectors.toList());
+    return ListUtils.isEqualList(transformedOldCols, transformedNewCols);
   }
 
   /**
@@ -516,10 +529,10 @@ public class MetaStoreServerUtils {
     if (p == s) {
       return true;
     }
-    if (p.size() > s.size()) {
+    if (p == null || s == null || p.size() > s.size()) {
       return false;
     }
-    return ListUtils.isEqualList(p, s.subList(0, p.size()));
+    return areSameColumns(p, s.subList(0, p.size()));
   }
 
   public static void updateBasicState(EnvironmentContext environmentContext, Map<String,String>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -884,5 +884,33 @@ public class TestMetaStoreServerUtils {
     sd.setLocation("s3a://bucket/other_path");
     Assert.assertTrue(MetaStoreUtils.validateTblStorage(sd));
   }
+
+  @Test
+  public void testSameColumns() {
+    FieldSchema col1 = new FieldSchema("col1", "string", "col1 comment");
+    FieldSchema Col1 = new FieldSchema("Col1", "string", "col1 comment");
+    FieldSchema col2 = new FieldSchema("col2", "string", "col2 comment");
+    Assert.assertTrue(MetaStoreServerUtils.areSameColumns(null, null));
+    Assert.assertFalse(MetaStoreServerUtils.areSameColumns(Arrays.asList(col1), null));
+    Assert.assertFalse(MetaStoreServerUtils.areSameColumns(null, Arrays.asList(col1)));
+    Assert.assertTrue(MetaStoreServerUtils.areSameColumns(Arrays.asList(col1), Arrays.asList(col1)));
+    Assert.assertTrue(MetaStoreServerUtils.areSameColumns(Arrays.asList(col1, col2), Arrays.asList(col1, col2)));
+    Assert.assertTrue(MetaStoreServerUtils.areSameColumns(Arrays.asList(Col1, col2), Arrays.asList(col1, col2)));
+  }
+
+  @Test
+  public void testPrefixColumns() {
+    FieldSchema col1 = new FieldSchema("col1", "string", "col1 comment");
+    FieldSchema Col1 = new FieldSchema("Col1", "string", "col1 comment");
+    FieldSchema col2 = new FieldSchema("col2", "string", "col2 comment");
+    FieldSchema col3 = new FieldSchema("col3", "string", "col3 comment");
+    Assert.assertTrue(MetaStoreServerUtils.arePrefixColumns(null, null));
+    Assert.assertFalse(MetaStoreServerUtils.arePrefixColumns(Arrays.asList(col1), null));
+    Assert.assertFalse(MetaStoreServerUtils.arePrefixColumns(null, Arrays.asList(col1)));
+    Assert.assertTrue(MetaStoreServerUtils.arePrefixColumns(Arrays.asList(col1), Arrays.asList(col1)));
+    Assert.assertTrue(MetaStoreServerUtils.arePrefixColumns(Arrays.asList(col1, col2), Arrays.asList(col1, col2, col3)));
+    Assert.assertTrue(MetaStoreServerUtils.arePrefixColumns(Arrays.asList(Col1, col2), Arrays.asList(col1, col2, col3)));
+    Assert.assertFalse(MetaStoreServerUtils.arePrefixColumns(Arrays.asList(col1, col2, col3), Arrays.asList(col1, col2)));
+  }
 }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix a bug in comparing column fields between old table and new table.


### Why are the changes needed?
Hive is case-insensitive in field name, but some engines are case-sensitive, so when calling `alter_table` the existing column name may not be equal because of the case.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
We add two unit tests, can be run with command:
```bash
$ mvn test -Dtest=org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils -pl :hive-standalone-metastore-server
```
