### PR TITLE
HIVE-14514: Cloning writerOptions when creating delete event writers …

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
@@ -146,7 +146,8 @@ public final class OrcFile extends org.apache.orc.OrcFile {
   /**
    * Options for creating ORC file writers.
    */
-  public static class WriterOptions extends org.apache.orc.OrcFile.WriterOptions {
+  public static class WriterOptions extends org.apache.orc.OrcFile.WriterOptions
+          implements Cloneable {
     private boolean explicitSchema = false;
     private ObjectInspector inspector = null;
     // Setting the default batch size to 1000 makes the memory check at 5000
@@ -164,6 +165,10 @@ public final class OrcFile extends org.apache.orc.OrcFile {
         memory(getThreadLocalOrcLlapMemoryManager(conf));
       }
       isCompaction = AcidUtils.isCompactionTable(tableProperties);
+    }
+
+    public WriterOptions clone() {
+        return (WriterOptions) super.clone();
     }
 
    /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
@@ -336,20 +336,11 @@ public class OrcRecordUpdater implements RecordUpdater {
         // The actual initialization of a writer only happens if any delete events are written
         //to avoid empty files.
         this.deleteEventPath = AcidUtils.createFilename(partitionRoot, deleteOptions);
-        /**
-         * HIVE-14514 is not done so we can't clone writerOptions().  So here we create a new
-         * options object to make sure insert and delete writers don't share them (like the
-         * callback object, for example)
-         * In any case insert writer and delete writer would most likely have very different
-         * characteristics - delete writer only writes a tiny amount of data.  Once we do early
-         * update split, each {@link OrcRecordUpdater} will have only 1 writer. (except for Mutate API)
-         * Then it would perhaps make sense to take writerOptions as input - how?.
-         */
-        this.deleteWriterOptions = OrcFile.writerOptions(optionsCloneForDelta.getTableProperties(),
-          optionsCloneForDelta.getConfiguration());
-        this.deleteWriterOptions.inspector(createEventObjectInspector(findRecId(options.getInspector(),
-          options.getRecordIdColumn())));
-        this.deleteWriterOptions.setSchema(createEventSchemaFromTableProperties(options.getTableProperties()));
+        this.deleteWriterOptions = writerOptions
+                .clone()
+                .inspector(createEventObjectInspector(findRecId(options.getInspector(),
+                        options.getRecordIdColumn())))
+                .setSchema(createEventSchemaFromTableProperties(options.getTableProperties()));
       }
 
       // get buffer size and stripe size for base writer


### PR DESCRIPTION
…in OrcRecordUpdater.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When split-update is enabled for ACID, OrcRecordUpdater creates two sets of writers: one for the insert deltas and one for the delete deltas. The deleteEventWriter is initialized with similar writerOptions as the normal writer, except that it has a different callback handler. Previously, when creating deleteWriterOptions it was needed to instantiate a new writer options similar to regular writer due to lack of clone method in WriterOptions class in Orc code. Now Orc WriterOptions class implements Cloneable and deleteWriterOptions can be instantiated by cloning the regular writer options.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improving code quality.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests and integration tests.