### PR TITLE
HIVE-26583: Make tests running on iceberg-catalog

### DIFF
--- a/iceberg/iceberg-catalog/pom.xml
+++ b/iceberg/iceberg-catalog/pom.xml
@@ -63,5 +63,10 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
@@ -168,7 +168,7 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
     AssertHelpers.assertThrows(
         "Should not be possible to start a new replace table txn",
         NoSuchTableException.class,
-        "No such table: hivedb.tbl",
+        "Table does not exist: hivedb.tbl",
         () -> catalog.newReplaceTableTransaction(TABLE_IDENTIFIER, SCHEMA, SPEC, false));
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-26583

We have found that the tests on iceberg-catalog are not running at all and HiveCreateReplaceTableTest.testReplaceTableTxnTableNotExists fails. 

### What changes were proposed in this pull request?
Use `junit-vintage-engine` to enable `junit-jupiter-api` tests running with Junit4 test runner. 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Run HiveCreateReplaceTableTest.testReplaceTableTxnTableNotExists
- Run all tests on iceberg-catalog