### PR TITLE
HIVE-21614: Replace EQUALS by LIKE when filtering tables by parameter…

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/metastore/TestTablesListByFilter.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/TestTablesListByFilter.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore;
+
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.client.MetaStoreClientTest;
+import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
+import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
+import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+@Category(MetastoreCheckinTest.class)
+public class TestTablesListByFilter extends MetaStoreClientTest {
+  private static final String DEFAULT_DATABASE = "test_tables_list_by_filter";
+  private AbstractMetaStoreService metaStore;
+  private HiveMetaStoreClient client;
+  private Table[] testTables = new Table[6];
+
+  public TestTablesListByFilter(String name, AbstractMetaStoreService metaStore) {
+    this.metaStore = metaStore;
+  }
+
+  @Before
+  public void setupDb() throws Exception {
+    client = metaStore.getClient();
+    // Clean up the database
+    client.dropDatabase(DEFAULT_DATABASE, true, true, true);
+    Configuration conf = metaStore.getConf();
+    new DatabaseBuilder().setName(DEFAULT_DATABASE).create(client, conf);
+
+    testTables[0] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_0")
+            .addCol("test_col", "int")
+            .setOwner("Owner1")
+            .setLastAccessTime(1000)
+            .addTableParam("param1", "value1")
+            .create(client, conf);
+
+    testTables[1] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_1")
+            .addCol("test_col", "int")
+            .setOwner("Owner1")
+            .setLastAccessTime(2000)
+            .addTableParam("param1", "value2")
+            .create(client, conf);
+
+    testTables[2] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_2")
+            .addCol("test_col", "int")
+            .setOwner("Owner2")
+            .setLastAccessTime(1000)
+            .addTableParam("param1", "value2")
+            .create(client, conf);
+
+    testTables[3] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_3")
+            .addCol("test_col", "int")
+            .setOwner("Owner3")
+            .setLastAccessTime(3000)
+            .addTableParam("param1", "value2")
+            .create(client, conf);
+
+    testTables[4] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_4")
+            .addCol("test_col", "int")
+            .setOwner("Tester")
+            .setLastAccessTime(2500)
+            .addTableParam("param1", "value4")
+            .create(client, conf);
+
+    testTables[5] =
+        new TableBuilder()
+            .setDbName(DEFAULT_DATABASE)
+            .setTableName("filter_test_table_5")
+            .addCol("test_col", "int")
+            .create(client, conf);
+
+    // Reload tables from the MetaStore
+    for(int i=0; i < testTables.length; i++) {
+      testTables[i] = client.getTable(testTables[i].getCatName(), testTables[i].getDbName(),
+          testTables[i].getTableName());
+    }
+  }
+
+  @After
+  public void tearDownDb() throws Exception {
+    try {
+      if (client != null) {
+        // Clean up the database
+        client.dropDatabase(DEFAULT_DATABASE, true, true, true);
+      }
+    } finally {
+      if (client != null) {
+        client.close();
+      }
+    }
+  }
+
+  @Test
+  public void testListTableNamesByFilterCheckParameter() throws Exception {
+    String filter = hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS + "param1=\"value2\"";
+    List<String> tableNames = client.listTableNamesByFilter(DEFAULT_DATABASE, filter, (short)-1);
+    Assert.assertEquals("Found tables", 3, tableNames.size());
+    Assert.assertTrue(tableNames.contains(testTables[1].getTableName()));
+    Assert.assertTrue(tableNames.contains(testTables[2].getTableName()));
+    Assert.assertTrue(tableNames.contains(testTables[3].getTableName()));
+  }
+
+  @Test
+  public void testListTableNamesByFilterCheckNotEquals() throws Exception {
+    String filter = hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS + "param1<>\"value2\"";
+    List<String> tableNames = client.listTableNamesByFilter(DEFAULT_DATABASE, filter, (short)-1);
+    filter = hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS + "param1 != \"value2\"";
+    List<String> tableNames1 = client.listTableNamesByFilter(DEFAULT_DATABASE, filter, (short) -1);
+    Assert.assertEquals(tableNames, tableNames1);
+    Assert.assertEquals("Found tables", 2, tableNames.size());
+    Assert.assertTrue(tableNames.contains(testTables[0].getTableName()));
+    Assert.assertTrue(tableNames.contains(testTables[4].getTableName()));
+  }
+
+  @Test
+  public void testListTableNamesByFilterCheckCombined() throws Exception {
+    // Combined: last_access<=3000 and (Owner="Tester" or param1="param2")
+    String filter = hive_metastoreConstants.HIVE_FILTER_FIELD_LAST_ACCESS + "<3000 and ("
+        + hive_metastoreConstants.HIVE_FILTER_FIELD_OWNER + "=\"Tester\" or "
+        + hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS + "param1=\"value2\")";
+    List<String> tableNames = client.listTableNamesByFilter(DEFAULT_DATABASE, filter, (short)-1);
+    Assert.assertEquals("Found tables", 3, tableNames.size());
+    Assert.assertTrue(tableNames.contains(testTables[1].getTableName()));
+    Assert.assertTrue(tableNames.contains(testTables[2].getTableName()));
+    Assert.assertTrue(tableNames.contains(testTables[4].getTableName()));
+  }
+
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -812,4 +812,9 @@ public class DatabaseProduct implements Configurable {
       derbyLock.unlock();
     }
   }
+
+  public static boolean isDerbyOracle() {
+    return dbType == DbType.DERBY || dbType == DbType.ORACLE;
+  }
+
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
@@ -27,6 +27,7 @@ import java.util.Stack;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.ColumnType;
+import org.apache.hadoop.hive.metastore.DatabaseProduct;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -342,6 +343,11 @@ public class ExpressionTree {
       operator = node.operator;
       value = node.value;
       isReverseOrder = node.isReverseOrder;
+      if (node.keyName.startsWith(hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS)
+          && DatabaseProduct.isDerbyOracle() && node.operator == Operator.EQUALS) {
+        // Rewrite the EQUALS operator to LIKE
+        operator = Operator.LIKE;
+      }
       if (partitionKeys != null) {
         generateJDOFilterOverPartitions(conf, params, filterBuilder, partitionKeys);
       } else {


### PR DESCRIPTION
… for Oracle and Derby

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The column `PARAM_VALUE` in table `TABLE_PARAMS` is declared as type CLOB in Oracle and Derby, when using get_table_names_by_filter to filter tables, HMS backed by Oracle throws:

> java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got CLOB
at oracle.jdbc.driver.T4CTTIoer11.processError(T4CTTIoer11.java:509)
        at oracle.jdbc.driver.T4CTTIoer11.processError(T4CTTIoer11.java:461)
        at oracle.jdbc.driver.T4C8Oall.processError(T4C8Oall.java:1104)
        at oracle.jdbc.driver.T4CTTIfun.receive(T4CTTIfun.java:550)
        at oracle.jdbc.driver.T4CTTIfun.doRPC(T4CTTIfun.java:268)
        at oracle.jdbc.driver.T4C8Oall.doOALL(T4C8Oall.java:655)
        at oracle.jdbc.driver.T4CPreparedStatement.doOall8(T4CPreparedStatement.java:270)
        at oracle.jdbc.driver.T4CPreparedStatement.doOall8(T4CPreparedStatement.java:91)
        at oracle.jdbc.driver.T4CPreparedStatement.executeForDescribe(T4CPreparedStatement.java:807)
        at oracle.jdbc.driver.OracleStatement.executeMaybeDescribe(OracleStatement.java:983)

and Derby throws:

> java.sql.SQLSyntaxErrorException: Comparisons between 'CLOB (UCS_BASIC)' and 'CLOB (UCS_BASIC)' are not supported. Types must be comparable. String types must also have matching collation. If collation does not match, a possible solution is to cast operands to force them to the default collation (e.g. SELECT tablename FROM sys.systables WHERE CAST(tablename AS VARCHAR(128)) = 'T1')
	at org.apache.derby.impl.jdbc.SQLExceptionFactory.getSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.Util.generateCsSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.TransactionResourceImpl.wrapInSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.TransactionResourceImpl.handleException(Unknown Source)
	at org.apache.derby.impl.jdbc.EmbedConnection.handleException(Unknown Source)
	at org.apache.derby.impl.jdbc.ConnectionChild.handleException(Unknown Source)
        ...

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
TestTablesList
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
