### PR TITLE
HIVE-26608: Iceberg: Allow parquet write properties to iceberg via session conf and Table Properties.

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -75,7 +75,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final BiMap<String, String> ICEBERG_TO_HMS_TRANSLATION = ImmutableBiMap.of(
       // gc.enabled in Iceberg and external.table.purge in Hive are meant to do the same things but with different names
       GC_ENABLED, "external.table.purge",
-      TableProperties.PARQUET_COMPRESSION, ParquetOutputFormat.COMPRESSION);
+      TableProperties.PARQUET_COMPRESSION, ParquetOutputFormat.COMPRESSION,
+      TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, ParquetOutputFormat.BLOCK_SIZE);
 
   /**
    * Provides key translation where necessary between Iceberg and HMS props. This translation is needed because some

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -33,11 +33,13 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.util.Progressable;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.hive.writer.HiveIcebergWriter;
 import org.apache.iceberg.mr.hive.writer.WriterBuilder;
 import org.apache.iceberg.mr.mapred.Container;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
 
 public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Container<Record>>,
     HiveOutputFormat<NullWritable, Container<Record>> {
@@ -68,6 +70,7 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     String tableName = jc.get(Catalogs.NAME);
     int poolSize = jc.getInt(DELETE_FILE_THREAD_POOL_SIZE, DELETE_FILE_THREAD_POOL_SIZE_DEFAULT);
 
+    setWriterLevelConfiguration(jc, table);
     return WriterBuilder.builderFor(table)
         .queryId(jc.get(HiveConf.ConfVars.HIVEQUERYID.varname))
         .tableName(tableName)
@@ -75,5 +78,19 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
         .poolSize(poolSize)
         .operation(HiveCustomStorageHandlerUtils.getWriteOperation(jc, tableName))
         .build();
+  }
+
+  private static void setWriterLevelConfiguration(JobConf jc, Table table) {
+    final String writeFormat = table.properties().get("write.format.default");
+    if (writeFormat == null || "PARQUET".equalsIgnoreCase(writeFormat)) {
+      if (table.properties().get(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES) == null &&
+          jc.get(ParquetOutputFormat.BLOCK_SIZE) != null) {
+        table.properties().put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, jc.get(ParquetOutputFormat.BLOCK_SIZE));
+      }
+      if (table.properties().get(TableProperties.PARQUET_COMPRESSION) == null &&
+          jc.get(ParquetOutputFormat.COMPRESSION) != null) {
+        table.properties().put(TableProperties.PARQUET_COMPRESSION, jc.get(ParquetOutputFormat.COMPRESSION));
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow parquet write related configurations via session & Table Properties.
