### PR TITLE
fix testThriftSetObjectInspector

### DIFF
--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestThriftObjectInspectors.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestThriftObjectInspectors.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hive.serde2.objectinspector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -150,6 +152,11 @@ public class TestThriftObjectInspectors {
       assertEquals(Category.STRUCT, oi1.getCategory());
       StructObjectInspector soi = (StructObjectInspector) oi1;
       List<? extends StructField> fields = soi.getAllStructFieldRefs();
+      Collections.sort(fields, new Comparator<StructField>() {
+        public int compare(StructField a, StructField b) {
+          return b.getFieldName().compareTo(a.getFieldName());
+        }
+      });
       assertEquals(2, fields.size());
       assertEquals(fields.get(0), soi.getStructFieldRef("sIntString"));
       assertEquals(fields.get(1), soi.getStructFieldRef("aString"));
@@ -176,6 +183,11 @@ public class TestThriftObjectInspectors {
       assertEquals("setString", soi.getStructFieldData(s, fields.get(1)));
 
       // sub fields
+      Collections.sort(fields, new Comparator<StructField>() {
+        public int compare(StructField a, StructField b) {
+          return a.getFieldObjectInspector().toString().compareTo(b.getFieldObjectInspector().toString());
+        }
+      });
       assertEquals(
           ObjectInspectorFactory
           .getStandardListObjectInspector(ObjectInspectorFactory


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added two sort field codes to make the list order determined.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This test is flaky test. This is because the StructField value uses a HashMap, which will cause the test sometimes pass and sometimes fail.

Run the test with 'NonDex' maven plugin. The command to recreate the flaky test failure is
`mvn -pl serde edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestThriftObjectInspectors#testThriftSetObjectInspector`


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
All tests passed. Run `mvn -pl serde edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestThriftObjectInspectors#testThriftSetObjectInspector` to see.
