### PR TITLE
HIVE-26491: Iceberg: Drop table should purge the data for V2 tables.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -295,6 +295,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       assertTableCanBeMigrated(hmsTable);
       isTableMigration = true;
 
+      setAutoPurgeProperty(hmsTable);
+
       StorageDescriptor sd = hmsTable.getSd();
       preAlterTableProperties = new PreAlterTableProperties();
       preAlterTableProperties.tableLocation = sd.getLocation();
@@ -353,6 +355,15 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       handleChangeColumn(hmsTable);
     } else if (AlterTableType.ADDPROPS.equals(currentAlterTableOp)) {
       assertNotCrossTableMetadataLocationChange(hmsTable.getParameters());
+    }
+  }
+
+  private void setAutoPurgeProperty(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+    // If the format version is 2 and the external table purge property isn't explicitly defined set it to True by
+    // default
+    if ("2".equals(hmsTable.getParameters().get(TableProperties.FORMAT_VERSION)) &&
+        hmsTable.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE) == null) {
+      hmsTable.getParameters().put(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE");
     }
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -200,10 +200,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       createHMSTableInHook = true;
     }
 
-    if (setAutoPurgeProperty(hmsTable)) {
-      catalogProperties.put(HiveTableOperations.translateToIcebergProp(InputFormatConfig.EXTERNAL_TABLE_PURGE), "TRUE");
-    }
-
     assertFileFormat(catalogProperties.getProperty(TableProperties.DEFAULT_FILE_FORMAT));
   }
 
@@ -362,16 +358,13 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
   }
 
-  private boolean setAutoPurgeProperty(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+  private void setAutoPurgeProperty(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
     // If the format version is 2 and the external table purge property isn't explicitly defined set it to True by
     // default
-    if (MetaStoreUtils.isExternalTable(hmsTable) &&
-        "2".equals(hmsTable.getParameters().get(TableProperties.FORMAT_VERSION)) &&
+    if ("2".equals(hmsTable.getParameters().get(TableProperties.FORMAT_VERSION)) &&
         hmsTable.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE) == null) {
       hmsTable.getParameters().put(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE");
-      return true;
     }
-    return false;
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -200,6 +200,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       createHMSTableInHook = true;
     }
 
+    if (setAutoPurgeProperty(hmsTable)) {
+      catalogProperties.put(HiveTableOperations.translateToIcebergProp(InputFormatConfig.EXTERNAL_TABLE_PURGE), "TRUE");
+    }
+
     assertFileFormat(catalogProperties.getProperty(TableProperties.DEFAULT_FILE_FORMAT));
   }
 
@@ -358,13 +362,16 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
   }
 
-  private void setAutoPurgeProperty(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+  private boolean setAutoPurgeProperty(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
     // If the format version is 2 and the external table purge property isn't explicitly defined set it to True by
     // default
-    if ("2".equals(hmsTable.getParameters().get(TableProperties.FORMAT_VERSION)) &&
+    if (MetaStoreUtils.isExternalTable(hmsTable) &&
+        "2".equals(hmsTable.getParameters().get(TableProperties.FORMAT_VERSION)) &&
         hmsTable.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE) == null) {
       hmsTable.getParameters().put(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE");
+      return true;
     }
+    return false;
   }
 
   /**

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -20,17 +20,22 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.StreamSupport;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -561,6 +566,57 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
       shell.executeStatement(testTables.getUpdateQuery(tableName, newRecords.get(0)));
       HiveIcebergTestUtils.validateData(table, newRecords, 0);
     }
+  }
+
+  @Test
+  public void testTablePurgeProperty() throws Exception {
+    final String tableName = "customer";
+    testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, HiveIcebergStorageHandlerTestUtils.OTHER_CUSTOMER_RECORDS_2, 2);
+
+    org.apache.hadoop.hive.metastore.api.Table tbl =
+        shell.metastore().getTable(TableIdentifier.of("default", tableName));
+    // Check if the purge property is set.
+    Assert.assertTrue(StringUtils.join(tbl.getParameters()),
+        tbl.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE).equalsIgnoreCase("TRUE"));
+
+    // Get the Iceberg table & validate gc.enabled got set to true.
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(TableIdentifier.of("default", tableName));
+    Assert.assertTrue(StringUtils.join(icebergTable.properties()),
+        icebergTable.properties().get(TableProperties.GC_ENABLED).equalsIgnoreCase("TRUE"));
+
+    // Check the location exists before drop & doesn't exist post that.
+    Path location = new Path(tbl.getSd().getLocation());
+    Assert.assertTrue(location.getFileSystem(shell.getHiveConf()).exists(location));
+    shell.executeStatement(String.format("DROP TABLE %s", tableName));
+    Assert.assertFalse(location.getFileSystem(shell.getHiveConf()).exists(location));
+  }
+
+  @Test
+  public void testTablePurgeExplicitProperty() throws Exception {
+
+    // Create a Iceberg table with purge explicitly set to false.
+    final String tableName = "customer";
+    testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, HiveIcebergStorageHandlerTestUtils.OTHER_CUSTOMER_RECORDS_2, 2,
+        Collections.singletonMap(InputFormatConfig.EXTERNAL_TABLE_PURGE, "FALSE"));
+
+    org.apache.hadoop.hive.metastore.api.Table tbl =
+        shell.metastore().getTable(TableIdentifier.of("default", tableName));
+    // Check if the purge property is not set to TRUE.
+    Assert.assertFalse(StringUtils.join(tbl.getParameters()),
+        "TRUE".equalsIgnoreCase(tbl.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE)));
+
+    // Get the Iceberg table & validate gc.enabled didn't got set to true.
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(TableIdentifier.of("default", tableName));
+    Assert.assertFalse(StringUtils.join(icebergTable.properties()),
+        "TRUE".equalsIgnoreCase(icebergTable.properties().get(TableProperties.GC_ENABLED)));
+
+    // Check the location exists before drop & exists post that as well since purge is set to false.
+    Path location = new Path(tbl.getSd().getLocation());
+    Assert.assertTrue(location.getFileSystem(shell.getHiveConf()).exists(location));
+    shell.executeStatement(String.format("DROP TABLE %s", tableName));
+    Assert.assertTrue(location.getFileSystem(shell.getHiveConf()).exists(location));
   }
 
   private static <T> PositionDelete<T> positionDelete(CharSequence path, long pos, T row) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make external table purge true when migration to  a V2 Iceberg table