### PR TITLE
HIVE-26420: Configurable timeout for HiveSplitGenerator to wait for LLAP instances

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5053,6 +5053,14 @@ public class HiveConf extends Configuration {
     // These are read by Hadoop IPC, so you should check the usage and naming conventions (e.g.
     // ".blocked" is a string hardcoded by Hadoop, and defaults are enforced elsewhere in Hive)
     // before making changes or copy-pasting these.
+    LLAP_ZK_REGISTRY_INSTANCE_TIMEOUT_BEFORE_SPLITGENERATION(
+        "hive.llap.zk.registry.instance.timeout.before.splitgeneration", 0,
+        "HiveSplitGenerator will wait this many milliseconds for LLAP instances to become ready before"
+            + "trying generate splits.\n"
+            + "This can prevent some exceptions when LLAP instances are not ready yet but the query is already "
+            + "assigned to the TezAM."
+            + "Default value is 0, which means no timeout (similar behavior applies to values smaller than 1000 "
+            + "due to the nature of retry logic inside)"),
     LLAP_SECURITY_ACL("hive.llap.daemon.acl", "*", "The ACL for LLAP daemon."),
     LLAP_SECURITY_ACL_DENY("hive.llap.daemon.acl.blocked", "", "The deny ACL for LLAP daemon."),
     LLAP_MANAGEMENT_ACL("hive.llap.management.acl", "*", "The ACL for LLAP daemon management."),

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestUtils.java
@@ -121,7 +121,7 @@ public class TestUtils {
 
     when(mockRegistry.getInstances()).thenReturn(mockInstanceSet);
     when(mockInstanceSet.getAllInstancesOrdered(anyBoolean())).thenReturn(instances);
-    SplitLocationProvider provider = Utils.getCustomSplitLocationProvider(mockRegistry, LOG);
+    SplitLocationProvider provider = Utils.getCustomSplitLocationProvider(mockRegistry, 0, LOG);
 
     assertLocations((HostAffinitySplitLocationProvider)provider, new String[] {ACTIVE});
 
@@ -133,7 +133,7 @@ public class TestUtils {
     instances.remove(dynamic);
     instances.add(fixed);
 
-    provider = Utils.getCustomSplitLocationProvider(mockRegistry, LOG);
+    provider = Utils.getCustomSplitLocationProvider(mockRegistry, 0, LOG);
 
     assertLocations((HostAffinitySplitLocationProvider)provider, new String[] {FIXED});
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce a timeout for LLAP split generation.


### Why are the changes needed?
Described on jira.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested on a Cloudera Data Warehouse.
