### PR TITLE
[HIVE-26391] [CVE-2020-36518] Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.0 to 2.13.2.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <ivy.version>2.4.0</ivy.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.13.3</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.3.1</jamon-runtime.version>
     <javaewah.version>0.3.2</javaewah.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -77,7 +77,7 @@
     <guava.version>19.0</guava.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.13.3</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>


### PR DESCRIPTION
[HIVE-26391] [CVE-2020-36518] - 
jackson-databind is a data-binding package for the Jackson Data Processor. jackson-databind allows a Java stack overflow exception and denial of service via a large depth of nested objects.

Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.0 to 2.13.2.1+ to fix the vulnerability.

Link to the JIRA - https://issues.apache.org/jira/browse/HIVE-26391
