### PR TITLE
HIVE-26127: Insert overwrite throws FileNotFound when destination partition is deleted

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4293,7 +4293,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
       // But not sure why we changed not to delete the oldPath in HIVE-8750 if it is
       // not the destf or its subdir?
       isOldPathUnderDestf = isSubDir(oldPath, destPath, oldFs, destFs, false);
-      if (isOldPathUnderDestf) {
+      if (isOldPathUnderDestf && oldFs.exists(oldPath)) {
         cleanUpOneDirectoryForReplace(oldPath, oldFs, pathFilter, conf, purge, isNeedRecycle);
       }
     } catch (IOException e) {

--- a/ql/src/test/queries/clientpositive/insert_overwrite.q
+++ b/ql/src/test/queries/clientpositive/insert_overwrite.q
@@ -1,0 +1,28 @@
+set hive.exec.dynamic.partition.mode=nonstrict;
+
+CREATE EXTERNAL TABLE ext_part (col string) partitioned by (par string);
+INSERT INTO ext_part PARTITION (par='1') VALUES ('first'), ('second');
+INSERT INTO ext_part PARTITION (par='2') VALUES ('first'), ('second');
+CREATE TABLE b (par string, col string);
+
+INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b;
+
+-- should be 4
+SELECT count(*) FROM ext_part;
+
+INSERT INTO b VALUES ('third', '1');
+
+INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b;
+
+-- should be 3
+SELECT count(*) FROM ext_part;
+
+SELECT * FROM ext_part ORDER BY par, col;
+
+-- removing a partition manually should not fail the next insert overwrite operation
+dfs -rm -r ${hiveconf:hive.metastore.warehouse.dir}/ext_part/par=1;
+INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b;
+
+drop table ext_part;
+drop table b;
+

--- a/ql/src/test/results/clientpositive/llap/insert_overwrite.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_overwrite.q.out
@@ -1,0 +1,127 @@
+PREHOOK: query: CREATE EXTERNAL TABLE ext_part (col string) partitioned by (par string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: CREATE EXTERNAL TABLE ext_part (col string) partitioned by (par string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ext_part
+PREHOOK: query: INSERT INTO ext_part PARTITION (par='1') VALUES ('first'), ('second')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ext_part@par=1
+POSTHOOK: query: INSERT INTO ext_part PARTITION (par='1') VALUES ('first'), ('second')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ext_part@par=1
+POSTHOOK: Lineage: ext_part PARTITION(par=1).col SCRIPT []
+PREHOOK: query: INSERT INTO ext_part PARTITION (par='2') VALUES ('first'), ('second')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ext_part@par=2
+POSTHOOK: query: INSERT INTO ext_part PARTITION (par='2') VALUES ('first'), ('second')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ext_part@par=2
+POSTHOOK: Lineage: ext_part PARTITION(par=2).col SCRIPT []
+PREHOOK: query: CREATE TABLE b (par string, col string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@b
+POSTHOOK: query: CREATE TABLE b (par string, col string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@b
+PREHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@b
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@b
+PREHOOK: query: SELECT count(*) FROM ext_part
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ext_part
+PREHOOK: Input: default@ext_part@par=1
+PREHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT count(*) FROM ext_part
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ext_part
+POSTHOOK: Input: default@ext_part@par=1
+POSTHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+4
+PREHOOK: query: INSERT INTO b VALUES ('third', '1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@b
+POSTHOOK: query: INSERT INTO b VALUES ('third', '1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@b
+POSTHOOK: Lineage: b.col SCRIPT []
+POSTHOOK: Lineage: b.par SCRIPT []
+PREHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@b
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@b
+POSTHOOK: Output: default@ext_part@par=1
+POSTHOOK: Lineage: ext_part PARTITION(par=1).col SIMPLE [(b)b.FieldSchema(name:par, type:string, comment:null), ]
+PREHOOK: query: SELECT count(*) FROM ext_part
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ext_part
+PREHOOK: Input: default@ext_part@par=1
+PREHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT count(*) FROM ext_part
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ext_part
+POSTHOOK: Input: default@ext_part@par=1
+POSTHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+3
+PREHOOK: query: SELECT * FROM ext_part ORDER BY par, col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ext_part
+PREHOOK: Input: default@ext_part@par=1
+PREHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM ext_part ORDER BY par, col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ext_part
+POSTHOOK: Input: default@ext_part@par=1
+POSTHOOK: Input: default@ext_part@par=2
+#### A masked pattern was here ####
+third	1
+first	2
+second	2
+#### A masked pattern was here ####
+PREHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@b
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@b
+POSTHOOK: Output: default@ext_part@par=1
+POSTHOOK: Lineage: ext_part PARTITION(par=1).col SIMPLE [(b)b.FieldSchema(name:par, type:string, comment:null), ]
+PREHOOK: query: drop table ext_part
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ext_part
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: drop table ext_part
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ext_part
+POSTHOOK: Output: default@ext_part
+PREHOOK: query: drop table b
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@b
+PREHOOK: Output: default@b
+POSTHOOK: query: drop table b
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@b
+POSTHOOK: Output: default@b


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR backports HIVE-26127 from master branch to branch-3 since the issue affects branch-3 releases as well.

### Why are the changes needed?
This PR fixes the issue reported in HIVE-26127.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a new q file. The original PR adds to a existing insert_overwrite.q but in branch-3 that qfile does not exist. This PR only creates a subset of the queries from master branch's insert_overwrite.q relevant to this issue.
