### PR TITLE
HIVE-26471: New metric for Compaction pooling

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
@@ -43,8 +43,6 @@ import org.slf4j.LoggerFactory;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +58,7 @@ import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTI
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_CLEANING_AGE;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_ENQUEUE_AGE;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_WORKING_AGE;
+import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_ITEM_COUNT;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_STATUS_PREFIX;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.NUM_ABORTED_TXNS;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.NUM_COMPLETED_TXN_COMPONENTS;
@@ -79,9 +78,6 @@ import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.TABLES_W
 import static org.apache.hadoop.hive.metastore.txn.CompactionMetricsData.MetricType.NUM_DELTAS;
 import static org.apache.hadoop.hive.metastore.txn.CompactionMetricsData.MetricType.NUM_OBSOLETE_DELTAS;
 import static org.apache.hadoop.hive.metastore.txn.CompactionMetricsData.MetricType.NUM_SMALL_DELTAS;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.NO_VAL;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getHostFromId;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getThreadIdFromId;
 
 /**
  * Collect and publish ACID and compaction related metrics.
@@ -336,6 +332,8 @@ public class AcidMetricService implements MetastoreTaskThread {
             .set(0);
       }
     }
+
+    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_ITEM_COUNT).update(metricData.getPoolCount());
 
     updateOldestCompactionMetric(COMPACTION_OLDEST_ENQUEUE_AGE, metricData.getOldestEnqueueTime());
     updateOldestCompactionMetric(COMPACTION_OLDEST_WORKING_AGE, metricData.getOldestWorkingTime());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/CompactionMetricData.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/CompactionMetricData.java
@@ -45,6 +45,8 @@ final class CompactionMetricData {
 
   private Map<String, Long> stateCount;
 
+  private Map<String, Integer> poolCount;
+
   private Double failedCompactionPercentage;
 
   private long initiatorsCount;
@@ -65,6 +67,7 @@ final class CompactionMetricData {
 
   private void init() {
     final Map<String, ShowCompactResponseElement> lastElements = new HashMap<>();
+    poolCount = new HashMap<>();
 
     oldestEnqueueTime = OLDEST_TIME_NO_VALUE;
     oldestWorkingTime = OLDEST_TIME_NO_VALUE;
@@ -80,6 +83,7 @@ final class CompactionMetricData {
       String state = element.getState();
       if (TxnStore.INITIATED_RESPONSE.equals(state) && (oldestEnqueueTime > element.getEnqueueTime())) {
         oldestEnqueueTime = element.getEnqueueTime();
+        poolCount.compute(element.getPoolName(), (k, old) -> (old == null) ? 1 : old + 1);
       }
 
       if (element.isSetStart()) {
@@ -146,6 +150,10 @@ final class CompactionMetricData {
 
   Map<String, Long> getStateCount() {
     return new HashMap<>(stateCount);
+  }
+
+  public Map<String, Integer> getPoolCount() {
+    return new HashMap<>(poolCount);
   }
 
   Long getOldestEnqueueTime() {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
@@ -31,6 +31,7 @@ public class MetricsConstants {
   public static final String COMPACTION_CLEANER_CYCLE_DURATION = "compaction_cleaner_cycle_duration";
   public static final String COMPACTION_CLEANER_FAILURE_COUNTER = "compaction_cleaner_failure_counter";
   public static final String COMPACTION_WORKER_CYCLE = "compaction_worker_cycle";
+  public static final String COMPACTION_POOLS_ITEM_COUNT = "compaction_pools_item_count";
 
   public static final String OLDEST_OPEN_REPL_TXN_ID = "oldest_open_repl_txn_id";
   public static final String OLDEST_OPEN_NON_REPL_TXN_ID = "oldest_open_non_repl_txn_id";


### PR DESCRIPTION

### What changes were proposed in this pull request?
A new metric is added:
Number of 'Initiated' compaction requests per compaction pool.


### Why are the changes needed?
To be able to properly supervise the pool based compaction.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually and through unit tests