### PR TITLE
HIVE-26576: Alter table calls on Iceberg tables can inadvertently change metadata_location

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCommitLock.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCommitLock.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hive;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.LockComponent;
+import org.apache.hadoop.hive.metastore.api.LockLevel;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.LockType;
+import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Tasks;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HiveCommitLock {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveCommitLock.class);
+
+  private static final String HIVE_ACQUIRE_LOCK_TIMEOUT_MS = "iceberg.hive.lock-timeout-ms";
+  private static final String HIVE_LOCK_CHECK_MIN_WAIT_MS = "iceberg.hive.lock-check-min-wait-ms";
+  private static final String HIVE_LOCK_CHECK_MAX_WAIT_MS = "iceberg.hive.lock-check-max-wait-ms";
+  private static final String HIVE_TABLE_LEVEL_LOCK_EVICT_MS = "iceberg.hive.table-level-lock-evict-ms";
+  private static final long HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT = 3 * 60 * 1000; // 3 minutes
+  private static final long HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT = 50; // 50 milliseconds
+  private static final long HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT = 5 * 1000; // 5 seconds
+
+  private static final long HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT = TimeUnit.MINUTES.toMillis(10);
+
+  private static Cache<String, ReentrantLock> commitLockCache;
+
+  private static synchronized void initTableLevelLockCache(long evictionTimeout) {
+    if (commitLockCache == null) {
+      commitLockCache = Caffeine.newBuilder()
+          .expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS)
+          .build();
+    }
+  }
+
+  private final String fullName;
+  private final String databaseName;
+  private final String tableName;
+  private final ClientPool<IMetaStoreClient, TException> metaClients;
+
+  private final long lockAcquireTimeout;
+  private final long lockCheckMinWaitTime;
+  private final long lockCheckMaxWaitTime;
+
+  private Optional<Long> hmsLockId = Optional.empty();
+  private Optional<ReentrantLock> jvmLock = Optional.empty();
+
+  public HiveCommitLock(Configuration conf, ClientPool<IMetaStoreClient, TException> metaClients,
+      String catalogName, String databaseName, String tableName) {
+    this.metaClients = metaClients;
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+    this.fullName = catalogName + "." + databaseName + "." + tableName;
+
+    this.lockAcquireTimeout =
+        conf.getLong(HIVE_ACQUIRE_LOCK_TIMEOUT_MS, HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT);
+    this.lockCheckMinWaitTime =
+        conf.getLong(HIVE_LOCK_CHECK_MIN_WAIT_MS, HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT);
+    this.lockCheckMaxWaitTime =
+        conf.getLong(HIVE_LOCK_CHECK_MAX_WAIT_MS, HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT);
+    long tableLevelLockCacheEvictionTimeout =
+        conf.getLong(HIVE_TABLE_LEVEL_LOCK_EVICT_MS, HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT);
+    initTableLevelLockCache(tableLevelLockCacheEvictionTimeout);
+  }
+
+  public void acquire() throws UnknownHostException, TException, InterruptedException {
+    // getting a process-level lock per table to avoid concurrent commit attempts to the same table from the same
+    // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
+    acquireJvmLock();
+    acquireLockFromHms();
+  }
+
+  public void release() {
+    releaseHmsLock();
+    releaseJvmLock();
+  }
+
+  // TODO add lock heart beating for cases where default lock timeout is too low.
+  private void acquireLockFromHms() throws UnknownHostException, TException, InterruptedException {
+    if (hmsLockId.isPresent()) {
+      throw new IllegalArgumentException(String.format("HMS lock ID=%s already acquired for table %s.%s",
+          hmsLockId.get(), databaseName, tableName));
+    }
+    final LockComponent lockComponent = new LockComponent(LockType.EXCL_WRITE, LockLevel.TABLE, databaseName);
+    lockComponent.setTablename(tableName);
+    final LockRequest lockRequest = new LockRequest(Lists.newArrayList(lockComponent),
+        System.getProperty("user.name"),
+        InetAddress.getLocalHost().getHostName());
+    LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
+    AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
+    long lockId = lockResponse.getLockid();
+    this.hmsLockId = Optional.of(lockId);
+
+    final long start = System.currentTimeMillis();
+    long duration = 0;
+    boolean timeout = false;
+
+    try {
+      if (state.get().equals(LockState.WAITING)) {
+        // Retry count is the typical "upper bound of retries" for Tasks.run() function. In fact, the maximum number of
+        // attempts the Tasks.run() would try is `retries + 1`. Here, for checking locks, we use timeout as the
+        // upper bound of retries. So it is just reasonable to set a large retry count. However, if we set
+        // Integer.MAX_VALUE, the above logic of `retries + 1` would overflow into Integer.MIN_VALUE. Hence,
+        // the retry is set conservatively as `Integer.MAX_VALUE - 100` so it doesn't hit any boundary issues.
+        Tasks.foreach(lockId)
+            .retry(Integer.MAX_VALUE - 100)
+            .exponentialBackoff(
+                lockCheckMinWaitTime,
+                lockCheckMaxWaitTime,
+                lockAcquireTimeout,
+                1.5)
+            .throwFailureWhenFinished()
+            .onlyRetryOn(WaitingForHmsLockException.class)
+            .run(id -> {
+              try {
+                LockResponse response = metaClients.run(client -> client.checkLock(id));
+                LockState newState = response.getState();
+                state.set(newState);
+                if (newState.equals(LockState.WAITING)) {
+                  throw new WaitingForHmsLockException("Waiting for lock.");
+                }
+              } catch (InterruptedException e) {
+                Thread.interrupted(); // Clear the interrupt status flag
+                LOG.warn("Interrupted while waiting for lock.", e);
+              }
+            }, TException.class);
+      }
+    } catch (WaitingForHmsLockException waitingForLockException) {
+      timeout = true;
+      duration = System.currentTimeMillis() - start;
+    } finally {
+      if (!state.get().equals(LockState.ACQUIRED)) {
+        releaseHmsLock();
+      }
+    }
+
+    // timeout and do not have lock acquired
+    if (timeout && !state.get().equals(LockState.ACQUIRED)) {
+      throw new CommitFailedException("Timed out after %s ms waiting for lock on %s.%s",
+          duration, databaseName, tableName);
+    }
+
+    if (!state.get().equals(LockState.ACQUIRED)) {
+      throw new CommitFailedException("Could not acquire the lock on %s.%s, " +
+          "lock request ended in state %s", databaseName, tableName, state);
+    }
+  }
+
+  private void releaseHmsLock() {
+    if (hmsLockId.isPresent()) {
+      try {
+        metaClients.run(client -> {
+          client.unlock(hmsLockId.get());
+          return null;
+        });
+        hmsLockId = Optional.empty();
+      } catch (Exception e) {
+        LOG.warn("Failed to unlock {}.{}", databaseName, tableName, e);
+      }
+    }
+  }
+
+  private void acquireJvmLock() {
+    if (jvmLock.isPresent()) {
+      throw new IllegalStateException(String.format("JVM lock already acquired for table %s", fullName));
+    }
+    jvmLock = Optional.of(commitLockCache.get(fullName, t -> new ReentrantLock(true)));
+    jvmLock.get().lock();
+  }
+
+  private void releaseJvmLock() {
+    if (jvmLock.isPresent()) {
+      jvmLock.get().unlock();
+      jvmLock = Optional.empty();
+    }
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  private static class WaitingForHmsLockException extends RuntimeException {
+    WaitingForHmsLockException(String message) {
+      super(message);
+    }
+  }
+}

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -132,7 +132,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
   @Test
   public void testLockAcquisitionAtFirstTime() throws TException, InterruptedException {
     doReturn(acquiredLockResponse).when(spyClient).lock(any());
-    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+    doNothing().when(spyClient).unlock(eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
 
@@ -150,7 +150,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .doReturn(acquiredLockResponse)
         .when(spyClient)
         .checkLock(eq(dummyLockId));
-    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+    doNothing().when(spyClient).unlock(eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -425,6 +425,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
         // meanwhile. The base metadata locations differ, while we know that this wasn't an intentional, manual
         // metadata_location set by a user. To protect the interim commit we need to refresh the metadata file location.
         tblParams.put(BaseMetastoreTableOperations.METADATA_LOCATION_PROP, currentMetadata.metadataFileLocation());
+        LOG.warn("Detected an alter table operation attempting to do alterations on an Iceberg table with a stale " +
+            "metadata_location. Considered base metadata_location: {}, Actual metadata_location: {}. Will override " +
+            "this request with the refreshed metadata_location in order to preserve the concurrent commit.",
+            newMetadataLocation, currentMetadata.metadataFileLocation());
       }
     }
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -65,7 +65,6 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DeleteFiles;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -81,6 +80,8 @@ import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.hive.CachedClientPool;
+import org.apache.iceberg.hive.HiveCommitLock;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.apache.iceberg.io.FileIO;
@@ -95,6 +96,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.Pair;
 import org.apache.thrift.TException;
@@ -126,6 +128,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       Lists.newArrayList(org.apache.commons.lang3.tuple.Pair.of(1, new byte[0]));
   static final String MIGRATED_TO_ICEBERG = "MIGRATED_TO_ICEBERG";
   static final String ORC_FILES_ONLY = "iceberg.orc.files.only";
+  static final String MANUAL_ICEBERG_METADATA_LOCATION_CHANGE = "MANUAL_ICEBERG_METADATA_LOCATION_CHANGE";
 
   private final Configuration conf;
   private Table icebergTable = null;
@@ -140,6 +143,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
   private Transaction transaction;
   private AlterTableType currentAlterTableOp;
   private boolean createHMSTableInHook = false;
+  private HiveCommitLock commitLock;
 
   private enum FileFormat {
     ORC("orc"), PARQUET("parquet"), AVRO("avro");
@@ -175,7 +179,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       // If not using HiveCatalog check for existing table
       try {
 
-        this.icebergTable = IcebergTableUtil.getTable(conf, catalogProperties);
+        this.icebergTable = IcebergTableUtil.getTable(conf, catalogProperties, true);
 
         Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
             "Iceberg table already created - can not use provided schema");
@@ -299,8 +303,24 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       throws MetaException {
     catalogProperties = getCatalogProperties(hmsTable);
     setupAlterOperationType(hmsTable, context);
+    if (commitLock == null) {
+      commitLock = new HiveCommitLock(conf, new CachedClientPool(conf, Maps.fromProperties(catalogProperties)),
+          catalogProperties.getProperty(Catalogs.NAME), hmsTable.getDbName(), hmsTable.getTableName());
+    }
+
     try {
-      icebergTable = IcebergTableUtil.getTable(conf, catalogProperties);
+      commitLock.acquire();
+      doPreAlterTable(hmsTable, context);
+    } catch (Exception e) {
+      commitLock.release();
+      throw new MetaException(StringUtils.stringifyException(e));
+    }
+  }
+
+  private void doPreAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context)
+      throws MetaException {
+    try {
+      icebergTable = IcebergTableUtil.getTable(conf, catalogProperties, true);
     } catch (NoSuchTableException nte) {
       context.getProperties().put(MIGRATE_HIVE_TO_ICEBERG, "true");
       // If the iceberg table does not exist, then this is an ALTER command aimed at migrating the table to iceberg
@@ -322,8 +342,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       // If there are partition keys specified remove them from the HMS table and add them to the column list
       try {
         Hive db = SessionState.get().getHiveDb();
-        preAlterTableProperties.partitionSpecProxy = db.getMSC().listPartitionSpecs(hmsTable.getCatName(),
-            hmsTable.getDbName(), hmsTable.getTableName(), Integer.MAX_VALUE);
+        preAlterTableProperties.partitionSpecProxy = db.getMSC().listPartitionSpecs(
+            hmsTable.getCatName(), hmsTable.getDbName(), hmsTable.getTableName(), Integer.MAX_VALUE);
         if (hmsTable.isSetPartitionKeys() && !hmsTable.getPartitionKeys().isEmpty()) {
           db.dropPartitions(hmsTable.getDbName(), hmsTable.getTableName(), EMPTY_FILTER, DROP_OPTIONS);
 
@@ -345,8 +365,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
 
       sd.setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
       sd.setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
-      sd.setSerdeInfo(new SerDeInfo("icebergSerde", HiveIcebergSerDe.class.getCanonicalName(),
-          Collections.emptyMap()));
+      sd.setSerdeInfo(new SerDeInfo("icebergSerde", HiveIcebergSerDe.class.getCanonicalName(), Collections.emptyMap()));
       setCommonHmsTablePropertiesForIceberg(hmsTable);
       // set an additional table prop to designate that this table has been migrated to Iceberg, i.e.
       // all or some of its data files have not been written out using the Iceberg writer, and therefore those data
@@ -367,8 +386,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       // that users can change data types or reorder columns too with this alter op type, so its name is misleading..)
       assertNotMigratedTable(hmsTable.getParameters(), "CHANGE COLUMN");
       handleChangeColumn(hmsTable);
-    } else if (AlterTableType.ADDPROPS.equals(currentAlterTableOp)) {
-      assertNotCrossTableMetadataLocationChange(hmsTable.getParameters());
+    } else {
+      assertNotCrossTableMetadataLocationChange(hmsTable.getParameters(), context);
     }
 
     // Migration case is already handled above, in case of migration we don't have all the properties set till this
@@ -385,7 +404,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
    * the current metadata uuid and the new metadata uuid matches.
    * @param tblParams hms table properties, must be non-null
    */
-  private void assertNotCrossTableMetadataLocationChange(Map<String, String> tblParams) {
+  private void assertNotCrossTableMetadataLocationChange(Map<String, String> tblParams, EnvironmentContext context) {
     if (tblParams.containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)) {
       Preconditions.checkArgument(icebergTable != null,
           "Cannot perform table migration to Iceberg and setting the snapshot location in one step. " +
@@ -399,6 +418,13 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
             String.format("Cannot change iceberg table %s metadata location pointing to another table's metadata %s",
                 icebergTable.name(), newMetadataLocation)
         );
+      }
+      if (!currentMetadata.metadataFileLocation().equals(newMetadataLocation) &&
+          !context.getProperties().containsKey(MANUAL_ICEBERG_METADATA_LOCATION_CHANGE)) {
+        // If we got here then this is an alter table operation where the table to be changed had an Iceberg commit
+        // meanwhile. The base metadata locations differ, while we know that this wasn't an intentional, manual
+        // metadata_location set by a user. To protect the interim commit we need to refresh the metadata file location.
+        tblParams.put(BaseMetastoreTableOperations.METADATA_LOCATION_PROP, currentMetadata.metadataFileLocation());
       }
     }
   }
@@ -475,6 +501,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
   @Override
   public void commitAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context)
       throws MetaException {
+    if (commitLock == null) {
+      throw new IllegalStateException("Hive commit lock should already be set");
+    }
+    commitLock.release();
     if (isTableMigration) {
       catalogProperties = getCatalogProperties(hmsTable);
       catalogProperties.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(preAlterTableProperties.schema));
@@ -507,6 +537,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
 
   @Override
   public void rollbackAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context) {
+    if (commitLock == null) {
+      throw new IllegalStateException("Hive commit lock should already be set");
+    }
+    commitLock.release();
     if (Boolean.parseBoolean(context.getProperties().getOrDefault(MIGRATE_HIVE_TO_ICEBERG, "false"))) {
       LOG.debug("Initiating rollback for table {} at location {}",
           hmsTable.getTableName(), hmsTable.getSd().getLocation());
@@ -866,4 +900,5 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     private List<FieldSchema> partitionKeys;
     private PartitionSpecProxy partitionSpecProxy;
   }
+
 }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -176,6 +176,10 @@ public class TestHiveShell {
     }
   }
 
+  public HiveSession getSession() {
+    return session;
+  }
+
   private HiveConf initializeConf() {
     HiveConf hiveConf = new HiveConf();
 

--- a/iceberg/iceberg-handler/src/test/results/negative/alter_acid_table_to_iceberg_failure.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/alter_acid_table_to_iceberg_failure.q.out
@@ -14,4 +14,6 @@ PREHOOK: query: alter table tbl_orc set tblproperties ('storage_handler'='org.ap
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tbl_orc
 PREHOOK: Output: default@tbl_orc
-FAILED: Execution Error, return code 40013 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to alter table. Converting non-external, temporary or transactional hive table to iceberg table is not allowed.
+FAILED: Execution Error, return code 40013 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to alter table. MetaException(message:Converting non-external, temporary or transactional hive table to iceberg table is not allowed.)
+#### A masked pattern was here ####
+

--- a/iceberg/iceberg-handler/src/test/results/negative/alter_managed_table_to_iceberg_failure.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/alter_managed_table_to_iceberg_failure.q.out
@@ -14,4 +14,6 @@ PREHOOK: query: alter table tbl_orc set tblproperties ('storage_handler'='org.ap
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tbl_orc
 PREHOOK: Output: default@tbl_orc
-FAILED: Execution Error, return code 40013 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to alter table. Converting non-external, temporary or transactional hive table to iceberg table is not allowed.
+FAILED: Execution Error, return code 40013 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to alter table. MetaException(message:Converting non-external, temporary or transactional hive table to iceberg table is not allowed.)
+#### A masked pattern was here ####
+

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -29,11 +29,13 @@ import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import org.apache.hadoop.hive.common.type.SnapshotContext;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.Context.Operation;
+import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec;
@@ -509,5 +511,15 @@ public interface HiveStorageHandler extends Configurable {
    */
   default SnapshotContext getCurrentSnapshotContext(org.apache.hadoop.hive.ql.metadata.Table table) {
     return null;
+  }
+
+  /**
+   * Alter table operations can rely on this to customize the EnvironmentContext to be used during the alter table
+   * invocation (both on client and server side of HMS)
+   * @param alterTableDesc the alter table desc (e.g.: AlterTableSetPropertiesDesc) containing the work to do
+   * @param environmentContext an existing EnvironmentContext created prior, now to be filled/amended
+   */
+  default void prepareAlterTableEnvironmentContext(AbstractAlterTableDesc alterTableDesc,
+      EnvironmentContext environmentContext) {
   }
 }


### PR DESCRIPTION
Concurrent alter_table calls can interfere and can cause the metadata_location property of an Iceberg table to be messed up.

Basically there's no table level locking for Iceberg tables in Hive during the usual operations, and thus some extra performance related features are available, like concurrent inserts, as opposed to native Hive tables. This was done under the assumption that the optimistic locking pattern that is used in HiveTableOperations protects changing the metadata_location by the use of an HMS table lock there only.

This is fine until some other alter_table calls get into the system such as one from StatTask or DDLTask. Such tasks perform their work as:

- get the current table
- do the alteration
- send the changes via alter_table call to HMS

In between the retrieval of the table and the alter_table call a legit commit from HiveTableOperations might bump the metadata_location, but this will get reverted as these tasks consider an outdated metadata_location (and the alter table call will overwrite all table props including this one too..)

This is a design issue, and to solve this while preserving the concurrency features I propose to make use of HiveIcebergMetaHook where all such alter_table calls are intercepted, and the same locking mechanism could be used there as the one found in HiveTableOperations. The proposed flow on HMS client side would be:

- hook: preAlterTable
  - request table level lock
  - refresh the Iceberg table from catalog (HMS) to see if new updates have arrived
  - compare the current metadata with the one thought to be the base of this request, if metadata_location is outdated overwrite it with the fresh, current one in this request
  - do the alter_table call to HMS with the relevant changes (updated stats or other properties)
- hook: post/rollbackAlterTable
  - release table level lock
 
This can work as the metadata_location should never be changed by anything other than HiveTableOperations, which is the only thing not using this hook (if it did we'd be in an endless loop). There's actually one exception which is if a user wants to change the metadata_location by hand. I can make an exception to that signalling this fact from an environmentContext instance when the corresponding AlterTableSetPropertiesDesc is constructed.