### PR TITLE
HIVE-26373: ClassCastException while inserting Avro data into Hbase table for nested struct with Timestamp

### DIFF
--- a/data/files/nested_ts.avsc
+++ b/data/files/nested_ts.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "name": "TableRecord",
+  "namespace": "org.apache.hive",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "dischargedate",
+      "type": {
+        "name": "DateRecord",
+        "type": "record",
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "type": "long",
+              "logicalType": "timestamp-millis"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
+++ b/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
@@ -1,5 +1,7 @@
 dfs -cp ${system:hive.root}data/files/nested_ts.avsc ${system:test.tmp.dir}/nested_ts.avsc;
 
+set hive.avro.timestamp.skip.conversion=true;
+
 CREATE EXTERNAL TABLE tbl(
 `key` string COMMENT '',
 `data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
@@ -18,4 +20,5 @@ TBLPROPERTIES (
 
 set hive.vectorized.execution.enabled=false;
 set hive.fetch.task.conversion=none;
+
 select data_frV4.dischargedate.value from tbl;

--- a/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
+++ b/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
@@ -1,0 +1,21 @@
+dfs -cp ${system:hive.root}data/files/nested_ts.avsc ${system:test.tmp.dir}/nested_ts.avsc;
+
+CREATE EXTERNAL TABLE tbl(
+`key` string COMMENT '',
+`data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
+ROW FORMAT SERDE
+  'org.apache.hadoop.hive.hbase.HBaseSerDe'
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+'serialization.format'='1',
+'hbase.columns.mapping' = ':key,data:frV4',
+'data.frV4.serialization.type'='avro',
+'data.frV4.avro.schema.url'='${system:test.tmp.dir}/nested_ts.avsc'
+)
+TBLPROPERTIES (
+'hbase.table.name' = 'HiveAvroTable',
+'hbase.struct.autogenerate'='true');
+
+set hive.vectorized.execution.enabled=false;
+set hive.fetch.task.conversion=none;
+select data_frV4.dischargedate.value from tbl;

--- a/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
+++ b/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
@@ -1,6 +1,6 @@
 dfs -cp ${system:hive.root}data/files/nested_ts.avsc ${system:test.tmp.dir}/nested_ts.avsc;
 
-CREATE EXTERNAL TABLE tbl(
+CREATE EXTERNAL TABLE hbase_avro_table(
 `key` string COMMENT '',
 `data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
 ROW FORMAT SERDE
@@ -19,4 +19,4 @@ TBLPROPERTIES (
 set hive.vectorized.execution.enabled=false;
 set hive.fetch.task.conversion=none;
 
-select data_frV4.dischargedate.value from tbl;
+select data_frV4.dischargedate.value from hbase_avro_table;

--- a/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
+++ b/hbase-handler/src/test/queries/positive/hbase_avro_nested_timestamp.q
@@ -1,7 +1,5 @@
 dfs -cp ${system:hive.root}data/files/nested_ts.avsc ${system:test.tmp.dir}/nested_ts.avsc;
 
-set hive.avro.timestamp.skip.conversion=true;
-
 CREATE EXTERNAL TABLE tbl(
 `key` string COMMENT '',
 `data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)

--- a/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
@@ -1,0 +1,45 @@
+PREHOOK: query: CREATE EXTERNAL TABLE tbl(
+`key` string COMMENT '',
+`data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
+ROW FORMAT SERDE
+  'org.apache.hadoop.hive.hbase.HBaseSerDe'
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+'serialization.format'='1',
+'hbase.columns.mapping' = ':key,data:frV4',
+'data.frV4.serialization.type'='avro',
+#### A masked pattern was here ####
+)
+TBLPROPERTIES (
+'hbase.table.name' = 'HiveAvroTable',
+'hbase.struct.autogenerate'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: CREATE EXTERNAL TABLE tbl(
+`key` string COMMENT '',
+`data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
+ROW FORMAT SERDE
+  'org.apache.hadoop.hive.hbase.HBaseSerDe'
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES (
+'serialization.format'='1',
+'hbase.columns.mapping' = ':key,data:frV4',
+'data.frV4.serialization.type'='avro',
+#### A masked pattern was here ####
+)
+TBLPROPERTIES (
+'hbase.table.name' = 'HiveAvroTable',
+'hbase.struct.autogenerate'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+PREHOOK: query: select data_frV4.dischargedate.value from tbl
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl
+#### A masked pattern was here ####
+POSTHOOK: query: select data_frV4.dischargedate.value from tbl
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl
+#### A masked pattern was here ####
+1970-01-19 20:16:19.2

--- a/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
@@ -42,4 +42,4 @@ POSTHOOK: query: select data_frV4.dischargedate.value from tbl
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl
 #### A masked pattern was here ####
-2022-07-04 17:00:00
+2022-07-05 00:00:00

--- a/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
@@ -42,4 +42,4 @@ POSTHOOK: query: select data_frV4.dischargedate.value from tbl
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl
 #### A masked pattern was here ####
-1970-01-19 20:16:19.2
+2022-07-04 17:00:00

--- a/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_avro_nested_timestamp.q.out
@@ -1,4 +1,4 @@
-PREHOOK: query: CREATE EXTERNAL TABLE tbl(
+PREHOOK: query: CREATE EXTERNAL TABLE hbase_avro_table(
 `key` string COMMENT '',
 `data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
 ROW FORMAT SERDE
@@ -15,8 +15,8 @@ TBLPROPERTIES (
 'hbase.struct.autogenerate'='true')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
-PREHOOK: Output: default@tbl
-POSTHOOK: query: CREATE EXTERNAL TABLE tbl(
+PREHOOK: Output: default@hbase_avro_table
+POSTHOOK: query: CREATE EXTERNAL TABLE hbase_avro_table(
 `key` string COMMENT '',
 `data_frv4` struct<`id`:string, `dischargedate`:struct<`value`:timestamp>>)
 ROW FORMAT SERDE
@@ -33,13 +33,13 @@ TBLPROPERTIES (
 'hbase.struct.autogenerate'='true')
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
-POSTHOOK: Output: default@tbl
-PREHOOK: query: select data_frV4.dischargedate.value from tbl
+POSTHOOK: Output: default@hbase_avro_table
+PREHOOK: query: select data_frV4.dischargedate.value from hbase_avro_table
 PREHOOK: type: QUERY
-PREHOOK: Input: default@tbl
+PREHOOK: Input: default@hbase_avro_table
 #### A masked pattern was here ####
-POSTHOOK: query: select data_frV4.dischargedate.value from tbl
+POSTHOOK: query: select data_frV4.dischargedate.value from hbase_avro_table
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@tbl
+POSTHOOK: Input: default@hbase_avro_table
 #### A masked pattern was here ####
 2022-07-05 00:00:00

--- a/itests/util/src/main/java/org/apache/hadoop/hive/hbase/HBaseTestSetup.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/hbase/HBaseTestSetup.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.hbase;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -172,8 +173,8 @@ public class HBaseTestSetup extends QTestSetup {
   }
 
   private static byte[] createAvroRecordWithNestedTimestamp() throws IOException {
-    String dataDir = System.getProperty("test.data.dir");
-    Schema schema = new Schema.Parser().parse(new File(dataDir + File.separator + "nested_ts.avsc"));
+    File schemaFile = Paths.get(System.getProperty("test.data.dir"), "nested_ts.avsc").toFile();
+    Schema schema = new Schema.Parser().parse(schemaFile);
     GenericData.Record rootRecord = new GenericData.Record(schema);
     rootRecord.put("id", "X338092");
     GenericData.Record dateRecord = new GenericData.Record(schema.getField("dischargedate").schema());

--- a/itests/util/src/main/java/org/apache/hadoop/hive/hbase/HBaseTestSetup.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/hbase/HBaseTestSetup.java
@@ -22,7 +22,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 
 import org.apache.avro.Schema;
@@ -176,7 +177,9 @@ public class HBaseTestSetup extends QTestSetup {
     GenericData.Record rootRecord = new GenericData.Record(schema);
     rootRecord.put("id", "X338092");
     GenericData.Record dateRecord = new GenericData.Record(schema.getField("dischargedate").schema());
-    dateRecord.put("value", LocalDate.of(2022,7,5).atStartOfDay().atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
+    final LocalDateTime _2022_07_05 = LocalDate.of(2022, 7, 5).atStartOfDay();
+    // Store in UTC as required per Avro specification and as done by Hive in other parts of the system
+    dateRecord.put("value", _2022_07_05.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
     rootRecord.put("dischargedate", dateRecord);
 
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroLazyObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroLazyObjectInspector.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.serde2.avro;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -498,6 +499,6 @@ public class AvroLazyObjectInspector extends LazySimpleStructObjectInspector {
    * */
   private boolean isPrimitive(Class<?> clazz) {
     return clazz.isPrimitive() || ClassUtils.wrapperToPrimitive(clazz) != null
-        || clazz.getSimpleName().equals("String");
+      || Arrays.asList("String", "Timestamp").contains(clazz.getSimpleName());
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
`isPrimitive` returns `true` for Timestamp


### Why are the changes needed?
`isPrimitive` was returning `false` and because of that `Timestamp` type was not getting converted to `LazyTimestamp`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
`mvn test -Dtest=TestHBaseCliDriver -Dtest.output.overwrite=true -Dqfile=hbase_avro_nested_timestamp.q`
