### PR TITLE
HIVE-26253: upgrade postgresql to 42.4.1 due to security issues

### DIFF
--- a/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestBeelineArgParsing.java
@@ -113,9 +113,9 @@ public class TestBeelineArgParsing {
         + File.separator + "org"
         + File.separator + "postgresql"
         + File.separator + "postgresql"
-        + File.separator + "42.2.14"
+        + File.separator + "42.4.1"
         + File.separator
-        + "postgresql-42.2.14.jar";
+        + "postgresql-42.4.1.jar";
     return Arrays.asList(new Object[][] {
         { "jdbc:postgresql://host:5432/testdb", "org.postgresql.Driver", pathToPostgresJar, true },
         { "jdbc:dummy://host:5432/testdb", dummyDriverClazzName, pathToDummyDriver, false } });

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.27</mysql.version>
-    <postgres.version>42.2.14</postgres.version>
+    <postgres.version>42.4.1</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.6.9</orc.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -69,7 +69,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.27</mysql.version>
-    <postgres.version>42.2.14</postgres.version>
+    <postgres.version>42.4.1</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade postgres version from 42.2.14 to 42.4.1


### Why are the changes needed?
CVE and security issues
issues visible in https://mvnrepository.com/artifact/org.postgresql/postgresql


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Maven build and Unit test.
