### PR TITLE
HIVE-26705. Fix Typo in hive-kudu-handler.

### DIFF
--- a/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
+++ b/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
@@ -115,7 +115,7 @@ public final class KuduHiveUtils {
     }
   }
 
-  /* This method converts a Kudu type to to the corresponding Hive type */
+  /* This method converts a Kudu type to the corresponding Hive type */
   public static PrimitiveTypeInfo toHiveType(Type kuduType, ColumnTypeAttributes attributes)
       throws SerDeException {
     switch (kuduType) {

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduInputFormat.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduInputFormat.java
@@ -143,7 +143,7 @@ public class TestKuduInputFormat {
         (KuduRecordReader) input.getRecordReader(split, jobConf, null);
     assertTrue(reader.nextKeyValue());
     RowResult value = reader.getCurrentValue().getRowResult();
-    verfiyRow(value);
+    verifyRow(value);
     assertFalse(reader.nextKeyValue());
   }
 
@@ -313,11 +313,11 @@ public class TestKuduInputFormat {
           (KuduRecordReader) input.getRecordReader(split, jobConf, null);
       assertTrue(reader.nextKeyValue());
       RowResult value = reader.getCurrentValue().getRowResult();
-      verfiyRow(value);
+      verifyRow(value);
       assertFalse("Extra row on column: " + col.getName(), reader.nextKeyValue());
     }
   }
-  private void verfiyRow(RowResult value) {
+  private void verifyRow(RowResult value) {
     assertEquals(SCHEMA.getColumnCount(), value.getSchema().getColumnCount());
     assertEquals(ROW.getByte(0), value.getByte(0));
     assertEquals(ROW.getShort(1), value.getShort(1));


### PR DESCRIPTION
JIRA: HIVE-26705. Fix Typo in hive-kudu-handler.

When reading the code, I found typo and repaired the typo of the moudle.