### PR TITLE
HIVE-26440: Duplicate hive-standalone-metastore-server dependency in QFile module

### DIFF
--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -66,12 +66,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-standalone-metastore-server</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
       <artifactId>hive-it-custom-serde</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove duplicate dependency declaration

### Why are the changes needed?
Improve build stability and remove warning

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No tests needed