### PR TITLE
HIVE-26544: javax.jms:jms:jar artifact resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,9 +219,9 @@
   <repositories>
    <!-- This needs to be removed before checking in-->
     <repository>
-      <id>datanucleus</id>
-      <name>datanucleus maven repository</name>
-      <url>http://www.datanucleus.org/downloads/maven2</url>
+      <id>jboss-maven2</id>
+      <name>jboss maven2 repository</name>
+      <url>https://repository.jboss.org/maven2/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding JBoss maven2 artifact to resolve the  javax.jms:jms:jar issue, by adding build will pass locally on macos-m1.
jira- [HIVE-26544](https://issues.apache.org/jira/browse/HIVE-26544)


### Why are the changes needed?
From the pom.xml, we need to change this beow explained
old repo:
  <url>http://www.datanucleus.org/downloads/maven2</url>
new repo
https://repository.jboss.org/maven2/


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
without this patchm the build failed as explained in [HIVE-26544](https://issues.apache.org/jira/browse/HIVE-26544)
By applying this proposed patch, it gets succeded. 
