### PR TITLE
HIVE-26467: SessionState should be accessible inside ThreadPool

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -619,7 +619,7 @@ public class SessionState implements ISessionAuthState{
    * Singleton Session object per thread.
    *
    **/
-  private static ThreadLocal<SessionStates> tss = new ThreadLocal<SessionStates>() {
+  private static InheritableThreadLocal<SessionStates> tss = new InheritableThreadLocal<SessionStates>() {
     @Override
     protected SessionStates initialValue() {
       return new SessionStates();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Change ThreadLocal Variable to Inheritable ThreadLocal variable


### Why are the changes needed?

Currently SessionState.get() returns null if it is called inside a ThreadPool. If there is any custom third party component leverages SessionState.get() for some operations like getting the session state or session config inside a thread pool it will result in null since session state is thread local (https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java#L622) and ThreadLocal variable are not inheritable to child threads / thread pools.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit Test was added to test the feature
