### PR TITLE
HIVE-26512: ST_GeometryProcessing is incorrectly registered as function.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
@@ -66,7 +66,6 @@ import org.apache.hadoop.hive.ql.udf.esri.ST_GeomFromShape;
 import org.apache.hadoop.hive.ql.udf.esri.ST_GeomFromText;
 import org.apache.hadoop.hive.ql.udf.esri.ST_GeomFromWKB;
 import org.apache.hadoop.hive.ql.udf.esri.ST_GeometryN;
-import org.apache.hadoop.hive.ql.udf.esri.ST_GeometryProcessing;
 import org.apache.hadoop.hive.ql.udf.esri.ST_GeometryType;
 import org.apache.hadoop.hive.ql.udf.esri.ST_InteriorRingN;
 import org.apache.hadoop.hive.ql.udf.esri.ST_Intersection;
@@ -703,7 +702,6 @@ public final class FunctionRegistry {
     system.registerFunction("ST_GeodesicLengthWGS84", ST_GeodesicLengthWGS84.class);
     system.registerFunction("ST_GeomCollection", ST_GeomCollection.class);
     system.registerFunction("ST_GeometryN", ST_GeometryN.class);
-    system.registerFunction("ST_GeometryProcessing", ST_GeometryProcessing.class);
     system.registerFunction("ST_GeomFromGeoJson", ST_GeomFromGeoJson.class);
     system.registerFunction("ST_GeomFromJson", ST_GeomFromJson.class);
     system.registerFunction("ST_GeomFromShape", ST_GeomFromShape.class);

--- a/ql/src/test/results/clientpositive/llap/show_functions.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_functions.q.out
@@ -371,7 +371,6 @@ st_exteriorring
 st_geodesiclengthwgs84
 st_geomcollection
 st_geometryn
-st_geometryprocessing
 st_geometrytype
 st_geomfromgeojson
 st_geomfromjson
@@ -983,7 +982,6 @@ st_exteriorring
 st_geodesiclengthwgs84
 st_geomcollection
 st_geometryn
-st_geometryprocessing
 st_geometrytype
 st_geomfromgeojson
 st_geomfromjson


### PR DESCRIPTION
Remove the unused udf function from being registered, it is just a wrapper class, no need to register and have runtime issues while using it.