### PR TITLE
HIVE-1626: stop using java.util.Stack

### DIFF
--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/AccumuloRangeGenerator.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/AccumuloRangeGenerator.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.serde2.lazy.LazyUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.io.Text;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -89,7 +89,7 @@ public class AccumuloRangeGenerator implements SemanticNodeProcessor {
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
     // If it's not some operator, pass it back
     if (!(nd instanceof ExprNodeGenericFuncDesc)) {

--- a/common/src/java/org/apache/hadoop/hive/ql/lib/Dispatcher.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/lib/Dispatcher.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Dispatcher interface for Operators Used in operator graph walking to dispatch
@@ -41,7 +41,7 @@ public interface Dispatcher {
    * @return Object The return object from the processing call.
    * @throws HiveException
    */
-  Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+  Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws HiveException;
 
 }

--- a/common/src/java/org/apache/hadoop/hive/ql/lib/NodeProcessor.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/lib/NodeProcessor.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Base class for processing operators which is no-op. The specific processors
@@ -39,6 +39,6 @@ public interface NodeProcessor {
    * @return Object to be returned by the process call
    * @throws HiveException
    */
-  Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                  Object... nodeOutputs) throws HiveException;
 }

--- a/common/src/java/org/apache/hadoop/hive/ql/lib/Rule.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/lib/Rule.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Rule interface for Operators Used in operator dispatching to dispatch
@@ -33,7 +33,7 @@ public interface Rule {
    *         matches
    * @throws HiveException
    */
-  int cost(Stack<Node> stack) throws HiveException;
+  int cost(ArrayStack<Node> stack) throws HiveException;
 
   /**
    * @return the name of the rule - may be useful for debugging

--- a/common/src/java/org/apache/hive/common/util/ArrayStack.java
+++ b/common/src/java/org/apache/hive/common/util/ArrayStack.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.common.util;
+
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * ArrayStack is a non-synchronized version of a Stack. It's faster than
+ * a Stack, since it doesn't have synchronization lock overhead.
+ * Deque is a more preferred interface than Stack, but it lacks indexed
+ * accesses, such as get(int). ArrayStack provides get(int) for compatibility.
+ * @see Stack
+ */
+public class ArrayStack<E> extends AbstractCollection<E>
+    implements Collection<E> {
+  /**
+   * An array list is used for indexed accesses.
+   */
+  protected final List<E> list = new ArrayList<>();
+
+  @Override
+  public Iterator<E> iterator() {
+    return list.iterator();
+  }
+
+  @Override
+  public int size() {
+    return list.size();
+  }
+
+  /**
+   * @see Stack#get(int)
+   */
+  public E get(int index) {
+    return list.get(index);
+  }
+
+  /**
+   * @see Stack#push(Object)
+   */
+  public void push(E element) {
+    list.add(element);
+  }
+
+  /**
+   * @see Stack#pop()
+   */
+  public E pop() {
+    if (isEmpty()) {
+      return null;
+    } else {
+      return list.remove(list.size() - 1);
+    }
+  }
+
+  /**
+   * @see Stack#peek()
+   */
+  public E peek() {
+    if (isEmpty()) {
+      return null;
+    } else {
+      return list.get(list.size() - 1);
+    }
+  }
+}

--- a/common/src/test/org/apache/hive/common/util/ArrayStackTest.java
+++ b/common/src/test/org/apache/hive/common/util/ArrayStackTest.java
@@ -16,36 +16,47 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.lib;
+package org.apache.hive.common.util;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-import org.apache.hadoop.hive.ql.parse.SemanticException;
-import org.apache.hive.common.util.ArrayStack;
+import java.util.Stack;
 
-/**
- * Rule that matches a particular type of node.
- */
-public class TypeRule implements SemanticRule {
+public class ArrayStackTest {
+  final Stack<Integer> stack = new Stack<>();
+  final ArrayStack<Integer> arrayStack = new ArrayStack<>();
 
-  private Class<?> nodeClass;
-
-  public TypeRule(Class<?> nodeClass) {
-    this.nodeClass = nodeClass;
+  @Before
+  public void setUp() {
+    stack.clear();
+    arrayStack.clear();
   }
 
-  @Override
-  public int cost(ArrayStack<Node> stack) throws SemanticException {
-    if (stack == null) {
-      return -1;
-    }
-    if (nodeClass.isInstance(stack.peek())) {
-      return 1;
-    }
-    return -1;
+  @Test
+  public void test() {
+    push(1);
+    peekAndCheck();
+    push(2);
+    peekAndCheck();
+    push(3);
+    peekAndCheck();
+    popAndCheck();
+    popAndCheck();
+    popAndCheck();
   }
 
-  @Override
-  public String getName() {
-    return nodeClass.getName();
+  private void popAndCheck() {
+    Assert.assertEquals(stack.pop(), arrayStack.pop());
+  }
+
+  private void peekAndCheck() {
+    Assert.assertEquals(stack.peek(), arrayStack.peek());
+  }
+
+  private void push(int i) {
+    stack.push(i);
+    arrayStack.push(i);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/create/CreateMacroAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/create/CreateMacroAnalyzer.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Analyzer for macro creation commands.
@@ -93,7 +93,7 @@ public class CreateMacroAnalyzer extends BaseSemanticAnalyzer {
       Node expression = (Node) root.getChild(2);
       PreOrderWalker walker = new PreOrderWalker(new SemanticDispatcher() {
         @Override
-        public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs) throws SemanticException {
+        public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs) throws SemanticException {
           if (nd instanceof ASTNode) {
             ASTNode node = (ASTNode)nd;
             if (node.getType() == HiveParser.TOK_TABLE_OR_COL) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -34,7 +34,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -55,6 +53,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hive.common.util.HiveStringUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateDelegationTokenOptions;
@@ -216,7 +215,7 @@ public class DagUtils {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       for (Node n : stack) {
         Operator<? extends OperatorDesc> op = (Operator<? extends OperatorDesc>) n;

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/AccurateEstimatesCheckerHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/AccurateEstimatesCheckerHook.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.hooks;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.ExplainTask;
@@ -47,6 +46,7 @@ import org.apache.hadoop.hive.ql.plan.Statistics;
 import org.apache.hadoop.hive.ql.plan.TezWork;
 
 import com.google.common.collect.Lists;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Adds an extra check for Explain Analyze queries.
@@ -61,7 +61,7 @@ public class AccurateEstimatesCheckerHook extends AbstractSemanticAnalyzerHook {
     Map<String, Operator<?>> opMap = new HashMap<>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       Operator op = (Operator) nd;
       Statistics stats = op.getStatistics();

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/OperatorHealthCheckerHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/OperatorHealthCheckerHook.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import com.google.common.collect.Lists;
 
@@ -58,6 +57,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceWork;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.ql.plan.TezWork;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Checks some operator quality rules.
@@ -73,7 +73,7 @@ public class OperatorHealthCheckerHook implements ExecuteWithHookContext {
     Map<String, Operator<?>> opMap = new HashMap<>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
 
       Operator<?> op = (Operator<?>) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/index/IndexPredicateAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/index/IndexPredicateAnalyzer.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToUnixTimeStamp;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToUtcTimestamp;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToVarchar;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +55,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 /**
  * IndexPredicateAnalyzer decomposes predicates, separating the parts
@@ -145,7 +145,7 @@ public class IndexPredicateAnalyzer {
     Map<SemanticRule, SemanticNodeProcessor> opRules = new LinkedHashMap<SemanticRule, SemanticNodeProcessor>();
     SemanticNodeProcessor nodeProcessor = new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/CompositeProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/CompositeProcessor.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * CompositeProcessor. Holds a list of node processors to be fired by the same
@@ -35,7 +35,7 @@ public class CompositeProcessor implements SemanticNodeProcessor {
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
     for (SemanticNodeProcessor proc: procs) {
       proc.process(nd, stack, procCtx, nodeOutputs);

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/CostLessRuleDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/CostLessRuleDispatcher.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import com.google.common.collect.SetMultimap;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Dispatches calls to relevant method in processor. The user registers various
@@ -55,7 +55,7 @@ public class CostLessRuleDispatcher implements SemanticDispatcher {
    * @param ndStack the operators encountered so far
    * @throws SemanticException
    */
-  @Override public Object dispatch(Node nd, Stack<Node> ndStack, Object... nodeOutputs)
+  @Override public Object dispatch(Node nd, ArrayStack<Node> ndStack, Object... nodeOutputs)
       throws SemanticException {
 
     int nodeType = ((ASTNode) nd).getType();

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultGraphWalker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultGraphWalker.java
@@ -26,9 +26,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * base class for operator graph walker this class takes list of starting ops
@@ -42,7 +42,7 @@ public class DefaultGraphWalker implements SemanticGraphWalker {
    * opStack keeps the nodes that have been visited, but have not been
    * dispatched yet
    */
-  protected final Stack<Node> opStack;
+  protected final ArrayStack<Node> opStack;
   /**
    * opQueue keeps the nodes in the order that the were dispatched.
    * Then it is used to go through the processed nodes and store
@@ -65,7 +65,7 @@ public class DefaultGraphWalker implements SemanticGraphWalker {
    */
   public DefaultGraphWalker(SemanticDispatcher disp) {
     dispatcher = disp;
-    opStack = new Stack<Node>();
+    opStack = new ArrayStack<Node>();
     opQueue = new LinkedList<Node>();
   }
 
@@ -85,14 +85,14 @@ public class DefaultGraphWalker implements SemanticGraphWalker {
    *          stack of nodes encountered
    * @throws SemanticException
    */
-  public void dispatch(Node nd, Stack<Node> ndStack) throws SemanticException {
+  public void dispatch(Node nd, ArrayStack<Node> ndStack) throws SemanticException {
     dispatchAndReturn(nd, ndStack);
   }
 
   /**
    * Returns dispatch result
    */
-  public <T> T dispatchAndReturn(Node nd, Stack<Node> ndStack) throws SemanticException {
+  public <T> T dispatchAndReturn(Node nd, ArrayStack<Node> ndStack) throws SemanticException {
     Object[] nodeOutputs = null;
     if (nd.getChildren() != null) {
       nodeOutputs = new Object[nd.getChildren().size()];
@@ -148,7 +148,7 @@ public class DefaultGraphWalker implements SemanticGraphWalker {
     opStack.push(nd);
 
     // While there are still nodes to dispatch...
-    while (!opStack.empty()) {
+    while (!opStack.isEmpty()) {
       Node node = opStack.peek();
 
       if (node.getChildren() == null ||

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultRuleDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultRuleDispatcher.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.hive.ql.lib;
 
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Dispatches calls to relevant method in processor. The user registers various
@@ -61,7 +61,7 @@ public class DefaultRuleDispatcher implements SemanticDispatcher {
    * @throws SemanticException
    */
   @Override
-  public Object dispatch(Node nd, Stack<Node> ndStack, Object... nodeOutputs)
+  public Object dispatch(Node nd, ArrayStack<Node> ndStack, Object... nodeOutputs)
       throws SemanticException {
 
     // find the firing rule

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/ForwardWalker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/ForwardWalker.java
@@ -64,7 +64,7 @@ public class ForwardWalker extends DefaultGraphWalker {
    */
   @Override
   protected void walk(Node nd) throws SemanticException {
-    if (opStack.empty() || nd != opStack.peek()) {
+    if (opStack.isEmpty() || nd != opStack.peek()) {
       opStack.push(nd);
     }
     if (allParentsDispatched(nd)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/LevelOrderWalker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/LevelOrderWalker.java
@@ -24,12 +24,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * This is a level-wise walker implementation which dispatches the node in the order
@@ -121,8 +121,9 @@ public class LevelOrderWalker extends DefaultGraphWalker {
       }
 
       opStack.clear();
-      opStack.push(nd);
-      walk(nd, 0, opStack);
+      final MyArrayStack<Node> myArrayStack = new MyArrayStack<>();
+      myArrayStack.push(nd);
+      walk(nd, 0, myArrayStack);
       if (nodeOutput != null && getDispatchedList().contains(nd)) {
         nodeOutput.put(nd, retMap.get(nd));
       }
@@ -139,7 +140,7 @@ public class LevelOrderWalker extends DefaultGraphWalker {
    * @throws SemanticException
    */
   @SuppressWarnings("unchecked")
-  private void walk(Node nd, int level, Stack<Node> stack)
+  private void walk(Node nd, int level, MyArrayStack<Node> stack)
       throws SemanticException {
     List<Operator<? extends OperatorDesc>> parents =
         ((Operator<? extends OperatorDesc>) nd).getParentOperators();
@@ -153,6 +154,16 @@ public class LevelOrderWalker extends DefaultGraphWalker {
       stack.add(0, parent);
       walk(parent, level + 1, stack);
       stack.remove(0);
+    }
+  }
+
+  private static class MyArrayStack<E> extends ArrayStack<E> {
+    public void add(int index, E element) {
+      list.add(index, element);
+    }
+
+    public E remove(int index) {
+      return list.remove(index);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/RuleExactMatch.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/RuleExactMatch.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Implentation of the Rule interface for Nodes Used in Node dispatching to dispatch
@@ -63,7 +63,7 @@ public class RuleExactMatch implements SemanticRule {
    * @throws SemanticException
    */
   @Override
-  public int cost(Stack<Node> stack) throws SemanticException {
+  public int cost(ArrayStack<Node> stack) throws SemanticException {
     int numElems = (stack != null ? stack.size() : 0);
     if (numElems != pattern.length) {
       return -1;

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/RuleRegExp.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/RuleRegExp.java
@@ -23,11 +23,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Rule interface for Nodes Used in Node dispatching to dispatch process/visitor
@@ -128,7 +128,7 @@ public class RuleRegExp implements SemanticRule {
    * @return cost of the function
    * @throws SemanticException
    */
-  private int costPatternWithoutWildCardChar(Stack<Node> stack) throws SemanticException {
+  private int costPatternWithoutWildCardChar(ArrayStack<Node> stack) throws SemanticException {
     int numElems = (stack != null ? stack.size() : 0);
 
     // No elements
@@ -160,7 +160,7 @@ public class RuleRegExp implements SemanticRule {
    * @return cost of the function
    * @throws SemanticException
    */
-  private int costPatternWithORWildCardChar(Stack<Node> stack) throws SemanticException {
+  private int costPatternWithORWildCardChar(ArrayStack<Node> stack) throws SemanticException {
     int numElems = (stack != null ? stack.size() : 0);
 
     // No elements
@@ -225,7 +225,7 @@ public class RuleRegExp implements SemanticRule {
    * @return cost of the function
    * @throws SemanticException
    */
-  private int costPatternWithWildCardChar(Stack<Node> stack) throws SemanticException {
+  private int costPatternWithWildCardChar(ArrayStack<Node> stack) throws SemanticException {
     int numElems = (stack != null ? stack.size() : 0);
     StringBuilder name = new StringBuilder();
     Matcher m = patternWithWildCardChar.matcher("");
@@ -271,7 +271,7 @@ public class RuleRegExp implements SemanticRule {
    * @throws SemanticException
    */
   @Override
-  public int cost(Stack<Node> stack) throws SemanticException {
+  public int cost(ArrayStack<Node> stack) throws SemanticException {
     if (rulePatternIsValidWithoutWildCardChar()) {
       return costPatternWithoutWildCardChar(stack);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticDispatcher.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Dispatcher interface for Operators Used in operator graph walking to dispatch
@@ -42,7 +42,7 @@ public interface SemanticDispatcher extends Dispatcher {
    * @throws SemanticException
    */
   @Override
-  Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+  Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException;
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticNodeProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticNodeProcessor.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Base class for processing operators which is no-op. The specific processors
@@ -40,6 +40,6 @@ public interface SemanticNodeProcessor extends NodeProcessor {
    * @throws SemanticException
    */
   @Override
-  Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/SemanticRule.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Rule interface for Operators Used in operator dispatching to dispatch
@@ -34,7 +34,7 @@ public interface SemanticRule extends Rule {
    * @throws SemanticException
    */
   @Override
-  int cost(Stack<Node> stack) throws SemanticException;
+  int cost(ArrayStack<Node> stack) throws SemanticException;
 
   /**
    * @return the name of the rule - may be useful for debugging

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/TaskGraphWalker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/TaskGraphWalker.java
@@ -24,11 +24,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.ConditionalTask;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * base class for operator graph walker this class takes list of starting ops
@@ -52,7 +52,7 @@ public class TaskGraphWalker implements SemanticGraphWalker {
     }
   }
 
-  protected Stack<Node> opStack;
+  protected ArrayStack<Node> opStack;
   private final List<Node> toWalk = new ArrayList<Node>();
   private final HashMap<Node, Object> retMap = new HashMap<Node, Object>();
   private final SemanticDispatcher dispatcher;
@@ -66,7 +66,7 @@ public class TaskGraphWalker implements SemanticGraphWalker {
    */
   public TaskGraphWalker(SemanticDispatcher disp) {
     dispatcher = disp;
-    opStack = new Stack<Node>();
+    opStack = new ArrayStack<Node>();
     walkerCtx = new TaskGraphWalkerContext(retMap);
   }
 
@@ -93,7 +93,7 @@ public class TaskGraphWalker implements SemanticGraphWalker {
    *          stack of nodes encountered
    * @throws SemanticException
    */
-  public void dispatch(Node nd, Stack<Node> ndStack,TaskGraphWalkerContext walkerCtx) throws SemanticException {
+  public void dispatch(Node nd, ArrayStack<Node> ndStack,TaskGraphWalkerContext walkerCtx) throws SemanticException {
     Object[] nodeOutputs = null;
     if (nd.getChildren() != null) {
       nodeOutputs = new Object[nd.getChildren().size()+1];
@@ -143,7 +143,7 @@ public class TaskGraphWalker implements SemanticGraphWalker {
       if (getDispatchedList().contains(nd)) {
         return;
       }
-      if (opStack.empty() || nd != opStack.peek()) {
+      if (opStack.isEmpty() || nd != opStack.peek()) {
         opStack.push(nd);
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/Utils.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.hive.ql.lib;
 
-import java.util.Stack;
+import org.apache.hive.common.util.ArrayStack;
+
 
 /**
  * Contains common utility functions to manipulate nodes, walkers etc.
@@ -34,10 +35,10 @@ public class Utils {
    * 
    * @return Node The Nth ancestor in the path with respect to the current node.
    */
-  public static Node getNthAncestor(Stack<Node> st, int n) {
+  public static Node getNthAncestor(ArrayStack<Node> st, int n) {
     assert(st.size() - 1 >= n);
     
-    Stack<Node> tmpStack = new Stack<Node>();
+    ArrayStack<Node> tmpStack = new ArrayStack<Node>();
     for(int i=0; i<=n; i++)
       tmpStack.push(st.pop());
    
@@ -56,7 +57,7 @@ public class Utils {
    * Returns null if not found.
    */
   @SuppressWarnings("unchecked")
-  public static <T> T findNode(Stack<Node> stack, Class<T> target) {
+  public static <T> T findNode(ArrayStack<Node> stack, Class<T> target) {
     for (int i = stack.size() - 2; i >= 0; i--) {
       if (target.isInstance(stack.get(i))) {
         return (T) stack.get(i);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractBucketJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractBucketJoinProc.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -55,6 +54,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.MapJoinDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * this transformation does bucket map join optimization.
@@ -71,7 +71,7 @@ abstract public class AbstractBucketJoinProc implements SemanticNodeProcessor {
   }
 
   @Override
-  abstract public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  abstract public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException;
 
   public static List<String> getBucketFilePathsOfPartition(

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractSMBJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractSMBJoinProc.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -57,6 +56,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.SMBJoinDesc;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hive.common.util.ArrayStack;
 
 //try to replace a bucket map join with a sorted merge map join
 abstract public class AbstractSMBJoinProc extends AbstractBucketJoinProc implements SemanticNodeProcessor {
@@ -70,7 +70,7 @@ abstract public class AbstractSMBJoinProc extends AbstractBucketJoinProc impleme
   }
 
   @Override
-  abstract public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  abstract public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
          Object... nodeOutputs) throws SemanticException;
 
   /*
@@ -81,7 +81,7 @@ abstract public class AbstractSMBJoinProc extends AbstractBucketJoinProc impleme
    *    of the sort columns.
    */
   protected boolean canConvertBucketMapJoinToSMBJoin(MapJoinOperator mapJoinOp,
-    Stack<Node> stack,
+    ArrayStack<Node> stack,
     SortBucketJoinProcCtx smbJoinContext,
     Object... nodeOutputs) throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketMapJoinOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketMapJoinOptimizer.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
@@ -81,7 +81,7 @@ public class BucketMapJoinOptimizer extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs)
           throws SemanticException {
         return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketMapjoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketMapjoinProc.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 public class BucketMapjoinProc extends AbstractBucketJoinProc implements SemanticNodeProcessor {
   public BucketMapjoinProc(ParseContext pGraphContext) {
@@ -37,7 +37,7 @@ public class BucketMapjoinProc extends AbstractBucketJoinProc implements Semanti
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
     BucketJoinProcCtx context = (BucketJoinProcCtx) procCtx;
     MapJoinOperator mapJoinOperator = (MapJoinOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketVersionPopulator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketVersionPopulator.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -41,6 +40,7 @@ import org.apache.hadoop.hive.ql.lib.SemanticNodeProcessor;
 import org.apache.hadoop.hive.ql.lib.SemanticRule;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +103,7 @@ public class BucketVersionPopulator extends Transform {
   private static class IdentifyBucketGroups implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       Operator<?> o = (Operator<?>) nd;
       OpGroup g;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketingSortingReduceSinkOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/BucketingSortingReduceSinkOptimizer.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -56,6 +55,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.SMBJoinDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +104,7 @@ public class BucketingSortingReduceSinkOptimizer extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
         return null;
       }
@@ -379,7 +379,7 @@ public class BucketingSortingReduceSinkOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // We should not use this optimization if sorted dynamic partition optimizer is used,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
@@ -27,9 +27,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +102,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerFilterProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator op = (FilterOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -133,7 +133,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerGroupByProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       GroupByOperator gbOp = (GroupByOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -225,7 +225,7 @@ public final class ColumnPrunerProcFactory {
   public static class ColumnPrunerScriptProc implements SemanticNodeProcessor {
     @Override
     @SuppressWarnings("unchecked")
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
 
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -280,7 +280,7 @@ public final class ColumnPrunerProcFactory {
   public static class ColumnPrunerLimitProc extends ColumnPrunerDefaultProc {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       super.process(nd, stack, ctx, nodeOutputs);
       List<FieldNode> cols = ((ColumnPrunerProcCtx) ctx).getPrunedColLists().get(nd);
@@ -309,7 +309,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerPTFProc extends ColumnPrunerScriptProc {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
 
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -457,7 +457,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerDefaultProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
       cppCtx.getPrunedColLists().put((Operator<? extends OperatorDesc>) nd,
@@ -482,7 +482,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerTableScanProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator scanOp = (TableScanOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -570,7 +570,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerReduceSinkProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator op = (ReduceSinkOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -650,7 +650,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerLateralViewJoinProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       LateralViewJoinOperator op = (LateralViewJoinOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -702,7 +702,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerLateralViewForwardProc extends ColumnPrunerDefaultProc {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       super.process(nd, stack, ctx, nodeOutputs);
       LateralViewForwardOperator op = (LateralViewForwardOperator) nd;
@@ -746,7 +746,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerSelectProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       SelectOperator op = (SelectOperator) nd;
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
@@ -974,7 +974,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerJoinProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       JoinOperator op = (JoinOperator) nd;
       pruneJoinOperator(ctx, op, op.getConf(), op.getColumnExprMap(), null,
@@ -997,7 +997,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerMapJoinProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       AbstractMapJoinOperator<MapJoinDesc> op = (AbstractMapJoinOperator<MapJoinDesc>) nd;
       pruneJoinOperator(ctx, op, op.getConf(), op.getColumnExprMap(), op
@@ -1020,7 +1020,7 @@ public final class ColumnPrunerProcFactory {
    */
   public static class ColumnPrunerUnionProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       ColumnPrunerProcCtx cppCtx = (ColumnPrunerProcCtx) ctx;
       UnionOperator op = (UnionOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -97,6 +96,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1032,7 +1032,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateFilterProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       FilterOperator op = (FilterOperator) nd;
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
@@ -1083,7 +1083,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateGroupByProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       GroupByOperator op = (GroupByOperator) nd;
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
@@ -1133,7 +1133,7 @@ public final class ConstantPropagateProcFactory {
   public static class ConstantPropagateDefaultProc implements SemanticNodeProcessor {
     @Override
     @SuppressWarnings("unchecked")
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
       Operator<? extends Serializable> op = (Operator<? extends Serializable>) nd;
@@ -1172,7 +1172,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateSelectProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       SelectOperator op = (SelectOperator) nd;
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
@@ -1243,7 +1243,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateFileSinkProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       FileSinkOperator op = (FileSinkOperator) nd;
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
@@ -1297,7 +1297,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateStopProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       Operator<?> op = (Operator<?>) nd;
       ConstantPropagateProcCtx cppCtx = (ConstantPropagateProcCtx) ctx;
@@ -1320,7 +1320,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateReduceSinkProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       ReduceSinkOperator op = (ReduceSinkOperator) nd;
       ReduceSinkDesc rsDesc = op.getConf();
@@ -1420,7 +1420,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateJoinProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       JoinOperator op = (JoinOperator) nd;
       JoinDesc conf = op.getConf();
@@ -1488,7 +1488,7 @@ public final class ConstantPropagateProcFactory {
    */
   public static class ConstantPropagateTableScanProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       TableScanOperator op = (TableScanOperator) nd;
       TableScanDesc conf = op.getConf();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -76,6 +75,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.Pr
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +106,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
    * might as well do it here.
    */
   public Object
-      process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+      process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
           throws SemanticException {
 
     OptimizeTezProcContext context = (OptimizeTezProcContext) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/CountDistinctRewriteProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/CountDistinctRewriteProc.java
@@ -23,9 +23,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.util.NullOrdering;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -114,7 +114,7 @@ public class CountDistinctRewriteProc extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+      public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
           Object... nodeOutputs) throws SemanticException {
         return null;
       }
@@ -481,7 +481,7 @@ public class CountDistinctRewriteProc extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       GroupByOperator mGby = (GroupByOperator) stack.get(stack.size() - 3);
       ReduceSinkOperator rs = (ReduceSinkOperator) stack.get(stack.size() - 2);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/DynamicPartitionPruningOptimization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/DynamicPartitionPruningOptimization.java
@@ -24,7 +24,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -79,6 +78,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
 import org.apache.hadoop.hive.ql.util.NullOrdering;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +96,7 @@ public class DynamicPartitionPruningOptimization implements SemanticNodeProcesso
       .getName());
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
     ParseContext parseContext;
     if (procCtx instanceof OptimizeTezProcContext) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/FixedBucketPruningOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/FixedBucketPruningOptimizer.java
@@ -22,7 +22,6 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hive.common.type.Date;
@@ -55,6 +54,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 
 import com.google.common.base.Preconditions;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Fixed bucket pruning optimizer goes through all the table scans and annotates them
@@ -70,7 +70,7 @@ public class FixedBucketPruningOptimizer extends Transform {
 
   public class NoopWalker implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // do nothing
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRFileSink1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRFileSink1.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
@@ -63,7 +63,7 @@ public class GenMRFileSink1 implements SemanticNodeProcessor {
    *          context
    */
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;
     ParseContext parseCtx = ctx.getParseCtx();
@@ -171,7 +171,7 @@ public class GenMRFileSink1 implements SemanticNodeProcessor {
    * @return the final file name to which the FileSinkOperator should store.
    * @throws SemanticException
    */
-  private Path processFS(FileSinkOperator fsOp, Stack<Node> stack,
+  private Path processFS(FileSinkOperator fsOp, ArrayStack<Node> stack,
                          NodeProcessorCtx opProcCtx, boolean chDir) throws SemanticException {
 
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMROperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMROperator.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.lib.Node;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.optimizer.GenMRProcContext.GenMapRedCtx;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - no specific rule fired.
@@ -45,7 +45,7 @@ public class GenMROperator implements SemanticNodeProcessor {
    * @param procCtx
    *          context
    */
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
     GenMRProcContext ctx = (GenMRProcContext) procCtx;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink1.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
@@ -31,6 +30,7 @@ import org.apache.hadoop.hive.ql.optimizer.GenMRProcContext.GenMapRedCtx;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - table scan followed by reduce sink.
@@ -52,7 +52,7 @@ public class GenMRRedSink1 implements SemanticNodeProcessor {
    * @param opProcCtx
    *          context
    */
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     ReduceSinkOperator op = (ReduceSinkOperator) nd;
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink2.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink2.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.optimizer.GenMRProcContext.GenMapRedCtx;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - reduce sink followed by reduce sink.
@@ -47,7 +47,7 @@ public class GenMRRedSink2 implements SemanticNodeProcessor {
    * @param opProcCtx
    *          context
    */
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     ReduceSinkOperator op = (ReduceSinkOperator) nd;
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink3.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRRedSink3.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
@@ -34,6 +33,7 @@ import org.apache.hadoop.hive.ql.optimizer.GenMRProcContext.GenMapRedCtx;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - union followed by reduce sink.
@@ -51,7 +51,7 @@ public class GenMRRedSink3 implements SemanticNodeProcessor {
    * @param opProcCtx
    *          context
    */
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     ReduceSinkOperator op = (ReduceSinkOperator) nd;
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.stats.BasicStatsNoJobTask;
 import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - table scan.
@@ -59,7 +59,7 @@ public class GenMRTableScan1 implements SemanticNodeProcessor {
    *          context
    */
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     TableScanOperator op = (TableScanOperator) nd;
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRUnion1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRUnion1.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.Context;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Processor for the rule - TableScan followed by Union.
@@ -57,7 +57,7 @@ public class GenMRUnion1 implements SemanticNodeProcessor {
    * @return
    * @throws SemanticException
    */
-  private Object processMapOnlyUnion(UnionOperator union, Stack<Node> stack,
+  private Object processMapOnlyUnion(UnionOperator union, ArrayStack<Node> stack,
       GenMRProcContext ctx, UnionProcContext uCtx) throws SemanticException {
 
     // merge currTask from multiple topOps
@@ -163,7 +163,7 @@ public class GenMRUnion1 implements SemanticNodeProcessor {
    * @throws SemanticException
    */
   private void processSubQueryUnionMerge(GenMRProcContext ctx,
-      GenMRUnionCtx uCtxTask, UnionOperator union, Stack<Node> stack)
+      GenMRUnionCtx uCtxTask, UnionOperator union, ArrayStack<Node> stack)
       throws SemanticException {
     // The current plan can be thrown away after being merged with the union
     // plan
@@ -189,7 +189,7 @@ public class GenMRUnion1 implements SemanticNodeProcessor {
    *          context
    */
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx opProcCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx opProcCtx,
       Object... nodeOutputs) throws SemanticException {
     UnionOperator union = (UnionOperator) nd;
     GenMRProcContext ctx = (GenMRProcContext) opProcCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GroupByOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GroupByOptimizer.java
@@ -26,8 +26,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -119,7 +119,7 @@ public class GroupByOptimizer extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
         return null;
       }
@@ -169,7 +169,7 @@ public class GroupByOptimizer extends Transform {
     }
 
     protected void processGroupBy(GroupByOptimizerContext ctx,
-        Stack<Node> stack,
+        ArrayStack<Node> stack,
         GroupByOperator groupByOp,
         int depth) throws SemanticException {
       HiveConf hiveConf = ctx.getConf();
@@ -253,7 +253,7 @@ public class GroupByOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // GBY,RS,GBY... (top to bottom)
       GroupByOperator groupByOp = (GroupByOperator) stack.get(stack.size() - 3);
@@ -268,7 +268,7 @@ public class GroupByOptimizer extends Transform {
 
     // Should this group by be converted to a map-side group by, because the grouping keys for
     // the base table for the group by matches the skewed keys
-    protected GroupByOptimizerSortMatch checkSortGroupBy(Stack<Node> stack,
+    protected GroupByOptimizerSortMatch checkSortGroupBy(ArrayStack<Node> stack,
         GroupByOperator groupByOp)
         throws SemanticException {
 
@@ -586,7 +586,7 @@ public class GroupByOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // GBY,RS,GBY,RS,GBY... (top to bottom)
       GroupByOperator groupByOp = (GroupByOperator) stack.get(stack.size() - 5);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/IdentityProjectRemover.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/IdentityProjectRemover.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterators;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -96,7 +96,7 @@ public class IdentityProjectRemover extends Transform {
   private static class ProjectRemover implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
     	
       SelectOperator sel = (SelectOperator)nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/LimitPushdownOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/LimitPushdownOptimizer.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.LimitDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Make RS calculate top-K selection for limit clause.
@@ -115,7 +115,7 @@ public class LimitPushdownOptimizer extends Transform {
   private static class TopNReducer implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack,
+    public Object process(Node nd, ArrayStack<Node> stack,
                           NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator rs = null;
       for (int i = stack.size() - 2 ; i >= 0; i--) {
@@ -160,7 +160,7 @@ public class LimitPushdownOptimizer extends Transform {
   private static class TopNPropagator implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack,
+    public Object process(Node nd, ArrayStack<Node> stack,
                           NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator cRS = (ReduceSinkOperator) nd;
       if (cRS.getConf().getTopN() == -1) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MapJoinFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MapJoinFactory.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.AbstractMapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MapredLocalWork;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Operator factory for MapJoin processing.
@@ -45,7 +45,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 public final class MapJoinFactory {
 
   public static int getPositionParent(AbstractMapJoinOperator<? extends MapJoinDesc> op,
-      Stack<Node> stack) {
+      ArrayStack<Node> stack) {
     int pos = 0;
     int size = stack.size();
     assert size >= 2 && stack.get(size - 1) == op;
@@ -187,7 +187,7 @@ public final class MapJoinFactory {
      * the map join operator is enhanced to contain the bucketing info. when it is encountered.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       AbstractMapJoinOperator<MapJoinDesc> mapJoin = (AbstractMapJoinOperator<MapJoinDesc>) nd;
       GenMRProcContext ctx = (GenMRProcContext) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MapJoinProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MapJoinProcessor.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.Path;
@@ -80,6 +79,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -947,7 +947,7 @@ public class MapJoinProcessor extends Transform {
      * Store the current mapjoin in the context.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       MapJoinWalkerCtx ctx = (MapJoinWalkerCtx) procCtx;
@@ -1057,7 +1057,7 @@ public class MapJoinProcessor extends Transform {
      * Store the current mapjoin in a list of mapjoins followed by a filesink.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       MapJoinWalkerCtx ctx = (MapJoinWalkerCtx) procCtx;
@@ -1084,7 +1084,7 @@ public class MapJoinProcessor extends Transform {
      * Store the mapjoin in a rejected list.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       MapJoinWalkerCtx ctx = (MapJoinWalkerCtx) procCtx;
       AbstractMapJoinOperator<? extends MapJoinDesc> mapJoin = ctx.getCurrMapJoinOp();
@@ -1103,7 +1103,7 @@ public class MapJoinProcessor extends Transform {
      * Nothing to do.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       return null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MergeJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/MergeJoinProc.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.optimizer;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
 import org.apache.hadoop.hive.ql.exec.DummyStoreOperator;
@@ -34,11 +33,12 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.TezEdgeProperty;
 import org.apache.hadoop.hive.ql.plan.TezWork;
 import org.apache.hadoop.hive.ql.plan.TezWork.VertexType;
+import org.apache.hive.common.util.ArrayStack;
 
 public class MergeJoinProc implements SemanticNodeProcessor {
   @Override
   public Object
-      process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+      process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
           throws SemanticException {
     GenTezProcContext context = (GenTezProcContext) procCtx;
     CommonMergeJoinOperator mergeJoinOp = (CommonMergeJoinOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/NonBlockingOpDeDupProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/NonBlockingOpDeDupProc.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -51,6 +50,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * merges SEL-SEL or FIL-FIL into single operator
@@ -88,7 +88,7 @@ public class NonBlockingOpDeDupProc extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       SelectOperator cSEL = (SelectOperator) nd;
       SelectOperator pSEL = (SelectOperator) stack.get(stack.size() - 2);
@@ -222,7 +222,7 @@ public class NonBlockingOpDeDupProc extends Transform {
   private class FilterDedup implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator cFIL = (FilterOperator) nd;
       FilterOperator pFIL = (FilterOperator) stack.get(stack.size() - 2);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/OrderlessLimitPushDownOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/OrderlessLimitPushDownOptimizer.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.LimitOperator;
@@ -47,6 +46,7 @@ import org.apache.hadoop.hive.ql.plan.JoinCondDesc;
 import org.apache.hadoop.hive.ql.plan.JoinDesc;
 import org.apache.hadoop.hive.ql.plan.LimitDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class OrderlessLimitPushDownOptimizer extends Transform {
 
   private static class LimitPushDown implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator reduceSink = findReduceSink(stack);
       if (reduceSink == null || !reduceSink.getConf().hasOrderBy()) { // LIMIT + ORDER BY handled by TopNKey push down
         pushDown((LimitOperator) nd);
@@ -77,7 +77,7 @@ public class OrderlessLimitPushDownOptimizer extends Transform {
       return null;
     }
 
-    private ReduceSinkOperator findReduceSink(Stack<Node> stack) {
+    private ReduceSinkOperator findReduceSink(ArrayStack<Node> stack) {
       for (int i = stack.size() - 2 ; i >= 0; i--) {
         Operator<?> operator = (Operator<?>) stack.get(i);
         if (operator instanceof ReduceSinkOperator) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PartitionColumnsSeparator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PartitionColumnsSeparator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -52,6 +51,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFStruct;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +90,7 @@ public class PartitionColumnsSeparator extends Transform {
   private class StructInTransformer implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator filterOp = (FilterOperator) nd;
       ExprNodeDesc predicate = filterOp.getConf().getPredicate();
@@ -337,7 +337,7 @@ public class PartitionColumnsSeparator extends Transform {
      * containing only partition columns.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprNodeGenericFuncDesc fd = getInExprNode((ExprNodeDesc)nd);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PointLookupOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PointLookupOptimizer.java
@@ -23,9 +23,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.calcite.util.Pair;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.Description;
@@ -100,7 +100,7 @@ public class PointLookupOptimizer extends Transform {
   private class FilterTransformer implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator filterOp = (FilterOperator) nd;
       ExprNodeDesc predicate = filterOp.getConf().getPredicate();
@@ -137,7 +137,7 @@ public class PointLookupOptimizer extends Transform {
   private class OrExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprNodeGenericFuncDesc fd = (ExprNodeGenericFuncDesc) nd;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PrunerExpressionOperatorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PrunerExpressionOperatorFactory.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.ArrayList;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.lib.Node;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeFieldDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Expression processor factory for pruning. Each processor tries to
@@ -47,7 +47,7 @@ public abstract class PrunerExpressionOperatorFactory {
   public static class GenericFuncExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       ExprNodeDesc newfd = null;
@@ -111,7 +111,7 @@ public abstract class PrunerExpressionOperatorFactory {
   public static class FieldExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       ExprNodeFieldDesc fnd = (ExprNodeFieldDesc) nd;
@@ -148,7 +148,7 @@ public abstract class PrunerExpressionOperatorFactory {
   public static abstract class ColumnExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       ExprNodeDesc newcd = null;
@@ -177,7 +177,7 @@ public abstract class PrunerExpressionOperatorFactory {
   public static class DefaultExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       if (nd instanceof ExprNodeConstantDesc) {
         return ((ExprNodeConstantDesc) nd).clone();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PrunerOperatorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/PrunerOperatorFactory.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -31,6 +30,7 @@ import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.type.ExprNodeTypeCheck;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Operator factory for pruning processing of operator graph We find
@@ -51,7 +51,7 @@ public abstract class PrunerOperatorFactory {
   public static abstract class FilterPruner implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator fop = (FilterOperator) nd;
       FilterOperator fop2 = null;
@@ -175,7 +175,7 @@ public abstract class PrunerOperatorFactory {
   public static class DefaultPruner implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Nothing needs to be done.
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ReduceSinkMapJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ReduceSinkMapJoinProc.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.HashTableDummyOperator;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
@@ -59,6 +58,7 @@ import org.apache.hadoop.hive.ql.plan.TezWork;
 import org.apache.hadoop.hive.ql.plan.TezWork.VertexType;
 import org.apache.hadoop.hive.ql.stats.StatsUtils;
 import org.apache.hadoop.hive.ql.util.NullOrdering;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +78,7 @@ public class ReduceSinkMapJoinProc implements SemanticNodeProcessor {
    * or reduce work.
    */
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procContext, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procContext, Object... nodeOutputs)
       throws SemanticException {
     GenTezProcContext context = (GenTezProcContext) procContext;
     MapJoinOperator mapJoinOp = (MapJoinOperator)nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/RedundantDynamicPruningConditionsRemoval.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/RedundantDynamicPruningConditionsRemoval.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.calcite.util.Pair;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hive.ql.plan.FilterDesc;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBaseCompare;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +95,7 @@ public class RedundantDynamicPruningConditionsRemoval extends Transform {
   private class FilterTransformer implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       FilterOperator filter = (FilterOperator) nd;
       FilterDesc desc = filter.getConf();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/RemoveDynamicPruningBySize.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/RemoveDynamicPruningBySize.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.ql.optimizer;
 
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -42,7 +42,7 @@ public class RemoveDynamicPruningBySize implements SemanticNodeProcessor {
   static final private Logger LOG = LoggerFactory.getLogger(RemoveDynamicPruningBySize.class.getName());
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procContext,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procContext,
       Object... nodeOutputs)
       throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
@@ -25,9 +25,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FileStatus;
@@ -131,7 +131,7 @@ public class SamplePruner extends Transform {
   public static class FilterPPR implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator filOp = (FilterOperator) nd;
       FilterDesc filOpDesc = filOp.getConf();
@@ -161,7 +161,7 @@ public class SamplePruner extends Transform {
   public static class DefaultPPR implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Nothing needs to be done.
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SetHashGroupByMinReduction.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SetHashGroupByMinReduction.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
 import org.apache.hadoop.hive.ql.lib.Node;
@@ -33,6 +32,7 @@ import org.apache.hadoop.hive.ql.plan.GroupByDesc.Mode;
 import org.apache.hadoop.hive.ql.plan.Statistics;
 import org.apache.hadoop.hive.ql.plan.Statistics.State;
 import org.apache.hadoop.hive.ql.stats.StatsUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class SetHashGroupByMinReduction implements SemanticNodeProcessor {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Object process(Node nd, Stack<Node> stack,
+  public Object process(Node nd, ArrayStack<Node> stack,
                         NodeProcessorCtx procContext, Object... nodeOutputs)
       throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SetReducerParallelism.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SetReducerParallelism.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.optimizer;
 
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -52,7 +52,7 @@ public class SetReducerParallelism implements SemanticNodeProcessor {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Object process(Node nd, Stack<Node> stack,
+  public Object process(Node nd, ArrayStack<Node> stack,
                         NodeProcessorCtx procContext, Object... nodeOutputs)
       throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchAggregation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchAggregation.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -49,6 +48,7 @@ import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 // execute final aggregation stage for simple fetch query on fetch task
 public class SimpleFetchAggregation extends Transform {
@@ -86,7 +86,7 @@ public class SimpleFetchAggregation extends Transform {
       this.pctx = pctx;
     }
 
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FileSinkOperator FS = (FileSinkOperator) nd;
       int shift = stack.get(stack.size() - 2) instanceof SelectOperator ? 0 : 1;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SkewJoinOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SkewJoinOptimizer.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -68,6 +67,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters.Converter;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +88,7 @@ public class SkewJoinOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
       // We should be having a tree which looks like this
       //  TS -> * -> RS -

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionOptimizer.java
@@ -27,7 +27,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -80,6 +79,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.orc.OrcConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,7 +143,7 @@ public class SortedDynPartitionOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // introduce RS and EX before FS. If the operator tree already contains

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionTimeGranularityOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedDynPartitionTimeGranularityOptimizer.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.parquet.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +86,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
@@ -131,7 +131,7 @@ public class SortedDynPartitionTimeGranularityOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // introduce RS and EX before FS

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeBucketMapJoinOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeBucketMapJoinOptimizer.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.hive.ql.optimizer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -122,7 +122,7 @@ public class SortedMergeBucketMapJoinOptimizer extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs)
           throws SemanticException {
         return null;
@@ -135,7 +135,7 @@ public class SortedMergeBucketMapJoinOptimizer extends Transform {
   private SemanticNodeProcessor getCheckCandidateJoin() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+      public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
         SortBucketJoinProcCtx smbJoinContext = (SortBucketJoinProcCtx)procCtx;
         JoinOperator joinOperator = (JoinOperator)nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeBucketMapjoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeBucketMapjoinProc.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.optimizer;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -29,6 +28,7 @@ import org.apache.hadoop.hive.ql.lib.SemanticNodeProcessor;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 public class SortedMergeBucketMapjoinProc extends AbstractSMBJoinProc implements SemanticNodeProcessor {
   public SortedMergeBucketMapjoinProc(ParseContext pctx) {
@@ -39,7 +39,7 @@ public class SortedMergeBucketMapjoinProc extends AbstractSMBJoinProc implements
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
     if (nd instanceof SMBMapJoinOperator) {
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SortedMergeJoinProc.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.optimizer;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.lib.Node;
@@ -26,6 +25,7 @@ import org.apache.hadoop.hive.ql.lib.SemanticNodeProcessor;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 public class SortedMergeJoinProc extends AbstractSMBJoinProc implements SemanticNodeProcessor {
 
@@ -37,7 +37,7 @@ public class SortedMergeJoinProc extends AbstractSMBJoinProc implements Semantic
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
 
     JoinOperator joinOp = (JoinOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/StatsOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/StatsOptimizer.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +86,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 
 /** There is a set of queries which can be answered entirely from statistics stored in metastore.
@@ -249,7 +249,7 @@ public class StatsOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // 1. Do few checks to determine eligibility of optimization

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/TablePropertyEnrichmentOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/TablePropertyEnrichmentOptimizer.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.hive.common.util.ReflectionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +99,7 @@ class TablePropertyEnrichmentOptimizer extends Transform {
   private static class Processor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
       TableScanOperator tsOp = (TableScanOperator) nd;
       WalkerCtx context = (WalkerCtx)procCtx;
       TableScanDesc tableScanDesc = tsOp.getConf();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/HiveOpConverterPostProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/HiveOpConverterPostProc.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hive.ql.optimizer.Transform;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 public class HiveOpConverterPostProc extends Transform {
 
@@ -81,7 +81,7 @@ public class HiveOpConverterPostProc extends Transform {
   private class JoinAnnotate implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       JoinOperator joinOp = (JoinOperator) nd;
 
@@ -129,7 +129,7 @@ public class HiveOpConverterPostProc extends Transform {
   private class TableScanAnnotate implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator tableScanOp = (TableScanOperator) nd;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/CorrelationOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/CorrelationOptimizer.java
@@ -28,8 +28,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.ContentSummary;
@@ -572,7 +572,7 @@ public class CorrelationOptimizer extends Transform {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       CorrelationNodeProcCtx corrCtx = (CorrelationNodeProcCtx) ctx;
       ReduceSinkOperator op = (ReduceSinkOperator) nd;
@@ -634,7 +634,7 @@ public class CorrelationOptimizer extends Transform {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx ctx, Object... nodeOutputs) throws SemanticException {
         Operator<? extends OperatorDesc> op = (Operator<? extends OperatorDesc>) nd;
         LOG.info("Walk to operator " + op.getIdentifier() + " "

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVECONVERTJOINNOCON
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -45,6 +44,7 @@ import org.apache.hadoop.hive.ql.lib.RuleRegExp;
 import org.apache.hadoop.hive.ql.optimizer.Transform;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +135,7 @@ public class ReduceSinkDeDuplication extends Transform {
    */
   static class DefaultProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       return null;
     }
@@ -144,7 +144,7 @@ public class ReduceSinkDeDuplication extends Transform {
   public abstract static class AbstractReducerReducerProc implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ReduceSinkDeduplicateProcCtx dedupCtx = (ReduceSinkDeduplicateProcCtx) procCtx;
       if (dedupCtx.hasBeenRemoved((Operator<?>) nd)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkJoinDeDuplication.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkJoinDeDuplication.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
@@ -41,6 +40,7 @@ import org.apache.hadoop.hive.ql.optimizer.Transform;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc.ReducerTraits;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +110,7 @@ public class ReduceSinkJoinDeDuplication extends Transform {
    */
   static class DefaultProc implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       return null;
     }
@@ -119,7 +119,7 @@ public class ReduceSinkJoinDeDuplication extends Transform {
   static class ReducerProc implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ReduceSinkJoinDeDuplicateProcCtx dedupCtx = (ReduceSinkJoinDeDuplicateProcCtx) procCtx;
       ReduceSinkOperator cRS = (ReduceSinkOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/ExprProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/ExprProcFactory.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
@@ -58,6 +57,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeFieldDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Expression processor factory for lineage. Each processor is responsible to
@@ -85,7 +85,7 @@ public class ExprProcFactory {
   public static class ColumnExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       ExprNodeColumnDesc cd = (ExprNodeColumnDesc) nd;
@@ -117,7 +117,7 @@ public class ExprProcFactory {
   public static class GenericExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       assert (nd instanceof ExprNodeGenericFuncDesc || nd instanceof ExprNodeFieldDesc);
@@ -154,7 +154,7 @@ public class ExprProcFactory {
   public static class DefaultExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       assert (nd instanceof ExprNodeConstantDesc || nd instanceof ExprDynamicParamDesc);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/OpProcFactory.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -64,6 +63,7 @@ import org.apache.hadoop.hive.ql.plan.JoinCondDesc;
 import org.apache.hadoop.hive.ql.plan.JoinDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Operator factory for the rule processors for lineage.
@@ -78,7 +78,7 @@ public class OpProcFactory {
    * @return Operator The parent operator in the current path.
    */
   @SuppressWarnings("unchecked")
-  protected static Operator<? extends OperatorDesc> getParent(Stack<Node> stack) {
+  protected static Operator<? extends OperatorDesc> getParent(ArrayStack<Node> stack) {
     return (Operator<? extends OperatorDesc>)Utils.getNthAncestor(stack, 1);
   }
 
@@ -88,7 +88,7 @@ public class OpProcFactory {
   public static class TransformLineage extends DefaultLineage implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // LineageCTx
@@ -147,7 +147,7 @@ public class OpProcFactory {
   public static class TableScanLineage extends DefaultLineage implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // LineageCtx
@@ -206,7 +206,7 @@ public class OpProcFactory {
     private final HashMap<Node, Object> outputMap = new HashMap<Node, Object>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // Assert that there is at least one item in the stack. This should never
@@ -307,7 +307,7 @@ public class OpProcFactory {
    */
   public static class LateralViewJoinLineage extends DefaultLineage implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       // Assert that there is at least one item in the stack. This should never
@@ -355,7 +355,7 @@ public class OpProcFactory {
     private final HashMap<Node, Object> outputMap = new HashMap<Node, Object>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       LineageCtx lctx = (LineageCtx)procCtx;
@@ -411,7 +411,7 @@ public class OpProcFactory {
     private final HashMap<Node, Object> outputMap = new HashMap<Node, Object>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       LineageCtx lctx = (LineageCtx)procCtx;
@@ -535,7 +535,7 @@ public class OpProcFactory {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Assert that there is at least one item in the stack. This should never
       // be called for leafs.
@@ -573,7 +573,7 @@ public class OpProcFactory {
     private final HashMap<Node, Object> outputMap = new HashMap<Node, Object>();
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Assert that there is at least one item in the stack. This should never
       // be called for leafs.
@@ -642,7 +642,7 @@ public class OpProcFactory {
   public static class FilterLineage implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Assert that there is at least one item in the stack. This should never
       // be called for leafs.
@@ -684,7 +684,7 @@ public class OpProcFactory {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Assert that there is at least one item in the stack. This should never
       // be called for leafs.

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.*;
 import org.apache.hadoop.hive.ql.plan.ptf.PTFExpressionDef;
 import org.apache.hadoop.hive.ql.plan.ptf.PartitionDef;
+import org.apache.hive.common.util.ArrayStack;
 
 /*
  * This class populates the following operator traits for the entire operator tree:
@@ -72,7 +73,7 @@ public class OpTraitsRulesProcFactory {
   public static class DefaultRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       @SuppressWarnings("unchecked")
       Operator<? extends OperatorDesc> op = (Operator<? extends OperatorDesc>)nd;
@@ -89,7 +90,7 @@ public class OpTraitsRulesProcFactory {
   public static class ReduceSinkRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       ReduceSinkOperator rs = (ReduceSinkOperator)nd;
@@ -212,7 +213,7 @@ public class OpTraitsRulesProcFactory {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator ts = (TableScanOperator)nd;
       AnnotateOpTraitsProcCtx opTraitsCtx = (AnnotateOpTraitsProcCtx)procCtx;
@@ -252,7 +253,7 @@ public class OpTraitsRulesProcFactory {
   public static class GroupByRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       GroupByOperator gbyOp = (GroupByOperator)nd;
       List<String> gbyKeys = new ArrayList<>();
@@ -285,7 +286,7 @@ public class OpTraitsRulesProcFactory {
   public static class PTFRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       PTFOperator ptfOp = (PTFOperator) nd;
       List<String> partitionKeys = new ArrayList<>();
@@ -364,7 +365,7 @@ public class OpTraitsRulesProcFactory {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       SelectOperator selOp = (SelectOperator) nd;
       List<List<String>> parentBucketColNames =
@@ -404,7 +405,7 @@ public class OpTraitsRulesProcFactory {
   public static class JoinRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       JoinOperator joinOp = (JoinOperator) nd;
       List<List<String>> bucketColsList = new ArrayList<List<String>>();
@@ -481,7 +482,7 @@ public class OpTraitsRulesProcFactory {
   public static class MultiParentRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       @SuppressWarnings("unchecked")
       Operator<? extends OperatorDesc> operator = (Operator<? extends OperatorDesc>) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/pcr/PcrExprProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/pcr/PcrExprProcFactory.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.lib.DefaultRuleDispatcher;
@@ -54,6 +53,7 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +209,7 @@ public final class PcrExprProcFactory {
   public static class ColumnExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprNodeColumnDesc cd = (ExprNodeColumnDesc) nd;
       PcrExprProcCtx epc = (PcrExprProcCtx) procCtx;
@@ -252,7 +252,7 @@ public final class PcrExprProcFactory {
    */
   public static class GenericFuncExprProcessor implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       PcrExprProcCtx ctx = (PcrExprProcCtx) procCtx;
       ExprNodeGenericFuncDesc fd = (ExprNodeGenericFuncDesc) nd;
@@ -500,7 +500,7 @@ public final class PcrExprProcFactory {
   public static class FieldExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprNodeFieldDesc fnd = (ExprNodeFieldDesc) nd;
       boolean unknown = false;
@@ -528,7 +528,7 @@ public final class PcrExprProcFactory {
   public static class DefaultExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       if (nd instanceof ExprNodeConstantDesc) {
         return new NodeInfoWrapper(WalkState.CONSTANT, null,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/pcr/PcrOpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/pcr/PcrOpProcFactory.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.hive.ql.optimizer.pcr;
 
 import java.util.ArrayList;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -59,7 +59,7 @@ public final class PcrOpProcFactory {
   public static class FilterPCR implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       PcrOpWalkerCtx owc = (PcrOpWalkerCtx) procCtx;
       FilterOperator fop = (FilterOperator) nd;
@@ -161,7 +161,7 @@ public final class PcrOpProcFactory {
   public static class DefaultPCR implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       // Nothing needs to be done.
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AbstractJoinTaskDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AbstractJoinTaskDispatcher.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer.physical;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Path;
@@ -33,6 +32,7 @@ import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.lib.TaskGraphWalker.TaskGraphWalkerContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Common iteration methods for converting joins and sort-merge joins.
@@ -151,7 +151,7 @@ public abstract class AbstractJoinTaskDispatcher implements SemanticDispatcher {
   }
 
   @Override
-  public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+  public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException {
     if (nodeOutputs == null || nodeOutputs.length == 0) {
       throw new SemanticException("No Dispatch Context");

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AnnotateRunTimeStatsOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AnnotateRunTimeStatsOptimizer.java
@@ -22,9 +22,9 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.OperatorUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
@@ -63,7 +63,7 @@ public class AnnotateRunTimeStatsOptimizer implements PhysicalPlanResolver {
     }
 
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
         throws SemanticException {
       Task<?> currTask = (Task<?>) nd;
       Set<Operator<? extends OperatorDesc>> ops = new HashSet<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/BucketingSortingOpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/BucketingSortingOpProcFactory.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -49,6 +48,7 @@ import org.apache.hadoop.hive.ql.plan.JoinDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public class BucketingSortingOpProcFactory {
   public static class DefaultInferrer implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       return null;
@@ -115,7 +115,7 @@ public class BucketingSortingOpProcFactory {
    * @return Operator The parent operator in the current path.
    */
   @SuppressWarnings("unchecked")
-  protected static Operator<? extends OperatorDesc> getParent(Stack<Node> stack) {
+  protected static Operator<? extends OperatorDesc> getParent(ArrayStack<Node> stack) {
     return (Operator<? extends OperatorDesc>)Utils.getNthAncestor(stack, 1);
   }
 
@@ -132,7 +132,7 @@ public class BucketingSortingOpProcFactory {
    */
   public static class JoinInferrer extends DefaultInferrer implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       BucketingSortingCtx bctx = (BucketingSortingCtx)procCtx;
@@ -328,7 +328,7 @@ public class BucketingSortingOpProcFactory {
    */
   public static class SelectInferrer extends DefaultInferrer implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       BucketingSortingCtx bctx = (BucketingSortingCtx)procCtx;
@@ -458,7 +458,7 @@ public class BucketingSortingOpProcFactory {
    */
   public static class FileSinkInferrer extends DefaultInferrer implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       BucketingSortingCtx bctx = (BucketingSortingCtx)procCtx;
@@ -580,7 +580,7 @@ public class BucketingSortingOpProcFactory {
 
   public static class MultiGroupByInferrer extends GroupByInferrer implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       BucketingSortingCtx bctx = (BucketingSortingCtx)procCtx;
       GroupByOperator gop = (GroupByOperator)nd;
@@ -622,7 +622,7 @@ public class BucketingSortingOpProcFactory {
    */
   public static class GroupByInferrer extends DefaultInferrer implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       BucketingSortingCtx bctx = (BucketingSortingCtx)procCtx;
@@ -719,7 +719,7 @@ public class BucketingSortingOpProcFactory {
   public static class ForwardingInferrer extends DefaultInferrer implements SemanticNodeProcessor {
     @SuppressWarnings("unchecked")
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       processForward((Operator<? extends OperatorDesc>)nd, (BucketingSortingCtx)procCtx,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/CrossProductHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/CrossProductHandler.java
@@ -25,11 +25,11 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 import java.util.TreeMap;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.plan.*;
+import org.apache.hive.common.util.ArrayStack;
 import org.apache.tez.runtime.library.cartesianproduct.CartesianProductVertexManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +111,7 @@ public class CrossProductHandler implements PhysicalPlanResolver, SemanticDispat
   }
 
   @Override
-  public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+  public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException {
     @SuppressWarnings("unchecked")
     Task<?> currTask = (Task<?>) nd;
@@ -290,7 +290,7 @@ public class CrossProductHandler implements PhysicalPlanResolver, SemanticDispat
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       @SuppressWarnings("unchecked")
       AbstractMapJoinOperator<? extends MapJoinDesc> mjOp = (AbstractMapJoinOperator<? extends MapJoinDesc>) nd;
@@ -366,7 +366,7 @@ public class CrossProductHandler implements PhysicalPlanResolver, SemanticDispat
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator rsOp = (ReduceSinkOperator) nd;
       ReduceSinkDesc rsDesc = rsOp.getConf();
@@ -387,7 +387,7 @@ public class CrossProductHandler implements PhysicalPlanResolver, SemanticDispat
 
   static class NoopProcessor implements SemanticNodeProcessor {
     @Override
-    public final Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public final Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
      return nd;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LlapPreVectorizationPass.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LlapPreVectorizationPass.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hive.ql.optimizer.physical.LlapDecider.LlapMode.
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.BaseWork;
 import org.apache.hadoop.hive.ql.plan.TezWork;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +77,7 @@ public class LlapPreVectorizationPass implements PhysicalPlanResolver {
     }
 
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
         throws SemanticException {
       @SuppressWarnings("unchecked")
       Task<?> currTask = (Task<?>) nd;
@@ -102,7 +102,7 @@ public class LlapPreVectorizationPass implements PhysicalPlanResolver {
         opRules.put(new RuleRegExp("Disable grace hash join if LLAP mode and not dynamic partition hash join",
             MapJoinOperator.getOperatorName() + "%"), new SemanticNodeProcessor() {
               @Override
-              public Object process(Node n, Stack<Node> s, NodeProcessorCtx c, Object... os) {
+              public Object process(Node n, ArrayStack<Node> s, NodeProcessorCtx c, Object... os) {
                 MapJoinOperator mapJoinOp = (MapJoinOperator) n;
                 if (mapJoinOp.getConf().isHybridHashJoin() && !(mapJoinOp.getConf().isDynamicPartitionHashJoin())) {
                   mapJoinOp.getConf().setHybridHashJoin(false);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LocalMapJoinProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LocalMapJoinProcFactory.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -75,7 +75,7 @@ public final class LocalMapJoinProcFactory {
   public static SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+      public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
           Object... nodeOutputs) throws SemanticException {
         return null;
       }
@@ -87,7 +87,7 @@ public final class LocalMapJoinProcFactory {
    *
    */
   public static class MapJoinFollowedByGroupByProcessor implements SemanticNodeProcessor {
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       LocalMapJoinProcCtx context = (LocalMapJoinProcCtx) ctx;
       if (!nd.getName().equals("GBY")) {
@@ -107,7 +107,7 @@ public final class LocalMapJoinProcFactory {
    *
    */
   public static class LocalMapJoinProcessor implements SemanticNodeProcessor {
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx, Object... nodeOutputs)
         throws SemanticException {
       LocalMapJoinProcCtx context = (LocalMapJoinProcCtx) ctx;
       if (!nd.getName().equals("MAPJOIN")) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MapJoinResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MapJoinResolver.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.Context;
@@ -58,6 +57,7 @@ import org.apache.hadoop.hive.ql.plan.ConditionalWork;
 import org.apache.hadoop.hive.ql.plan.MapredLocalWork;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * An implementation of PhysicalPlanResolver. It iterator each MapRedTask to see whether the task
@@ -225,7 +225,7 @@ public class MapJoinResolver implements PhysicalPlanResolver {
     }
 
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
         throws SemanticException {
       Task<?> currTask = (Task<?>) nd;
       // not map reduce task or not conditional task, just skip

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MemoryDecider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MemoryDecider.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.Stack;
 import java.util.TreeSet;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -51,6 +50,7 @@ import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MergeJoinWork;
 import org.apache.hadoop.hive.ql.plan.ReduceWork;
 import org.apache.hadoop.hive.ql.plan.TezWork;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +81,7 @@ public class MemoryDecider implements PhysicalPlanResolver {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException {
       Task<?> currTask = (Task<?>) nd;
       if (currTask instanceof StatsTask) {
@@ -132,7 +132,7 @@ public class MemoryDecider implements PhysicalPlanResolver {
       rules.put(new RuleRegExp("Map join memory estimator",
               MapJoinOperator.getOperatorName() + "%"), new SemanticNodeProcessor() {
           @Override
-          public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+          public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
               Object... nodeOutputs) {
             mapJoins.add((MapJoinOperator) nd);
             return null;
@@ -262,7 +262,7 @@ public class MemoryDecider implements PhysicalPlanResolver {
     public class DefaultRule implements SemanticNodeProcessor {
 
       @Override
-      public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+      public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
           Object... nodeOutputs) throws SemanticException {
         return null;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MetadataOnlyOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/MetadataOnlyOptimizer.java
@@ -22,8 +22,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -110,7 +110,7 @@ public class MetadataOnlyOptimizer implements PhysicalPlanResolver {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator tsOp = (TableScanOperator) nd;
       WalkerCtx walkerCtx = (WalkerCtx) procCtx;
@@ -129,7 +129,7 @@ public class MetadataOnlyOptimizer implements PhysicalPlanResolver {
 
   static private class FileSinkProcessor implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       WalkerCtx walkerCtx = (WalkerCtx) procCtx;
       // There can be atmost one element eligible to be converted to

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/NullScanOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/NullScanOptimizer.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hive.ql.optimizer.physical.MetadataOnlyOptimizer.Walker
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +112,7 @@ public class NullScanOptimizer implements PhysicalPlanResolver {
   private static class WhereFalseProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       FilterOperator filter = (FilterOperator) nd;
@@ -142,7 +142,7 @@ public class NullScanOptimizer implements PhysicalPlanResolver {
   private static class Limit0Processor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       LimitOperator limitOp = (LimitOperator)nd;
@@ -168,7 +168,7 @@ public class NullScanOptimizer implements PhysicalPlanResolver {
   private static class TSMarker implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ((WalkerCtx)procCtx).setMayBeMetadataOnly((TableScanOperator)nd);
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/NullScanTaskDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/NullScanTaskDispatcher.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -64,6 +63,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.NullStructSerDe;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -234,7 +234,7 @@ public class NullScanTaskDispatcher implements SemanticDispatcher {
   }
 
   @Override
-  public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+  public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException {
     Task<?> task = (Task<?>) nd;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SerializeFilter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SerializeFilter.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.exec.StatsTask;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MergeJoinWork;
 import org.apache.hadoop.hive.ql.plan.ReduceWork;
 import org.apache.hadoop.hive.ql.plan.TezWork;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public class SerializeFilter implements PhysicalPlanResolver {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
       throws SemanticException {
       Task<?> currTask = (Task<?>) nd;
       if (currTask instanceof StatsTask) {
@@ -116,7 +116,7 @@ public class SerializeFilter implements PhysicalPlanResolver {
       rules.put(new RuleRegExp("TS finder",
               TableScanOperator.getOperatorName() + "%"), new SemanticNodeProcessor() {
           @Override
-          public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+          public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
               Object... nodeOutputs) {
             tableScans.add((TableScanOperator) nd);
             return null;
@@ -155,7 +155,7 @@ public class SerializeFilter implements PhysicalPlanResolver {
     public class DefaultRule implements SemanticNodeProcessor {
 
       @Override
-      public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+      public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
           Object... nodeOutputs) throws SemanticException {
         return null;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SkewJoinProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SkewJoinProcFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.optimizer.physical;
 
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.optimizer.physical.SkewJoinResolver.SkewJoinProcCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Node processor factory for skew join resolver.
@@ -47,7 +47,7 @@ public final class SkewJoinProcFactory {
    *
    */
   public static class SkewJoinJoinProcessor implements SemanticNodeProcessor {
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       SkewJoinProcCtx context = (SkewJoinProcCtx) ctx;
       JoinOperator op = (JoinOperator) nd;
@@ -66,7 +66,7 @@ public final class SkewJoinProcFactory {
    *
    */
   public static class SkewJoinDefaultProcessor implements SemanticNodeProcessor {
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx ctx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx ctx,
         Object... nodeOutputs) throws SemanticException {
       return null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SkewJoinResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SkewJoinResolver.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.optimizer.physical;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.ConditionalTask;
@@ -40,6 +39,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.LoadFileDesc;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 
 /**
@@ -73,7 +73,7 @@ public class SkewJoinResolver implements PhysicalPlanResolver {
     }
 
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
         throws SemanticException {
       Task<?> task = (Task<?>) nd;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -35,14 +35,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Stack;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
-import org.apache.hadoop.hive.ql.exec.vector.expressions.ConvertDecimal64ToDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorCoalesce;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.gen.DecimalColDivideDecimalScalar;
 import org.apache.hadoop.hive.ql.exec.vector.mapjoin.VectorMapJoinAntiJoinLongOperator;
@@ -52,6 +50,7 @@ import org.apache.hadoop.hive.ql.exec.vector.reducesink.*;
 import org.apache.hadoop.hive.ql.exec.vector.udf.VectorUDFArgDesc;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe2;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
@@ -988,7 +987,7 @@ public class Vectorizer implements PhysicalPlanResolver {
   class VectorizationDispatcher implements SemanticDispatcher {
 
     @Override
-    public Object dispatch(Node nd, Stack<Node> stack, Object... nodeOutputs)
+    public Object dispatch(Node nd, ArrayStack<Node> stack, Object... nodeOutputs)
         throws SemanticException {
       Task<?> currTask = (Task<?>) nd;
       if (currTask instanceof MapRedTask) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -32,7 +32,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Stack;
 
 import com.google.common.base.Preconditions;
 import org.apache.calcite.rel.metadata.RelMdUtil;
@@ -40,7 +39,6 @@ import org.apache.hadoop.hive.common.ndv.NumDistinctValueEstimator;
 import org.apache.hadoop.hive.common.ndv.NumDistinctValueEstimatorFactory;
 import org.apache.hadoop.hive.common.ndv.hll.HyperLogLog;
 import org.apache.hadoop.hive.common.type.Timestamp;
-import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.Context;
@@ -127,6 +125,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +149,7 @@ public class StatsRulesProcFactory {
   public static class TableScanStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator tsop = (TableScanOperator) nd;
       AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
@@ -196,7 +195,7 @@ public class StatsRulesProcFactory {
   public static class SelectStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       SelectOperator sop = (SelectOperator) nd;
@@ -275,7 +274,7 @@ public class StatsRulesProcFactory {
   public static class FilterStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
       FilterOperator fop = (FilterOperator) nd;
@@ -1410,7 +1409,7 @@ public class StatsRulesProcFactory {
   public static class GroupByStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       GroupByOperator gop = (GroupByOperator) nd;
@@ -1912,7 +1911,7 @@ public class StatsRulesProcFactory {
   public static class JoinStatsRule extends FilterStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       long newNumRows = 0;
       CommonJoinOperator<? extends JoinDesc> jop = (CommonJoinOperator<? extends JoinDesc>) nd;
@@ -2838,7 +2837,7 @@ public class StatsRulesProcFactory {
   public static class LimitStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
       LimitOperator lop = (LimitOperator) nd;
@@ -2893,7 +2892,7 @@ public class StatsRulesProcFactory {
   public static class ReduceSinkStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       ReduceSinkOperator rop = (ReduceSinkOperator) nd;
       Operator<? extends OperatorDesc> parent = rop.getParentOperators().get(0);
@@ -2950,7 +2949,7 @@ public class StatsRulesProcFactory {
    */
   public static class UDTFStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
       UDTFOperator uop = (UDTFOperator) nd;
@@ -3009,7 +3008,7 @@ public class StatsRulesProcFactory {
    */
   public static class LateralViewJoinStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       final LateralViewJoinOperator lop = (LateralViewJoinOperator) nd;
       final AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
@@ -3068,7 +3067,7 @@ public class StatsRulesProcFactory {
   public static class DefaultStatsRule implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       Operator<? extends OperatorDesc> op = (Operator<? extends OperatorDesc>) nd;
       OperatorDesc conf = op.getConf();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyProcessor.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.ql.optimizer.topnkey;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.OperatorFactory;
@@ -34,6 +33,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.TopNKeyDesc;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public class TopNKeyProcessor implements SemanticNodeProcessor {
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                         Object... nodeOutputs) throws SemanticException {
 
     // Get ReduceSinkOperator

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hive.ql.optimizer.topnkey.TopNKeyProcessor.copyD
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
 import org.apache.hadoop.hive.ql.plan.TopNKeyDesc;
 import org.apache.hadoop.hive.ql.plan.api.OperatorType;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(TopNKeyPushdownProcessor.class);
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                         Object... nodeOutputs) throws SemanticException {
     pushdown((TopNKeyOperator) nd);
     return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/unionproc/UnionProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/unionproc/UnionProcFactory.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.AbstractFileMergeOperator;
@@ -39,6 +38,7 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Operator factory for union processing.
@@ -49,7 +49,7 @@ public final class UnionProcFactory {
     // prevent instantiation
   }
 
-  public static int getPositionParent(UnionOperator union, Stack<Node> stack) {
+  public static int getPositionParent(UnionOperator union, ArrayStack<Node> stack) {
     int pos = 0;
     int size = stack.size();
     assert size >= 2 && stack.get(size - 1) == union;
@@ -68,7 +68,7 @@ public final class UnionProcFactory {
   public static class MapRedUnion implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       UnionOperator union = (UnionOperator) nd;
       UnionProcContext ctx = (UnionProcContext) procCtx;
@@ -93,7 +93,7 @@ public final class UnionProcFactory {
   public static class MapUnion implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       UnionOperator union = (UnionOperator) nd;
       UnionProcContext ctx = (UnionProcContext) procCtx;
@@ -118,7 +118,7 @@ public final class UnionProcFactory {
   public static class UnknownUnion implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       UnionOperator union = (UnionOperator) nd;
       UnionProcContext ctx = (UnionProcContext) procCtx;
@@ -176,7 +176,7 @@ public final class UnionProcFactory {
   public static class UnionNoProcessFile implements SemanticNodeProcessor {
 
     private void pushOperatorsAboveUnion(UnionOperator union,
-      Stack<Node> stack, int pos) throws SemanticException {
+      ArrayStack<Node> stack, int pos) throws SemanticException {
       // Clone all the operators between union and filescan, and push them above
       // the union. Remove the union (the tree below union gets delinked after that)
       try {
@@ -247,7 +247,7 @@ public final class UnionProcFactory {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FileSinkOperator fileSinkOp   = (FileSinkOperator)nd;
 
@@ -313,7 +313,7 @@ public final class UnionProcFactory {
   public static class NoUnion implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       return null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/AppMasterEventProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/AppMasterEventProcessor.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.parse;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.AppMasterEventOperator;
@@ -40,7 +40,7 @@ public class AppMasterEventProcessor implements SemanticNodeProcessor {
   static final private Logger LOG = LoggerFactory.getLogger(AppMasterEventProcessor.class.getName());
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
     GenTezProcContext context = (GenTezProcContext) procCtx;
     AppMasterEventOperator event = (AppMasterEventOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/FileSinkProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/FileSinkProcessor.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -37,7 +37,7 @@ public class FileSinkProcessor implements SemanticNodeProcessor {
   static final private Logger LOG = LoggerFactory.getLogger(FileSinkProcessor.class.getName());
 
   @Override
-  public Object process(Node nd, Stack<Node> stack,
+  public Object process(Node nd, ArrayStack<Node> stack,
                         NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hive.ql.plan.TezEdgeProperty.EdgeType;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBetween;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInBloomFilter;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -834,7 +835,7 @@ public class GenTezUtils {
   private static class DynamicValuePredicateProc implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       DynamicValuePredicateContext ctx = (DynamicValuePredicateContext) procCtx;
       ExprNodeDesc parent = (ExprNodeDesc) stack.get(stack.size() - 2);
@@ -913,7 +914,7 @@ public class GenTezUtils {
      * found
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprNodeDynamicListDesc desc = (ExprNodeDynamicListDesc) nd;
       DynamicPartitionPrunerContext context = (DynamicPartitionPrunerContext) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
@@ -508,7 +508,7 @@ public class GenTezWork implements SemanticNodeProcessor {
   private static int indexOf(ArrayStack<Node> stack, Node node) {
     final int size = stack.size();
     for (int i = 0; i < size; i++) {
-      if (stack.get(i) == node) {
+      if (stack.get(i).equals(node)) {
         return i;
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
@@ -23,7 +23,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
@@ -49,6 +48,7 @@ import org.apache.hadoop.hive.ql.plan.TezEdgeProperty.EdgeType;
 import org.apache.hadoop.hive.ql.plan.TezWork;
 import org.apache.hadoop.hive.ql.plan.TezWork.VertexType;
 import org.apache.hadoop.hive.ql.plan.UnionWork;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class GenTezWork implements SemanticNodeProcessor {
   }
 
   @Override
-  public Object process(Node nd, Stack<Node> stack,
+  public Object process(Node nd, ArrayStack<Node> stack,
                         NodeProcessorCtx procContext, Object... nodeOutputs)
       throws SemanticException {
 
@@ -500,9 +500,19 @@ public class GenTezWork implements SemanticNodeProcessor {
 
   @SuppressWarnings("unchecked")
   private Operator<? extends OperatorDesc> getParentFromStack(Node currentMergeJoinOperator,
-      Stack<Node> stack) {
-    int pos = stack.indexOf(currentMergeJoinOperator);
+      ArrayStack<Node> stack) {
+    int pos = indexOf(stack, currentMergeJoinOperator);
     return (Operator<? extends OperatorDesc>) stack.get(pos - 1);
+  }
+
+  private static int indexOf(ArrayStack<Node> stack, Node node) {
+    final int size = stack.size();
+    for (int i = 0; i < size; i++) {
+      if (stack.get(i) == node) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   private void connectUnionWorkWithWork(UnionWork unionWork, BaseWork work, TezWork tezWork,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.parse;
 
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -61,7 +61,7 @@ public class ProcessAnalyzeTable implements SemanticNodeProcessor {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procContext,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procContext,
       Object... nodeOutputs) throws SemanticException {
 
     GenTezProcContext context = (GenTezProcContext) procContext;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQuery.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQuery.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.parse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.ql.Context;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hive.common.util.ArrayStack;
 
 public class QBSubQuery implements ISubQueryJoinInfo {
 
@@ -259,7 +259,7 @@ public class QBSubQuery implements ISubQueryJoinInfo {
     boolean forHavingClause;
     String parentQueryNewAlias;
     SemanticNodeProcessor defaultExprProcessor;
-    Stack<Node> stack;
+    ArrayStack<Node> stack;
 
     ConjunctAnalyzer(RowResolver parentQueryRR,
         boolean forHavingClause,
@@ -268,7 +268,7 @@ public class QBSubQuery implements ISubQueryJoinInfo {
       defaultExprProcessor = ExprNodeTypeCheck.getExprNodeDefaultExprProcessor();
       this.forHavingClause = forHavingClause;
       this.parentQueryNewAlias = parentQueryNewAlias;
-      stack = new Stack<Node>();
+      stack = new ArrayStack<Node>();
     }
 
     /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -313,6 +313,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.math.IntMath;
 import com.google.common.math.LongMath;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * Implementation of the semantic analyzer. It generates the query plan.
@@ -2709,7 +2710,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
       SemanticDispatcher nodeOriginDispatcher = new SemanticDispatcher() {
         @Override
-        public Object dispatch(Node nd, java.util.Stack<Node> stack,
+        public Object dispatch(Node nd, ArrayStack<Node> stack,
                                Object... nodeOutputs) {
           ((ASTNode) nd).setOrigin(viewOrigin);
           return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TableAccessAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TableAccessAnalyzer.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
@@ -95,7 +95,7 @@ public class TableAccessAnalyzer {
   private SemanticNodeProcessor getDefaultProc() {
     return new SemanticNodeProcessor() {
       @Override
-      public Object process(Node nd, Stack<Node> stack,
+      public Object process(Node nd, ArrayStack<Node> stack,
                             NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
         return null;
       }
@@ -113,7 +113,7 @@ public class TableAccessAnalyzer {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) {
       GroupByOperator op = (GroupByOperator)nd;
       TableAccessCtx tableAccessCtx = (TableAccessCtx)procCtx;
@@ -160,7 +160,7 @@ public class TableAccessAnalyzer {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) {
       JoinOperator op = (JoinOperator)nd;
       TableAccessCtx tableAccessCtx = (TableAccessCtx)procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -145,6 +145,7 @@ import org.apache.hadoop.hive.ql.stats.OperatorStats;
 import org.apache.hadoop.hive.ql.stats.StatsUtils;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFBloomFilter.GenericUDAFBloomFilterEvaluator;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -840,7 +841,7 @@ public class TezCompiler extends TaskCompiler {
   private static class SMBJoinOpProc implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       SMBJoinOpProcContext ctx = (SMBJoinOpProcContext) procCtx;
       ctx.JoinOpToTsOpMap.put((CommonMergeJoinOperator) nd,
@@ -978,7 +979,7 @@ public class TezCompiler extends TaskCompiler {
     private PlanMapper planMapper;
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       ParseContext pCtx = ((OptimizeTezProcContext) procCtx).parseContext;
       planMapper = pCtx.getContext().getPlanMapper();
@@ -1008,7 +1009,7 @@ public class TezCompiler extends TaskCompiler {
     private PlanMapper planMapper;
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       ParseContext pCtx = ((OptimizeTezProcContext) procCtx).parseContext;
       planMapper = pCtx.getContext().getPlanMapper();
@@ -1091,7 +1092,7 @@ public class TezCompiler extends TaskCompiler {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       ReduceSinkOperator rs = (ReduceSinkOperator) nd;
       SemiJoinRemovalContext rCtx = (SemiJoinRemovalContext) procCtx;
@@ -1207,7 +1208,7 @@ public class TezCompiler extends TaskCompiler {
   private static class DynamicPruningRemovalRedundantProc implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       AppMasterEventOperator event = (AppMasterEventOperator) nd;
       if (!(event.getConf() instanceof DynamicPruningEventDesc)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/UnionProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/UnionProcessor.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
-import java.util.Stack;
 
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.UnionOperator;
@@ -37,7 +37,7 @@ public class UnionProcessor implements SemanticNodeProcessor {
   static final private Logger LOG = LoggerFactory.getLogger(UnionProcessor.class.getName());
 
   @Override
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
       throws SemanticException {
     GenTezProcContext context = (GenTezProcContext) procCtx;
     UnionOperator union = (UnionOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/JoinCondTypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/JoinCondTypeCheckProcFactory.java
@@ -19,9 +19,7 @@ package org.apache.hadoop.hive.ql.parse.type;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.lib.Node;
@@ -32,6 +30,7 @@ import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.RowResolver;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 
 /**
@@ -61,7 +60,7 @@ public class JoinCondTypeCheckProcFactory<T> extends TypeCheckProcFactory<T> {
   public class JoinCondColumnExprProcessor extends ColumnExprProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       JoinTypeCheckCtx ctx = (JoinTypeCheckCtx) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -74,6 +73,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TimestampLocalTZTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,7 +250,7 @@ public class TypeCheckProcFactory<T> {
   public class NullExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -273,7 +273,7 @@ public class TypeCheckProcFactory<T> {
   public class DynamicParameterProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -311,7 +311,7 @@ public class TypeCheckProcFactory<T> {
   public class NumExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -381,7 +381,7 @@ public class TypeCheckProcFactory<T> {
   public class StrExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -438,7 +438,7 @@ public class TypeCheckProcFactory<T> {
   public class BoolExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -483,7 +483,7 @@ public class TypeCheckProcFactory<T> {
   public class DateTimeExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -538,7 +538,7 @@ public class TypeCheckProcFactory<T> {
   public class IntervalExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -597,7 +597,7 @@ public class TypeCheckProcFactory<T> {
   public class ColumnExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
       if (ctx.getError() != null) {
@@ -667,9 +667,9 @@ public class TypeCheckProcFactory<T> {
           // It's not a column or a table alias.
           if (input.getIsExprResolver()) {
             ASTNode exprNode = expr;
-            if (!stack.empty()) {
+            if (!stack.isEmpty()) {
               ASTNode tmp = (ASTNode) stack.pop();
-              if (!stack.empty()) {
+              if (!stack.isEmpty()) {
                 exprNode = (ASTNode) stack.peek();
               }
               stack.push(tmp);
@@ -1295,7 +1295,7 @@ public class TypeCheckProcFactory<T> {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
 
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
@@ -1504,7 +1504,7 @@ public class TypeCheckProcFactory<T> {
   public class SubQueryExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
 
       TypeCheckCtx ctx = (TypeCheckCtx) procCtx;
@@ -1674,7 +1674,7 @@ public class TypeCheckProcFactory<T> {
   public static class ValueAliasProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs) throws SemanticException {
       ASTNode astNode = (ASTNode) nd;
       ((TypeCheckCtx) procCtx).addColumnAlias(astNode.getChild(0).getText());
       return ALIAS_PLACEHOLDER;

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/mapper/AuxOpTreeSignature.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/mapper/AuxOpTreeSignature.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.plan.mapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -34,6 +33,7 @@ import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.optimizer.signature.OpTreeSignature;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * This signature is used to establish related parts to connect pre/post PPD optimizations.
@@ -69,7 +69,7 @@ public final class AuxOpTreeSignature {
     }
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx, Object... nodeOutputs)
         throws SemanticException {
       Operator<?> op = (Operator<?>) nd;
       AuxOpTreeSignature treeSig = pm.getAuxSignatureOf(op);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/ExprWalkerProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/ExprWalkerProcFactory.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
@@ -45,6 +44,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeFieldDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.ppd.ExprWalkerInfo.ExprInfo;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +67,7 @@ public final class ExprWalkerProcFactory {
      * Converts the reference from child row resolver to current row resolver.
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprWalkerInfo ctx = (ExprWalkerInfo) procCtx;
       ExprNodeColumnDesc colref = (ExprNodeColumnDesc) nd;
@@ -170,7 +170,7 @@ public final class ExprWalkerProcFactory {
   public static class FieldExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprWalkerInfo ctx = (ExprWalkerInfo) procCtx;
       String alias = null;
@@ -220,7 +220,7 @@ public final class ExprWalkerProcFactory {
   public static class GenericFuncExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprWalkerInfo ctx = (ExprWalkerInfo) procCtx;
       String alias = null;
@@ -284,7 +284,7 @@ public final class ExprWalkerProcFactory {
   public static class DefaultExprProcessor implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       ExprWalkerInfo ctx = (ExprWalkerInfo) procCtx;
       ExprInfo exprInfo = ctx.addOrGetExprInfo((ExprNodeDesc) nd);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.Stack;
 
 import javolution.util.FastBitSet;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -79,6 +78,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPLessThan;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,7 +164,7 @@ public final class OpProcFactory {
   public static class ScriptPPD extends DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       // script operator is a black-box to hive so no optimization here
@@ -197,7 +197,7 @@ public final class OpProcFactory {
      * @see org.apache.hadoop.hive.ql.ppd.OpProcFactory.ScriptPPD#process(org.apache.hadoop.hive.ql.lib.Node, java.util.Stack, org.apache.hadoop.hive.ql.lib.NodeProcessorCtx, java.lang.Object[])
      */
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -369,7 +369,7 @@ public final class OpProcFactory {
 
   public static class UDTFPPD extends DefaultPPD implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       super.process(nd, stack, procCtx, nodeOutputs);
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -388,7 +388,7 @@ public final class OpProcFactory {
   public static class LateralViewForwardPPD extends DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -414,7 +414,7 @@ public final class OpProcFactory {
   public static class TableScanPPD extends DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -441,12 +441,12 @@ public final class OpProcFactory {
   public static class FilterPPD extends DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       return process(nd, stack, procCtx, false, nodeOutputs);
     }
 
-    Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
             boolean onlySyntheticJoinPredicate, Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
 
@@ -498,7 +498,7 @@ public final class OpProcFactory {
 
   public static class SimpleFilterPPD extends FilterPPD implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       FilterOperator filterOp = (FilterOperator) nd;
       // We try to push the full Filter predicate iff:
@@ -534,7 +534,7 @@ public final class OpProcFactory {
    */
   public static class JoinerPPD extends DefaultPPD implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -653,7 +653,7 @@ public final class OpProcFactory {
 
   public static class ReduceSinkPPD extends DefaultPPD implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
                           Object... nodeOutputs) throws SemanticException {
       super.process(nd, stack, procCtx, nodeOutputs);
       Operator<?> operator = (Operator<?>) nd;
@@ -967,7 +967,7 @@ public final class OpProcFactory {
   public static class GroupByPPD extends DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       super.process(nd, stack, procCtx, nodeOutputs);
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;
@@ -1063,7 +1063,7 @@ public final class OpProcFactory {
   public static class DefaultPPD implements SemanticNodeProcessor {
 
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       LOG.debug("Processing for {}", nd.toString());
       OpWalkerInfo owi = (OpWalkerInfo) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/PredicateTransitivePropagate.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/PredicateTransitivePropagate.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -52,6 +51,7 @@ import org.apache.hadoop.hive.ql.plan.FilterDesc;
 import org.apache.hadoop.hive.ql.plan.JoinCondDesc;
 import org.apache.hadoop.hive.ql.plan.JoinDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  * propagates filters to other aliases based on join condition
@@ -136,7 +136,7 @@ public class PredicateTransitivePropagate extends Transform {
 
   private static class JoinTransitive implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
       @SuppressWarnings("unchecked")
       CommonJoinOperator<JoinDesc> join = (CommonJoinOperator) nd;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/SyntheticJoinPredicate.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/SyntheticJoinPredicate.java
@@ -24,13 +24,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
 import org.apache.hadoop.hive.ql.exec.SelectOperator;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
+import org.apache.hive.common.util.ArrayStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -139,7 +139,7 @@ public class SyntheticJoinPredicate extends Transform {
 
   private static class JoinSynthetic implements SemanticNodeProcessor {
     @Override
-    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+    public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
         Object... nodeOutputs) throws SemanticException {
 
       SyntheticContext sCtx = (SyntheticContext) procCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/tools/LineageInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/tools/LineageInfo.java
@@ -20,11 +20,9 @@ package org.apache.hadoop.hive.ql.tools;
 
 import org.apache.hadoop.hive.ql.parse.ParseUtils;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Stack;
 import java.util.TreeSet;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -40,10 +38,9 @@ import org.apache.hadoop.hive.ql.lib.SemanticRule;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
-import org.apache.hadoop.hive.ql.parse.ParseException;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hive.common.util.ArrayStack;
 
 /**
  *
@@ -81,7 +78,7 @@ public class LineageInfo implements SemanticNodeProcessor {
   /**
    * Implements the process method for the NodeProcessor interface.
    */
-  public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+  public Object process(Node nd, ArrayStack<Node> stack, NodeProcessorCtx procCtx,
       Object... nodeOutputs) throws SemanticException {
     ASTNode pt = (ASTNode) nd;
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/lib/TestRuleRegExp.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lib/TestRuleRegExp.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.lib;
 import static org.junit.Assert.*;
 
 import java.util.List;
-import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.SelectOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hive.common.util.ArrayStack;
 import org.junit.Test;
 
 public class TestRuleRegExp {
@@ -60,7 +60,7 @@ public class TestRuleRegExp {
     assertEquals(rule1.rulePatternIsValidWithoutWildCardChar(), true);
     assertEquals(rule1.rulePatternIsValidWithWildCardChar(), false);
     // positive test
-    Stack<Node> ns1 = new Stack<Node>();
+    ArrayStack<Node> ns1 = new ArrayStack<Node>();
     ns1.push(new TestNode(ReduceSinkOperator.getOperatorName()));
     ns1.push(new TestNode(SelectOperator.getOperatorName()));
     ns1.push(new TestNode(FileSinkOperator.getOperatorName()));
@@ -70,7 +70,7 @@ public class TestRuleRegExp {
       fail(e.getMessage());
 	}
     // negative test
-    Stack<Node> ns2 = new Stack<Node>();
+    ArrayStack<Node> ns2 = new ArrayStack<Node>();
     ns2.push(new TestNode(ReduceSinkOperator.getOperatorName()));
     ns1.push(new TestNode(TableScanOperator.getOperatorName()));
     ns1.push(new TestNode(FileSinkOperator.getOperatorName()));
@@ -91,10 +91,10 @@ public class TestRuleRegExp {
     assertEquals(rule1.rulePatternIsValidWithoutWildCardChar(), false);
     assertEquals(rule1.rulePatternIsValidWithWildCardChar(), true);
     // positive test
-    Stack<Node> ns1 = new Stack<Node>();
+    ArrayStack<Node> ns1 = new ArrayStack<Node>();
     ns1.push(new TestNode(TableScanOperator.getOperatorName()));
     ns1.push(new TestNode(FilterOperator.getOperatorName()));
-    Stack<Node> ns2 = new Stack<Node>();
+    ArrayStack<Node> ns2 = new ArrayStack<Node>();
     ns2.push(new TestNode(TableScanOperator.getOperatorName()));
     ns2.push(new TestNode(FileSinkOperator.getOperatorName()));
     try {
@@ -104,7 +104,7 @@ public class TestRuleRegExp {
       fail(e.getMessage());
 	}
     // negative test
-    Stack<Node> ns3 = new Stack<Node>();
+    ArrayStack<Node> ns3 = new ArrayStack<Node>();
     ns3.push(new TestNode(ReduceSinkOperator.getOperatorName()));
     ns3.push(new TestNode(ReduceSinkOperator.getOperatorName()));
     ns3.push(new TestNode(FileSinkOperator.getOperatorName()));


### PR DESCRIPTION
We currently use Stack as part of the generic node walking library. Stack should not be used for this since its inheritance from Vector incurs superfluous synchronization overhead. ArrayStack is implemented to replace Stack.

### What changes were proposed in this pull request?
* Stack<Node> calls were replaced with ArrayStack<Node>.
* ArrayStack has same pop, push, peek methods as Stack without synchronization.
* LevelOrderWalker uses an extended ArrayStack that allows add(0, element) and remove(0).
* Stack#empty was replaced with ArrayStack#isEmpty.

### Why are the changes needed?
* Stack was used in query planning, but it's very slow because of synchronization overhead.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
* All existing tests passed on http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-3434/4/pipeline/628/.
* ArrayStackTest was added to test whether ArrayStack work same as Stack.
