### PR TITLE
Improve LDAP auth to support include generic user filters (Naveen Gan…

### DIFF
--- a/service/src/java/org/apache/hive/service/auth/ldap/CustomQueryFilterFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/ldap/CustomQueryFilterFactory.java
@@ -59,7 +59,7 @@ public class CustomQueryFilterFactory implements FilterFactory {
     }
 
     @Override
-    public void apply(DirSearch client, String user) throws AuthenticationException {
+    public void apply(DirSearch client, final String user) throws AuthenticationException {
       List<String> resultList;
       try {
         resultList = client.executeCustomQuery(query);
@@ -74,6 +74,18 @@ public class CustomQueryFilterFactory implements FilterFactory {
             LOG.info("Authentication succeeded based on result set from LDAP query");
             return;
           }
+        }
+
+        // try a generic user search
+        String userSearchQuery = query.replace("{0}", user);
+        try {
+          resultList = client.executeCustomQuery(userSearchQuery);
+        } catch (NamingException e) {
+          throw new AuthenticationException("LDAP Authentication failed for user", e);
+        }
+        if (resultList != null && resultList.size() == 1) {
+          LOG.info("Authentication succeeded based on result from custom user search query");
+          return;
         }
       }
       LOG.info("Authentication failed based on result set from custom LDAP query");

--- a/service/src/java/org/apache/hive/service/auth/ldap/CustomQueryFilterFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/ldap/CustomQueryFilterFactory.java
@@ -77,15 +77,18 @@ public class CustomQueryFilterFactory implements FilterFactory {
         }
 
         // try a generic user search
-        String userSearchQuery = query.replace("{0}", user);
-        try {
-          resultList = client.executeCustomQuery(userSearchQuery);
-        } catch (NamingException e) {
-          throw new AuthenticationException("LDAP Authentication failed for user", e);
-        }
-        if (resultList != null && resultList.size() == 1) {
-          LOG.info("Authentication succeeded based on result from custom user search query");
-          return;
+        if (query.contains("%s")) {
+          String userSearchQuery = query.replace("%s", user);
+          LOG.info("Trying with generic user search in ldap:" + userSearchQuery);
+          try {
+            resultList = client.executeCustomQuery(userSearchQuery);
+          } catch (NamingException e) {
+            throw new AuthenticationException("LDAP Authentication failed for user", e);
+          }
+          if (resultList != null && resultList.size() == 1) {
+            LOG.info("Authentication succeeded based on result from custom user search query");
+            return;
+          }
         }
       }
       LOG.info("Authentication failed based on result set from custom LDAP query");

--- a/service/src/test/org/apache/hive/service/auth/TestLdapAtnProviderWithMiniDS.java
+++ b/service/src/test/org/apache/hive/service/auth/TestLdapAtnProviderWithMiniDS.java
@@ -45,8 +45,8 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(FrameworkRunner.class)
 @CreateLdapServer(transports = {
-  @CreateTransport(protocol = "LDAP"),
-  @CreateTransport(protocol = "LDAPS")
+  @CreateTransport(protocol = "LDAP", port = 10389 ),
+  @CreateTransport(protocol = "LDAPS", port = 10636 )
 })
 
 @CreateDS(partitions = {
@@ -455,15 +455,21 @@ public class TestLdapAtnProviderWithMiniDS extends AbstractLdapTestUnit {
     testCase.assertAuthenticatePasses(USER1.credentialsWithDn());
     testCase.assertAuthenticatePasses(USER4.credentialsWithId());
     testCase.assertAuthenticatePasses(USER4.credentialsWithDn());
+
+    testCase = defaultBuilder()
+        .baseDN("ou=People,dc=example,dc=com")
+        .customQuery("(&(objectClass=person)(uid=%s))")
+        .build();
+
+    testCase.assertAuthenticatePasses(USER1.credentialsWithId());
+    testCase.assertAuthenticatePasses(USER2.credentialsWithId());
   }
 
   @Test
   public void testCustomQueryNegative() {
     testCase = defaultBuilder()
         .baseDN("ou=People,dc=example,dc=com")
-        .customQuery(
-            String.format("(&(objectClass=person)(uid=%s))",
-                USER1.getId()))
+        .customQuery("(&(objectClass=person)(cn=%s))")
         .build();
 
     testCase.assertAuthenticateFails(USER2.credentialsWithDn());


### PR DESCRIPTION
…gam)

<!--
### What changes were proposed in this pull request?
A minor enhancement to the current ldap auth for HS2. Using baseDN and customQuery config params, we can search for a user in ldap to support user filtering. Currently the user filter support in HS2 uses multiple DN patterns. This provides an alternate way of search for users using generic ldap search-like strings for custom query.


### Why are the changes needed?
Improvement to custom query support in ldap auth

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually in a cluster with ldap authentication enabled.