### PR TITLE
HIVE-26458: Add explicit dependency to commons-dbcp2 in hive-exec module

### DIFF
--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -85,6 +85,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Why are the changes needed?
See HIVE-26458

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Existing tests.
- Cherry-picking the change in internal Hive branches and running `TestMiniLLapLocalCliDriver` with tests including external JDBC tables 