### PR TITLE
HIVE-26635

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -906,6 +906,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     if ((icebergTable == null || ((BaseTable) icebergTable).operations().current().formatVersion() == 1) &&
         "2".equals(newProps.get(TableProperties.FORMAT_VERSION))) {
       newProps.put(TableProperties.DELETE_MODE, "merge-on-read");
+      newProps.put(TableProperties.UPDATE_MODE, "merge-on-read");
+      newProps.put(TableProperties.MERGE_MODE, "merge-on-read");
     }
   }
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergV2.java
@@ -621,7 +621,7 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
       while (e.getCause() != null) {
         e = e.getCause();
       }
-      Assert.assertTrue(e.getMessage().contains("Hive doesn't support copy-on-write delete mode."));
+      Assert.assertTrue(e.getMessage().contains("Hive doesn't support copy-on-write mode"));
     }
 
     // attempt an update
@@ -631,7 +631,7 @@ public class TestHiveIcebergV2 extends HiveIcebergStorageHandlerWithEngineBase {
       while (e.getCause() != null) {
         e = e.getCause();
       }
-      Assert.assertTrue(e.getMessage().contains("Hive doesn't support copy-on-write delete mode."));
+      Assert.assertTrue(e.getMessage().contains("Hive doesn't support copy-on-write mode"));
     }
 
   }


### PR DESCRIPTION
[HIVE-26596](https://issues.apache.org/jira/browse/HIVE-26596) took care of maintaining the delete-mode setting on Iceberg V2 tables, but lacks the same for update- and merge modes.