### PR TITLE
HIVE-26532: Remove logger from critical path in VectorMapJoinInnerLon…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/VectorMapJoinInnerLongOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/VectorMapJoinInnerLongOperator.java
@@ -77,6 +77,8 @@ public class VectorMapJoinInnerLongOperator extends VectorMapJoinInnerGenerateRe
   // The column number for this one column join specialization.
   private transient int singleJoinColumn;
 
+  private transient boolean isDebugEnabled;
+
   //---------------------------------------------------------------------------
   // Pass-thru constructors.
   //
@@ -84,15 +86,18 @@ public class VectorMapJoinInnerLongOperator extends VectorMapJoinInnerGenerateRe
   /** Kryo ctor. */
   protected VectorMapJoinInnerLongOperator() {
     super();
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   public VectorMapJoinInnerLongOperator(CompilationOpContext ctx) {
     super(ctx);
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   public VectorMapJoinInnerLongOperator(CompilationOpContext ctx, OperatorDesc conf,
       VectorizationContext vContext, VectorDesc vectorDesc) throws HiveException {
     super(ctx, conf, vContext, vectorDesc);
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   //---------------------------------------------------------------------------
@@ -197,7 +202,7 @@ public class VectorMapJoinInnerLongOperator extends VectorMapJoinInnerGenerateRe
          * Common repeated join result processing.
          */
 
-        if (LOG.isDebugEnabled()) {
+        if (isDebugEnabled) {
           LOG.debug(CLASS_NAME + " batch #" + batchCounter + " repeated joinResult " + joinResult.name());
         }
         finishInnerRepeated(batch, joinResult, hashMapResults[0]);
@@ -207,7 +212,7 @@ public class VectorMapJoinInnerLongOperator extends VectorMapJoinInnerGenerateRe
          * NOT Repeating.
          */
 
-        if (LOG.isDebugEnabled()) {
+        if (isDebugEnabled) {
           LOG.debug(CLASS_NAME + " batch #" + batchCounter + " non-repeated");
         }
 
@@ -361,7 +366,7 @@ public class VectorMapJoinInnerLongOperator extends VectorMapJoinInnerGenerateRe
           }
         }
 
-        if (LOG.isDebugEnabled()) {
+        if (isDebugEnabled) {
           LOG.debug(CLASS_NAME +
               " allMatchs " + intArrayToRangesString(allMatchs,allMatchCount) +
               " equalKeySeriesHashMapResultIndices " + intArrayToRangesString(equalKeySeriesHashMapResultIndices, equalKeySeriesCount) +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/VectorMapJoinOuterStringOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/VectorMapJoinOuterStringOperator.java
@@ -73,6 +73,8 @@ public class VectorMapJoinOuterStringOperator extends VectorMapJoinOuterGenerate
   // The column number for this one column join specialization.
   protected transient int singleJoinColumn;
 
+  private transient boolean isDebugEnabled;
+
   //---------------------------------------------------------------------------
   // Pass-thru constructors.
   //
@@ -80,15 +82,18 @@ public class VectorMapJoinOuterStringOperator extends VectorMapJoinOuterGenerate
   /** Kryo ctor. */
   protected VectorMapJoinOuterStringOperator() {
     super();
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   public VectorMapJoinOuterStringOperator(CompilationOpContext ctx) {
     super(ctx);
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   public VectorMapJoinOuterStringOperator(CompilationOpContext ctx, OperatorDesc conf,
       VectorizationContext vContext, VectorDesc vectorDesc) throws HiveException {
     super(ctx, conf, vContext, vectorDesc);
+    isDebugEnabled = LOG.isDebugEnabled();
   }
 
   //---------------------------------------------------------------------------
@@ -204,7 +209,7 @@ public class VectorMapJoinOuterStringOperator extends VectorMapJoinOuterGenerate
          * Common repeated join result processing.
          */
 
-        if (LOG.isDebugEnabled()) {
+        if (isDebugEnabled) {
           LOG.debug(CLASS_NAME + " batch #" + batchCounter + " repeated joinResult " + joinResult.name());
         }
         finishOuterRepeated(batch, joinResult, hashMapResults[0], someRowsFilteredOut,
@@ -369,7 +374,7 @@ public class VectorMapJoinOuterStringOperator extends VectorMapJoinOuterGenerate
           }
         }
 
-        if (LOG.isDebugEnabled()) {
+        if (isDebugEnabled) {
           LOG.debug(CLASS_NAME + " batch #" + batchCounter +
               " allMatchs " + intArrayToRangesString(allMatchs,allMatchCount) +
               " equalKeySeriesHashMapResultIndices " + intArrayToRangesString(equalKeySeriesHashMapResultIndices, equalKeySeriesCount) +


### PR DESCRIPTION
HIVE-26532 :Remove logger from critical path in VectorMapJoinInnerLongOperator::processBatch

Trivial patch