### PR TITLE
HIVE-26707: Iceberg: Write failing due to Ranger Authorization failure.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -541,21 +541,31 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   public URI getURIForAuth(org.apache.hadoop.hive.metastore.api.Table hmsTable) throws URISyntaxException {
     String dbName = hmsTable.getDbName();
     String tableName = hmsTable.getTableName();
-    StringBuilder authURI = new StringBuilder(ICEBERG_URI_PREFIX).append(dbName).append("/").append(tableName)
-        .append("?snapshot=");
+    StringBuilder authURI =
+        new StringBuilder(ICEBERG_URI_PREFIX).append(encodeString(dbName)).append("/").append(encodeString(tableName))
+            .append("?snapshot=");
     Optional<String> locationProperty = SessionStateUtil.getProperty(conf, hive_metastoreConstants.META_TABLE_LOCATION);
     if (locationProperty.isPresent()) {
       Preconditions.checkArgument(locationProperty.get() != null,
           "Table location is not set in SessionState. Authorization URI cannot be supplied.");
       // this property is set during the create operation before the hive table was created
       // we are returning a dummy iceberg metadata file
-      authURI.append(URI.create(locationProperty.get()).getPath()).append("/metadata/dummy.metadata.json");
+      authURI.append(encodeString(URI.create(locationProperty.get()).getPath()))
+          .append(encodeString("/metadata/dummy.metadata.json"));
     } else {
       Table table = IcebergTableUtil.getTable(conf, hmsTable);
-      authURI.append(URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath());
+      authURI.append(
+          encodeString(URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath()));
     }
     LOG.debug("Iceberg storage handler authorization URI {}", authURI);
-    return new URI(HiveConf.EncoderDecoderFactory.URL_ENCODER_DECODER.encode(authURI.toString()));
+    return new URI(authURI.toString());
+  }
+
+  private String encodeString(String rawString) {
+    if (rawString == null) {
+      return null;
+    }
+    return HiveConf.EncoderDecoderFactory.URL_ENCODER_DECODER.encode(rawString);
   }
 
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -561,7 +561,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     return new URI(authURI.toString());
   }
 
-  private String encodeString(String rawString) {
+  @VisibleForTesting
+  static String encodeString(String rawString) {
     if (rawString == null) {
       return null;
     }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -1437,6 +1437,13 @@ public class TestHiveIcebergStorageHandlerNoScan {
     storageHandler.setConf(shell.getHiveConf());
     URI uriForAuth = storageHandler.getURIForAuth(hmsTable);
 
+    Assert.assertEquals("iceberg://" +
+            HiveIcebergStorageHandler.encodeString(target.namespace().toString()) + "/" +
+            HiveIcebergStorageHandler.encodeString(target.name()) + "?snapshot=" +
+            HiveIcebergStorageHandler.encodeString(
+            URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath()),
+        uriForAuth.toString());
+
     Assert.assertEquals("iceberg://" + target.namespace() + "/" + target.name() + "?snapshot=" +
         URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath(),
         HiveConf.EncoderDecoderFactory.URL_ENCODER_DECODER.decode(uriForAuth.toString()));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Following the same semantics as Hive-Hbase Handler, encode only the relevant components rather than the complete URI

### How was this patch tested?

Tested in actual Env