### PR TITLE
HIVE-26446: HiveProtoLoggingHook fails to populate TablesWritten fiel…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.ql.hooks;
 
+import static org.apache.hadoop.hive.ql.hooks.Entity.Type.PARTITION;
+import static org.apache.hadoop.hive.ql.hooks.Entity.Type.TABLE;
 import static org.apache.hadoop.hive.ql.plan.HiveOperation.ALTERDATABASE;
 import static org.apache.hadoop.hive.ql.plan.HiveOperation.ALTERDATABASE_OWNER;
 import static org.apache.hadoop.hive.ql.plan.HiveOperation.ALTERPARTITION_BUCKETNUM;
@@ -487,7 +489,7 @@ public class HiveProtoLoggingHook implements ExecuteWithHookContext {
     private List<String> getTablesFromEntitySet(Set<? extends Entity> entities) {
       List<String> tableNames = new ArrayList<>();
       for (Entity entity : entities) {
-        if (entity.getType() == Entity.Type.TABLE) {
+        if (entity.getType() == TABLE || entity.getType() == PARTITION) {
           tableNames.add(entity.getTable().getDbName() + "." + entity.getTable().getTableName());
         }
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHiveProtoLoggingHook.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHiveProtoLoggingHook.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.hive.ql.hooks;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +33,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.mr.ExecDriver;
@@ -43,6 +47,8 @@ import org.apache.hadoop.hive.ql.hooks.HookContext.HookType;
 import org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.HiveHookEventProto;
 import org.apache.hadoop.hive.ql.hooks.proto.HiveHookEvents.MapFieldEntry;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.TezWork;
@@ -121,6 +127,16 @@ public class TestHiveProtoLoggingHook {
     assertOtherInfo(event, OtherInfoType.HIVE_ADDRESS, "hive_addr");
     assertOtherInfo(event, OtherInfoType.CONF, null);
     assertOtherInfo(event, OtherInfoType.QUERY, null);
+  }
+
+  @Test
+  public void testNonPartionedTable() throws Exception {
+    testTablesWritten(new WriteEntity(newTable(false), WriteEntity.WriteType.INSERT), false);
+  }
+
+  @Test
+  public void testPartitionedTable() throws Exception {
+    testTablesWritten(addPartitionOutput(newTable(true), WriteEntity.WriteType.INSERT), true);
   }
 
   @Test
@@ -322,4 +338,63 @@ public class TestHiveProtoLoggingHook {
       Assert.assertEquals(value, val);
     }
   }
+
+  private void testTablesWritten(WriteEntity we, boolean isPartitioned) throws Exception {
+    String query = isPartitioned ?
+            "insert into test_partition partition(dt = '20220102', lable = 'test1') values('20220103', 'banana');" :
+            "insert into default.testTable1 values('ab')";
+    HashSet<WriteEntity> tableWritten = new HashSet<>();
+    tableWritten.add(we);
+    QueryState state = new QueryState.Builder().withHiveConf(conf).build();
+    @SuppressWarnings("serial")
+    QueryPlan queryPlan = new QueryPlan(HiveOperation.QUERY) {
+    };
+    queryPlan.setQueryId("test_queryId");
+    queryPlan.setQueryStartTime(1234L);
+    queryPlan.setQueryString(query);
+    queryPlan.setRootTasks(new ArrayList<>());
+    queryPlan.setInputs(new HashSet<>());
+    queryPlan.setOutputs(tableWritten);
+    PerfLogger perf = PerfLogger.getPerfLogger(conf, true);
+    HookContext ctx = new HookContext(queryPlan, state, null, "test_user", "192.168.10.11",
+            "hive_addr", "test_op_id", "test_session_id", "test_thread_id", true, perf, null);
+
+    ctx.setHookType(HookType.PRE_EXEC_HOOK);
+    EventLogger evtLogger = new EventLogger(conf, SystemClock.getInstance());
+    evtLogger.handle(ctx);
+    evtLogger.shutdown();
+
+    HiveHookEventProto event = loadEvent(conf, tmpFolder);
+
+    Assert.assertEquals(EventType.QUERY_SUBMITTED.name(), event.getEventType());
+    Assert.assertEquals(we.getTable().getFullyQualifiedName(), event.getTablesWritten(0));
+  }
+
+  private Table newTable(boolean isPartitioned) {
+    Table t = new Table("default", "testTable");
+    if (isPartitioned) {
+      FieldSchema fs = new FieldSchema();
+      fs.setName("version");
+      fs.setType("String");
+      List<FieldSchema> partCols = new ArrayList<FieldSchema>(1);
+      partCols.add(fs);
+      t.setPartCols(partCols);
+    }
+    Map<String, String> tblProps = t.getParameters();
+    if (tblProps == null) {
+      tblProps = new HashMap<>();
+    }
+    tblProps.put(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL, "true");
+    t.setParameters(tblProps);
+    return t;
+  }
+
+  private WriteEntity addPartitionOutput(Table t, WriteEntity.WriteType writeType) throws Exception {
+    Map<String, String> partSpec = new HashMap<String, String>();
+    partSpec.put("version", Integer.toString(1));
+    Partition p = new Partition(t, partSpec, new Path("/dev/null"));
+    WriteEntity we = new WriteEntity(p, writeType);
+    return we;
+  }
+
 }


### PR DESCRIPTION
…d for partitioned tables

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
entity.getType() returns the value as  "PARTITION" for partitioned tables instead of "TABLE" as a result the above check returns false and the tablesWritten field in the hiveProtologger is left unpopulated for partitioned tables.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit Test and manual test.