### PR TITLE
HIVE-25790 Make managed table copies handle updates (FileUtils)

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/TestCopyUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/TestCopyUtils.java
@@ -333,7 +333,7 @@ public class TestCopyUtils {
     // The destination will leave root(a(A)) only, and b(D) will be deleted.
     CopyUtils copyUtils = new CopyUtils("", new HiveConf(), destinationFs);
     copyUtils.leaveIdenticalFilesOnly(
-        sourceFs, new Path[] {root},
+        sourceFs, new Path[] {a, b},
         destinationFs, root
     );
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changed FileUtils.copy() to skip identical files on the destination directory to improve copy performance. FileUtils.copy() originally just removed and recreated the destination directory. This change makes it compare each file and directory, and delete only different files and directories.

### Why are the changes needed?
In an optimized replication bootstrap scenario, it copies many files from source to destination. It can copy thousands of files. If it fails during copying process, it retries. Then it has some files already copied, but its implementation removes them and copy all of them entirely. It should skip the already copied ones.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
It introduced few JUnit test scenarios in TestFileUtils and TestCopyUtils. It will be tested with automated regression test suites on the test server.