### PR TITLE
HIVE-26452: NPE when converting join to mapjoin and join column referenced more than once

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
@@ -71,7 +71,11 @@ public class ExprNodeDescUtils {
   protected static final Logger LOG = LoggerFactory.getLogger(ExprNodeDescUtils.class);
 
   public static int indexOf(ExprNodeDesc origin, List<ExprNodeDesc> sources) {
-    for (int i = 0; i < sources.size(); i++) {
+    return indexOf(origin, sources, 0);
+  }
+
+  public static int indexOf(ExprNodeDesc origin, List<ExprNodeDesc> sources, int startIndex) {
+    for (int i = startIndex; i < sources.size(); i++) {
       if (origin.isSame(sources.get(i))) {
         return i;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
@@ -537,9 +537,9 @@ public class ExprNodeDescUtils {
         if(columnInternalName.startsWith(Utilities.ReduceField.VALUE.toString())) {
           continue;
         }
-        if (source instanceof ExprNodeColumnDesc) {
+        ColumnInfo columnInfo = reduceSinkOp.getSchema().getColumnInfo(columnInternalName);
+        if (source instanceof ExprNodeColumnDesc && columnInfo != null) {
           // The join key is a table column. Create the ExprNodeDesc based on this column.
-          ColumnInfo columnInfo = reduceSinkOp.getSchema().getColumnInfo(columnInternalName);
           return new ExprNodeColumnDesc(columnInfo);
         } else {
           // Join key expression is likely some expression involving functions/operators, so there


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When collecting columns for join's child RS operator's row schema search for all the key column occurrences and add them to the row schema. Name the column using the corresponding key index.

### Why are the changes needed?
See jira description.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Force calling `checkAndConvertSMBJoin` by setting `mapJoinConversion` to `null` when Converting join to mapjoin by changing the line
https://github.com/apache/hive/blob/8b312d54ea206461cb50450ac95ec267aba60b21/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java#L158

to
```
MapJoinConversion mapJoinConversion = null;
```

```
set hive.auto.convert.join=true;
set hive.auto.convert.sortmerge.join=true;
set hive.optimize.dynamic.partition.hashjoin=true;

create table LU_CUSTOMER (CUSTOMER_ID int, value string);
create table ORDER_FACT (CUSTOMER_ID int, order_value string);


explain
select count(*)
from LU_CUSTOMER pa11
      join        ORDER_FACT        a15
      on         (pa11.CUSTOMER_ID = a15.CUSTOMER_ID)
      join        LU_CUSTOMER        a16
      on         (a15.CUSTOMER_ID = a16.CUSTOMER_ID and pa11.CUSTOMER_ID = a16.CUSTOMER_ID)
;

explain
select count(*)
from LU_CUSTOMER pa11
      join        ORDER_FACT        a15
      on         (pa11.CUSTOMER_ID = a15.CUSTOMER_ID)
      join        LU_CUSTOMER        a16
      on         (a15.CUSTOMER_ID = a16.CUSTOMER_ID)
where pa11.CUSTOMER_ID = a16.CUSTOMER_ID
;
```