### PR TITLE
HIVE-13288: Confusing exception message in DagUtils.localizeResource

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1448,9 +1448,10 @@ public class DagUtils {
         // Only log on the first wait, and check after wait on the last iteration.
         if (!checkOrWaitForTheFile(
             srcFs, src, dest, conf, notifierOld, waitAttempts, sleepInterval, true)) {
-          LOG.error("Could not find the jar that was being uploaded");
-          throw new IOException("Previous writer likely failed to write " + dest +
-              ". Failing because I am unlikely to write too.");
+          LOG.error("Could not find the jar that was being uploaded: src = {}, dest = {}, type = {}", src, dest, type);
+          throw new IOException("Could not find jar while attempting to localize resource. Previous writer may have " +
+              "failed to write " + dest + ". Failing because I am unlikely to write too. Refer to exception for more " +
+              "troubleshooting details.", e);
         }
       } finally {
         if (notifier == notifierNew) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve logging in `DagUtils#localizeResource` to clarify root cause for why localizing a resource has failed.

### Why are the changes needed?

While creating a Tez session, `DagUtils#localizeResource` is responsible for copying the client's hive-exec.jar into HDFS (`hive.jar.directory`). This process can be triggered from multiple threads concurrently, in which case one thread performs the copy while the others wait, polling for arrival of the destination file.

If there is an `IOException` during this process, it's assumed that the thread attempting the write failed, and all others abort. No information about the underlying `IOException` is logged. Instead, the log states "previous writer likely failed to write." In some cases though, the `IOException` can occur on a polling thread for reasons unrelated to what happened in a writing thread. For example, in a production incident, the root cause was really that an external process had corrupted the copy of hive-exec.jar in `hive.jar.directory`, causing failure of the file length validation check in `DagUtils#checkPreExisting`. Since the logs didn't say anything about this, it made it much more difficult to troubleshoot.

This patch clarifies the logging by stating that a failure on the writing thread is just one possible reason for the error. It also logs the exception stack trace to make it easier to find the real root cause. This is a patch I ran to help recover from the production incident.

### Does this PR introduce _any_ user-facing change?

There is no behavior change, but it does change the logging output.

### How was this patch tested?

This patch was deployed as part of resolving the production incident that I mentioned. I was also able to create a reproduction in a test environment by externally overwriting the hive-exec.jar in `hive.jar.directory` to simulate the production incident.