### PR TITLE
HIVE-26618: Add setting to turn on/off removing sections of a query plan known never produces rows

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2621,6 +2621,8 @@ public class HiveConf extends Configuration {
     HIVE_OPTIMIZE_LIMIT_TRANSPOSE_REDUCTION_TUPLES("hive.optimize.limittranspose.reductiontuples", (long) 0,
         "When hive.optimize.limittranspose is true, this variable specifies the minimal reduction in the\n" +
         "number of tuples of the outer input of the join or the input of the union that you should get in order to apply the rule."),
+    HIVE_OPTIMIZE_PRUNE_EMPTY_RESULT("hive.optimize.prune.empty.result", true,
+        "Enable removing sections of query plan known never produces rows."),
 
     HIVE_OPTIMIZE_CONSTRAINTS_JOIN("hive.optimize.constraints.join", true, "Whether to use referential constraints\n" +
         "to optimize (remove or transform) join operators"),

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1947,18 +1947,20 @@ public class CalcitePlanner extends SemanticAnalyzer {
                 HiveAntiSemiJoinRule.INSTANCE);
       }
 
-      generatePartialProgram(program, true, HepMatchOrder.DEPTH_FIRST,
-              HiveRemoveEmptySingleRules.PROJECT_INSTANCE,
-              HiveRemoveEmptySingleRules.FILTER_INSTANCE,
-              HiveRemoveEmptySingleRules.JOIN_LEFT_INSTANCE,
-              HiveRemoveEmptySingleRules.SEMI_JOIN_LEFT_INSTANCE,
-              HiveRemoveEmptySingleRules.JOIN_RIGHT_INSTANCE,
-              HiveRemoveEmptySingleRules.SEMI_JOIN_RIGHT_INSTANCE,
-              HiveRemoveEmptySingleRules.ANTI_JOIN_RIGHT_INSTANCE,
-              HiveRemoveEmptySingleRules.SORT_INSTANCE,
-              HiveRemoveEmptySingleRules.SORT_FETCH_ZERO_INSTANCE,
-              HiveRemoveEmptySingleRules.AGGREGATE_INSTANCE,
-              HiveRemoveEmptySingleRules.UNION_INSTANCE);
+      if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_OPTIMIZE_PRUNE_EMPTY_RESULT, true)) {
+        generatePartialProgram(program, true, HepMatchOrder.DEPTH_FIRST,
+                HiveRemoveEmptySingleRules.PROJECT_INSTANCE,
+                HiveRemoveEmptySingleRules.FILTER_INSTANCE,
+                HiveRemoveEmptySingleRules.JOIN_LEFT_INSTANCE,
+                HiveRemoveEmptySingleRules.SEMI_JOIN_LEFT_INSTANCE,
+                HiveRemoveEmptySingleRules.JOIN_RIGHT_INSTANCE,
+                HiveRemoveEmptySingleRules.SEMI_JOIN_RIGHT_INSTANCE,
+                HiveRemoveEmptySingleRules.ANTI_JOIN_RIGHT_INSTANCE,
+                HiveRemoveEmptySingleRules.SORT_INSTANCE,
+                HiveRemoveEmptySingleRules.SORT_FETCH_ZERO_INSTANCE,
+                HiveRemoveEmptySingleRules.AGGREGATE_INSTANCE,
+                HiveRemoveEmptySingleRules.UNION_INSTANCE);
+      }
 
       // Trigger program
       perfLogger.perfLogBegin(this.getClass().getName(), PerfLogger.OPTIMIZER);

--- a/ql/src/test/queries/clientpositive/empty_result.q
+++ b/ql/src/test/queries/clientpositive/empty_result.q
@@ -7,9 +7,25 @@ explain cbo
 select a1 from t1
 join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
 
+set hive.optimize.prune.empty.result=false;
+
+explain cbo
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
+
+set hive.optimize.prune.empty.result=true;
+
 explain
 select a1 from t1
 join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
+
+set hive.optimize.prune.empty.result=false;
+
+explain
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
+
+set hive.optimize.prune.empty.result=true;
 
 explain cbo
 select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0;

--- a/ql/src/test/results/clientpositive/llap/empty_result.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result.q.out
@@ -32,6 +32,34 @@ Explain
 CBO PLAN:
 HiveValues(tuples=[[]])
 
+PREHOOK: query: explain cbo
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveProject(a1=[$0])
+  HiveJoin(condition=[=($1, $0)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(a1=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+    HiveProject(a2=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveProject(a2=[$0])
+          HiveSortLimit(fetch=[0])
+            HiveProject(a2=[$0])
+              HiveTableScan(table=[[default, t2]], table:alias=[t2])
+
 PREHOOK: query: explain
 select a1 from t1
 join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
@@ -54,6 +82,102 @@ STAGE PLANS:
   Stage: Stage-0
     Fetch Operator
       limit: 0
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+Explain
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: a1 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: a1 is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: a1 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Limit
+                    Number of rows: 0
+                    Statistics: Num rows: 0 Data size: 0 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: a2 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 0 Data size: 0 Basic stats: NONE Column stats: NONE
+                      Filter Operator
+                        predicate: _col0 is not null (type: boolean)
+                        Statistics: Num rows: 0 Data size: 0 Basic stats: NONE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 0 Data size: 0 Basic stats: NONE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: PARTIAL Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: PARTIAL Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
       Processor Tree:
         ListSink
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Add config setting to control whether to remove parts of query plan produces empty result.
* Query the setting from the config stored in session when creating `HiveRelBuilder` instance and override the `empty()` method based on the value to create `HiveValues` with no tuples or `HiveSortLimit` with limit = 0
* Remove unused methods

### Why are the changes needed?
* add feature switch

### Does this PR introduce _any_ user-facing change?
New config setting is introduced. Based on the values of the config query execution plan may changes.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=empty_result.q -pl itests/qtest -Pitests
```