### PR TITLE
HIVE-26464: New credential provider for replicating to the cloud

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -70,6 +70,7 @@ public class Constants {
 
   public static final String HIVE_SERVER2_JOB_CREDSTORE_PASSWORD_ENVVAR = "HIVE_JOB_CREDSTORE_PASSWORD";
   public static final String HADOOP_CREDENTIAL_PASSWORD_ENVVAR = "HADOOP_CREDSTORE_PASSWORD";
+  public static final String HADOOP_CREDENTIAL_PASSWORD_DEFAULT = "none";
   public static final String HADOOP_CREDENTIAL_PROVIDER_PATH_CONFIG = "hadoop.security.credential.provider.path";
 
   public static final String MATERIALIZED_VIEW_REWRITING_TIME_WINDOW = "rewriting.time.window";
@@ -93,4 +94,13 @@ public class Constants {
   public static final String INSERT_ONLY_FETCH_BUCKET_ID = "insertonly.fetch.bucketid";
 
   public static final String ERROR_MESSAGE_NO_DETAILS_AVAILABLE = "No detailed message available";
+
+  public static final String HIVE_REPL_CLOUD_SCHEME_NAME = "hiverepljceks";
+  public static final String HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PATH =
+                                                  "hive.repl.cloud.credential.provider.path";
+  public static final String HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD =
+                                                  "hive.repl.cloud.credential.provider.password";
+  public static final String HIVE_REPL_CLOUD_KEYSTORE_TYPE = "jceks";
+  public static final String HIVE_REPL_CLOUD_ALGORITHM = "AES";
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
@@ -468,7 +468,7 @@ public class ReplUtils {
   public static Path getEncodedDumpRootPath(HiveConf conf, String dbname) throws UnsupportedEncodingException {
     return new Path(conf.getVar(HiveConf.ConfVars.REPLDIR),
       Base64.getEncoder().encodeToString(dbname
-        .getBytes(StandardCharsets.UTF_8.name())));
+        .getBytes(StandardCharsets.UTF_8.name())) + Path.SEPARATOR);
   }
 
   public static Path getLatestDumpPath(Path dumpRoot, HiveConf conf) throws IOException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/HiveReplCloudCredentialProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/HiveReplCloudCredentialProvider.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.security;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.conf.Constants;
+import org.apache.hadoop.security.ProviderUtils;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Credential provider for replicating to the cloud.
+ * It works the following way:
+ * <ol>
+ *   <li>
+ *     Load the HS2 keystore file
+ *   </li>
+ *   <li>
+ *     Gets a password from the HS2 keystore file
+ *   </li>
+ *   <li>
+ *     This password will be used to load another keystore file, located on HDFS,
+ *     that contains the cloud credentials for the Hive cloud replication
+ *   </li>
+ * </ol>
+ */
+@InterfaceAudience.Private
+public class HiveReplCloudCredentialProvider extends CredentialProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveReplCloudCredentialProvider.class);
+
+  private final Path path;
+  private final FileSystem fs;
+  private final char[] keystorePassword;
+  private final KeyStore keystore;
+  private FsPermission permissions;
+  private final Lock readLock;
+  private final Lock writeLock;
+  private boolean changed = false;
+
+  public HiveReplCloudCredentialProvider(URI hs2KeystoreURI, Configuration conf) throws IOException {
+    super();
+    this.path = getKeystorePath(conf);
+    this.fs = createFileSystem(conf);
+    this.keystorePassword = tryLoadKeystorePasswordFromHS2Keystore(hs2KeystoreURI, conf);
+    this.keystore = tryLoadHdfsKeystore();
+    ReadWriteLock lock = new ReentrantReadWriteLock(true);
+    this.readLock = lock.readLock();
+    this.writeLock = lock.writeLock();
+  }
+
+  private Path getKeystorePath(Configuration conf) {
+    String keystorePathStr = conf.get(Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PATH);
+    URI keystoreUri = new Path(keystorePathStr).toUri();
+    LOG.debug("Hive cloud replication keystore URI is {}", keystoreUri);
+    return ProviderUtils.unnestUri(keystoreUri);
+  }
+
+  @VisibleForTesting
+  FileSystem createFileSystem(Configuration conf) throws IOException {
+    return path.getFileSystem(conf);
+  }
+
+  private char[] tryLoadKeystorePasswordFromHS2Keystore(URI hs2KeystoreURI, Configuration conf)
+      throws IOException {
+    try {
+      char[] hs2KeystorePassword = getHS2KeystorePassword(conf);
+      KeyStore hs2Keystore = tryLoadHS2Keystore(hs2KeystoreURI, hs2KeystorePassword);
+      return getKeystorePassword(hs2Keystore, hs2KeystorePassword);
+    } catch (KeyStoreException e) {
+      throw new IOException("Can't create keystore", e);
+    } catch (GeneralSecurityException e) {
+      throw new IOException("Can't load keystore " + hs2KeystoreURI, e);
+    } catch (URISyntaxException e) {
+      throw new IOException("URI Syntax error: " + hs2KeystoreURI, e);
+    }
+  }
+
+  private char[] getHS2KeystorePassword(Configuration conf) throws IOException {
+    LOG.debug("Getting HS2 keystore password");
+    char[] hs2KeystorePassword = ProviderUtils.locatePassword(
+        Constants.HADOOP_CREDENTIAL_PASSWORD_ENVVAR,
+        conf.get(CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PASSWORD_FILE_KEY)
+    );
+    if (hs2KeystorePassword == null) {
+      hs2KeystorePassword = Constants.HADOOP_CREDENTIAL_PASSWORD_DEFAULT.toCharArray();
+      LOG.debug("Using default HS2 keystore password");
+    }
+    return hs2KeystorePassword;
+  }
+
+  private KeyStore tryLoadHS2Keystore(URI hs2KeystoreURI, char[] hs2KeystorePassword)
+      throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException,
+      URISyntaxException {
+    Path hs2KeystorePath = ProviderUtils.unnestUri(hs2KeystoreURI);
+    File hs2KeystoreFile = createHS2KeystoreFileInstance(hs2KeystorePath);
+    if (hs2KeystoreFile.exists() && hs2KeystoreFile.length() > 0) {
+      return loadHS2Keystore(hs2KeystoreFile, hs2KeystorePassword);
+    } else {
+      throw new IOException("HS2 keystore does not exist under: " + hs2KeystoreURI);
+    }
+  }
+
+  @VisibleForTesting
+  KeyStore loadHS2Keystore(File hs2KeystoreFile, char[] hs2KeystorePassword)
+      throws IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException {
+    LOG.debug("Start loading HS2 keystore: {}", hs2KeystoreFile.getPath());
+    KeyStore hs2Keystore = KeyStore.getInstance(getKeyStoreType());
+    try (InputStream in = Files.newInputStream(hs2KeystoreFile.toPath())) {
+      hs2Keystore.load(in, hs2KeystorePassword);
+    }
+    LOG.debug("Finished loading HS2 keystore: {}", hs2KeystoreFile.getPath());
+    return hs2Keystore;
+  }
+
+  @VisibleForTesting
+  File createHS2KeystoreFileInstance(Path hs2KeystorePath) throws URISyntaxException {
+    return new File(new URI(hs2KeystorePath.toString()));
+  }
+
+  private char[] getKeystorePassword(KeyStore hs2Keystore, char[] hs2KeystorePassword)
+      throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException, IOException {
+    LOG.debug("Getting Hive cloud replication Keystore password " +
+              Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD + " from HS2 keystore");
+    Key keystorePasswordKey = hs2Keystore.getKey(
+        Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD, hs2KeystorePassword
+    );
+    if (keystorePasswordKey == null) {
+      throw new IOException("Hive cloud replication keystore password " +
+                            Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD +
+                            " cannot be found in HS2 keystore!");
+    }
+    return bytesToChars(keystorePasswordKey);
+  }
+
+  private KeyStore tryLoadHdfsKeystore() throws IOException {
+    try {
+      if (fs.exists(getPath())) {
+        stashOriginalFilePermissions();
+        return loadHdfsKeystore();
+      } else {
+        throw new IOException("Hive cloud replication keystore does not exist: " + getPathStr());
+      }
+    } catch (KeyStoreException e) {
+      throw new IOException("Can't create keystore", e);
+    } catch (GeneralSecurityException e) {
+      throw new IOException("Can't load keystore " + getPathStr(), e);
+    }
+  }
+
+  /**
+   * Save off permissions in case we need to rewrite the keystore in {@link #flush()}
+   * @throws IOException propagated from {@link FileSystem#getFileStatus(Path)}.
+   */
+  private void stashOriginalFilePermissions() throws IOException {
+    LOG.debug("Start stashing HDFS file permissions: {}", getPath());
+    FileStatus fileStatus = fs.getFileStatus(getPath());
+    permissions = fileStatus.getPermission();
+    LOG.debug("Finished stashing HDFS file permissions: {}", getPath());
+  }
+
+  @VisibleForTesting
+  KeyStore loadHdfsKeystore()
+      throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+    LOG.debug("Start loading HDFS keystore: {}", getPath());
+    KeyStore hdfsKeystore = KeyStore.getInstance(getKeyStoreType());
+    try (InputStream in = fs.open(getPath())) {
+      hdfsKeystore.load(in, keystorePassword);
+    }
+    LOG.debug("Finished loading HDFS keystore: {}", getPath());
+    return hdfsKeystore;
+  }
+
+  protected String getKeyStoreType() {
+    return Constants.HIVE_REPL_CLOUD_KEYSTORE_TYPE;
+  }
+
+  protected String getAlgorithm() {
+    return Constants.HIVE_REPL_CLOUD_ALGORITHM;
+  }
+
+  @Override
+  public CredentialEntry getCredentialEntry(String alias) throws IOException {
+    readLock.lock();
+    try {
+      if (!keystore.containsAlias(alias)) {
+        return null;
+      }
+      SecretKeySpec key = (SecretKeySpec) keystore.getKey(alias, keystorePassword);
+      return new HiveCloudReplCredentialEntry(alias, bytesToChars(key));
+    } catch (KeyStoreException e) {
+      throw new IOException("Can't get credential " + alias + " from " + getPathStr(), e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IOException("Can't get algorithm for credential " + alias + " from " + getPathStr(), e);
+    } catch (UnrecoverableKeyException e) {
+      throw new IOException("Can't recover credential " + alias + " from " + getPathStr(), e);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public List<String> getAliases() throws IOException {
+    readLock.lock();
+    try {
+      return Collections.list(keystore.aliases());
+    } catch (KeyStoreException e) {
+      throw new IOException("Can't get aliases from " + getPathStr(), e);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public CredentialEntry createCredentialEntry(String alias, char[] credential) throws IOException {
+    writeLock.lock();
+    try {
+      if (keystore.containsAlias(alias)) {
+        throw new IOException("Credential " + alias + " already exists in " + getPathStr());
+      }
+      SecretKeySpec key = new SecretKeySpec(charsToBytes(credential), getAlgorithm());
+      setKeyEntry(alias, key, keystorePassword, null);
+      changed = true;
+      return new HiveCloudReplCredentialEntry(alias, credential);
+    } catch (KeyStoreException e) {
+      throw new IOException("Problem looking up credential " + alias + " in " + getPathStr(), e);
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  void setKeyEntry(String alias, SecretKeySpec key, char[] password, Certificate[] cert)
+      throws KeyStoreException {
+    keystore.setKeyEntry(alias, key, password, cert);
+  }
+
+  @Override
+  public void deleteCredentialEntry(String alias) throws IOException {
+    writeLock.lock();
+    try {
+      if (keystore.containsAlias(alias)) {
+        deleteEntry(alias);
+        changed = true;
+      } else {
+        throw new IOException("Credential " + alias + " does not exist in " + getPathStr());
+      }
+    } catch (KeyStoreException e) {
+      throw new IOException("Problem removing " + alias + " from " + getPathStr(), e);
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  void deleteEntry(String alias) throws KeyStoreException {
+    keystore.deleteEntry(alias);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    writeLock.lock();
+    try {
+      if (!changed) {
+        LOG.debug("Keystore hasn't changed, returning.");
+        return;
+      }
+      LOG.debug("Start flushing keystore: {}", getPathStr());
+      try (OutputStream out = FileSystem.create(fs, getPath(), permissions)) {
+        store(out, keystorePassword);
+      } catch (KeyStoreException e) {
+        throw new IOException("Can't store keystore " + getPathStr(), e);
+      } catch (NoSuchAlgorithmException e) {
+        throw new IOException("No such algorithm storing keystore " + getPathStr(), e);
+      } catch (CertificateException e) {
+        throw new IOException("Certificate exception storing keystore " + getPathStr(), e);
+      }
+      LOG.debug("Finished flushing keystore: {}", getPathStr());
+      changed = false;
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  void store(OutputStream out, char[] keystorePassword)
+      throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+    keystore.store(out, keystorePassword);
+  }
+
+  public static byte[] charsToBytes(char[] credential) {
+    return new String(credential).getBytes(StandardCharsets.UTF_8);
+  }
+
+  public static char[] bytesToChars(Key key) {
+    return bytesToChars(key.getEncoded());
+  }
+
+  public static char[] bytesToChars(byte[] bytes) {
+    return new String(bytes, StandardCharsets.UTF_8).toCharArray();
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  public String getPathStr() {
+    return getPath().toString();
+  }
+
+  public boolean isChanged() {
+    return changed;
+  }
+
+  public static class HiveCloudReplCredentialEntry extends CredentialProvider.CredentialEntry {
+    protected HiveCloudReplCredentialEntry(String alias, char[] credential) {
+      super(alias, credential);
+    }
+  }
+
+  public static class Factory extends CredentialProviderFactory {
+    @Override
+    public CredentialProvider createProvider(URI providerName, Configuration conf)
+        throws IOException {
+      if (Constants.HIVE_REPL_CLOUD_SCHEME_NAME.equals(providerName.getScheme())) {
+        return createCredentialProviderInstance(providerName, conf);
+      }
+      return null;
+    }
+
+    @VisibleForTesting
+    HiveReplCloudCredentialProvider createCredentialProviderInstance(
+        URI providerName, Configuration conf) throws IOException {
+      return new HiveReplCloudCredentialProvider(providerName, conf);
+    }
+  }
+
+}

--- a/ql/src/main/resources/META-INF/services/org.apache.hadoop.security.alias.CredentialProviderFactory
+++ b/ql/src/main/resources/META-INF/services/org.apache.hadoop.security.alias.CredentialProviderFactory
@@ -1,0 +1,15 @@
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+org.apache.hadoop.hive.ql.security.HiveReplCloudCredentialProvider$Factory

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestHiveCredentialProviders.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestHiveCredentialProviders.java
@@ -60,7 +60,7 @@ public class TestHiveCredentialProviders {
    * Dirty hack to set the environment variables using reflection code. This method is for testing
    * purposes only and should not be used elsewhere
    */
-  private final static void setEnv(Map<String, String> newenv) throws Exception {
+  public static void setEnv(Map<String, String> newenv) throws Exception {
     Class[] classes = Collections.class.getDeclaredClasses();
     Map<String, String> env = System.getenv();
     for (Class cl : classes) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/TestHiveReplCloudCredentialProvider.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/TestHiveReplCloudCredentialProvider.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.security;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.conf.Constants;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.TestHiveCredentialProviders;
+import org.apache.hadoop.security.ProviderUtils;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProvider.CredentialEntry;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestHiveReplCloudCredentialProvider {
+
+  private static final String HS2_CREDSTORE_PATH_STR =
+    Constants.HIVE_REPL_CLOUD_SCHEME_NAME + "://file/path/to/hiveserver2/creds.localjceks";
+  private static final String HDFS_CREDSTORE_PATH_STR =
+    Constants.HIVE_REPL_CLOUD_KEYSTORE_TYPE + "://hdfs@source.com:8020/hive-replication/creds.jceks";
+  private static final String HS2_CREDSTORE_PASSWORD = "hs2CredstorePassword";
+  private static final String HDFS_CREDSTORE_PASSWORD = "hdfsCredstorePassword";
+  private static final FsPermission FS_PERMISSION = FsPermission.createImmutable((short) 420);
+  private static final String ACCESS_ALIAS = "fs.s3a.access.key";
+  private static final String SECRET_ALIAS = "fs.s3a.secret.key";
+  private static final String SOME_S3A_ACCESS_KEY = "some-s3a-access-key";
+  private static final String SOME_S3A_SECRET_KEY = "some-s3a-secret-key";
+  private static final String NON_EXISTING_ALIAS = "non.existing.alias";
+  private static final String NON_EXISTING_KEY = "non-existing-key";
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+  private Map<String, String> env;
+  private FileSystem fs;
+  private File hs2KeystoreFile;
+  private KeyStore hs2Keystore;
+  private KeyStoreSpi hs2KeystoreSpi;
+  private List<String> hs2KeystoreAliases;
+  private Path hdfsCredstorePath;
+  private KeyStore hdfsKeystore;
+  private KeyStoreSpi hdfsKeystoreSpi;
+  private List<String> hdfsKeystoreAliases;
+  private HiveReplCloudCredentialProvider credentialProvider;
+
+  @Before
+  public void setup() throws Exception {
+    setEnvironmentVariables();
+    mockFileSystem();
+    mockHS2KeystoreFile();
+    mockHS2Keystore();
+    mockHdfsKeystore();
+    createCredentialProvider();
+  }
+
+  private void setEnvironmentVariables() throws Exception {
+    env = new HashMap<>();
+    env.put(Constants.HADOOP_CREDENTIAL_PASSWORD_ENVVAR, HS2_CREDSTORE_PASSWORD);
+    TestHiveCredentialProviders.setEnv(env);
+  }
+
+  private void mockFileSystem() throws IOException {
+    fs = mock(FileSystem.class);
+    hdfsCredstorePath = ProviderUtils.unnestUri(new Path(HDFS_CREDSTORE_PATH_STR).toUri());
+    when(fs.exists(hdfsCredstorePath)).thenReturn(true);
+    FileStatus hdfsCredstoreFileStatus = mock(FileStatus.class);
+    when(hdfsCredstoreFileStatus.getPermission()).thenReturn(FS_PERMISSION);
+    when(fs.getFileStatus(hdfsCredstorePath)).thenReturn(hdfsCredstoreFileStatus);
+    when(fs.open(hdfsCredstorePath)).thenReturn(mock(FSDataInputStream.class));
+  }
+
+  private void mockHS2KeystoreFile() {
+    hs2KeystoreFile = mock(File.class);
+    when(hs2KeystoreFile.exists()).thenReturn(true);
+    when(hs2KeystoreFile.length()).thenReturn(1024L);
+  }
+
+  private void mockHS2Keystore() throws Exception {
+    hs2KeystoreAliases = new ArrayList<>();
+    hs2KeystoreSpi = mock(KeyStoreSpi.class);
+    hs2Keystore = createMockedKeystore(hs2KeystoreSpi);
+    setCredstoreEntry(hs2KeystoreSpi,
+                      Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD, HDFS_CREDSTORE_PASSWORD);
+    when(hs2KeystoreSpi.engineAliases()).thenReturn(Collections.enumeration(hs2KeystoreAliases));
+  }
+
+  private void mockHdfsKeystore() throws Exception {
+    hdfsKeystoreAliases = new ArrayList<>();
+    hdfsKeystoreSpi = mock(KeyStoreSpi.class);
+    hdfsKeystore = createMockedKeystore(hdfsKeystoreSpi);
+    setCredstoreEntry(hdfsKeystoreSpi, ACCESS_ALIAS, SOME_S3A_ACCESS_KEY);
+    setCredstoreEntry(hdfsKeystoreSpi, SECRET_ALIAS, SOME_S3A_SECRET_KEY);
+    when(hdfsKeystoreSpi.engineAliases()).thenReturn(Collections.enumeration(hdfsKeystoreAliases));
+  }
+
+  private KeyStore createMockedKeystore(KeyStoreSpi keyStoreSpi) throws Exception {
+    KeyStore keyStoreMock = new KeyStore(keyStoreSpi, null, "test"){ };
+    keyStoreMock.load(null);
+    return keyStoreMock;
+  }
+
+  private void setCredstoreEntry(KeyStoreSpi keystoreSpi, String alias, String key)
+      throws Exception {
+    String password;
+    if (keystoreSpi == hs2KeystoreSpi) {
+      if (env.containsKey(Constants.HADOOP_CREDENTIAL_PASSWORD_ENVVAR)) {
+        password = HS2_CREDSTORE_PASSWORD;
+      } else {
+        password = Constants.HADOOP_CREDENTIAL_PASSWORD_DEFAULT;
+      }
+      hs2KeystoreAliases.add(alias);
+    } else if (keystoreSpi == hdfsKeystoreSpi) {
+      password = HDFS_CREDSTORE_PASSWORD;
+      hdfsKeystoreAliases.add(alias);
+    } else {
+      throw new IllegalArgumentException("Unknown keystoreSpi: " + keystoreSpi);
+    }
+    when(keystoreSpi.engineContainsAlias(alias)).thenReturn(true);
+    SecretKeySpec keySpec = null;
+    if (key != null) {
+      keySpec = createKeySpec(key);
+    }
+    when(keystoreSpi.engineGetKey(alias, password.toCharArray())).thenReturn(keySpec);
+  }
+
+  private SecretKeySpec createKeySpec(String key) {
+    return new SecretKeySpec(key.getBytes(), Constants.HIVE_REPL_CLOUD_ALGORITHM);
+  }
+
+  private void createCredentialProvider() throws IOException {
+    URI hs2KeystoreURI = new Path(HS2_CREDSTORE_PATH_STR).toUri();
+    HiveConf conf = new HiveConf();
+    conf.set(Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PATH, HDFS_CREDSTORE_PATH_STR);
+    conf.set(Constants.HADOOP_CREDENTIAL_PROVIDER_PATH_CONFIG, HS2_CREDSTORE_PATH_STR);
+    Factory factory = new Factory();
+    credentialProvider = spy(
+        (HiveReplCloudCredentialProvider) factory.createProvider(hs2KeystoreURI, conf)
+    );
+    assertNotNull(credentialProvider);
+  }
+
+  @Test
+  public void testFactoryForNonMatchingScheme() throws Exception {
+    URI hdfsCredstoreUri = new URI(HDFS_CREDSTORE_PATH_STR);
+    Factory factory = new Factory();
+    CredentialProvider provider = factory.createProvider(hdfsCredstoreUri, new HiveConf());
+    assertNull(provider);
+  }
+
+  @Test
+  public void testCreationWithDefaultPassword() throws Exception {
+    unsetEnvironmentVariables();
+    mockHS2Keystore();
+    createCredentialProvider();
+  }
+
+  private void unsetEnvironmentVariables() throws Exception {
+    env = Collections.emptyMap();
+    TestHiveCredentialProviders.setEnv(env);
+  }
+
+  @Test
+  public void testHs2KeystoreNotExist() throws Exception {
+    expectIOException();
+    when(hs2KeystoreFile.exists()).thenReturn(false);
+    createCredentialProvider();
+  }
+
+  @Test
+  public void testHs2KeystoreEmpty() throws Exception {
+    expectIOException();
+    when(hs2KeystoreFile.length()).thenReturn(0L);
+    createCredentialProvider();
+  }
+
+  @Test
+  public void testHdfsPasswordNotFoundInHS2Keystore() throws Exception {
+    expectIOException();
+    setCredstoreEntry(hs2KeystoreSpi, Constants.HIVE_REPL_CLOUD_CREDENTIAL_PROVIDER_PASSWORD, null);
+    createCredentialProvider();
+  }
+
+  @Test
+  public void testHdfsKeystoreNotExist() throws Exception {
+    expectIOException();
+    when(fs.exists(hdfsCredstorePath)).thenReturn(false);
+    createCredentialProvider();
+  }
+
+  @Test
+  public void testGetCredentialEntry() throws Exception {
+    CredentialEntry accessKeyEntry = credentialProvider.getCredentialEntry(ACCESS_ALIAS);
+    assertArrayEquals(SOME_S3A_ACCESS_KEY.toCharArray(), accessKeyEntry.getCredential());
+    CredentialEntry secretKeyEntry = credentialProvider.getCredentialEntry(SECRET_ALIAS);
+    assertArrayEquals(SOME_S3A_SECRET_KEY.toCharArray(), secretKeyEntry.getCredential());
+    CredentialEntry unknownEntry = credentialProvider.getCredentialEntry(NON_EXISTING_ALIAS);
+    assertNull(unknownEntry);
+  }
+
+  @Test
+  public void testGetAliases() throws Exception {
+    List<String> aliases = credentialProvider.getAliases();
+    assertNotNull(aliases);
+    assertEquals(2, aliases.size());
+    assertTrue(aliases.contains(ACCESS_ALIAS));
+    assertTrue(aliases.contains(SECRET_ALIAS));
+  }
+
+  @Test
+  public void testCreateCredentialEntry() throws Exception {
+    assertFalse(credentialProvider.isChanged());
+    CredentialEntry credentialEntry = credentialProvider.createCredentialEntry(
+        NON_EXISTING_ALIAS, NON_EXISTING_KEY.toCharArray()
+    );
+    assertTrue(credentialProvider.isChanged());
+    assertEquals(NON_EXISTING_ALIAS, credentialEntry.getAlias());
+    assertArrayEquals(NON_EXISTING_KEY.toCharArray(), credentialEntry.getCredential());
+    verify(credentialProvider).setKeyEntry(NON_EXISTING_ALIAS, createKeySpec(NON_EXISTING_KEY),
+                                           HDFS_CREDSTORE_PASSWORD.toCharArray(), null);
+  }
+
+  @Test
+  public void testCreateAlreadyExistingCredentialEntry() throws IOException {
+    expectIOException();
+    credentialProvider.createCredentialEntry(ACCESS_ALIAS, SOME_S3A_ACCESS_KEY.toCharArray());
+  }
+
+  @Test
+  public void testDeleteCredentialEntry() throws Exception {
+    assertFalse(credentialProvider.isChanged());
+    credentialProvider.deleteCredentialEntry(SECRET_ALIAS);
+    assertTrue(credentialProvider.isChanged());
+    verify(credentialProvider).deleteEntry(SECRET_ALIAS);
+  }
+
+  @Test
+  public void testDeleteNonExistingCredentialEntry() throws IOException {
+    expectIOException();
+    credentialProvider.deleteCredentialEntry(NON_EXISTING_ALIAS);
+  }
+
+  @Test
+  public void testFlush() throws Exception {
+    testDeleteCredentialEntry();
+    assertTrue(credentialProvider.isChanged());
+    credentialProvider.flush();
+    assertFalse(credentialProvider.isChanged());
+    verify(credentialProvider).store(any(), eq(HDFS_CREDSTORE_PASSWORD.toCharArray()));
+  }
+
+  @Test
+  public void testFlushWithoutChanged() throws Exception {
+    assertFalse(credentialProvider.isChanged());
+    credentialProvider.flush();
+    assertFalse(credentialProvider.isChanged());
+    verify(credentialProvider, never()).store(any(), eq(HDFS_CREDSTORE_PASSWORD.toCharArray()));
+  }
+
+  @Test
+  public void testGetters() {
+    assertEquals(Constants.HIVE_REPL_CLOUD_KEYSTORE_TYPE, credentialProvider.getKeyStoreType());
+    assertEquals(Constants.HIVE_REPL_CLOUD_ALGORITHM, credentialProvider.getAlgorithm());
+  }
+
+  private void expectIOException() {
+    exception.expect(IOException.class);
+  }
+
+  private class Factory extends HiveReplCloudCredentialProvider.Factory {
+    @Override
+    HiveReplCloudCredentialProvider createCredentialProviderInstance(URI providerName,
+                                                                     Configuration conf)
+        throws IOException {
+      return new HiveReplCloudCredentialProviderMocked(providerName, conf);
+    }
+  }
+
+  private class HiveReplCloudCredentialProviderMocked extends HiveReplCloudCredentialProvider {
+
+    public HiveReplCloudCredentialProviderMocked(URI hs2KeystoreURI, Configuration conf)
+        throws IOException {
+      super(hs2KeystoreURI, conf);
+    }
+
+    @Override
+    FileSystem createFileSystem(Configuration conf) throws IOException {
+      return fs;
+    }
+
+    @Override
+    File createHS2KeystoreFileInstance(Path hs2KeystorePath) throws URISyntaxException {
+      return hs2KeystoreFile;
+    }
+
+    @Override
+    KeyStore loadHS2Keystore(File hs2KeystoreFile, char[] hs2KeystorePassword)
+        throws IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException {
+      return hs2Keystore;
+    }
+
+    @Override
+    KeyStore loadHdfsKeystore()
+        throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+      return hdfsKeystore;
+    }
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
HIVE-26464


### Why are the changes needed?
It is needed for on-prem to cloud replication


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
* I've tested it on a real cloud environment, replicated a test database from on-prem to AWS
* Added new JUnit tests