### PR TITLE
HIVE-26496,Improvement to fetch operator to scan only delete_delta fo…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -540,7 +540,7 @@ public class AcidUtils {
    */
   public static AcidOutputFormat.Options
                     parseBaseOrDeltaBucketFilename(Path bucketFile,
-                                                   Configuration conf) throws IOException {
+                                                   Configuration conf) {
     AcidOutputFormat.Options result = new AcidOutputFormat.Options(conf);
     String filename = bucketFile.getName();
     int bucket = parseBucketId(bucketFile);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestAcidUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestAcidUtils.java
@@ -111,7 +111,7 @@ public class TestAcidUtils {
   }
 
   @Test
-  public void testParsing() throws Exception {
+  public void testParsing() {
     Configuration conf = new Configuration();
     MockFileSystem fs = new MockFileSystem(conf,
         //new MockFile("mock:/tmp/base_000123/bucket_00001", 500, new byte[0]),

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSplit.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSplit.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.orc;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.ValidReadTxnList;
+import org.apache.hadoop.hive.common.ValidTxnList;
+import org.apache.hadoop.hive.common.ValidWriteIdList;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.io.*;
+import org.apache.hadoop.hive.ql.io.AcidUtils.Directory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.orc.OrcConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.BitSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for OrcSplit class
+ */
+public class TestOrcSplit {
+
+  private JobConf conf;
+  private FileSystem fs;
+  private Path root;
+  private ObjectInspector inspector;
+  public static class DummyRow {
+    LongWritable field;
+    RecordIdentifier ROW__ID;
+
+    DummyRow(long val, long rowId, long origTxn, int bucket) {
+      field = new LongWritable(val);
+      bucket = BucketCodec.V1.encode(new AcidOutputFormat.Options(null).bucket(bucket));
+      ROW__ID = new RecordIdentifier(origTxn, bucket, rowId);
+    }
+
+    static String getColumnNamesProperty() {
+      return "field";
+    }
+    static String getColumnTypesProperty() {
+      return "bigint";
+    }
+
+  }
+
+  @Before
+  public void setup() throws Exception {
+    conf = new JobConf();
+    conf.set(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL, "true");
+    conf.setBoolean(HiveConf.ConfVars.HIVE_TRANSACTIONAL_TABLE_SCAN.varname, true);
+    conf.set(hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES, "default");
+    conf.setInt(HiveConf.ConfVars.HIVE_TXN_OPERATIONAL_PROPERTIES.varname,
+        AcidUtils.AcidOperationalProperties.getDefault().toInt());
+    conf.set(IOConstants.SCHEMA_EVOLUTION_COLUMNS, DummyRow.getColumnNamesProperty());
+    conf.set(IOConstants.SCHEMA_EVOLUTION_COLUMNS_TYPES, DummyRow.getColumnTypesProperty());
+    conf.setBoolean(HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED.varname, true);
+    conf.set(HiveConf.ConfVars.HIVE_ORC_SPLIT_STRATEGY.varname, "BI");
+    OrcConf.ROWS_BETWEEN_CHECKS.setLong(conf, 1);
+
+    Path workDir = new Path(System.getProperty("test.tmp.dir",
+        "target" + File.separator + "test" + File.separator + "tmp"));
+    root = new Path(workDir, "TestOrcSplit.testDump");
+    fs = root.getFileSystem(conf);
+    root = fs.makeQualified(root);
+    fs.delete(root, true);
+    synchronized (TestOrcFile.class) {
+      inspector = ObjectInspectorFactory.getReflectionObjectInspector
+          (DummyRow.class, ObjectInspectorFactory.ObjectInspectorOptions.JAVA);
+    }
+  }
+
+  private List<OrcInputFormat.SplitStrategy<?>> getSplitStrategies() throws Exception {
+    conf.setInt(HiveConf.ConfVars.HIVE_TXN_OPERATIONAL_PROPERTIES.varname,
+            AcidUtils.AcidOperationalProperties.getDefault().toInt());
+    OrcInputFormat.Context context = new OrcInputFormat.Context(conf);
+    OrcInputFormat.FileGenerator gen = new OrcInputFormat.FileGenerator(
+            context, () -> fs, root, false, null);
+    Directory adi = gen.call();
+    return OrcInputFormat.determineSplitStrategies(
+            null, context, adi.getFs(), adi.getPath(), adi.getFiles(), adi.getDeleteDeltas(),
+            null, null, true);
+  }
+
+  /**
+   * This test checks that a split filters out delete_delta folders which only have transactions that happened
+   * in the past relative to the current split
+   */
+  @Test
+  public void testDeleteDeltasFiltering() throws Exception {
+
+    int bucket = 0;
+    AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf)
+            .filesystem(fs)
+            .bucket(bucket)
+            .writingBase(false)
+            .minimumWriteId(1)
+            .maximumWriteId(1)
+            .inspector(inspector)
+            .reporter(Reporter.NULL)
+            .recordIdColumn(1)
+            .finalDestination(root);
+
+    RecordUpdater updater = new OrcRecordUpdater(root, options);
+
+    // Inserting a new record and then deleting it, 3 times.
+    // Every insertion/deletion is in a separate transaction.
+    // When reading, this will generate 3 splits, one per insert event.
+    for (int i = 1; i <= 5; i = i + 2) {
+      // Transaction that inserts one row with value i
+      options.minimumWriteId(i)
+              .maximumWriteId(i);
+      updater = new OrcRecordUpdater(root, options);
+      updater.insert(options.getMinimumWriteId(),
+              new DummyRow(i, 0, options.getMinimumWriteId(), bucket));
+      updater.close(false);
+
+      // Transaction that deletes previously inserted row
+      options.minimumWriteId(i+1)
+              .maximumWriteId(i+1);
+      updater = new OrcRecordUpdater(root, options);
+      updater.delete(options.getMinimumWriteId(),
+              new DummyRow(-1, 0, i, bucket));
+      updater.close(false);
+    }
+
+    conf.set(ValidTxnList.VALID_TXNS_KEY,
+            new ValidReadTxnList(new long[0], new BitSet(), 1000, Long.MAX_VALUE).writeToString());
+    conf.set(ValidWriteIdList.VALID_WRITEIDS_KEY,
+            "tbl:6:" + Long.MAX_VALUE + "::");
+
+    List<OrcInputFormat.SplitStrategy<?>> splitStrategies = getSplitStrategies();
+    assertEquals(1, splitStrategies.size());
+    List<OrcSplit> splits = ((OrcInputFormat.ACIDSplitStrategy)splitStrategies.get(0)).getSplits();
+
+    assertEquals(3, splits.size());
+
+    // Split for transaction #1 should include all 3 delete deltas
+    assertEquals(3, splits.get(0).getDeltas().size());
+    assertEquals(2, splits.get(0).getDeltas().get(0).getMinWriteId());
+    assertEquals(2, splits.get(0).getDeltas().get(0).getMaxWriteId());
+    assertEquals(4, splits.get(0).getDeltas().get(1).getMinWriteId());
+    assertEquals(4, splits.get(0).getDeltas().get(1).getMaxWriteId());
+    assertEquals(6, splits.get(0).getDeltas().get(2).getMinWriteId());
+    assertEquals(6, splits.get(0).getDeltas().get(2).getMaxWriteId());
+
+    // Split for transaction #3 should include only 2 deltas with transactions #4 & #6
+    assertEquals(2, splits.get(1).getDeltas().size());
+    assertEquals(4, splits.get(1).getDeltas().get(0).getMinWriteId());
+    assertEquals(4, splits.get(1).getDeltas().get(0).getMaxWriteId());
+    assertEquals(6, splits.get(1).getDeltas().get(1).getMinWriteId());
+    assertEquals(6, splits.get(1).getDeltas().get(1).getMaxWriteId());
+
+    // Split for transaction #5 should include only 1 deltas with transactions #6
+    assertEquals(1, splits.get(2).getDeltas().size());
+    assertEquals(6, splits.get(2).getDeltas().get(0).getMinWriteId());
+    assertEquals(6, splits.get(2).getDeltas().get(0).getMaxWriteId());
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
@@ -1185,7 +1185,7 @@ public class TestVectorizedOrcAcidRowBatchReader {
   }
 
   @Test
-  public void testIsQualifiedDeleteDeltaForSplit() throws IOException {
+  public void testIsQualifiedDeleteDeltaForSplit() {
     // Original file
     checkPath("00000_0", "delete_delta_000012_000012_0000", true);
     checkPath("00000_0", "delete_delta_000001_000001", true);
@@ -1231,7 +1231,7 @@ public class TestVectorizedOrcAcidRowBatchReader {
     checkPath("delta_0000002_0000002/bucket_00001", "delete_delta_0000002_0000002_0001", true);
   }
 
-  private void checkPath(String splitPath, String deleteDeltaPath, boolean expected) throws IOException {
+  private void checkPath(String splitPath, String deleteDeltaPath, boolean expected) {
     String tableDir = "";//hdfs://localhost:59316/base/warehouse/acid_test/";
     AcidOutputFormat.Options ao = AcidUtils.parseBaseOrDeltaBucketFilename(new Path(tableDir + splitPath), conf);
     ParsedDeltaLight parsedDelta = ParsedDeltaLight.parse(new Path(tableDir + deleteDeltaPath));


### PR DESCRIPTION
…lders containing transactions relevant to the currently processed split.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The proposed changes improve performance of FetchOperator.
Currently, when a table has a list of delta and delete_delta folders, for every split the system is scanning for delete events in all delete_delta folders. But this filtering is not needed for delete_delta folders which only have events that happened in the past relative to the current split.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As reporting in HIVE-26496, for a table having 21 delta and delete_delta folders the unnecessary scanning of all delete_delta folders for every split makes select query executions super slow, even when there is minimal dataset present in the table.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Execution of unit and integration tests.