### PR TITLE
HIVE-26534: GROUPING() function errors out due to case-sensitivity of function name

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -3359,7 +3359,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         ASTNode root = (ASTNode) t;
         if (root.getType() == HiveParser.TOK_FUNCTION) {
           ASTNode func = (ASTNode) ParseDriver.adaptor.getChild(root, 0);
-          if (func.getText().equals("grouping") && func.getChildCount() == 0) {
+          if (func.getText().equalsIgnoreCase("grouping") && func.getChildCount() == 0) {
             int numberOperands = ParseDriver.adaptor.getChildCount(root);
             // We implement this logic using replaceChildren instead of replacing
             // the root node itself because windowing logic stores multiple

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -3359,7 +3359,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         ASTNode root = (ASTNode) t;
         if (root.getType() == HiveParser.TOK_FUNCTION) {
           ASTNode func = (ASTNode) ParseDriver.adaptor.getChild(root, 0);
-          if (func.getText().equalsIgnoreCase("grouping") && func.getChildCount() == 0) {
+          if ("grouping".equalsIgnoreCase(func.getText()) && func.getChildCount() == 0) {
             int numberOperands = ParseDriver.adaptor.getChildCount(root);
             // We implement this logic using replaceChildren instead of replacing
             // the root node itself because windowing logic stores multiple

--- a/ql/src/test/queries/clientpositive/grouping_upper_lower_case.q
+++ b/ql/src/test/queries/clientpositive/grouping_upper_lower_case.q
@@ -1,0 +1,8 @@
+
+create table test(
+    col1 string,
+    col2 int
+);
+
+select grouping(col2) from test group by col2 with rollup;
+select GROUPING(col2) from test group by col2 with rollup;

--- a/ql/src/test/results/clientpositive/llap/grouping_upper_lower_case.q.out
+++ b/ql/src/test/results/clientpositive/llap/grouping_upper_lower_case.q.out
@@ -1,0 +1,32 @@
+PREHOOK: query: create table test(
+    col1 string,
+    col2 int
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test
+POSTHOOK: query: create table test(
+    col1 string,
+    col2 int
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test
+PREHOOK: query: select grouping(col2) from test group by col2 with rollup
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test
+#### A masked pattern was here ####
+POSTHOOK: query: select grouping(col2) from test group by col2 with rollup
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test
+#### A masked pattern was here ####
+1
+PREHOOK: query: select GROUPING(col2) from test group by col2 with rollup
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test
+#### A masked pattern was here ####
+POSTHOOK: query: select GROUPING(col2) from test group by col2 with rollup
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test
+#### A masked pattern was here ####
+1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Using `equalsIgnoreCase` instead of `equals` to compare String.


### Why are the changes needed?
Without this change `grouping` and `GROUPING` behaves differently.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile=grouping_upper_lower_case.q
