### PR TITLE
[WIP]HIVE-26435: HMS Summary

### DIFF
--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -31,6 +31,11 @@
       <version>4.0.0-alpha-2-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-catalog</artifactId>
+      <version>4.0.0-alpha-2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
       <exclusions>
@@ -341,6 +346,54 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>2.32.0</version>
       <scope>test</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>4.0.0-alpha-2-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>4.0.0-alpha-2-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>4.0.0-alpha-2-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>4.0.0-alpha-2-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>4.0.0-alpha-2-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>4.0.0-alpha-2-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>4.0.0-alpha-2-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>4.0.0-alpha-2-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <profiles>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -3,9 +3,7 @@
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,11 +26,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-standalone-metastore-common</artifactId>
-      <version>4.0.0-alpha-2-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-iceberg-catalog</artifactId>
       <version>4.0.0-alpha-2-SNAPSHOT</version>
     </dependency>
     <dependency>
@@ -346,54 +339,6 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>2.32.0</version>
       <scope>test</scope>
-    </dependency>
-      <dependency>
-          <groupId>org.apache.hive</groupId>
-          <artifactId>hive-metastore</artifactId>
-          <version>4.0.0-alpha-2-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>4.0.0-alpha-2-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>4.0.0-alpha-2-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-      <dependency>
-          <groupId>org.apache.hive</groupId>
-          <artifactId>hive-metastore</artifactId>
-          <version>4.0.0-alpha-2-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.apache.hive</groupId>
-          <artifactId>hive-metastore</artifactId>
-          <version>4.0.0-alpha-2-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>4.0.0-alpha-2-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-      <dependency>
-          <groupId>org.apache.hive</groupId>
-          <artifactId>hive-metastore</artifactId>
-          <version>4.0.0-alpha-2-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>4.0.0-alpha-2-SNAPSHOT</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
   <profiles>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.metastore;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_USE_CUSTOM_POOL;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.newMetaException;
 import static org.apache.hadoop.hive.metastore.utils.StringUtils.normalizeIdentifier;
 
 import java.io.IOException;
@@ -51,9 +50,6 @@ import javax.jdo.Transaction;
 import javax.jdo.datastore.JDOConnection;
 import javax.jdo.identity.IntIdentity;
 
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.*;
-import org.apache.iceberg.hive.HiveCatalog;
 import com.google.common.util.concurrent.Striped;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/CatalogSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/CatalogSummary.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.tools.metatool;
+import java.util.*;
+
+public class CatalogSummary {
+    String cat_name;
+    List<DatabaseSummary> database_names;
+
+    public CatalogSummary(String cat_name, List<DatabaseSummary> database_names) {
+        this.cat_name = cat_name;
+        this.database_names = database_names;
+    }
+
+    public String getCat_name() {
+        return cat_name;
+    }
+
+    public void setCat_name(String cat_name) {
+        this.cat_name = cat_name;
+    }
+
+    public List<DatabaseSummary> getDatabase_names() {
+        return database_names;
+    }
+
+    public void setDatabase_names(List<DatabaseSummary> database_names) {
+        this.database_names = database_names;
+    }
+
+    @Override
+    public String toString() {
+        return "CatalogSummary{" +
+                "cat_name='" + cat_name + '\'' +
+                ", database_names=" + database_names +
+                '}';
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/DatabaseSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/DatabaseSummary.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.tools.metatool;
+
+import java.util.*;
+
+
+public class DatabaseSummary {
+
+    String db_name;
+    String cat_name;
+    List<TableSummary> table_names;
+
+    public DatabaseSummary(String db_name, String cat_name, List<TableSummary> table_names) {
+        this.db_name = db_name;
+        this.cat_name = cat_name;
+        this.table_names = table_names;
+    }
+
+    public String getDb_name() {
+        return db_name;
+    }
+
+    public void setDb_name(String db_name) {
+        this.db_name = db_name;
+    }
+
+    public String getCat_name() {
+        return cat_name;
+    }
+
+    public void setCat_name(String cat_name) {
+        this.cat_name = cat_name;
+    }
+
+    public List<TableSummary> getTable_names() {
+        return table_names;
+    }
+
+    public void setTable_names(List<TableSummary> table_names) {
+        this.table_names = table_names;
+    }
+
+    @Override
+    public String toString() {
+        return "DatabaseSummary{" +
+                "db_name='" + db_name + '\'' +
+                ", cat_name='" + cat_name + '\'' +
+                ", table_names=" + table_names +
+                '}';
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/DatabaseSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/DatabaseSummary.java
@@ -22,14 +22,13 @@ import java.util.*;
 
 
 public class DatabaseSummary {
-
-    String db_name;
     String cat_name;
+    String db_name;
     List<TableSummary> table_names;
 
-    public DatabaseSummary(String db_name, String cat_name, List<TableSummary> table_names) {
-        this.db_name = db_name;
+    public DatabaseSummary(String cat_name, String db_name, List<TableSummary> table_names) {
         this.cat_name = cat_name;
+        this.db_name = db_name;
         this.table_names = table_names;
     }
 
@@ -60,8 +59,8 @@ public class DatabaseSummary {
     @Override
     public String toString() {
         return "DatabaseSummary{" +
-                "db_name='" + db_name + '\'' +
-                ", cat_name='" + cat_name + '\'' +
+                "cat_name='" + cat_name + '\'' +
+                ", db_name='" + db_name + '\'' +
                 ", table_names=" + table_names +
                 '}';
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/HiveMetaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/HiveMetaTool.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  * - list the file system root
  * - execute JDOQL against the metastore using DataNucleus
  * - perform HA name node upgrade
+ * - summarize the data in HMS
  */
 public final class HiveMetaTool {
   private static final Logger LOGGER = LoggerFactory.getLogger(HiveMetaTool.class.getName());
@@ -38,11 +39,10 @@ public final class HiveMetaTool {
 
   public static void main(String[] args) {
     HiveMetaToolCommandLine cl = HiveMetaToolCommandLine.parseArguments(args);
-
     ObjectStore objectStore = new ObjectStore();
     objectStore.setConf(MetastoreConf.newMetastoreConf());
-
     MetaToolTask task = null;
+
     try {
       if (cl.isListFSRoot()) {
         task = new MetaToolTaskListFSRoot();
@@ -54,9 +54,12 @@ public final class HiveMetaTool {
         task = new MetaToolTaskListExtTblLocs();
       } else if (cl.isDiffExtTblLocs()) {
         task = new MetaToolTaskDiffExtTblLocs();
+      } else if (cl.isMetadataSummary()) {
+        task = new MetaToolTaskMetadataSummary();
       } else {
         throw new IllegalArgumentException("No task was specified!");
       }
+
 
       task.setObjectStore(objectStore);
       task.setCommandLine(cl);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.tools.metatool;
+
+import java.nio.file.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.hadoop.hive.metastore.HiveMetaException;
+import org.apache.hadoop.hive.metastore.ObjectStore;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.tools.SQLGenerator;
+import javax.jdo.PersistenceManager;
+import javax.jdo.datastore.JDOConnection;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.List;
+
+public class MetaToolTaskMetadataSummary extends MetaToolTask {
+    private PersistenceManager pm = null;
+
+    @Override
+    void execute() {
+        try{
+            String query = getCl().getMetadataSummaryFormat();
+            ObjectStore objectStore = getObjectStore();
+            pm = objectStore.getPersistenceManager();
+            JDOConnection jdoConn = pm.getDataStoreConnection();
+            Statement stmt = ((Connection) jdoConn.getNativeConnection()).createStatement();
+            ObjectStore.updateMetastoreSummary(stmt);
+            MetadataSummary metadataSummary = ObjectStore.getMetadataSummary(stmt);
+            if(query.toLowerCase().trim().equals("-json")) {
+                exportInJson(metadataSummary);
+            } else if(query.toLowerCase().trim().equals("-console")) {
+                exportInConsole(metadataSummary);
+            } else {
+                System.out.println("invalid format!");
+            }
+        }
+        catch(SQLException e) {
+            System.out.println(e);
+        }
+    }
+
+    /**
+     * Exporting the MetadataSummary in JSON format.
+     * @param metadataSummary
+     */
+    public void exportInJson(MetadataSummary metadataSummary) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String jsonOutput = gson.toJson(metadataSummary);
+        writeJsonInFile(jsonOutput);
+    }
+
+    /**
+     * Exporting the MetadataSummary in CONSOLE.
+     * @param metadataSummary
+     */
+    public void exportInConsole(MetadataSummary metadataSummary) {
+        outputConsole(metadataSummary);
+    }
+
+    /**
+     * Helper method of exportInConsole.
+     * @param metadataSummary
+     */
+    private void outputConsole(MetadataSummary metadataSummary) {
+        List<CatalogSummary> catalogSummaries = metadataSummary.getCatalog_names();
+        System.out.println("-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        System.out.println("                                                                                                    Metadata Summary                                                                                                        ");
+        System.out.println("-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        System.out.println("----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----Catalog Summary-----    ----    ----    ----    ---    -----     ----    ----    ----    -----     ");
+        System.out.printf("%100s", "Catalog_Name");
+        System.out.println();
+        System.out.println("-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        for(CatalogSummary ctlg: catalogSummaries) {
+            System.out.format("%100s", ctlg.getCat_name());
+            System.out.println();
+        }
+        System.out.println("----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----Database Summary----    ----    ----    ----    ----    -----     ----    ----    ----    -----  ");
+        System.out.printf("%70s %70s", "db_name", "cat_name");
+        System.out.println();
+        System.out.println("-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        for(CatalogSummary ctlg: catalogSummaries) {
+            List<DatabaseSummary> databaseSummaries = ctlg.getDatabase_names();
+            for(DatabaseSummary dbs: databaseSummaries) {
+                System.out.format("%70s %70s", dbs.getDb_name(), dbs.getCat_name());
+                System.out.println();
+            }
+
+        }
+        System.out.println("----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----Table Summary----    ----    ----    ----    ----    -----     ----    ----    ----    -----    ");
+        System.out.printf("%10s %28s %35s %10s %20s %15s %10s %10s %10s %10s %15s", "cat_name", "db_name", "table_name", "column_count",
+                "table_type", "file_format", "compression_type", "num_rows", "size_bytes", "num_files", "partition_col_count");
+        System.out.println();
+        System.out.println("------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        for(CatalogSummary ctlg: catalogSummaries) {
+            List<DatabaseSummary> databaseSummaries = ctlg.getDatabase_names();
+            for(DatabaseSummary dbs: databaseSummaries) {
+                List<TableSummary> tableSummaries = dbs.getTable_names();
+                for(TableSummary tbs: tableSummaries) {
+                    System.out.format("%10s %28s %35s %10d %20s %15s %10s %10s %10s %10s %15s", tbs.getCat_name(), tbs.getDb_name(),
+                            tbs.getTable_name(), tbs.getColumn_count(), tbs.getTable_type(), tbs.getFile_format(),
+                            tbs.getCompression_type(), tbs.getSize_numRows(), tbs.getSize_bytes(),
+                            tbs.getSize_numFiles(), tbs.getPartition_column_count());
+                    System.out.println();
+                }
+            }
+        }
+        System.out.println("------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+    }
+
+    /**
+     * Helper method of exportInJson.
+     * @param jsonOutput A string, JSON formatted string about metadataSummary.
+     */
+    private void writeJsonInFile(String jsonOutput) {
+        try {
+            File myObj = new File("/tmp/MetastoreSummary_JSON.txt");
+            if (myObj.createNewFile()) {
+                System.out.println("File created: " + myObj.getName());
+            } else {
+                System.out.println("File already exists.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+        // Creating an instance of file
+        Path path
+                = Paths.get("/tmp/MetastoreSummary_JSON.txt");
+
+        byte[] arr = jsonOutput.getBytes();
+
+        // Try block to check for exceptions
+        try {
+            Files.write(path, arr);
+            System.out.println("write in file successfully");
+        }
+        // Catch block to handle the exceptions
+        catch (IOException ex) {
+            // Print message as exception occurred when invalid path of local machine is passed
+            System.out.print("Invalid Path");
+        }
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
@@ -57,6 +57,8 @@ public class MetaToolTaskMetadataSummary extends MetaToolTask {
         }
         catch(SQLException e) {
             System.out.println(e);
+        } catch (MetaException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskMetadataSummary.java
@@ -46,6 +46,7 @@ public class MetaToolTaskMetadataSummary extends MetaToolTask {
             JDOConnection jdoConn = pm.getDataStoreConnection();
             Statement stmt = ((Connection) jdoConn.getNativeConnection()).createStatement();
             ObjectStore.updateMetastoreSummary(stmt);
+
             MetadataSummary metadataSummary = ObjectStore.getMetadataSummary(stmt);
             if(query.toLowerCase().trim().equals("-json")) {
                 exportInJson(metadataSummary);
@@ -58,6 +59,7 @@ public class MetaToolTaskMetadataSummary extends MetaToolTask {
         catch(SQLException e) {
             System.out.println(e);
         } catch (MetaException e) {
+            System.out.println(e);
             throw new RuntimeException(e);
         }
     }
@@ -110,7 +112,7 @@ public class MetaToolTaskMetadataSummary extends MetaToolTask {
 
         }
         System.out.println("----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----    ----Table Summary----    ----    ----    ----    ----    -----     ----    ----    ----    -----    ");
-        System.out.printf("%10s %28s %35s %10s %20s %15s %10s %10s %10s %10s %15s", "cat_name", "db_name", "table_name", "column_count",
+        System.out.printf("%10s %20s %50s %10s %20s %15s %10s %10s %10s %10s %15s", "cat_name", "db_name", "table_name", "column_count",
                 "table_type", "file_format", "compression_type", "num_rows", "size_bytes", "num_files", "partition_col_count");
         System.out.println();
         System.out.println("------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
@@ -119,7 +121,7 @@ public class MetaToolTaskMetadataSummary extends MetaToolTask {
             for(DatabaseSummary dbs: databaseSummaries) {
                 List<TableSummary> tableSummaries = dbs.getTable_names();
                 for(TableSummary tbs: tableSummaries) {
-                    System.out.format("%10s %28s %35s %10d %20s %15s %10s %10s %10s %10s %15s", tbs.getCat_name(), tbs.getDb_name(),
+                    System.out.format("%10s %20s %50s %10d %20s %15s %10s %10s %10s %10s %15s", tbs.getCat_name(), tbs.getDb_name(),
                             tbs.getTable_name(), tbs.getColumn_count(), tbs.getTable_type(), tbs.getFile_format(),
                             tbs.getCompression_type(), tbs.getSize_numRows(), tbs.getSize_bytes(),
                             tbs.getSize_numFiles(), tbs.getPartition_column_count());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetadataSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetadataSummary.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.tools.metatool;
+
+import java.util.List;
+
+
+public class MetadataSummary {
+    List<CatalogSummary> catalog_names;
+
+    public MetadataSummary(List<CatalogSummary> catalog_names) {
+        this.catalog_names = catalog_names;
+    }
+
+    public List<CatalogSummary> getCatalog_names() {
+        return catalog_names;
+    }
+
+    public void setCatalog_names(List<CatalogSummary> catalog_names) {
+        this.catalog_names = catalog_names;
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataSummary{" +
+                "catalog_names=" + catalog_names +
+                '}';
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.hive.metastore.tools.metatool;
 import java.math.BigInteger;
 
 public class TableSummary{
-    String table_name;
-    String db_name;
     String cat_name;
+    String db_name;
+    String table_name;
     int column_count;
     int partition_column_count;
     int partition_count;
@@ -37,9 +37,9 @@ public class TableSummary{
     public TableSummary(String cat_name, String db_name, String table_name, int column_count,
                         int partition_column_count, int partition_count, BigInteger size_bytes, BigInteger size_numRows,
                         BigInteger size_numFiles, String table_type, String file_format, String compression_type) {
-        this.table_name = table_name;
-        this.db_name = db_name;
         this.cat_name = cat_name;
+        this.db_name = db_name;
+        this.table_name = table_name;
         this.column_count = column_count;
         this.partition_column_count = partition_column_count;
         this.partition_count = partition_count;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.tools.metatool;
+
+public class TableSummary{
+    String table_name;
+    String db_name;
+    String cat_name;
+    int column_count;
+    int partition_column_count;
+    long size_bytes;
+    long size_numRows;
+    long size_numFiles;
+    String table_type;
+    String file_format;
+    String compression_type;
+
+    public TableSummary(String table_name, String db_name, String cat_name, int column_count,
+                        int partition_column_count, long size_bytes, long size_numRows, long size_numFiles,
+                        String table_type, String file_format, String compression_type) {
+        this.table_name = table_name;
+        this.db_name = db_name;
+        this.cat_name = cat_name;
+        this.column_count = column_count;
+        this.partition_column_count = partition_column_count;
+        this.size_bytes = size_bytes;
+        this.size_numRows = size_numRows;
+        this.size_numFiles = size_numFiles;
+        this.table_type = table_type;
+        this.file_format = file_format;
+        this.compression_type = compression_type;
+    }
+
+    public String getTable_name() {
+        return table_name;
+    }
+
+    public void setTable_name(String table_name) {
+        this.table_name = table_name;
+    }
+
+    public String getDb_name() {
+        return db_name;
+    }
+
+    public void setDb_name(String db_name) {
+        this.db_name = db_name;
+    }
+
+    public String getCat_name() {
+        return cat_name;
+    }
+
+    public void setCat_name(String cat_name) {
+        this.cat_name = cat_name;
+    }
+
+    public int getColumn_count() {
+        return column_count;
+    }
+
+    public void setColumn_count(int column_count) {
+        this.column_count = column_count;
+    }
+
+    public int getPartition_column_count() {
+        return partition_column_count;
+    }
+
+    public void setPartition_column_count(int partition_column_count) {
+        this.partition_column_count = partition_column_count;
+    }
+
+    public long getSize_bytes() {
+        return size_bytes;
+    }
+
+    public void setSize_bytes(long size_bytes) {
+        this.size_bytes = size_bytes;
+    }
+
+    public long getSize_numRows() {
+        return size_numRows;
+    }
+
+    public void setSize_numRows(long size_numRows) {
+        this.size_numRows = size_numRows;
+    }
+
+    public long getSize_numFiles() {
+        return size_numFiles;
+    }
+
+    public void setSize_numFiles(long size_numFiles) {
+        this.size_numFiles = size_numFiles;
+    }
+
+    public String getTable_type() {
+        return table_type;
+    }
+
+    public void setTable_type(String table_type) {
+        this.table_type = table_type;
+    }
+
+    public String getFile_format() {
+        return file_format;
+    }
+
+    public void setFile_format(String file_format) {
+        this.file_format = file_format;
+    }
+
+    public String getCompression_type() {
+        return compression_type;
+    }
+
+    public void setCompression_type(String compression_type) {
+        this.compression_type = compression_type;
+    }
+
+    @Override
+    public String toString() {
+        return "TableSummary{" +
+                "table_name='" + table_name + '\'' +
+                ", db_name='" + db_name + '\'' +
+                ", cat_name='" + cat_name + '\'' +
+                ", column_count=" + column_count +
+                ", partition_column_count=" + partition_column_count +
+                ", size_bytes=" + size_bytes +
+                ", size_numRows=" + size_numRows +
+                ", size_numFiles=" + size_numFiles +
+                ", table_type='" + table_type + '\'' +
+                ", file_format='" + file_format + '\'' +
+                ", compression_type='" + compression_type + '\'' +
+                '}';
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/TableSummary.java
@@ -17,33 +17,50 @@
  */
 package org.apache.hadoop.hive.metastore.tools.metatool;
 
+import java.math.BigInteger;
+
 public class TableSummary{
     String table_name;
     String db_name;
     String cat_name;
     int column_count;
     int partition_column_count;
-    long size_bytes;
-    long size_numRows;
-    long size_numFiles;
+    int partition_count;
+    BigInteger size_bytes;
+    BigInteger size_numRows;
+    BigInteger size_numFiles;
     String table_type;
     String file_format;
     String compression_type;
 
-    public TableSummary(String table_name, String db_name, String cat_name, int column_count,
-                        int partition_column_count, long size_bytes, long size_numRows, long size_numFiles,
-                        String table_type, String file_format, String compression_type) {
+
+    public TableSummary(String cat_name, String db_name, String table_name, int column_count,
+                        int partition_column_count, int partition_count, BigInteger size_bytes, BigInteger size_numRows,
+                        BigInteger size_numFiles, String table_type, String file_format, String compression_type) {
         this.table_name = table_name;
         this.db_name = db_name;
         this.cat_name = cat_name;
         this.column_count = column_count;
         this.partition_column_count = partition_column_count;
+        this.partition_count = partition_count;
         this.size_bytes = size_bytes;
         this.size_numRows = size_numRows;
         this.size_numFiles = size_numFiles;
         this.table_type = table_type;
         this.file_format = file_format;
         this.compression_type = compression_type;
+    }
+
+    public TableSummary() {
+
+    }
+
+    public int getPartition_count() {
+        return partition_count;
+    }
+
+    public void setPartition_count(int partition_count) {
+        this.partition_count = partition_count;
     }
 
     public String getTable_name() {
@@ -86,27 +103,27 @@ public class TableSummary{
         this.partition_column_count = partition_column_count;
     }
 
-    public long getSize_bytes() {
+    public BigInteger getSize_bytes() {
         return size_bytes;
     }
 
-    public void setSize_bytes(long size_bytes) {
+    public void setSize_bytes(BigInteger size_bytes) {
         this.size_bytes = size_bytes;
     }
 
-    public long getSize_numRows() {
+    public BigInteger getSize_numRows() {
         return size_numRows;
     }
 
-    public void setSize_numRows(long size_numRows) {
+    public void setSize_numRows(BigInteger size_numRows) {
         this.size_numRows = size_numRows;
     }
 
-    public long getSize_numFiles() {
+    public BigInteger getSize_numFiles() {
         return size_numFiles;
     }
 
-    public void setSize_numFiles(long size_numFiles) {
+    public void setSize_numFiles(BigInteger size_numFiles) {
         this.size_numFiles = size_numFiles;
     }
 
@@ -137,11 +154,12 @@ public class TableSummary{
     @Override
     public String toString() {
         return "TableSummary{" +
-                "table_name='" + table_name + '\'' +
+                "cat_name='" + cat_name + '\'' +
                 ", db_name='" + db_name + '\'' +
-                ", cat_name='" + cat_name + '\'' +
+                ", table_name='" + table_name + '\'' +
                 ", column_count=" + column_count +
                 ", partition_column_count=" + partition_column_count +
+                ", partition_count=" + partition_count +
                 ", size_bytes=" + size_bytes +
                 ", size_numRows=" + size_numRows +
                 ", size_numFiles=" + size_numFiles +

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/metatool/TestHiveMetaToolCommandLine.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/metatool/TestHiveMetaToolCommandLine.java
@@ -87,7 +87,7 @@ public class TestHiveMetaToolCommandLine {
   @Test
   public void testNoTask() throws ParseException {
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("exactly one of -listFSRoot, -executeJDOQL, -updateLocation, -listExtTblLocs, -diffExtTblLocs must be set");
+    exception.expectMessage("exactly one of -listFSRoot, -executeJDOQL, -updateLocation, -listExtTblLocs, -diffExtTblLocs, -metadataSummary must be set");
 
     new HiveMetaToolCommandLine(new String[] {});
   }
@@ -95,7 +95,7 @@ public class TestHiveMetaToolCommandLine {
   @Test
   public void testMultipleTask() throws ParseException {
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("exactly one of -listFSRoot, -executeJDOQL, -updateLocation, -listExtTblLocs, -diffExtTblLocs must be set");
+    exception.expectMessage("exactly one of -listFSRoot, -executeJDOQL, -updateLocation, -listExtTblLocs, -diffExtTblLocs, -metadataSummary must be set");
 
     new HiveMetaToolCommandLine(new String[] {"-listFSRoot", "-executeJDOQL", "select a from b"});
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
 add the MetadataSummary to hivemetatool so that the metatool can get the summary of HMS, including JSON format and console format.
-->


### Why are the changes needed?
<!--
Hive Metastore currently lacks visibility into its metadata. This work includes enhancing the Hive Metatool to include an option(JSON, CONSOLE) to print a summary (catalog name, database name, table name, partition column count, number of rows. table type, file type, compression type, total data size, etc). 
-->


### Does this PR introduce _any_ user-facing change?
<!--
Console output of HMS summary, JSON output of HMS summary(under /tmp/).
-->


### How was this patch tested?
<!--
Have used a nightly cluster to test. Waiting to test with the larger database which is being created.
-->
