### PR TITLE
HIVE-26648:Upgrade Bouncy Castle to 1.70 due to high CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <arrow.version>2.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.8.2</avro.version>
-    <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
+    <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
     <calcite.version>1.25.0</calcite.version>
     <datanucleus-api-jdo.version>5.2.8</datanucleus-api-jdo.version>
     <datanucleus-core.version>5.2.10</datanucleus-core.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 

### What changes were proposed in this pull request?
Upgrade Bouncy Castle to 1.70 


### Why are the changes needed?
fix cve


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manual
