### PR TITLE
HIVE-26371: Constant propagation does not evaluate constraint expressions at merge when CBO is enabled

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/Optimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/Optimizer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.HiveOpConverterPostProc;
 import org.apache.hadoop.hive.ql.optimizer.correlation.CorrelationOptimizer;
 import org.apache.hadoop.hive.ql.optimizer.correlation.ReduceSinkDeDuplication;
@@ -109,9 +110,10 @@ public class Optimizer {
     }
 
     if (HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVEOPTCONSTANTPROPAGATION) &&
-            !pctx.getContext().isCboSucceeded()) {
+        (!pctx.getContext().isCboSucceeded() || pctx.getContext().getOperation() == Context.Operation.MERGE)) {
       // We run constant propagation twice because after predicate pushdown, filter expressions
       // are combined and may become eligible for reduction (like is not null filter).
+      // CBO can not handle merge statements and some constraint check can be evaluated by constant propagation
       transformations.add(new ConstantPropagate());
     }
 

--- a/ql/src/test/queries/clientnegative/check_merge.q
+++ b/ql/src/test/queries/clientnegative/check_merge.q
@@ -1,0 +1,19 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+CREATE TABLE t_target(
+name string CHECK (length(name)<=20),
+age int,
+gpa double CHECK (gpa BETWEEN 0.0 AND 4.0))
+stored as orc TBLPROPERTIES ('transactional'='true');
+
+CREATE TABLE t_source(
+name string,
+age int,
+gpa double);
+
+insert into t_source(name, age, gpa) values ('student1', 16, null);
+
+insert into t_target(name, age, gpa) values ('student1', 16, 2.0);
+
+merge into t_target using t_source source on source.age=t_target.age when matched then update set gpa=6;

--- a/ql/src/test/results/clientnegative/check_merge.q.out
+++ b/ql/src/test/results/clientnegative/check_merge.q.out
@@ -1,0 +1,53 @@
+PREHOOK: query: CREATE TABLE t_target(
+name string CHECK (length(name)<=20),
+age int,
+gpa double CHECK (gpa BETWEEN 0.0 AND 4.0))
+stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_target
+POSTHOOK: query: CREATE TABLE t_target(
+name string CHECK (length(name)<=20),
+age int,
+gpa double CHECK (gpa BETWEEN 0.0 AND 4.0))
+stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_target
+PREHOOK: query: CREATE TABLE t_source(
+name string,
+age int,
+gpa double)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_source
+POSTHOOK: query: CREATE TABLE t_source(
+name string,
+age int,
+gpa double)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_source
+PREHOOK: query: insert into t_source(name, age, gpa) values ('student1', 16, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_source
+POSTHOOK: query: insert into t_source(name, age, gpa) values ('student1', 16, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_source
+POSTHOOK: Lineage: t_source.age SCRIPT []
+POSTHOOK: Lineage: t_source.gpa EXPRESSION []
+POSTHOOK: Lineage: t_source.name SCRIPT []
+PREHOOK: query: insert into t_target(name, age, gpa) values ('student1', 16, 2.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t_target
+POSTHOOK: query: insert into t_target(name, age, gpa) values ('student1', 16, 2.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t_target
+POSTHOOK: Lineage: t_target.age SCRIPT []
+POSTHOOK: Lineage: t_target.gpa SCRIPT []
+POSTHOOK: Lineage: t_target.name SCRIPT []
+FAILED: DataConstraintViolationError org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: Either CHECK or NOT NULL constraint violated!

--- a/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
@@ -2939,15 +2939,16 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
-                    dataColumnCount: 4
-                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:string, VALUE._col1:string, VALUE._col2:string
+                    dataColumnCount: 1
+                    dataColumns: KEY.reducesinkkey0:string
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: []
+                    scratchColumnTypeNames: [string, string, string, string]
             Reduce Operator Tree:
                 Select Vectorization:
                     className: VectorSelectOperator
                     native: true
-                    projectedOutputColumnNums: [0, 1, 2, 3]
+                    projectedOutputColumnNums: [1, 2, 3, 4]
+                    selectExpressions: ConstantVectorExpression(val this) -> 1:string, ConstantVectorExpression(val should) -> 2:string, ConstantVectorExpression(val not) -> 3:string, ConstantVectorExpression(val be there) -> 4:string
                   File Sink Vectorization:
                       className: VectorFileSinkOperator
                       native: false

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -2583,11 +2583,11 @@ STAGE PLANS:
                     predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), '1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
+                      expressions: _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
-                        predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
+                        predicate: enforce_constraint(((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false) (type: boolean)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
@@ -2595,7 +2595,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2649,7 +2649,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -2852,11 +2852,11 @@ STAGE PLANS:
                     predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), '1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
+                      expressions: _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
-                        predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
+                        predicate: enforce_constraint(((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false) (type: boolean)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
@@ -2864,7 +2864,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2939,7 +2939,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
@@ -163,8 +163,8 @@ STAGE PLANS:
                     predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int), 7 (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: _col2 (type: int)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -172,7 +172,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: _col2 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -244,7 +243,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -750,8 +749,8 @@ STAGE PLANS:
                     predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int), 7 (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: _col2 (type: int)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -759,7 +758,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: _col2 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -831,7 +829,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -4637,8 +4637,8 @@ STAGE PLANS:
                     predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), '1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
+                      expressions: _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
@@ -4649,7 +4649,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -4703,7 +4703,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -4923,8 +4923,8 @@ STAGE PLANS:
                     predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), '1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
+                      expressions: _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
@@ -4935,7 +4935,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5010,7 +5010,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -5495,8 +5495,8 @@ STAGE PLANS:
                     predicate: ((_col5 = _col1) and (_col1 < 3)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col5 (type: int), '1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
+                      expressions: _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
                       Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
@@ -5507,7 +5507,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col5 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5566,7 +5566,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), '1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
@@ -2860,28 +2860,24 @@ STAGE PLANS:
                   predicate: _col0 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col1 (type: int), 'a1' (type: string), null (type: void)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: _col1 (type: int)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                      Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
-                      Select Operator
-                        expressions: _col0 (type: int), _col1 (type: string), CAST( _col2 AS STRING) (type: string)
-                        outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col2 (type: string)
-                          null sort order: a
-                          sort order: +
-                          Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: null (type: string)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: null (type: string)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), 'a1' (type: string), null (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -2894,7 +2890,7 @@ STAGE PLANS:
                       name: default.acidtable
                   Write Type: INSERT
                 Select Operator
-                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
+                  expressions: _col0 (type: int), 'a1' (type: string), null (type: string)
                   outputColumnNames: key, a1, value
                   Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
@@ -3120,40 +3116,36 @@ STAGE PLANS:
                     predicate: ((_col4 = _col1) and (_col1 > 3) and (_col1 >= 3)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), 'a1' (type: string), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
                           null sort order: a
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: int), _col1 (type: string)
+                          Statistics: Num rows: 1 Data size: 94 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int)
                   Filter Operator
                     predicate: _col4 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), null (type: void)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 95 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col1 (type: int), _col0 (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 91 Basic stats: COMPLETE Column stats: COMPLETE
                       Filter Operator
                         predicate: enforce_constraint(_col0 is not null) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 95 Basic stats: COMPLETE Column stats: COMPLETE
-                        Select Operator
-                          expressions: _col0 (type: int), _col1 (type: string), CAST( _col2 AS STRING) (type: string)
-                          outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 1 Data size: 175 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            key expressions: _col2 (type: string)
-                            null sort order: a
-                            sort order: +
-                            Map-reduce partition columns: _col2 (type: string)
-                            Statistics: Num rows: 1 Data size: 175 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: int), _col1 (type: string)
+                        Statistics: Num rows: 1 Data size: 91 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: null (type: string)
+                          null sort order: a
+                          sort order: +
+                          Map-reduce partition columns: null (type: string)
+                          Statistics: Num rows: 1 Data size: 91 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: string)
                   Filter Operator
                     predicate: (_col4 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3211,7 +3203,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), 'a1' (type: string), KEY.reducesinkkey0 (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 180 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -3227,7 +3219,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), null (type: string)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 175 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -3474,20 +3466,18 @@ STAGE PLANS:
                   predicate: _col0 is null (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
-                    expressions: 404 (type: int)
-                    outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
-                      key expressions: _col0 (type: int)
+                      key expressions: 404 (type: int)
                       null sort order: a
                       sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
+                      Map-reduce partition columns: 404 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int)
+                expressions: 404 (type: int)
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -3500,7 +3490,7 @@ STAGE PLANS:
                       name: default.acidtable2
                   Write Type: INSERT
                 Select Operator
-                  expressions: _col0 (type: int)
+                  expressions: 404 (type: int)
                   outputColumnNames: key
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Group By Operator

--- a/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
@@ -146,8 +146,8 @@ STAGE PLANS:
                     predicate: ((_col2 = _col3) and (_col3 <= 8)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: _col2 (type: int), 7 (type: int)
-                      outputColumnNames: _col0, _col1
+                      expressions: _col2 (type: int)
+                      outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
@@ -155,7 +155,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: _col2 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -227,7 +226,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -663,7 +662,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), 7 (type: int)
+                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col2 = _col3) (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -721,7 +720,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 7 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
@@ -218,16 +218,15 @@ STAGE PLANS:
                     predicate: (_col3 = _col0) (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: int), 99 (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: _col3 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
@@ -283,7 +282,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 99 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -778,30 +777,30 @@ STAGE PLANS:
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), 99 (type: int), _col3 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: int), _col3 (type: int)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: int)
                   Filter Operator
                     predicate: _col4 is null (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: int), _col1 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -843,7 +842,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 99 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -859,7 +858,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1097,30 +1096,30 @@ STAGE PLANS:
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), 98 (type: int), _col3 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: int), _col3 (type: int)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: int)
                   Filter Operator
                     predicate: _col4 is null (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: int), _col1 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1162,7 +1161,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 98 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1178,7 +1177,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1416,30 +1415,30 @@ STAGE PLANS:
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), 97 (type: int), _col3 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: int), _col3 (type: int)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: int)
                   Filter Operator
                     predicate: _col4 is null (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: int), _col1 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1481,7 +1480,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 97 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1497,7 +1496,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1735,30 +1734,30 @@ STAGE PLANS:
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col4 (type: int), 96 (type: int), _col3 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col4 (type: int), _col3 (type: int)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: int)
                   Filter Operator
                     predicate: _col4 is null (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col0 (type: int), _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col0 (type: int), _col1 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
                   Filter Operator
                     predicate: (_col4 = _col0) (type: boolean)
                     Statistics: Num rows: 2 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1800,7 +1799,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 96 (type: int), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -1816,7 +1815,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
                 Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -2103,16 +2102,15 @@ STAGE PLANS:
                     predicate: _col3 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col1 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (_col3 = _col0) (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2154,7 +2152,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -2419,30 +2417,28 @@ STAGE PLANS:
                     predicate: (_col3 = _col0) (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col3 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col3 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: _col3 is null (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      expressions: _col1 (type: int), 1 (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      expressions: _col1 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: a
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (_col3 = _col0) (type: boolean)
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2484,7 +2480,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
@@ -2500,7 +2496,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                expressions: KEY.reducesinkkey0 (type: int), 1 (type: int)
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable constant propagation for merge statments after predicate push down even if CBO succeeded.

### Why are the changes needed?
CBO can not handle merge statements and enforce constraint call is added after CBO. This case the constant propagator delivered by Hive is called only with the option `ConstantPropagateOption.SHORTCUT` but with this setting the algorithm does not evaluate deterministic functions like `BETWEEN`.
As a result constraint checks having expressions with constants are also evaluated at execution time only.

### Does this PR introduce _any_ user-facing change?
No. But when submitting a merge statement constraint violations may detected faster.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestNegativeLlapCliDriver -Dqfile=check_merge.q -pl itests/qtest -Pitests
```