### PR TITLE
HIVE-26476: map ORCFILE to ORC while creating an iceberg table

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
@@ -153,6 +153,32 @@ public class TestHiveIcebergInserts extends HiveIcebergStorageHandlerWithEngineB
   }
 
   @Test
+  public void testInsertIntoORCFile() throws IOException {
+    Assume.assumeTrue("Testing the create table ... stored as ORCFILE syntax is enough for a single scenario.",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
+    shell.executeStatement("CREATE TABLE t2(c0 DOUBLE , c1 DOUBLE , c2 DECIMAL) STORED BY " +
+        "ICEBERG STORED AS ORCFILE");
+    shell.executeStatement("INSERT INTO t2(c1, c0) VALUES(0.1803113419993464, 0.9381388537256228)");
+    List<Object[]> results = shell.executeStatement("SELECT * FROM t2");
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(0.9381388537256228, results.get(0)[0]);
+    Assert.assertEquals(0.1803113419993464, results.get(0)[1]);
+    Assert.assertEquals(null, results.get(0)[2]);
+  }
+
+
+  @Test
+  public void testStoredByIcebergInTextFile() {
+    Assume.assumeTrue("Testing the create table ... stored as TEXTFILE syntax is enough for a single scenario.",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
+    AssertHelpers.assertThrows("Create table should not work with textfile", IllegalArgumentException.class,
+        "Unsupported fileformat",
+        () ->
+            shell.executeStatement("CREATE TABLE IF NOT EXISTS t2(c0 DOUBLE , c1 DOUBLE , c2 DECIMAL) STORED BY " +
+                "ICEBERG STORED AS TEXTFILE"));
+  }
+
+  @Test
   public void testInsertSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);

--- a/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_as_fileformat.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_as_fileformat.q.out
@@ -43,7 +43,7 @@ Table Parameters:
 	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	uuid                	#Masked#
-	write.format.default	ORC                 
+	write.format.default	orc                 
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -104,7 +104,7 @@ Table Parameters:
 	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	uuid                	#Masked#
-	write.format.default	PARQUET             
+	write.format.default	parquet             
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -165,7 +165,7 @@ Table Parameters:
 	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	uuid                	#Masked#
-	write.format.default	AVRO                
+	write.format.default	avro                
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -226,7 +226,7 @@ Table Parameters:
 	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	uuid                	#Masked#
-	write.format.default	AVRO                
+	write.format.default	avro                
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -284,7 +284,7 @@ Table Parameters:
 	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	uuid                	#Masked#
-	write.format.default	ORC                 
+	write.format.default	orc                 
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Hive allows creating tables stored in ORC in two different syntaxes

1. > `STORED AS ORC`
2. > `STORED AS ORCFILE`

When running a create iceberg table statement that is using the second option we should map the `ORCFILE` keyword to `ORC`

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  4. If you fix some SQL features, you can provide some references of other DBMSes.
  5. If there is design documentation, please add the link.
  6. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The iceberg library throws an exception when the table was created using the `ORCFILE` syntax.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manual test, unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
