### PR TITLE
HIVE-26376: HMS leaks filesystem objects (memory) when using StorageBasedAuthorizationProvider

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -407,24 +407,25 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
       return;
     }
 
-    final FileSystem fs = path.getFileSystem(conf);
+    try(FileSystem fs = path.getFileSystem(conf)) {
 
-    FileStatus pathStatus = FileUtils.getFileStatusOrNull(fs, path);
-    if (pathStatus != null) {
-      checkPermissions(fs, pathStatus, actions, authenticator.getUserName());
-    } else if (path.getParent() != null) {
-      // find the ancestor which exists to check its permissions
-      Path par = path.getParent();
-      FileStatus parStatus = null;
-      while (par != null) {
-        parStatus = FileUtils.getFileStatusOrNull(fs, par);
-        if (parStatus != null) {
-          break;
+      FileStatus pathStatus = FileUtils.getFileStatusOrNull(fs, path);
+      if (pathStatus != null) {
+        checkPermissions(fs, pathStatus, actions, authenticator.getUserName());
+      } else if (path.getParent() != null) {
+        // find the ancestor which exists to check its permissions
+        Path par = path.getParent();
+        FileStatus parStatus = null;
+        while (par != null) {
+          parStatus = FileUtils.getFileStatusOrNull(fs, par);
+          if (parStatus != null) {
+            break;
+          }
+          par = par.getParent();
         }
-        par = par.getParent();
-      }
 
-      checkPermissions(fs, parStatus, actions, authenticator.getUserName());
+        checkPermissions(fs, parStatus, actions, authenticator.getUserName());
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Close filesystem references in StorageBasedAuthorizationProvider after use.

### Why are the changes needed?
To prevent leaving filesystem objects and hitting OOM error see HIVE-26376 for more details.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual tests.
