### PR TITLE
HIVE-26437: Dump unpartitioned tables in parallel.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -529,7 +529,7 @@ public class HiveConf extends Configuration {
             + "task increment that would cross the specified limit."),
     REPL_PARTITIONS_DUMP_PARALLELISM("hive.repl.partitions.dump.parallelism",100,
         "Number of threads that will be used to dump partition data information during repl dump."),
-    REPL_TABLE_DUMP_PARALLELISM("hive.repl.table.dump.parallelism", 100,
+    REPL_TABLE_DUMP_PARALLELISM("hive.repl.table.dump.parallelism", 15,
             "Number of threads that will be used to dump table data information during repl dump."),
     REPL_RUN_DATA_COPY_TASKS_ON_TARGET("hive.repl.run.data.copy.tasks.on.target", true,
             "Indicates whether replication should run data copy tasks during repl load operation."),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -529,6 +529,8 @@ public class HiveConf extends Configuration {
             + "task increment that would cross the specified limit."),
     REPL_PARTITIONS_DUMP_PARALLELISM("hive.repl.partitions.dump.parallelism",100,
         "Number of threads that will be used to dump partition data information during repl dump."),
+    REPL_TABLE_DUMP_PARALLELISM("hive.repl.table.dump.parallelism", 100,
+            "Number of threads that will be used to dump table data information during repl dump."),
     REPL_RUN_DATA_COPY_TASKS_ON_TARGET("hive.repl.run.data.copy.tasks.on.target", true,
             "Indicates whether replication should run data copy tasks during repl load operation."),
     REPL_DUMP_METADATA_ONLY("hive.repl.dump.metadata.only", false,

--- a/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/ql/exec/DumbTableExport.java
+++ b/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/ql/exec/DumbTableExport.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.benchmark.ql.exec;
+
+import org.apache.hadoop.hive.ql.exec.repl.util.FileList;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.parse.repl.dump.TableExport;
+
+class DumbTableExport extends TableExport {
+  @Override
+  protected void write(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws SemanticException {
+    try {
+      Thread.sleep(100); // 0.1 second
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/ql/exec/TableAndPartitionExportBench.java
+++ b/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/ql/exec/TableAndPartitionExportBench.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.benchmark.ql.exec;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.parse.repl.dump.ExportService;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class TableAndPartitionExportBench {
+
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @State(Scope.Benchmark)
+  @BenchmarkMode(Mode.SingleShotTime)
+  public static class BaseBench {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(BaseBench.class);
+    static final ExportService exportService = ExportService.getInstance();
+    final HiveConf conf = new HiveConf();
+    final int nTables = 500;
+
+    @Benchmark
+    public void parallel() throws SemanticException, InterruptedException {
+      exportService.configure(conf, true);
+      try {
+        for (int i = 0; i < nTables; i++) {
+          new DumbTableExport().parallelWrite(true, null, true);
+        }
+      } catch (HiveException e) {
+        throw new SemanticException(e);
+      }
+      exportService.shutdown();
+      try {
+        exportService.await(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new InterruptedException(e.getMessage());
+      }
+    }
+
+    @Benchmark
+    public void serial() throws SemanticException, InterruptedException {
+      exportService.configure(conf, true);
+      try {
+        for (int i = 0; i < nTables; i++) {
+          new DumbTableExport().serialWrite(true, null, true);
+        }
+      } catch (SemanticException e) {
+        throw new SemanticException(e);
+      }
+      exportService.shutdown();
+      try {
+        exportService.await(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new InterruptedException(e.getMessage());
+      }
+    }
+  }
+
+    public static void main(String[] args) throws RunnerException {
+      Options opt =
+          new OptionsBuilder().include(".*" + TableAndPartitionExportBench.class.getSimpleName() + ".*").build();
+      new Runner(opt).run();
+    }
+}
+

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ExportTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ExportTask.java
@@ -50,7 +50,7 @@ public class ExportTask extends Task<ExportWork> implements Serializable {
       work.acidPostProcess(db);
       TableExport tableExport = new TableExport(exportPaths, work.getTableSpec(),
           work.getReplicationSpec(), db, null, conf, work.getMmContext());
-      tableExport.write(true, null, false);
+      tableExport.serialWrite(true, null, false);
     } catch (Exception e) {
       LOG.error("failed", e);
       setException(e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -953,8 +953,8 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
             prevSnaps = getListFromFileList(snapPathFileList);
           }
         }
+        ExportService exportService = new ExportService(conf);
         for(String matchedDbName : Utils.matchesDb(hiveDb, work.dbNameOrPattern)) {
-          ExportService exportService = new ExportService(conf);
           for (String tableName : Utils.matchesTbl(hiveDb, matchedDbName, work.replScope)) {
             try {
               Table table = hiveDb.getTable(matchedDbName, tableName);
@@ -991,7 +991,6 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
             }
             try {
               exportService.await(60, TimeUnit.SECONDS);
-              exportService = null;
             } catch (Exception e) {
               LOG.error("Error while shutting down ExportService ", e);
             }
@@ -1219,6 +1218,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
         FileList extTableFileList = createTableFileList(dumpRoot, EximUtil.FILE_LIST_EXTERNAL, conf);
         FileList snapPathFileList = isSnapshotEnabled ? createTableFileList(
             SnapshotUtils.getSnapshotFileListPath(dumpRoot), EximUtil.FILE_LIST_EXTERNAL_SNAPSHOT_CURRENT, conf) : null) {
+      ExportService exportService = new ExportService(conf);
       for (String dbName : Utils.matchesDb(hiveDb, work.dbNameOrPattern)) {
         LOG.debug("Dumping db: " + dbName);
         // TODO : Currently we don't support separate table list for each database.
@@ -1273,7 +1273,6 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
             // Get the counter to store the snapshots created & deleted at source.
             replSnapshotCount = new SnapshotUtils.ReplSnapshotCount();
           }
-          ExportService exportService = new ExportService(conf);
           for (String tblName : Utils.matchesTbl(hiveDb, dbName, work.replScope)) {
             Table table = null;
             try {
@@ -1319,7 +1318,6 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
             }
             try {
               exportService.await(60, TimeUnit.SECONDS);
-              exportService = null;
             } catch (Exception e) {
               LOG.error("Error while shutting down ExportService ", e);
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1751,7 +1751,7 @@ public class Hive {
    */
   private ValidWriteIdList getValidWriteIdList(String dbName, String tableName) throws LockException {
     ValidWriteIdList validWriteIdList = null;
-    long txnId = SessionState.get().getTxnMgr() != null ? SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
+    long txnId = SessionState.get() != null && SessionState.get().getTxnMgr() != null ? SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
     if (txnId > 0) {
       validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1683,7 +1683,7 @@ public class Hive {
       if (checkTransactional) {
         ValidWriteIdList validWriteIdList = null;
         long txnId = SessionState.get() != null && SessionState.get().getTxnMgr() != null ?
-             SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
+            SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
         if (txnId > 0) {
           validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/ExportJob.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/ExportJob.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse.repl.dump;
+
+/**
+ * A runnable export job
+ */
+public interface ExportJob extends Runnable {
+
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/ExportService.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/ExportService.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse.repl.dump;
+
+import com.cronutils.utils.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A service to dump/export table and partition in parallel manner using asynchronous threads
+ */
+public class ExportService {
+
+  /**
+   * Executor service to execute runnable export jobs
+   */
+  private ExecutorService execService;
+  private static final Logger LOG = LoggerFactory.getLogger(ExportService.class);
+  private List<Future<?>> futures = new LinkedList<>();
+  private AtomicBoolean isServiceRunning =  new AtomicBoolean(false);;
+  private final int threadPoolSizeLimit = 100;
+
+  /**
+   * Class private constructor to create empty INSTANCE
+   */
+  private ExportService() {
+  }
+
+  /**
+   * A singleton instance of ExportService
+   */
+  private static final ExportService INSTANCE = new ExportService();
+
+  /**
+   * A static method to return a singleton instance of ExportService.
+   * @return Singleton instance of ExportService.
+   */
+  public static ExportService getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Configure ExportService request to create provided number of parallel threads.
+   * @param hiveConf
+   *          HiveConfig containing value of REPL_TABLE_DUMP_PARALLELISM config variable
+   *          which indicates number of parallel threads to be created.
+   * @param cancelCurrentJob
+   *          A boolean flag to indicate whether to cancel current ongoing task or shutdown
+   *          export service immediately.
+   */
+  public void configure(HiveConf hiveConf, boolean cancelCurrentJob) {
+    if (execService != null) {
+      if (cancelCurrentJob) {
+        execService.shutdownNow();
+      } else {
+        execService.shutdown();
+      }
+    }
+    int nDumpThreads = hiveConf.getIntVar(HiveConf.ConfVars.REPL_TABLE_DUMP_PARALLELISM);
+    if (nDumpThreads == 0) {
+      LOG.warn("ExportService is disabled since thread pool size (REPL_TABLE_DUMP_PARALLELISM) is specified as 0");
+      isServiceRunning.set(false);
+      return;
+    }
+    if (nDumpThreads > threadPoolSizeLimit) {
+      LOG.warn("Thread pool size for ExportService (REPL_TABLE_DUMP_PARALLELISM) is specified higher than limit. " +
+              "Choosing thread pool size as 100");
+      nDumpThreads = threadPoolSizeLimit;
+    }
+    ThreadFactory namingThreadFactory = new ThreadFactoryBuilder().setNameFormat("TableAndPartition-dump-thread-%d").build();
+    execService = Executors.newFixedThreadPool(nDumpThreads, namingThreadFactory);
+    LOG.debug("ExportService started with thread pool size {} ", nDumpThreads);
+    isServiceRunning.set(true);
+  }
+
+  /**
+   * Tells whether ExportService is started and configured.
+   * If it is shutdown return false else return true
+   * @return false/true
+   */
+  public boolean isExportServiceStarted() {
+    return isServiceRunning.get();
+  }
+  /**
+   * Executes the submitted ExportJob
+   * @param job
+   */
+  public void submit(ExportJob job) {
+    assert (execService != null);
+    futures.add(execService.submit(job));
+  }
+
+  /**
+   * Shutdown the ExportService and does not allow further ExportJob to be submitted.
+   */
+  public void shutdown() {
+    assert (execService != null);
+    LOG.debug("ExportService got shutdown");
+    execService.shutdown();
+    isServiceRunning.set(false);
+  }
+
+  /**
+   * Shutdown immediately the ExportService and does not allow further ExportJob to be submitted
+   */
+  public void shutdownNow() {
+    assert (execService != null);
+    LOG.debug("ExportService got shutdownNow");
+    execService.shutdownNow();
+    isServiceRunning.set(false);
+  }
+
+  /**
+   * Wait for termination of all submitted ExportJob to the ExportService.
+   * @param timeout indicates time to wait until all tasks complete execution
+   * @param unit time unit for wait timeout
+   * @return true if executor terminated and false if timeout elapsed
+   * @throws InterruptedException
+   */
+  public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+    assert (execService != null);
+    LOG.debug("ExportService : awaiting termination of submitted jobs");
+    return execService.awaitTermination(timeout, unit);
+  }
+
+  /**
+   * Wait for all tasks submitted to ExecutorService threads to complete execution.
+   * @throws HiveException
+   */
+  public void waitForTasksToFinish() throws HiveException {
+   for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (Exception e) {
+        LOG.error("ExportService thread failed to perform task ", e.getCause());
+        // If not removed task remains as stale task and further table dump operation fails
+        // with similar exception
+        futures.remove(future);
+        throw new HiveException(e.getCause().getMessage(), e.getCause());
+      }
+    }
+  }
+
+  /**
+   * Only for testing purpose. It returns how many number of tasks were executed
+   * in parallel manner at an instant by ExportService.
+   * @return Returns total number of executed tasks in parallel at an instant by ExportService.
+   */
+  @VisibleForTesting
+  public long getTotalTaskEverExecuted() {
+    assert (execService != null);
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) execService;
+    return executor.getTaskCount();
+  }
+
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/TableExport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/TableExport.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.parse.repl.dump;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -24,6 +25,7 @@ import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.repl.util.FileList;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
@@ -97,7 +99,53 @@ public class TableExport {
     this.mmCtx = mmCtx;
   }
 
-  public void write(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws SemanticException {
+  @VisibleForTesting
+  public TableExport() {
+    this.replicationSpec = null;
+    this.tableSpec = null;
+    this.db = null;
+    this.conf = null;
+    this.distCpDoAsUser = "";
+    this.paths = null;
+    this.mmCtx = null;
+  }
+
+  /**
+   * Write table or partition data one after another
+   * @param isExportTask Indicates whether task is export or not
+   * @param fileList List of files to be written
+   * @param dataCopyAtLoad Indicates whether data need to be distcp during load only or not
+   * @throws SemanticException
+   */
+  public void serialWrite(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws SemanticException {
+    write(isExportTask, fileList, dataCopyAtLoad);
+  }
+
+  /**
+   * Write table or partition data simultaneously using ExportService.
+   * Create ExportJob to write data and submit it to the ExportService.
+   * @param isExportTask Indicates whether task is export or not
+   * @param fileList List of files to be written
+   * @param dataCopyAtLoad Indicates whether data need to be distcp during load only or not.
+   * @throws HiveException
+   */
+  public void parallelWrite(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws HiveException {
+    ExportService.getInstance().submit(() -> {
+      if (tableSpec != null) {
+        logger.debug("Starting parallel export of table {} ", tableSpec.getTableName());
+      }
+      try {
+        write(isExportTask, fileList, dataCopyAtLoad);
+        //As soon as write is over, close current thread MS client connection with Metastore server.
+        Hive.closeCurrent();
+      } catch (Exception e) {
+        throw new RuntimeException(e.getCause().getMessage(), e.getCause());
+      }
+    }
+    );
+  }
+
+  protected void write(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws SemanticException {
     if (tableSpec == null) {
       writeMetaData(null);
     } else if (shouldExport()) {
@@ -121,8 +169,15 @@ public class TableExport {
           if (replicationSpec.isMetadataOnly()) {
             return null;
           } else {
-            return new PartitionIterable(db, tableSpec.tableHandle, null, conf.getIntVar(
-                HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX), true);
+            // There are separate threads for exporting each table. getPartitions in each thread
+            // has only one MS client embedded inside Hive object. When parallel thread
+            // initiate connections to MetadataStore server, stream gets overwritten. So stream
+            // becomes invalid for old client and its gets errors like socket closed or broken pipe
+            // Hence, we create a local thread variable of Hive class and use it here while constructing
+            // PartitionIterable object. This creates a local copy of MS client for each thread.
+
+            return new PartitionIterable(Hive.get(conf), tableSpec.tableHandle, null, MetastoreConf.getIntVar(
+                conf, MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX), true);
           }
         } else {
           // PARTITIONS specified - partitions inside tableSpec
@@ -175,7 +230,7 @@ public class TableExport {
                 replicationSpec, conf);
         if (!(isExportTask || dataCopyAtLoad)) {
           fileList.add(new DataCopyPath(replicationSpec, tableSpec.tableHandle.getDataLocation(),
-                  paths.dataExportDir()).convertToString());
+              paths.dataExportDir()).convertToString());
         }
         new FileOperations(dataPathList, paths.dataExportDir(), distCpDoAsUser, conf, mmCtx)
                 .export(isExportTask, (dataCopyAtLoad));

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/TableExport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/TableExport.java
@@ -129,8 +129,9 @@ public class TableExport {
    * @param dataCopyAtLoad Indicates whether data need to be distcp during load only or not.
    * @throws HiveException
    */
-  public void parallelWrite(boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws HiveException {
-    ExportService.getInstance().submit(() -> {
+  public void parallelWrite(ExportService exportService, boolean isExportTask, FileList fileList, boolean dataCopyAtLoad) throws HiveException {
+    assert (exportService != null && exportService.isExportServiceRunning());
+    exportService.submit(() -> {
       if (tableSpec != null) {
         logger.debug("Starting parallel export of table {} ", tableSpec.getTableName());
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.ql.exec.repl.util.FileList;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.EximUtil;
+import org.apache.hadoop.hive.ql.parse.repl.dump.ExportService;
 import org.apache.hadoop.hive.ql.parse.repl.dump.HiveWrapper;
 import org.apache.hadoop.hive.ql.parse.repl.dump.Utils;
 import org.apache.hadoop.hive.ql.parse.repl.load.DumpMetaData;
@@ -131,7 +132,7 @@ public class TestReplDumpTask {
       private int tableDumpCount = 0;
 
       @Override
-      void dumpTable(String dbName, String tblName, String validTxnList,
+      void dumpTable(ExportService exportService, String dbName, String tblName, String validTxnList,
                      Path dbRootMetadata, Path dbRootData,
                      long lastReplId, Hive hiveDb,
                      HiveWrapper.Tuple<Table> tuple, FileList managedTableDirFileList, boolean dataCopyAtLoad)

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
@@ -91,10 +91,4 @@ public class TestExportService {
     Assert.assertTrue(exportService.await(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
   }
 
-  @Test(expected = java.lang.AssertionError.class)
-  public void testExportServiceWithParallelismExpectAwaitTerminationFails() throws Exception {
-    configureAndSubmitTasks();
-    Assert.assertTrue(exportService.await(10, TimeUnit.MICROSECONDS));
-  }
-
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse.repl.dump;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.junit.Test;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LoggerFactory.class, ExportService.class})
+
+public class TestExportService {
+  protected static final Logger LOG = LoggerFactory.getLogger(TestExportService.class);
+  @Mock
+  HiveConf conf;
+  private final int nThreads = 50;
+  private static int taskNumber = 0;
+  private final int totalTask = 50;
+  private Semaphore sem;
+  private ExportService exportService;
+
+  @After
+  public void finalize()
+  {
+    for (int i = 0; i < totalTask; i++) {
+      sem.release();
+    }
+  }
+
+  private ExportJob runParallelTask() {
+    return new ExportJob() {
+      @Override
+      public void run() {
+        Assert.assertTrue(sem.tryAcquire());
+        ++taskNumber;
+        LOG.debug("Current task number is: {} and thread is: {} ", taskNumber, Thread.currentThread().getName());
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  private void configureAndSubmitTasks() {
+    when(conf.getIntVar(HiveConf.ConfVars.REPL_TABLE_DUMP_PARALLELISM)).thenReturn(nThreads);
+    exportService = ExportService.getInstance();
+    exportService.configure(conf, true);
+    taskNumber = 0;
+    sem = new Semaphore(totalTask);
+    for (int i = 0; i < totalTask; i++) {
+      exportService.submit(runParallelTask());
+    }
+    exportService.shutdown();
+  }
+
+  @Test
+  public void testExportServiceWithParallelism() throws Exception {
+    configureAndSubmitTasks();
+    final long actualNumTasksExecuted = exportService.getTotalTaskEverExecuted();
+    Assert.assertEquals(totalTask, actualNumTasksExecuted);
+    Assert.assertTrue(exportService.await(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
+  }
+
+  @Test(expected = java.lang.AssertionError.class)
+  public void testExportServiceWithParallelismExpectAwaitTerminationFails() throws Exception {
+    configureAndSubmitTasks();
+    Assert.assertTrue(exportService.await(10, TimeUnit.MICROSECONDS));
+  }
+
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.parse.repl.dump;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
@@ -71,16 +72,15 @@ public class TestExportService {
     };
   }
 
-  private void configureAndSubmitTasks() {
+  private void configureAndSubmitTasks() throws HiveException {
     when(conf.getIntVar(HiveConf.ConfVars.REPL_TABLE_DUMP_PARALLELISM)).thenReturn(nThreads);
-    exportService = ExportService.getInstance();
-    exportService.configure(conf, true);
+    exportService = new ExportService(conf);
     taskNumber = 0;
     sem = new Semaphore(totalTask);
     for (int i = 0; i < totalTask; i++) {
       exportService.submit(runParallelTask());
     }
-    exportService.shutdown();
+    exportService.waitForTasksToFinishAndShutdown();
   }
 
   @Test

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -78,6 +78,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveMetaStoreClientWithLocalCache;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.events.NotificationEventPoll;
 import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
+import org.apache.hadoop.hive.ql.parse.repl.dump.ExportService;
 import org.apache.hadoop.hive.ql.parse.repl.metric.MetricSink;
 import org.apache.hadoop.hive.ql.plan.mapper.StatsSources;
 import org.apache.hadoop.hive.ql.scheduled.ScheduledQueryExecutionService;
@@ -167,6 +168,7 @@ public class HiveServer2 extends CompositeService {
   private SettableFuture<Boolean> notLeaderTestFuture = SettableFuture.create();
   private ZooKeeperHiveHelper zooKeeperHelper = null;
   private ScheduledQueryExecutionService scheduledQueryService;
+  private ExportService exportService;
 
   public HiveServer2() {
     super(HiveServer2.class.getSimpleName());
@@ -269,6 +271,10 @@ public class HiveServer2 extends CompositeService {
     HiveMaterializedViewsRegistry.get().init();
 
     StatsSources.initialize(hiveConf);
+
+    // Create and configure Table and Partition dump ExportService
+    this.exportService = ExportService.getInstance();
+    this.exportService.configure(hiveConf, true);
 
     if (hiveConf.getBoolVar(ConfVars.HIVE_SCHEDULED_QUERIES_EXECUTOR_ENABLED)) {
       scheduledQueryService = ScheduledQueryExecutionService.startScheduledQueryExecutorService(hiveConf);
@@ -1007,6 +1013,17 @@ public class HiveServer2 extends CompositeService {
       // this is mostly for testing purposes to make sure that SAML client is
       // reinitialized after a HS2 is restarted.
       HiveSaml2Client.shutdown();
+    }
+
+    // shutdown ExportService
+    if (exportService != null) {
+      exportService.shutdown();
+      try {
+        exportService.await(60, TimeUnit.SECONDS);
+        exportService = null;
+      } catch (Exception e) {
+        LOG.error("Error while shutting down ExportService ", e);
+      }
     }
   }
 


### PR DESCRIPTION
Currently partitions of table is dump in parallel manner. But if table is not partitioned, it is dumped serially.
This change introduces parallelism at table level as well. A single thread pool which is currently being used
for partition level is also used for table level. The table level dump task is added to same thread pool.
The degree of parallelism depends upon config parameter REPL_PARTITIONS_DUMP_PARALLELISM whose defaul value is 100.
The new ExportService is introduced with this change which would be responsible for exporting table and partitions during repl dump. The ExportService is initialized and configured with thread pools by HiveServer2 service.
A new Hiveconfig variable ie "REPL_TABLE_DUMP_PARALLELISM is introduced to define the number of threads which would be created in thread pool.
The ExportService which is created as singleton instance would be used by ReplDumpTask.