### PR TITLE
HIVE-26709: Iceberg: Count(*) fails for V2 tables with delete files.

### DIFF
--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -880,6 +880,11 @@
       <scope>compile</scope>
       <version>${esri.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+      <version>0.9.22</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>
@@ -1095,6 +1100,8 @@
                   <include>org.apache.calcite:*</include>
                   <include>org.apache.calcite.avatica:avatica</include>
                   <include>com.esri.geometry:esri-geometry-api</include>
+                  <include>org.roaringbitmap:RoaringBitmap</include>
+                  <include>org.roaringbitmap:shims</include>
                 </includes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the RoaringBitmap to hive-exec jar required by iceberg during Runtime for processing delete files.


### Why are the changes needed?

Queries with Iceberg Table fails

### How was this patch tested?

In Actual env. Doesn't reproduces in Unit Test, Maven puts all the jars on the class path, but during execution these jars aren't there at Runtime with Tez