### PR TITLE
HIVE-26627: Remove HiveRelBuilder.aggregateCall override and refactor callers to use existing public methods

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelBuilder.java
@@ -53,8 +53,6 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.functions.HiveSqlSumAggFuncti
 import org.apache.hadoop.hive.ql.optimizer.calcite.functions.HiveSqlSumEmptyIsZeroAggFunction;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFloorDate;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -241,10 +239,4 @@ public class HiveRelBuilder extends RelBuilder {
     }
   }
 
-  /** Make the method visible */
-  @Override
-  public AggCall aggregateCall(SqlAggFunction aggFunction, boolean distinct, boolean approximate, boolean ignoreNulls,
-      RexNode filter, ImmutableList<RexNode> orderKeys, String alias, ImmutableList<RexNode> operands) {
-    return super.aggregateCall(aggFunction, distinct, approximate, ignoreNulls, filter, orderKeys, alias, operands);
-  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRewriteToDataSketchesRules.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRewriteToDataSketchesRules.java
@@ -53,7 +53,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.apache.hadoop.hive.ql.exec.DataSketchesFunctions;
-import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveAggregate;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
@@ -540,17 +539,8 @@ public final class HiveRewriteToDataSketchesRules {
         RexNode key = orderKey.getKey();
         key = rexBuilder.makeCast(getFloatType(), key);
 
-        // @formatter:off
-        AggCall aggCall = ((HiveRelBuilder) relBuilder).aggregateCall(
-            (SqlAggFunction) getSqlOperator(DataSketchesFunctions.DATA_TO_SKETCH),
-            /* distinct */ false,
-            /* approximate */ false,
-            /* ignoreNulls */ true,
-            null,
-            ImmutableList.of(),
-            null,
-            ImmutableList.of(key));
-        // @formatter:on
+        SqlAggFunction dataToSketchFunction = (SqlAggFunction) getSqlOperator(DataSketchesFunctions.DATA_TO_SKETCH);
+        AggCall aggCall = relBuilder.aggregateCall(dataToSketchFunction, key).ignoreNulls(true);
 
         relBuilder.aggregate(relBuilder.groupKey(partitionKeys), aggCall);
 


### PR DESCRIPTION
### Why are the changes needed?
1. Reduce maintenance overhead
2. Improve code readability

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests