### PR TITLE
HIVE-26428 Limit usage of LLAP BPWrapper to threads of IO threadpools

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapPooledIOThread.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapPooledIOThread.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.llap.daemon.impl;
+
+/**
+ * Marker class for threads created for the purpose of doing IO work in LLAP. Currently used by LRFU cache policy to
+ * distinguish from ephemeral threads (e.g. TezTR) and decide whether ThreadLocal-based features are applicable or not.
+ */
+public class LlapPooledIOThread extends Thread {
+
+  public LlapPooledIOThread(Runnable runnable) {
+    super(runnable);
+  }
+}


### PR DESCRIPTION
BPWrapper is used in LRFU cache eviction policy to decrease the time spent waiting for lock on the heap. This is done by adding a buffer as threadlocal and accumulating CacheableBuffer instances there before trying to acquire a lock. This works well when we have threads from pools such as IO-Elevator threads or OrcEncode threads.

For ephemeral threads there's no advantage of doing this as the buffers in threadlocals may never reach the heap or list structures of LRFU, thereby also making evictions less efficient. This can happen e.g. LLAPCacheAwareFS is used with Parquet, where we're using the Tez threads for both execution and IO.

We should disable BPWrappers for such cases.