### PR TITLE
HIVE-26656:Remove hsqldb dependency in hive due to CVE-2022-41853

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -646,6 +646,12 @@
         <groupId>org.apache.pig</groupId>
         <artifactId>pig</artifactId>
         <version>${pig.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:


-->

### What changes were proposed in this pull request?
Remove hsqldb dependency in hive due to CVE-2022-41853


### Why are the changes needed?
fix cve


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manual
