### PR TITLE
HIVE-26684: Upgrade maven-shade-plugin from 3.4.1 for bug fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ standalone-metastore/metastore-common/src/gen/version
 kafka-handler/src/test/gen
 **/.vscode/
 /.recommenders/
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.build-helper.plugin.version>1.12</maven.build-helper.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
+    <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <!-- Library Dependency Versions -->
     <accumulo.version>1.10.1</accumulo.version>
@@ -1422,6 +1423,11 @@
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>${felix.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven.shade.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Hive build currently runs with maven-shade-plugin version 3.1.1, released in April 2018. This issue proposes to upgrade to the latest version, 3.4.1, released in October 2022.

The new version by default also generates `dependency-reduced-pom.xml` files, as documented here: [`createDependencyReducedPom`](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#createDependencyReducedPom). These files don't need to go into source control, and it's common to put a pattern in .gitignore.

### Why are the changes needed?

See [HIVE-26648](https://issues.apache.org/jira/browse/HIVE-26648) for an example of another patch that is blocked due to a bug in version 3.1.1.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I applied the [HIVE-26648](https://issues.apache.org/jira/browse/HIVE-26648) patch locally and tried to build:

```
mvn clean package -Piceberg -DskipTests
```

I observed the same `IllegalArgumentException` shown in that patch's [Jenkins CI run](http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-3688/1/pipeline/). I then applied my patch, reran the build, and it was successful.