### PR TITLE
Hive 25945: Upgrade H2 database version to 2.1.214

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <flatbuffers.version>1.9.0</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.21</groovy.version>
-    <h2database.version>2.1.210</h2database.version>
+    <h2database.version>2.1.214</h2database.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION


### What changes were proposed in this pull request?
version upgrade for h2

### Why are the changes needed?
To address some CVEs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
not tested
