### PR TITLE
HIVE-26556: Iceberg: Properties set in HiveIcebergSerde are not propagated to jobconf

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -77,7 +77,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   private Collection<String> partitionColumns;
   private Map<ObjectInspector, Deserializer> deserializers = Maps.newHashMapWithExpectedSize(1);
   private Container<Record> row = new Container<>();
-  private Map<String, String> jobConfs =  Maps.newHashMap();
+  private Map<String, String> jobConf =  Maps.newHashMap();
 
   @Override
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties,
@@ -132,13 +132,13 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     }
 
     this.projectedSchema =
-        projectedSchema(configuration, serDeProperties.getProperty(Catalogs.NAME), tableSchema, jobConfs);
+        projectedSchema(configuration, serDeProperties.getProperty(Catalogs.NAME), tableSchema, jobConf);
 
     // Currently ClusteredWriter is used which requires that records are ordered by partition keys.
     // Here we ensure that SortedDynPartitionOptimizer will kick in and do the sorting.
     // TODO: remove once we have both Fanout and ClusteredWriter available: HIVE-25948
-    jobConfs.put(HiveConf.ConfVars.HIVEOPTSORTDYNAMICPARTITIONTHRESHOLD.varname, "1");
-    jobConfs.put(HiveConf.ConfVars.DYNAMICPARTITIONINGMODE.varname, "nonstrict");
+    jobConf.put(HiveConf.ConfVars.HIVEOPTSORTDYNAMICPARTITIONTHRESHOLD.varname, "1");
+    jobConf.put(HiveConf.ConfVars.DYNAMICPARTITIONINGMODE.varname, "nonstrict");
 
     try {
       this.inspector = IcebergObjectInspector.create(projectedSchema);
@@ -261,8 +261,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   }
 
   @Override
-  public void handleJobLevelConfigurations(HiveConf conf) {
-    for (Map.Entry<String, String> confs : jobConfs.entrySet()) {
+  public void handleJobLevelConfiguration(HiveConf conf) {
+    for (Map.Entry<String, String> confs : jobConf.entrySet()) {
       conf.set(confs.getKey(), confs.getValue());
     }
   }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSelects.java
@@ -189,7 +189,6 @@ public class TestHiveIcebergSelects extends HiveIcebergStorageHandlerWithEngineB
 
   @Test
   public void testScanTableCaseInsensitive() throws IOException {
-    shell.setHiveSessionValue(InputFormatConfig.CASE_SENSITIVE, false);
     testTables.createTable(shell, "customers",
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA_WITH_UPPERCASE, fileFormat,
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -314,6 +314,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTFInline;
 import org.apache.hadoop.hive.ql.util.DirectionUtils;
 import org.apache.hadoop.hive.ql.util.NullOrdering;
+import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -2901,8 +2902,13 @@ public class CalcitePlanner extends SemanticAnalyzer {
         // Virtual Cols
 
         // 3.1 Add Column info for non partion cols (Object Inspector fields)
-        StructObjectInspector rowObjectInspector = (StructObjectInspector) tabMetaData.getDeserializer()
+        final Deserializer deserializer = tabMetaData.getDeserializer();
+        StructObjectInspector rowObjectInspector = (StructObjectInspector) deserializer
             .getObjectInspector();
+
+        // Special handling for iceberg tables which set specific configurations during initialisation of Serde.
+        copyIcebergSerdeConfigurations(deserializer);
+
         List<? extends StructField> fields = rowObjectInspector.getAllStructFieldRefs();
         ColumnInfo colInfo;
         String colName;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -2907,7 +2907,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
             .getObjectInspector();
 
         // Special handling for iceberg tables which set specific configurations during initialisation of Serde.
-        copyIcebergSerdeConfigurations(deserializer);
+        deserializer.handleJobLevelConfigurations(conf);
 
         List<? extends StructField> fields = rowObjectInspector.getAllStructFieldRefs();
         ColumnInfo colInfo;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -2906,8 +2906,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
         StructObjectInspector rowObjectInspector = (StructObjectInspector) deserializer
             .getObjectInspector();
 
-        // Special handling for iceberg tables which set specific configurations during initialisation of Serde.
-        deserializer.handleJobLevelConfigurations(conf);
+        deserializer.handleJobLevelConfiguration(conf);
 
         List<? extends StructField> fields = rowObjectInspector.getAllStructFieldRefs();
         ColumnInfo colInfo;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -11572,7 +11572,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         StructObjectInspector rowObjectInspector = (StructObjectInspector) deserializer.getObjectInspector();
 
         // Specific Handling for Iceberg serde, which sets specific properties in SessionConf.
-        copyIcebergSerdeConfigurations(deserializer);
+        deserializer.handleJobLevelConfigurations(conf);
         List<? extends StructField> fields = rowObjectInspector
             .getAllStructFieldRefs();
         for (int i = 0; i < fields.size(); i++) {
@@ -11795,19 +11795,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     LOG.debug("Created Table Plan for {} {}", alias, op);
 
     return output;
-  }
-
-  void copyIcebergSerdeConfigurations(Deserializer deserializer) {
-    if (deserializer.getClass().getName().equals("org.apache.iceberg.mr.hive.HiveIcebergSerDe")) {
-      String customConfs = SessionState.getSessionConf().get("iceberg.serde.confs");
-      if (customConfs != null && !customConfs.isEmpty()) {
-        String[] configurations = customConfs.split(",");
-        for (String configuration : configurations) {
-          String[] keyValue = configuration.split(":");
-          conf.set(keyValue[0], keyValue[1]);
-        }
-      }
-    }
   }
 
   boolean isSkewedCol(String alias, QB qb, String colName) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -11571,8 +11571,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         final Deserializer deserializer = tab.getDeserializer();
         StructObjectInspector rowObjectInspector = (StructObjectInspector) deserializer.getObjectInspector();
 
-        // Specific Handling for Iceberg serde, which sets specific properties in SessionConf.
-        deserializer.handleJobLevelConfigurations(conf);
+        deserializer.handleJobLevelConfiguration(conf);
         List<? extends StructField> fields = rowObjectInspector
             .getAllStructFieldRefs();
         for (int i = 0; i < fields.size(); i++) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/SerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/SerDe.java
@@ -32,7 +32,11 @@ public interface SerDe {
    */
   SerDeStats getSerDeStats();
 
-  default void handleJobLevelConfigurations(HiveConf conf) {
+  /**
+   * Adds SerDe specific configurations to job conf.
+   * @param conf the job conf.
+   */
+  default void handleJobLevelConfiguration(HiveConf conf) {
     // Do nothing
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/SerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/SerDe.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive.serde2;
 
+import org.apache.hadoop.hive.conf.HiveConf;
+
 /**
  * A Hive Serializer/Deserializer.
  */
@@ -29,4 +31,8 @@ public interface SerDe {
    * @return {@link SerDeStats} object; or in case not supported: null
    */
   SerDeStats getSerDeStats();
+
+  default void handleJobLevelConfigurations(HiveConf conf) {
+    // Do nothing
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extract the properties set in the SessionConf in HiveIcebergSerde to the JobConf.

### How was this patch tested?
Removing the explicit set config in the UT added as a workaround for this case.
