### PR TITLE
HIVE-26657: [Iceberg] Filter out the metadata.json file when migrating

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
@@ -125,7 +125,7 @@ public class HiveTableUtil {
     while (fileStatusIterator.hasNext()) {
       LocatedFileStatus fileStatus = fileStatusIterator.next();
       String fileName = fileStatus.getPath().getName();
-      if (fileName.startsWith(".") || fileName.startsWith("_")) {
+      if (fileName.startsWith(".") || fileName.startsWith("_") || fileName.endsWith("metadata.json")) {
         continue;
       }
       dataFiles.addAll(TableMigrationUtil.listPartition(partitionKeys, fileStatus.getPath().toString(), format, spec,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Filter out metadata.json when migrating a hive table to iceberg.

### Why are the changes needed?
When migrating a hive table to an iceberg in certain cases a Runtime exception is raised

ERROR : Failed
java.lang.RuntimeException: s3a://dev-nfqe-base/cc-cdw-nfqe-q7wj9a/archive/env-8pt556/parquet/bakeoff/large/pli/metadata/00000-94fffe5c-c307-4341-9ea3-f5fa4863d301.metadata.json is not a Parquet file. Expected magic number at tail, but found [32, 93, 10, 125]

The hive-to-iceberg table migration has the following logic.

1. In order to walk through all the data files we request a file iterator from the filesystem. This iterator will provide all the references to be able to scan the data files.
2. The new iceberg table is created, meaning that a new entry is added to the hive catalog and on the file system level the metadata directory is created together with the first metadata file (*.metadata.json)
3. All the data files are scanned and the manifests are created.

The issue occurs when there are so many data files that it doesn't fit into memory in one go. So in step 3 when we walk through the data files list, the iterator has to run another round of file listing that reads up the content of the metadata directory that was created in step 2.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual test
