### PR TITLE
HIVE-26626: Cut dependencies between HiveXxPullUpConstantsRule and HiveReduceExpressionsRule

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSortPullUpConstantsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSortPullUpConstantsRule.java
@@ -125,8 +125,8 @@ public final class HiveSortPullUpConstantsRule {
         return;
       }
 
-      Map<RexNode, RexNode> conditionsExtracted = HiveReduceExpressionsRule.predicateConstants(
-          RexNode.class, rexBuilder, predicates);
+      Map<RexNode, RexNode> conditionsExtracted =
+          RexUtil.predicateConstants(RexNode.class, rexBuilder, predicates.pulledUpPredicates);
       Map<RexNode, RexNode> constants = new HashMap<>();
       for (int i = 0; i < count; i++) {
         RexNode expr = rexBuilder.makeInputRef(sortNode.getInput(), i);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveUnionPullUpConstantsRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveUnionPullUpConstantsRule.java
@@ -82,8 +82,8 @@ public class HiveUnionPullUpConstantsRule extends RelOptRule {
       return;
     }
 
-    Map<RexNode, RexNode> conditionsExtracted = HiveReduceExpressionsRule.predicateConstants(
-            RexNode.class, rexBuilder, predicates);
+    Map<RexNode, RexNode> conditionsExtracted =
+        RexUtil.predicateConstants(RexNode.class, rexBuilder, predicates.pulledUpPredicates);
     Map<RexNode, RexNode> constants = new HashMap<>();
     for (int i = 0; i < count ; i++) {
       RexNode expr = rexBuilder.makeInputRef(union, i);


### PR DESCRIPTION
### Why are the changes needed?
1. Reduce dependencies among rules
2. Avoid usage of deprecated methods

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests