### PR TITLE
HIVE-26614: Fix adding custom jars in Job Classpath.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4158,7 +4158,7 @@ public final class Utilities {
       if (!localFs.exists(new Path(path))) {
         throw new RuntimeException("Could not validate jar file " + path + " for class " + clazz);
       }
-      jars.add(path);
+      jars.add(localFs.makeQualified(new Path(path)).toString());
     }
     if (jars.isEmpty()) {
       return;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make the Jar path fully qualified, so as to prevent resolution to fs.defaultFs in any application


### Why are the changes needed?

Some applications don't explicitly assume the path to LFS, rather resolve to fs.defaultFs


### Does this PR introduce _any_ user-facing change?
Nopes.


### How was this patch tested?
Build distribution & tried the same command. Doesn't happen in Tests due to https://github.com/apache/hive/blob/9db31108e1a44b2fb0436134fa78eea79418d4ad/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java#L249-L252

May be specific to query engines as well. Tez I suppose alway expects the Path to be in LFS