### PR TITLE
HIVE-26661: Support partition filter for char and varchar types on Hive metastore

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -22,12 +22,14 @@ import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.apache.hadoop.hive.metastore.ColumnType.BIGINT_TYPE_NAME;
+import static org.apache.hadoop.hive.metastore.ColumnType.CHAR_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.DATE_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.INT_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.SMALLINT_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.STRING_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.TIMESTAMP_TYPE_NAME;
 import static org.apache.hadoop.hive.metastore.ColumnType.TINYINT_TYPE_NAME;
+import static org.apache.hadoop.hive.metastore.ColumnType.VARCHAR_TYPE_NAME;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -1261,7 +1263,7 @@ class MetaStoreDirectSql {
 
     private static enum FilterType {
       Integral(ImmutableSet.of(TINYINT_TYPE_NAME, SMALLINT_TYPE_NAME, INT_TYPE_NAME, BIGINT_TYPE_NAME), Long.class),
-      String(ImmutableSet.of(STRING_TYPE_NAME), String.class),
+      String(ImmutableSet.of(STRING_TYPE_NAME, CHAR_TYPE_NAME, VARCHAR_TYPE_NAME), String.class),
       Date(ImmutableSet.of(DATE_TYPE_NAME), java.sql.Date.class),
       Timestamp(ImmutableSet.of(TIMESTAMP_TYPE_NAME), java.sql.Timestamp.class),
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
@@ -458,7 +458,7 @@ public class ExpressionTree {
       String colType = partitionKeys.get(partColIndex).getType();
       // Can only support partitions whose types are string, or maybe integers
       // Date/Timestamp data type value is considered as string hence pushing down to JDO.
-      if (!ColumnType.STRING_TYPE_NAME.equalsIgnoreCase(colType) && !ColumnType.DATE_TYPE_NAME.equalsIgnoreCase(colType)
+      if (!ColumnType.StringTypes.contains(colType) && !ColumnType.DATE_TYPE_NAME.equalsIgnoreCase(colType)
           && !ColumnType.TIMESTAMP_TYPE_NAME.equalsIgnoreCase(colType)
           && (!isIntegralSupported || !ColumnType.IntegralTypes.contains(colType))) {
         filterBuilder.setError("Filtering is supported only on partition keys of type " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support partition filter for `char` and `varchar` types on HMS.


### Why are the changes needed?
Some users may set the partition type as `char` or `varchar`, it can improve the performance if we support these "string like" types in partition filter.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test.
