### PR TITLE
HIVE-26530:HS2 OOM-OperationManager.queryIdOperation does not properl…

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -409,4 +409,9 @@ public abstract class Operation {
   protected void markOperationCompletedTime() {
     operationComplete = System.currentTimeMillis();
   }
+
+  public String getQueryId() {
+    return queryState.getQueryId();
+  }
+
 }

--- a/service/src/java/org/apache/hive/service/cli/operation/OperationManager.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/OperationManager.java
@@ -186,7 +186,7 @@ public class OperationManager extends AbstractService {
   }
 
   private String getQueryId(Operation operation) {
-    return operation.getParentSession().getHiveConf().getVar(ConfVars.HIVEQUERYID);
+    return operation.getQueryId();
   }
 
   private void addOperation(Operation operation) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`service/src/java/org/apache/hive/service/cli/operation/Operation.java`

Add a function:

```java
public String getQueryId() {
    return queryState.getQueryId();
  }
```
`service/src/java/org/apache/hive/service/cli/operation/OperationManager.java`

Update the `getQueryId` function to :

```java
private String getQueryId(Operation operation) {
    return operation.getQueryId();
  }
```


### Why are the changes needed?
All operations using the same query id in the global Hive config, cause the id covered.
Hive Server2 will OOM.

I found the same issue: https://issues.apache.org/jira/browse/HIVE-22275

But it is only fixed on 4.0.0, But I using 3.1.2 and using the airflow to submit hive SQL.