### PR TITLE
HIVE-26410: Reading nested types within maps in Parquet Iceberg is not supported with vectorization

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
@@ -334,8 +334,6 @@ public class TestHiveIcebergInserts extends HiveIcebergStorageHandlerWithEngineB
 
   @Test
   public void testStructMapWithNull() throws IOException {
-    Assume.assumeTrue("Vectorized parquet read throws class cast exception",
-        !(fileFormat == FileFormat.PARQUET && isVectorized));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
         required(2, "mapofstructs", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
             Types.StructType.of(required(5, "something", Types.StringType.get()),


### PR DESCRIPTION
Vectorized reading of nested types of Parquet lists or maps is currently not supported by Hive's implementation of vectorized Parquet readers. It's an edge case, but we should fall back gracefully to non-vectorized read mode.