### PR TITLE
HIVE-26436: Hive on MR NullPointerException When initializeOp has not…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -6156,6 +6156,9 @@ public class HiveConf extends Configuration {
 
   public static String getVar(Configuration conf, ConfVars var) {
     assert (var.valClass == String.class) : var.varname;
+    if (conf == null) {
+      return var.defaultStrVal;
+    }
     return var.altName != null ? conf.get(var.varname, conf.get(var.altName, var.defaultStrVal))
       : conf.get(var.varname, var.defaultStrVal);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
@@ -478,7 +478,10 @@ public abstract class Operator<T extends OperatorDesc> implements Serializable,C
   }
 
   public String getCounterName(Counter counter, Configuration hconf) {
-    String context = hconf.get(Operator.CONTEXT_NAME_KEY, "");
+    String context = "";
+    if (hconf != null) {
+      context = hconf.get(Operator.CONTEXT_NAME_KEY, "");
+    }
     if (StringUtils.isNotEmpty(context)) {
       context = "_" + context.replace(" ", "_");
     }
@@ -674,6 +677,13 @@ public abstract class Operator<T extends OperatorDesc> implements Serializable,C
       LOG.debug("Not all parent operators are closed. Not closing.");
       return;
     }
+
+    // if the operator has not been initialized, there is no need to close
+    if (!this.rootInitializeCalled) {
+      LOG.debug("No need to close operator {}", this);
+      return;
+    }
+
 
     // set state as CLOSE as long as all parents are closed
     // state == CLOSE doesn't mean all children are also in state CLOSE

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
@@ -700,7 +700,7 @@ public class TestOperators {
   public void testCloseOperator() throws HiveException {
       System.out.println("Testing Close Operator");
       Operator<FileSinkDesc> op = OperatorFactory.get(new CompilationOpContext(), FileSinkDesc.class);
-      op.close(false); 
+      op.close(false);
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.ql.plan.ScriptDesc;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.VectorSelectDesc;
+import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
@@ -693,6 +694,13 @@ public class TestOperators {
       }
     }
     return r;
+  }
+
+  @Test
+  public void testCloseOperator() throws HiveException {
+      System.out.println("Testing Close Operator");
+      Operator<FileSinkDesc> op = OperatorFactory.get(new CompilationOpContext(), FileSinkDesc.class);
+      op.close(false);
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperators.java
@@ -700,7 +700,7 @@ public class TestOperators {
   public void testCloseOperator() throws HiveException {
       System.out.println("Testing Close Operator");
       Operator<FileSinkDesc> op = OperatorFactory.get(new CompilationOpContext(), FileSinkDesc.class);
-      op.close(false);
+      op.close(false); 
   }
 
 }


### PR DESCRIPTION
… been called and close called.

### What changes were proposed in this pull request?
When the operator has not been called to initialize, and it is called to close, exception will happen.
I fix it by check conf is null so that the close could be finished. It work well in my cluster. 
However, I am not sure, it may be a better way to skip close if the operator has not been initialized ?

### Why are the changes needed?
I think it may be a bug.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. unit test passed.
2. apply the patch to cluster and task passed. 
