### PR TITLE
HIVE-16913: Support per-session S3 credentials

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -249,7 +249,11 @@ public class MetastoreConf {
       ConfVars.PARTITION_NAME_WHITELIST_PATTERN,
       ConfVars.CAPABILITY_CHECK,
       ConfVars.DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES,
-      ConfVars.EXPRESSION_PROXY_CLASS
+      ConfVars.EXPRESSION_PROXY_CLASS,
+      ConfVars.EXPRESSION_PROXY_CLASS,
+      ConfVars.HIVE_FS_S3A_ACCESS_KEY,
+      ConfVars.HIVE_FS_S3A_SECRET_KEY,
+      ConfVars.HIVE_FS_S3A_ENDPOINT
   };
 
   static {
@@ -1612,6 +1616,12 @@ public class MetastoreConf {
             "pools (HIVE-26443), running workers on HMS side is still supported but not suggested anymore. " +
             "This config value will be removed in the future.\n" +
             "Chooses where the compactor worker threads should run, Only possible values are \"metastore\" and \"hs2\""),
+    HIVE_FS_S3A_ACCESS_KEY("fs.s3a.access.key", "fs.s3a.access.key", "",
+        "AccessKey for accessing S3A-compatible blobstore."),
+    HIVE_FS_S3A_SECRET_KEY("fs.s3a.secret.key", "fs.s3a.secret.key", "",
+        "SecretKey for accessing S3A-compatible blobstore."),
+    HIVE_FS_S3A_ENDPOINT("fs.s3a.endpoint", "fs.s3a.endpoint", "s3.amazonaws.com",
+        "AWS S3 endpoint means where the data is stored."),
     // Hive values we have copied and use as is
     // These two are used to indicate that we are running tests
     HIVE_IN_TEST("hive.in.test", "hive.in.test", false, "internal usage only, true in test mode"),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -189,6 +189,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         handler.notifyMetaListenersOnShutDown();
       });
       HMSHandlerContext.clear();
+      Warehouse.removeWhThreadConf();
       logAndAudit("Done cleaning up thread local RawStore");
     }
   }
@@ -582,6 +583,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     if (ConfVars.TRY_DIRECT_SQL == confVar) {
       HMSHandler.LOG.info("Direct SQL optimization = {}",  value);
     }
+    wh.setWhConf(configuration);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. HMS use `Warehouse `to delete/create hdfs dir, so we should pass s3 credentials to `Warehouse `conf. Adding threadlocal conf in `Warehouse `so that we can pass session-level conf to `Warehouse `synchronously.  e.g. `set metaconf:fs.s3a.secret.key=my_secret_key;`
2. Make S3 related credentials param valid in` MetastoreConf.ConfVars`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Currently, users can only set S3 credentials  on the HMS server side and users cannot set different S3 credentials for multiple S3 buckets.  With this change, users can set per-session S3 credentials in client side.
e.g, we can set S3 credentials like this from beeline client:

`set fs.s3a.secret.key=my_secret_key;`
`set fs.s3a.access.key=my_access.key;`
`set fs.s3a.endpoint=my_endpoint;`
`set metaconf:fs.s3a.secret.key=my_secret_key;`
`set metaconf:fs.s3a.access.key=my_access_key; `
`set metaconf:fs.s3a.endpoint=my_endpoint;`
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Test with multiple s3 buckets and credentials in local env.