### PR TITLE
HIVE-26507: Do not allow hive to iceberg migration if source table contains CHAR or VARCHAR columns

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -85,7 +85,7 @@ class HiveSchemaConverter {
             return Types.BooleanType.get();
           case BYTE:
           case SHORT:
-            Preconditions.checkArgument(autoConvert, "Unsupported Hive type: %s, use integer " +
+            Preconditions.checkArgument(autoConvert, "Unsupported Hive type %s, use integer " +
                     "instead or enable automatic type conversion, set 'iceberg.mr.schema.auto.conversion' to true",
                 ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
 
@@ -99,12 +99,8 @@ class HiveSchemaConverter {
             return Types.BinaryType.get();
           case CHAR:
           case VARCHAR:
-            Preconditions.checkArgument(autoConvert, "Unsupported Hive type: %s, use integer " +
-                    "instead or enable automatic type conversion, set 'iceberg.mr.schema.auto.conversion' to true",
-                ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
-
-            LOG.debug("Using auto conversion from CHAR/VARCHAR to STRING");
-            return Types.StringType.get();
+            throw new IllegalArgumentException("Unsupported Hive type (" +
+                ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory() + ") for Iceberg tables.");
           case STRING:
             return Types.StringType.get();
           case TIMESTAMP:

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergCTAS.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergCTAS.java
@@ -239,7 +239,7 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
     for (String notSupportedType : notSupportedTypes.keySet()) {
       shell.executeStatement(String.format("CREATE TABLE source (s %s) STORED AS ORC", notSupportedType));
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-          "Unsupported Hive type: ", () -> {
+          "Unsupported Hive type ", () -> {
             shell.executeStatement(String.format(
                 "CREATE TABLE target STORED BY ICEBERG %s %s AS SELECT * FROM source",
                 testTables.locationForCreateTableSQL(TableIdentifier.of("default", "target")),
@@ -257,9 +257,7 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
     Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Map<String, Type> notSupportedTypes = ImmutableMap.of(
         "TINYINT", Types.IntegerType.get(),
-        "SMALLINT", Types.IntegerType.get(),
-        "VARCHAR(1)", Types.StringType.get(),
-        "CHAR(1)", Types.StringType.get());
+        "SMALLINT", Types.IntegerType.get());
 
     shell.setHiveSessionValue(InputFormatConfig.SCHEMA_AUTO_CONVERSION, "true");
 
@@ -292,19 +290,19 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
         "boolean_col_5 BOOLEAN, " +
         "float_col_6 FLOAT, " +
         "bigint_col_7 BIGINT, " +
-        "varchar0098_col_8 VARCHAR(98), " +
+        "string0098_col_8 STRING, " +
         "timestamp_col_9 TIMESTAMP, " +
         "bigint_col_10 BIGINT, " +
         "decimal0903_col_11 DECIMAL(9, 3), " +
         "timestamp_col_12 TIMESTAMP, " +
         "timestamp_col_13 TIMESTAMP, " +
         "float_col_14 FLOAT, " +
-        "char0254_col_15 CHAR(254), " +
+        "string0254_col_15 STRING, " +
         "double_col_16 DOUBLE, " +
         "timestamp_col_17 TIMESTAMP, " +
         "boolean_col_18 BOOLEAN, " +
         "decimal2608_col_19 DECIMAL(26, 8), " +
-        "varchar0216_col_20 VARCHAR(216), " +
+        "string0216_col_20 STRING, " +
         "string_col_21 STRING, " +
         "bigint_col_22 BIGINT, " +
         "boolean_col_23 BOOLEAN, " +
@@ -317,7 +315,7 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
         "decimal2020_col_30 DECIMAL(20, 20), " +
         "boolean_col_31 BOOLEAN, " +
         "double_col_32 DOUBLE, " +
-        "varchar0148_col_33 VARCHAR(148), " +
+        "string0148_col_33 STRING, " +
         "decimal2121_col_34 DECIMAL(21, 21), " +
         "tinyint_col_35 TINYINT, " +
         "boolean_col_36 BOOLEAN, " +
@@ -328,7 +326,7 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
         "decimal1408_col_41 DECIMAL(14, 8), " +
         "string_col_42 STRING, " +
         "decimal0902_col_43 DECIMAL(9, 2), " +
-        "varchar0204_col_44 VARCHAR(204), " +
+        "string0204_col_44 STRING, " +
         "boolean_col_45 BOOLEAN, " +
         "timestamp_col_46 TIMESTAMP, " +
         "boolean_col_47 BOOLEAN, " +
@@ -341,12 +339,12 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
         "timestamp_col_54 TIMESTAMP, " +
         "int_col_55 INT, " +
         "decimal0505_col_56 DECIMAL(5, 5), " +
-        "char0155_col_57 CHAR(155), " +
+        "string0155_col_57 STRING, " +
         "boolean_col_58 BOOLEAN, " +
         "bigint_col_59 BIGINT, " +
         "boolean_col_60 BOOLEAN, " +
         "boolean_col_61 BOOLEAN, " +
-        "char0249_col_62 CHAR(249), " +
+        "string0249_col_62 STRING, " +
         "boolean_col_63 BOOLEAN, " +
         "timestamp_col_64 TIMESTAMP, " +
         "decimal1309_col_65 DECIMAL(13, 9), " +
@@ -358,12 +356,12 @@ public class TestHiveIcebergCTAS extends HiveIcebergStorageHandlerWithEngineBase
         "timestamp_col_71 TIMESTAMP, " +
         "double_col_72 DOUBLE, " +
         "boolean_col_73 BOOLEAN, " +
-        "char0222_col_74 CHAR(222), " +
+        "string0222_col_74 STRING, " +
         "float_col_75 FLOAT, " +
         "string_col_76 STRING, " +
         "decimal2612_col_77 DECIMAL(26, 12), " +
         "timestamp_col_78 TIMESTAMP, " +
-        "char0128_col_79 CHAR(128), " +
+        "string0128_col_79 STRING, " +
         "timestamp_col_80 TIMESTAMP, " +
         "double_col_81 DOUBLE, " +
         "timestamp_col_82 TIMESTAMP, " +

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -780,9 +780,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Can not create INTERVAL types from normal create table, so leave them out from this test
     Map<String, Type> notSupportedTypes = ImmutableMap.of(
         "TINYINT", Types.IntegerType.get(),
-        "SMALLINT", Types.IntegerType.get(),
-        "VARCHAR(1)", Types.StringType.get(),
-         "CHAR(1)", Types.StringType.get());
+        "SMALLINT", Types.IntegerType.get());
 
     shell.setHiveSessionValue(InputFormatConfig.SCHEMA_AUTO_CONVERSION, "true");
 
@@ -796,6 +794,19 @@ public class TestHiveIcebergStorageHandlerNoScan {
       org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
       Assert.assertEquals(notSupportedTypes.get(notSupportedType), icebergTable.schema().columns().get(0).type());
       shell.executeStatement("DROP TABLE not_supported_types");
+    }
+
+    List<String> notCompatibleTypes = ImmutableList.of("VARCHAR(1)", "CHAR(1)");
+
+    for (String notCompatibleType : notCompatibleTypes) {
+      AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+          "Unsupported Hive type", () -> {
+            shell.executeStatement("CREATE EXTERNAL TABLE not_compatible_types (not_supported " + notCompatibleType +
+                ") STORED BY ICEBERG " +
+                testTables.locationForCreateTableSQL(identifier) +
+                testTables.propertiesForCreateTableSQL(
+                    ImmutableMap.of(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE")));
+          });
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Raise exception when trying to convert hive table to iceberg if the hive table contains CHAR or VARCHAR columns.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Previously CHAR and VARCHAR columns were mapped to STRING columns on the iceberg side since iceberg doesn't have support for those. 
CHAR and VARCHAR types are fixed-length meaning that the values can be shorter than the specified length, and the remaining characters are padded with spaces. These spaces are trimmed during comparison.

When a table is migrated to iceberg the CHAR columns are read as a STRING on the iceberg side, therefore the whole content of the record is considered important. When running a filter against these columns we would need to add the whole content of the record, including white spaces. This can cause confusion since the same query run on a hive and iceberg table can return different results.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
When running the iceberg migration command, an exception is raised if the source table contains CHAR or VARCHAR columns. As a workaround, the dataset of the source table should be converted to string.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
