### PR TITLE
HIVE-26448: Improve UnsignedInt128.setV*()

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/UnsignedInt128.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/UnsignedInt128.java
@@ -215,7 +215,9 @@ public final class UnsignedInt128 implements Comparable<UnsignedInt128>, Seriali
    */
   public void setV0(int val) {
     v[0] = val;
-    updateCount();
+    if (count < 2) {
+      updateCount();
+    }
   }
 
   /**
@@ -226,7 +228,9 @@ public final class UnsignedInt128 implements Comparable<UnsignedInt128>, Seriali
    */
   public void setV1(int val) {
     v[1] = val;
-    updateCount();
+    if (count < 3) {
+      updateCount();
+    }
   }
 
   /**
@@ -237,7 +241,9 @@ public final class UnsignedInt128 implements Comparable<UnsignedInt128>, Seriali
    */
   public void setV2(int val) {
     v[2] = val;
-    updateCount();
+    if (count < 4) {
+      updateCount();
+    }
   }
 
   /**

--- a/common/src/test/org/apache/hadoop/hive/common/type/TestUnsignedInt128.java
+++ b/common/src/test/org/apache/hadoop/hive/common/type/TestUnsignedInt128.java
@@ -187,6 +187,72 @@ public class TestUnsignedInt128 {
   }
 
   @Test
+  public void testUnsignedInt128Count() {
+    UnsignedInt128 minValue = UnsignedInt128.MIN_VALUE;
+    assertEquals((byte) 0, minValue.getCount());
+    UnsignedInt128 maxValue = UnsignedInt128.MAX_VALUE;
+    assertEquals((byte) 4, maxValue.getCount());
+    UnsignedInt128 unsignedInt128 = new UnsignedInt128(0, 0, 0, 0);
+    assertEquals((byte) 0, unsignedInt128.getCount());
+
+    // Let count equals 4. updateCount() will not be called if update v0, v1, v2, v3.
+    unsignedInt128.setV3(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.setV3(200);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.setV2(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.setV1(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.setV0(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.zeroClear();
+    assertEquals((byte) 0, unsignedInt128.getCount());
+
+    // Let count equals 3. updateCount() will not be called if update v0, v1, v2.
+    unsignedInt128.setV2(100);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV2(200);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV1(100);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV0(100);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV3(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.zeroClear();
+    assertEquals((byte) 0, unsignedInt128.getCount());
+
+    // Let count equals 2. updateCount() will not be called if update v0, v1.
+    unsignedInt128.setV1(100);
+    assertEquals((byte) 2, unsignedInt128.getCount());
+    unsignedInt128.setV1(100);
+    assertEquals((byte) 2, unsignedInt128.getCount());
+    unsignedInt128.setV0(1);
+    assertEquals((byte) 2, unsignedInt128.getCount());
+    unsignedInt128.setV2(100);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV3(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.zeroClear();
+    assertEquals((byte) 0, unsignedInt128.getCount());
+
+    // Let count equals 2. updateCount() will not be called if update v0.
+    unsignedInt128.setV0(2);
+    assertEquals((byte) 1, unsignedInt128.getCount());
+    unsignedInt128.setV0(2);
+    assertEquals((byte) 1, unsignedInt128.getCount());
+    unsignedInt128.setV1(100);
+    assertEquals((byte) 2, unsignedInt128.getCount());
+    unsignedInt128.setV2(100);
+    assertEquals((byte) 3, unsignedInt128.getCount());
+    unsignedInt128.setV3(100);
+    assertEquals((byte) 4, unsignedInt128.getCount());
+    unsignedInt128.zeroClear();
+    assertEquals((byte) 0, unsignedInt128.getCount());
+  }
+
+  @Test
   public void testUnsignedInt128UnsignedInt128() {
     assertEquals(1L, new UnsignedInt128(one).asLong());
     assertEquals(2L, new UnsignedInt128(two).asLong());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, these method `setV0`, `setV1`, `setV2` of `UnsignedInt128` call `updateCount` directly.
The `updateCount` of `UnsignedInt128` have a lot `if ... else ...` logic.
In fact, we can improve the code by judge `count` field of `UnsignedInt128`.


### Why are the changes needed?
Improve UnsignedInt128.setV*()


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
New test cases.
