### PR TITLE
HIVE-26409: Assign NO_TXN operation type for table in global locks for sch…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -454,8 +454,6 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       compBuilder.setDbName(GLOBAL_LOCKS);
       compBuilder.setTableName(lockName);
 
-//      // Initiatize a writeId for the __global_locks.lockName table.
-//      getTableWriteId(GLOBAL_LOCKS, lockName);
       globalLocks.add(compBuilder.build());
       LOG.debug("Adding global lock: " + lockName);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -437,7 +437,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     return lockState;
   }
 
-  private Collection<LockComponent> getGlobalLocks(Configuration conf) throws LockException {
+  private Collection<LockComponent> getGlobalLocks(Configuration conf) {
     String lockNames = conf.get(Constants.HIVE_QUERY_EXCLUSIVE_LOCK);
     if (StringUtils.isEmpty(lockNames)) {
       return Collections.emptyList();

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -437,7 +437,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     return lockState;
   }
 
-  private Collection<LockComponent> getGlobalLocks(Configuration conf) {
+  private Collection<LockComponent> getGlobalLocks(Configuration conf) throws LockException {
     String lockNames = conf.get(Constants.HIVE_QUERY_EXCLUSIVE_LOCK);
     if (StringUtils.isEmpty(lockNames)) {
       return Collections.emptyList();
@@ -453,6 +453,9 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       compBuilder.setOperationType(DataOperationType.UPDATE);
       compBuilder.setDbName(GLOBAL_LOCKS);
       compBuilder.setTableName(lockName);
+
+      // Initiatize a writeId for the __global_locks.lockName table.
+      getTableWriteId(GLOBAL_LOCKS, lockName);
       globalLocks.add(compBuilder.build());
       LOG.debug("Adding global lock: " + lockName);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -450,12 +450,12 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       }
       LockComponentBuilder compBuilder = new LockComponentBuilder();
       compBuilder.setExclusive();
-      compBuilder.setOperationType(DataOperationType.UPDATE);
+      compBuilder.setOperationType(DataOperationType.NO_TXN);
       compBuilder.setDbName(GLOBAL_LOCKS);
       compBuilder.setTableName(lockName);
 
-      // Initiatize a writeId for the __global_locks.lockName table.
-      getTableWriteId(GLOBAL_LOCKS, lockName);
+//      // Initiatize a writeId for the __global_locks.lockName table.
+//      getTableWriteId(GLOBAL_LOCKS, lockName);
       globalLocks.add(compBuilder.build());
       LOG.debug("Adding global lock: " + lockName);
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -3120,8 +3120,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
   }
 
   @Test
-  public void testScheduledQueriesCompletedTxnComponentsCleanup() throws Exception {
-    String tableName = "scheduledQueryTable";
+  public void testNoTxnComponentsForScheduledQueries() throws Exception {
+    String tableName = "scheduledquerytable";
     int[][] tableData = {{1, 2},{3, 4}};
     runStatementOnDriver("create table " + tableName + " (a int, b int) stored as orc tblproperties ('transactional'='true')");
 
@@ -3154,12 +3154,12 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     }
 
     // Check whether the table has delta files corresponding to the number of scheduled executions.
-//    FileSystem fs = FileSystem.get(hiveConf);
-//    FileStatus[] fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
-//    Assert.assertEquals(fileStatuses.length, noOfTimesScheduledQueryExecuted);
-//    for(FileStatus fileStatus : fileStatuses) {
-//      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.DELTA_PREFIX));
-//    }
+    FileSystem fs = FileSystem.get(hiveConf);
+    FileStatus[] fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+    Assert.assertEquals(fileStatuses.length, noOfTimesScheduledQueryExecuted);
+    for(FileStatus fileStatus : fileStatuses) {
+      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.DELTA_PREFIX));
+    }
 
     // Check whether the COMPLETED_TXN_COMPONENTS table has records with
     // '__global_locks' database and associate writeId corresponding to the
@@ -3179,17 +3179,12 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     houseKeeper.setConf(hiveConf);
     houseKeeper.run();
 
-    // Check whether the COMPLETED_TXN_COMPONENTS table has 1 record with
-    // '__global_locks' database and associate writeId after cleanup.
-//    Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from completed_txn_components" +
-//            " where ctc_database='__global_locks' and ctc_writeid is not null"), 1);
-
     // Check whether the table is compacted.
-//    fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
-//    Assert.assertEquals(fileStatuses.length, 1);
-//    for(FileStatus fileStatus : fileStatuses) {
-//      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
-//    }
+    fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+    Assert.assertEquals(fileStatuses.length, 1);
+    for(FileStatus fileStatus : fileStatuses) {
+      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+    }
 
     // Check whether the data in the table is correct.
     int[][] actualData = {{1,2}, {1,2}, {1,2}, {1,2}, {3,4}, {3,4}, {3,4}, {3,4}};

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -141,8 +141,6 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     super.initHiveConf();
     //TestTxnCommands2WithSplitUpdateAndVectorization has the vectorized version
     //of these tests.
-    HiveConf.setVar(hiveConf, HiveConf.ConfVars.HIVE_SCHEDULED_QUERIES_EXECUTOR_IDLE_SLEEP_TIME, "1s");
-    HiveConf.setVar(hiveConf, HiveConf.ConfVars.HIVE_SCHEDULED_QUERIES_EXECUTOR_PROGRESS_REPORT_INTERVAL, "1s");
     HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED, false);
     HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVEOPTIMIZEMETADATAQUERIES, false);
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -141,6 +141,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     super.initHiveConf();
     //TestTxnCommands2WithSplitUpdateAndVectorization has the vectorized version
     //of these tests.
+    HiveConf.setVar(hiveConf, HiveConf.ConfVars.HIVE_SCHEDULED_QUERIES_EXECUTOR_IDLE_SLEEP_TIME, "1s");
+    HiveConf.setVar(hiveConf, HiveConf.ConfVars.HIVE_SCHEDULED_QUERIES_EXECUTOR_PROGRESS_REPORT_INTERVAL, "1s");
     HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED, false);
     HiveConf.setBoolVar(hiveConf, HiveConf.ConfVars.HIVEOPTIMIZEMETADATAQUERIES, false);
   }
@@ -3152,12 +3154,12 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     }
 
     // Check whether the table has delta files corresponding to the number of scheduled executions.
-    FileSystem fs = FileSystem.get(hiveConf);
-    FileStatus[] fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
-    Assert.assertEquals(fileStatuses.length, noOfTimesScheduledQueryExecuted);
-    for(FileStatus fileStatus : fileStatuses) {
-      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.DELTA_PREFIX));
-    }
+//    FileSystem fs = FileSystem.get(hiveConf);
+//    FileStatus[] fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+//    Assert.assertEquals(fileStatuses.length, noOfTimesScheduledQueryExecuted);
+//    for(FileStatus fileStatus : fileStatuses) {
+//      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.DELTA_PREFIX));
+//    }
 
     // Check whether the COMPLETED_TXN_COMPONENTS table has records with
     // '__global_locks' database and associate writeId corresponding to the
@@ -3183,11 +3185,11 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
 //            " where ctc_database='__global_locks' and ctc_writeid is not null"), 1);
 
     // Check whether the table is compacted.
-    fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
-    Assert.assertEquals(fileStatuses.length, 1);
-    for(FileStatus fileStatus : fileStatuses) {
-      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
-    }
+//    fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+//    Assert.assertEquals(fileStatuses.length, 1);
+//    for(FileStatus fileStatus : fileStatuses) {
+//      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+//    }
 
     // Check whether the data in the table is correct.
     int[][] actualData = {{1,2}, {1,2}, {1,2}, {1,2}, {3,4}, {3,4}, {3,4}, {3,4}};

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -3163,8 +3163,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     // number of scheduled executions.
     Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf,
             "select count(*) from completed_txn_components" +
-            " where ctc_database='__global_locks' and ctc_writeid is not null"),
-            noOfTimesScheduledQueryExecuted);
+            " where ctc_database='__global_locks'"),
+            0);
 
     // Compact the table which has inserts from the scheduled query.
     runStatementOnDriver("alter table " + tableName + " compact 'major'");
@@ -3178,8 +3178,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
 
     // Check whether the COMPLETED_TXN_COMPONENTS table has 1 record with
     // '__global_locks' database and associate writeId after cleanup.
-    Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from completed_txn_components" +
-            " where ctc_database='__global_locks' and ctc_writeid is not null"), 1);
+//    Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from completed_txn_components" +
+//            " where ctc_database='__global_locks' and ctc_writeid is not null"), 1);
 
     // Check whether the table is compacted.
     fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -29,9 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -63,6 +66,10 @@ import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.lockmgr.TxnManagerFactory;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.metastore.txn.AcidOpenTxnsCounterService;
+import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionContext;
+import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionService;
+import org.apache.hadoop.hive.ql.schq.TestScheduledQueryService;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorMR;
 import org.apache.hadoop.hive.ql.txn.compactor.Worker;
 import org.apache.hadoop.io.Writable;
@@ -70,11 +77,15 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -3103,6 +3114,84 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     for(FileStatus fileStatus : fileStatuses) {
       Assert.assertFalse(fileStatus.getPath().getName().startsWith(AcidUtils.DELETE_DELTA_PREFIX));
     }
+  }
+
+  @Test
+  public void testScheduledQueriesCompletedTxnComponentsCleanup() throws Exception {
+    String tableName = "scheduledQueryTable";
+    int[][] tableData = {{1, 2},{3, 4}};
+    runStatementOnDriver("create table " + tableName + " (a int, b int) stored as orc tblproperties ('transactional'='true')");
+
+    int noOfTimesScheduledQueryExecuted = 4;
+
+    // Logic for executing scheduled queries multiple times.
+    for (int index = 0;index < noOfTimesScheduledQueryExecuted;index++) {
+      ExecutorService executor =
+              Executors.newCachedThreadPool(new ThreadFactoryBuilder().setDaemon(true)
+                      .setNameFormat("Scheduled queries for transactional tables").build());
+
+      // Mock service which initialises the query for execution.
+      TestScheduledQueryService.MockScheduledQueryService qService = new TestScheduledQueryService
+              .MockScheduledQueryService("insert into " + tableName + " (a,b) " + makeValuesClause(tableData));
+      ScheduledQueryExecutionContext ctx = new ScheduledQueryExecutionContext(executor, hiveConf, qService);
+
+      // Start the scheduled query execution.
+      try (ScheduledQueryExecutionService sQ = ScheduledQueryExecutionService.startScheduledQueryExecutorService(ctx)) {
+        // Wait for the scheduled query to finish. Hopefully 30 seconds should be more than enough.
+        SessionState.getConsole().logInfo("Waiting for query execution to finish ...");
+        synchronized (qService.notifier) {
+          qService.notifier.wait(30000);
+        }
+        SessionState.getConsole().logInfo("Done waiting for query execution!");
+      }
+
+      assertThat(qService.lastProgressInfo.isSetExecutorQueryId(), is(true));
+      assertThat(qService.lastProgressInfo.getExecutorQueryId(),
+              Matchers.containsString(ctx.executorHostName + "/"));
+    }
+
+    // Check whether the table has delta files corresponding to the number of scheduled executions.
+    FileSystem fs = FileSystem.get(hiveConf);
+    FileStatus[] fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+    Assert.assertEquals(fileStatuses.length, noOfTimesScheduledQueryExecuted);
+    for(FileStatus fileStatus : fileStatuses) {
+      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.DELTA_PREFIX));
+    }
+
+    // Check whether the COMPLETED_TXN_COMPONENTS table has records with
+    // '__global_locks' database and associate writeId corresponding to the
+    // number of scheduled executions.
+    Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf,
+            "select count(*) from completed_txn_components" +
+            " where ctc_database='__global_locks' and ctc_writeid is not null"),
+            noOfTimesScheduledQueryExecuted);
+
+    // Compact the table which has inserts from the scheduled query.
+    runStatementOnDriver("alter table " + tableName + " compact 'major'");
+    runWorker(hiveConf);
+    runCleaner(hiveConf);
+
+    // Run AcidHouseKeeperService to cleanup the COMPLETED_TXN_COMPONENTS.
+    MetastoreTaskThread houseKeeper = new AcidHouseKeeperService();
+    houseKeeper.setConf(hiveConf);
+    houseKeeper.run();
+
+    // Check whether the COMPLETED_TXN_COMPONENTS table has 1 record with
+    // '__global_locks' database and associate writeId after cleanup.
+    Assert.assertEquals(TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from completed_txn_components" +
+            " where ctc_database='__global_locks' and ctc_writeid is not null"), 1);
+
+    // Check whether the table is compacted.
+    fileStatuses = fs.globStatus(new Path(getWarehouseDir() + "/" + tableName + "/*"));
+    Assert.assertEquals(fileStatuses.length, 1);
+    for(FileStatus fileStatus : fileStatuses) {
+      Assert.assertTrue(fileStatus.getPath().getName().startsWith(AcidUtils.BASE_PREFIX));
+    }
+
+    // Check whether the data in the table is correct.
+    int[][] actualData = {{1,2}, {1,2}, {1,2}, {1,2}, {3,4}, {3,4}, {3,4}, {3,4}};
+    List<String> resData = runStatementOnDriver("select a,b from " + tableName + " order by a");
+    Assert.assertEquals(resData, stringifyValues(actualData));
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.metastore.txn.AcidOpenTxnsCounterService;
 import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionContext;
 import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionService;
+import org.apache.hadoop.hive.ql.schq.MockScheduledQueryService;
 import org.apache.hadoop.hive.ql.schq.TestScheduledQueryService;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorMR;
@@ -3131,8 +3132,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
                       .setNameFormat("Scheduled queries for transactional tables").build());
 
       // Mock service which initialises the query for execution.
-      TestScheduledQueryService.MockScheduledQueryService qService = new TestScheduledQueryService
-              .MockScheduledQueryService("insert into " + tableName + " (a,b) " + makeValuesClause(tableData));
+      MockScheduledQueryService qService = new
+              MockScheduledQueryService("insert into " + tableName + " (a,b) " + makeValuesClause(tableData));
       ScheduledQueryExecutionContext ctx = new ScheduledQueryExecutionContext(executor, hiveConf, qService);
 
       // Start the scheduled query execution.

--- a/ql/src/test/org/apache/hadoop/hive/ql/schq/MockScheduledQueryService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/schq/MockScheduledQueryService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.schq;
+
+import org.apache.hadoop.hive.metastore.api.QueryState;
+import org.apache.hadoop.hive.metastore.api.ScheduledQueryKey;
+import org.apache.hadoop.hive.metastore.api.ScheduledQueryPollResponse;
+import org.apache.hadoop.hive.metastore.api.ScheduledQueryProgressInfo;
+import org.apache.hadoop.hive.ql.scheduled.IScheduledQueryMaintenanceService;
+
+public class MockScheduledQueryService implements IScheduledQueryMaintenanceService {
+    // Use notify/wait on this object to indicate when the scheduled query has finished executing.
+    public final Object notifier = new Object();
+
+    int id = 0;
+    private String stmt;
+    public ScheduledQueryProgressInfo lastProgressInfo;
+
+    public MockScheduledQueryService(String string) {
+        stmt = string;
+    }
+
+    @Override
+    public ScheduledQueryPollResponse scheduledQueryPoll() {
+        ScheduledQueryPollResponse r = new ScheduledQueryPollResponse();
+        r.setQuery(stmt);
+        r.setScheduleKey(new ScheduledQueryKey("sch1", getClusterNamespace()));
+        r.setUser("nobody");
+        if (id == 0) {
+            r.setExecutionId(id++);
+            return r;
+        } else {
+            return r;
+        }
+    }
+
+    @Override
+    public void scheduledQueryProgress(ScheduledQueryProgressInfo info) {
+        System.out.printf("%d, state: %s, error: %s", info.getScheduledExecutionId(), info.getState(),
+                info.getErrorMessage());
+        lastProgressInfo = info;
+        if (info.getState() == QueryState.FINISHED || info.getState() == QueryState.FAILED) {
+            // Query is done, notify any waiters
+            synchronized (notifier) {
+                notifier.notifyAll();
+            }
+        }
+    }
+
+    @Override
+    public String getClusterNamespace() {
+        return "default";
+    }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
@@ -98,52 +98,6 @@ public class TestScheduledQueryService {
     return res.size();
   }
 
-
-  public static class MockScheduledQueryService implements IScheduledQueryMaintenanceService {
-    // Use notify/wait on this object to indicate when the scheduled query has finished executing.
-    public final Object notifier = new Object();
-
-    int id = 0;
-    private String stmt;
-    public ScheduledQueryProgressInfo lastProgressInfo;
-
-    public MockScheduledQueryService(String string) {
-      stmt = string;
-    }
-
-    @Override
-    public ScheduledQueryPollResponse scheduledQueryPoll() {
-      ScheduledQueryPollResponse r = new ScheduledQueryPollResponse();
-      r.setQuery(stmt);
-      r.setScheduleKey(new ScheduledQueryKey("sch1", getClusterNamespace()));
-      r.setUser("nobody");
-      if (id == 0) {
-        r.setExecutionId(id++);
-        return r;
-      } else {
-        return r;
-      }
-    }
-
-    @Override
-    public void scheduledQueryProgress(ScheduledQueryProgressInfo info) {
-      System.out.printf("%d, state: %s, error: %s", info.getScheduledExecutionId(), info.getState(),
-          info.getErrorMessage());
-      lastProgressInfo = info;
-      if (info.getState() == QueryState.FINISHED || info.getState() == QueryState.FAILED) {
-        // Query is done, notify any waiters
-        synchronized (notifier) {
-          notifier.notifyAll();
-        }
-      }
-    }
-
-    @Override
-    public String getClusterNamespace() {
-      return "default";
-    }
-  }
-
   @Test
   public void testScheduledQueryExecution() throws ParseException, Exception {
     IDriver driver = createDriver();

--- a/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
@@ -114,14 +114,14 @@ public class TestScheduledQueryService {
     @Override
     public ScheduledQueryPollResponse scheduledQueryPoll() {
       ScheduledQueryPollResponse r = new ScheduledQueryPollResponse();
-      r.setExecutionId(id++);
       r.setQuery(stmt);
       r.setScheduleKey(new ScheduledQueryKey("sch1", getClusterNamespace()));
       r.setUser("nobody");
-      if (id == 1) {
+      if (id == 0) {
+        r.setExecutionId(id++);
         return r;
       } else {
-        return null;
+        return r;
       }
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/schq/TestScheduledQueryService.java
@@ -101,11 +101,11 @@ public class TestScheduledQueryService {
 
   public static class MockScheduledQueryService implements IScheduledQueryMaintenanceService {
     // Use notify/wait on this object to indicate when the scheduled query has finished executing.
-    Object notifier = new Object();
+    public final Object notifier = new Object();
 
     int id = 0;
     private String stmt;
-    ScheduledQueryProgressInfo lastProgressInfo;
+    public ScheduledQueryProgressInfo lastProgressInfo;
 
     public MockScheduledQueryService(String string) {
       stmt = string;


### PR DESCRIPTION
…eduled queries

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Assigning NO_TXN operation for table in global locks for scheduled queries.


### Why are the changes needed?
NO_TXN operation type has to be assigned while acquiring locks for the table in global locks because this will not add records to COMPLETED_TXN_COMPONENTS table. Currently the record introduced by this lock had writeId as NULL. There was a situation which lead to large number of records in COMPLETED_TXN_COMPONENTS table because these records had writeId as NULL which weren't deleted by AcidHouseKeeperService/Cleaner and this subsequently lead to OOM errors.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test