### PR TITLE
HIVE-26426: Avoid StringIndexOutOfBoundsException in canCBOHandleAst() method

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -947,7 +947,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
     // Now check QB in more detail. canHandleQbForCbo returns null if query can
     // be handled.
     msg = CalcitePlanner.canHandleQbForCbo(queryProperties, conf, true, needToLogMessage);
-    if (msg == null) {
+    if (msg == null || msg.isEmpty()) {
       return Pair.of(true, msg);
     }
     msg = msg.substring(0, msg.length() - 2);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -947,10 +947,10 @@ public class CalcitePlanner extends SemanticAnalyzer {
     // Now check QB in more detail. canHandleQbForCbo returns null if query can
     // be handled.
     msg = CalcitePlanner.canHandleQbForCbo(queryProperties, conf, true, needToLogMessage);
-    if (msg == null || msg.isEmpty()) {
+    if (msg == null) {
       return Pair.of(true, msg);
     }
-    msg = msg.substring(0, msg.length() - 2);
+
     if (needToLogMessage) {
       STATIC_LOG.info("Not invoking CBO because the statement " + msg);
     }
@@ -1006,10 +1006,10 @@ public class CalcitePlanner extends SemanticAnalyzer {
       if (queryProperties.hasLateralViews()) {
         msg += "has lateral views; ";
       }
-
       if (msg.isEmpty()) {
         msg += "has some unspecified limitations; ";
       }
+      msg = msg.substring(0, msg.length() - 2);
     }
     return msg;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
It's a simple fix for not handling a case which results in a **StringIndexOutOfBoundsException**. Read the [ticket](https://issues.apache.org/jira/browse/HIVE-26426) for more details.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Locally.

