### PR TITLE
HIVE-26677: Constrain available processors to Jetty during test runs …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <test.excludes.additional/>
     <!-- Plugin and Plugin Dependency Versions -->
     <ant.contrib.version>1.0b3</ant.contrib.version>
-    <maven.test.jvm.args>-Xmx2048m</maven.test.jvm.args>
+    <maven.test.jvm.args>-Xmx2048m -DJETTY_AVAILABLE_PROCESSORS=4</maven.test.jvm.args>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.build-helper.plugin.version>1.12</maven.build-helper.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>


### PR DESCRIPTION
…to prevent thread exhaustion.

### What changes were proposed in this pull request?

As described during a [release candidate vote](https://lists.apache.org/thread/8qjf7x9t9v09d79hlzh712ls4zthdwrh):

[HIVE-24484](https://issues.apache.org/jira/browse/HIVE-24484) introduced a change to limit `hive.server2.webui.max.threads` to 4. Jetty enforces thread leasing to warn or abort if there aren't enough threads available [1]. During startup, it attempts to lease a thread per NIO selector [2]. By default, the number of NIO selectors to use is determined based on available CPUs [3]. This is mostly a passthrough to `Runtime.availableProcessors()` [4]. In my case, running on a machine with 16 CPUs, this ended up creating more than 4 selectors, therefore requiring more than 4 threads and violating the lease check. I was able to work around this by passing the `JETTY_AVAILABLE_PROCESSORS` system property to constrain the number of CPUs available to Jetty.

Since we are intentionally constraining the pool to 4 threads during itests, let's also limit `JETTY_AVAILABLE_PROCESSORS` in `maven.test.jvm.args` of the root pom.xml, so that others don't run into this problem later.

[1] https://github.com/eclipse/jetty.project/blob/jetty-9.4.40.v20210413/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPoolBudget.java#L165
[2] https://github.com/eclipse/jetty.project/blob/jetty-9.4.40.v20210413/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java#L255
[3] https://github.com/eclipse/jetty.project/blob/jetty-9.4.40.v20210413/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java#L79
[4] https://github.com/eclipse/jetty.project/blob/jetty-9.4.40.v20210413/jetty-util/src/main/java/org/eclipse/jetty/util/ProcessorUtils.java#L45

### Why are the changes needed?

This prevents spurious failures during itests, which could especially be a nuisance during release candidate verification.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

During the release candidate vote, I confirmed that this change fixed itests in my environment.