### PR TITLE
HIVE-26641:Upgrade Guava: Google Core Libraries for Java to v28.2/31.…

### DIFF
--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -25,7 +25,7 @@
   <name>Hive Druid Handler</name>
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <druid.guava.version>16.0.1</druid.guava.version>
+    <druid.guava.version>31.1-jre</druid.guava.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <druid.version>0.17.1</druid.version>
     <esri.version>2.2.4</esri.version>
     <flatbuffers.version>1.9.0</flatbuffers.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <groovy.version>2.4.21</groovy.version>
     <h2database.version>2.1.214</h2database.version>
     <hadoop.version>3.3.1</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,11 @@
         <version>${velocity.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>failureaccess</artifactId>
+        <version>1.0.1</version>
+      </dependency>
+      <dependency>
         <groupId>stax</groupId>
         <artifactId>stax-api</artifactId>
         <version>${stax.version}</version>

--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
@@ -549,9 +549,9 @@ public final class Util {
     HostAndPort hp = HostAndPort.fromString(host)
             .withDefaultPort(port);
 
-    LOG.info("Connecting to {}:{}", hp.getHostText(), hp.getPort());
+    LOG.info("Connecting to {}:{}", hp.getHost(), hp.getPort());
 
-    return new URI(THRIFT_SCHEMA, null, hp.getHostText(), hp.getPort(),
+    return new URI(THRIFT_SCHEMA, null, hp.getHost(), hp.getPort(),
             null, null, null);
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -74,7 +74,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.12.7</jackson.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>


### PR DESCRIPTION
…1-jre due to medium CVEs

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade Guava: Google Core Libraries for Java to v28.2/31.1-jre due to medium CVEs


### Why are the changes needed?
Fix Cve


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual
