### PR TITLE
HIVE-26471: Addendum: Fix metric computing

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
@@ -58,7 +58,10 @@ import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTI
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_CLEANING_AGE;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_ENQUEUE_AGE;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_OLDEST_WORKING_AGE;
-import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_ITEM_COUNT;
+import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_INITIATED_ITEM_COUNT;
+import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_OLDEST_INITIATED_AGE;
+import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_OLDEST_WORKING_AGE;
+import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_POOLS_WORKING_ITEM_COUNT;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.COMPACTION_STATUS_PREFIX;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.NUM_ABORTED_TXNS;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.NUM_COMPLETED_TXN_COMPONENTS;
@@ -333,7 +336,10 @@ public class AcidMetricService implements MetastoreTaskThread {
       }
     }
 
-    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_ITEM_COUNT).update(metricData.getPoolCount());
+    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_INITIATED_ITEM_COUNT).update(metricData.getInitiatedCountPerPool());
+    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_WORKING_ITEM_COUNT).update(metricData.getWorkingCountPerPool());
+    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_OLDEST_INITIATED_AGE).update(metricData.getLongestEnqueueDurationPerPool());
+    Metrics.getOrCreateMapMetrics(COMPACTION_POOLS_OLDEST_WORKING_AGE).update(metricData.getLongestWorkingDurationPerPool());
 
     updateOldestCompactionMetric(COMPACTION_OLDEST_ENQUEUE_AGE, metricData.getOldestEnqueueTime());
     updateOldestCompactionMetric(COMPACTION_OLDEST_WORKING_AGE, metricData.getOldestWorkingTime());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
@@ -31,7 +31,10 @@ public class MetricsConstants {
   public static final String COMPACTION_CLEANER_CYCLE_DURATION = "compaction_cleaner_cycle_duration";
   public static final String COMPACTION_CLEANER_FAILURE_COUNTER = "compaction_cleaner_failure_counter";
   public static final String COMPACTION_WORKER_CYCLE = "compaction_worker_cycle";
-  public static final String COMPACTION_POOLS_ITEM_COUNT = "compaction_pools_item_count";
+  public static final String COMPACTION_POOLS_INITIATED_ITEM_COUNT = "compaction_pools_initiated_item_count";
+  public static final String COMPACTION_POOLS_WORKING_ITEM_COUNT = "compaction_pools_working_item_count";
+  public static final String COMPACTION_POOLS_OLDEST_INITIATED_AGE = "compaction_pools_oldest_enqueue_age_in_sec";
+  public static final String COMPACTION_POOLS_OLDEST_WORKING_AGE = "compaction_pools_oldest_working_age_in_sec";
 
   public static final String OLDEST_OPEN_REPL_TXN_ID = "oldest_open_repl_txn_id";
   public static final String OLDEST_OPEN_NON_REPL_TXN_ID = "oldest_open_non_repl_txn_id";


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fix the INITIATED PER POOL metric computing by counting all the INITIATED queue items.
- Add 3 new metrics:
-- WORKING PER POOL
-- OLDEST ENQUEUE AGE PER POOL
-- OLDEST START AGE PER POOL

### Why are the changes needed?
The metric computing introduced was bad because only elements matching the oldestEnqueueTime > element.getEnqueueTime() were counted.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually