### PR TITLE
HIVE-26489: Use check-spelling/check-spelling@v0.0.20

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -55,3 +55,4 @@ LICENSE
 ^testutils/ptest2/src/test/resources/
 ^\.github/
 ^\Qql/src/test/resources/hsmm/hsmm_cfg_01.yaml\E$
+^\Qserde/pom.xml\E$

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,5 +1,4 @@
 AAAAABJRU
-aarry
 abcd
 abcde
 abcdef
@@ -40,7 +39,6 @@ bais
 baoi
 baos
 BArray
-basedir
 bdoi
 bdw
 bigint
@@ -195,7 +193,6 @@ isset
 itest
 ith
 JAGRAFESS
-javabean
 Javadoc
 javax
 jdbc
@@ -276,7 +273,6 @@ outputmp
 outputstream
 params
 php
-plugin
 png
 println
 prj
@@ -365,7 +361,6 @@ TFrozen
 threebytes
 Throwable
 timelabel
-timestamplocal
 TIMESTAMPLOCALTZ
 timestamptz
 timezone
@@ -442,11 +437,7 @@ writables
 www
 XDh
 xfer
-xml
-xmlns
-xsi
 yadda
 yes'okay
-yyyy
 YYYYMMDD
 zid

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,8 +11,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     outputs:
-      internal_state_directory: ${{ steps.spelling.outputs.internal_state_directory }}
+      followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
     if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
     concurrency:
@@ -20,28 +21,13 @@ jobs:
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: checkout-merge
-      if: "contains(github.event_name, 'pull_request')"
-      uses: actions/checkout@v2
-      with:
-        ref: refs/pull/${{github.event.pull_request.number}}/merge
-    - name: checkout
-      if: github.event_name == 'push'
-      uses: actions/checkout@v2
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.20-alpha3
+      uses: check-spelling/check-spelling@v0.0.20
       with:
         suppress_push_for_open_pull_request: 1
+        checkout: true
         post_comment: 0
-    - name: store-comment
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        retention-days: 1
-        name: "check-spelling-comment-${{ github.run_id }}"
-        path: |
-          ${{ steps.spelling.outputs.internal_state_directory }}
 
   comment:
     name: Comment
@@ -50,20 +36,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: always() && needs.spelling.result == 'failure' && needs.spelling.outputs.internal_state_directory
+    if: (success() || failure()) && needs.spelling.outputs.followup
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
-    - name: set up
-      run: |
-        mkdir /tmp/data
-    - name: retrieve-comment
-      uses: actions/download-artifact@v2
-      with:
-        name: "check-spelling-comment-${{ github.run_id }}"
-        path: /tmp/data
     - name: comment
-      uses: check-spelling/check-spelling@v0.0.20-alpha3
+      uses: check-spelling/check-spelling@v0.0.20
       with:
-        custom_task: comment
-        internal_state_directory: /tmp/data
+        checkout: true
+        task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Refreshes the workflow based on
https://github.com/check-spelling/spell-check-this/blob/744c66e2140fd8acaf5388efd0db3727d010d6e9/.github/workflows/spelling.yml
* Upgrades the action from v0.0.20-alpha3 to v0.0.20
* I'm excluded the `serde/pom.xml` file as in v0.0.20 it's flagged for a lot of items -- https://github.com/check-spelling/hive/commit/e2674ef68eb5067875a4c9bda6d422a1300c27a7#commitcomment-81785338 -- and it didn't seem worth adding the items, if that isn't the desired state, the file can be removed from `excludes.txt` and `expect.txt` can be updated per the instructions from check-spelling.

### Why are the changes needed?

Alpha releases were for interim development, some changes were made to how the action+workflow interact. Alpha releases are not intended to be supported indefinitely. I will probably disable the `v0.0.20-alpha*` releases at some point (people can still use them if they wish, but this is not recommended)

### Does this PR introduce _any_ user-facing change?

1. The failure seen here:
https://github.com/apache/hive/actions/runs/2758523671
should no longer happen. The refreshed workflow will handle this differently. It may result in an annotation explaining that it's unhappy because there's a merge conflict.

2. The most recent PR comment from check-spelling should be collapsed as new runs occur for the PR.

### How was this patch tested?

The last 4 runs in:
https://github.com/check-spelling/hive/actions
involved basic testing.