### PR TITLE
Hive Security - Upgrade Apache Log4j to 2.18.0 due to critical CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.27</mysql.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -84,7 +84,7 @@
     <junit.vintage.version>5.6.2</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <mockito-core.version>3.3.3</mockito-core.version>
     <orc.version>1.6.9</orc.version>
     <protobuf.version>3.21.4</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache Log4j2 to 2.18.0


### Why are the changes needed?
There are some critical CVEs. 
CVE-2019-17571 (CRITICAL severity) 
CVE-2020-9493 (CRITICAL severity)
CVE-2021-4104 (HIGH severity)
CVE-2022-23302 (HIGH severity)
CVE-2022-23305 (CRITICAL severity)
CVE-2022-23307 (HIGH severity)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests and maven clean build.
