### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.3.3-RC0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache</groupId>
@@ -133,7 +132,7 @@
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.21</groovy.version>
     <h2database.version>2.1.214</h2database.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.3-RC0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
     <hbase.version>2.0.0-alpha4</hbase.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -11,8 +11,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache</groupId>
@@ -75,7 +74,7 @@
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <guava.version>19.0</guava.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.3-RC0</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.12.7</jackson.version>
     <javolution.version>5.5.1</javolution.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -11,8 +11,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache</groupId>
@@ -29,7 +28,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
     <guava.version>19.0</guava.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.3-RC0</hadoop.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>
     <junit.vintage.version>5.6.3</junit.vintage.version>

--- a/upgrade-acid/pre-upgrade/pom.xml
+++ b/upgrade-acid/pre-upgrade/pom.xml
@@ -11,8 +11,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-upgrade-acid</artifactId>
@@ -36,7 +35,7 @@
     <test.forkcount>1</test.forkcount>
     <skipITests>true</skipITests>
     <hdp.hive.version>2.3.3</hdp.hive.version>
-    <hdp.hadoop.version>2.7.2</hdp.hadoop.version>
+    <hdp.hadoop.version>3.3.3-RC0</hdp.hadoop.version>
   </properties>
   <dependencies>
     <!--scope is 'provided' for all.  The UpgradeTool is provided as part of Hive 3.x and


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.apache.hadoop:hadoop-common 3.3.1
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)
- [CVE-2022-26612](https://www.oscs1024.com/hd/CVE-2022-26612)
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 3.3.1 to 3.3.3-RC0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS