### PR TITLE
HIVE-26628: Iceberg table is created when running explain ctas command

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -106,5 +106,5 @@ public class Constants {
   public static final String HTTP_HEADER_REQUEST_TRACK = "Request-Track";
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
 
-  public static final String IS_EXPLAIN = "explain";
+  public static final String IS_EXPLAIN_PLAN = "isExplainPlan";
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -105,4 +105,6 @@ public class Constants {
 
   public static final String HTTP_HEADER_REQUEST_TRACK = "Request-Track";
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
+
+  public static final String IS_EXPLAIN = "explain";
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -106,5 +106,5 @@ public class Constants {
   public static final String HTTP_HEADER_REQUEST_TRACK = "Request-Track";
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
 
-  public static final String IS_EXPLAIN_PLAN = "isExplainPlan";
+  public static final String EXPLAIN_CTAS_LOCATION = "explainCtasLocation";
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -121,12 +122,14 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         this.partitionColumns = ImmutableList.of();
         // create table for CTAS
         if (e instanceof NoSuchTableException &&
-            Boolean.parseBoolean(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
+            StringUtils.isNotBlank(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
           if (!Catalogs.hiveCatalog(configuration, serDeProperties)) {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }
 
-          createTableForCTAS(configuration, serDeProperties);
+          if (!Boolean.parseBoolean(serDeProperties.getProperty("explain"))) {
+            createTableForCTAS(configuration, serDeProperties);
+          }
         }
       }
     }
@@ -320,5 +323,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   @Override
   public boolean shouldStoreFieldsInMetastore(Map<String, String> tableParams) {
     return true;
+  }
+
+  public Schema getTableSchema() {
+    return tableSchema;
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -127,7 +127,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }
 
-          if (!Boolean.parseBoolean(serDeProperties.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN))) {
+          if (!Boolean.parseBoolean(serDeProperties.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN))) {
             createTableForCTAS(configuration, serDeProperties);
           }
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -122,7 +121,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         this.partitionColumns = ImmutableList.of();
         // create table for CTAS
         if (e instanceof NoSuchTableException &&
-            StringUtils.isNotBlank(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
+                Boolean.parseBoolean(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
           if (!Catalogs.hiveCatalog(configuration, serDeProperties)) {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -127,7 +127,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }
 
-          if (!Boolean.parseBoolean(serDeProperties.getProperty("explain"))) {
+          if (!Boolean.parseBoolean(serDeProperties.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN))) {
             createTableForCTAS(configuration, serDeProperties);
           }
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -127,7 +127,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }
 
-          if (!Boolean.parseBoolean(serDeProperties.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN))) {
+          if (!Boolean.parseBoolean(serDeProperties.getProperty(
+                  org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN))) {
             createTableForCTAS(configuration, serDeProperties);
           }
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
@@ -126,8 +127,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
             throw new SerDeException(CTAS_EXCEPTION_MSG);
           }
 
-          if (!Boolean.parseBoolean(serDeProperties.getProperty(
-                  org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN))) {
+          if (!serDeProperties.containsKey(Constants.EXPLAIN_CTAS_LOCATION)) {
             createTableForCTAS(configuration, serDeProperties);
           }
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -843,7 +843,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         map.put(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
         map.put(InputFormatConfig.SERIALIZED_TABLE_PREFIX + tableDesc.getTableName(),
             SerializationUtil.serializeToBase64(null));
-        String catalogName = props.getProperty(InputFormatConfig.CATALOG_NAME);
 
         String location = map.get(hive_metastoreConstants.META_TABLE_LOCATION);
         if (StringUtils.isBlank(location)) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -845,10 +845,9 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
             SerializationUtil.serializeToBase64(null));
 
         String location = map.get(hive_metastoreConstants.META_TABLE_LOCATION);
-        if (StringUtils.isBlank(location)) {
-          location = props.getProperty(hive_metastoreConstants.TABLE_IS_CTAS);
+        if (StringUtils.isNotBlank(location)) {
+          map.put(InputFormatConfig.TABLE_LOCATION, location);
         }
-        map.put(InputFormatConfig.TABLE_LOCATION, location);
 
         AbstractSerDe serDe = tableDesc.getDeserializer(configuration);
         HiveIcebergSerDe icebergSerDe = (HiveIcebergSerDe) serDe;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -835,7 +835,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       props.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
     } catch (NoSuchTableException ex) {
       if (!(StringUtils.isNotBlank(props.getProperty(hive_metastoreConstants.TABLE_IS_CTAS)) &&
-          Boolean.parseBoolean(props.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN)))) {
+          Boolean.parseBoolean(props.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN)))) {
         throw ex;
       }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -833,12 +833,12 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         throw ex;
       }
 
-      try {
-        location = map.get(hive_metastoreConstants.META_TABLE_LOCATION);
-        if (StringUtils.isBlank(location)) {
-          location = props.getProperty(Constants.EXPLAIN_CTAS_LOCATION);
-        }
+      location = map.get(hive_metastoreConstants.META_TABLE_LOCATION);
+      if (StringUtils.isBlank(location)) {
+        location = props.getProperty(Constants.EXPLAIN_CTAS_LOCATION);
+      }
 
+      try {
         AbstractSerDe serDe = tableDesc.getDeserializer(configuration);
         HiveIcebergSerDe icebergSerDe = (HiveIcebergSerDe) serDe;
         schema = icebergSerDe.getTableSchema();

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.SnapshotContext;
 import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -835,7 +836,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       props.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
     } catch (NoSuchTableException ex) {
       if (!(StringUtils.isNotBlank(props.getProperty(hive_metastoreConstants.TABLE_IS_CTAS)) &&
-          Boolean.parseBoolean(props.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN)))) {
+              StringUtils.isNotBlank(props.getProperty(Constants.EXPLAIN_CTAS_LOCATION)))) {
         throw ex;
       }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -835,7 +835,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       props.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
     } catch (NoSuchTableException ex) {
       if (!(StringUtils.isNotBlank(props.getProperty(hive_metastoreConstants.TABLE_IS_CTAS)) &&
-          Boolean.parseBoolean(props.getProperty("explain")))) {
+          Boolean.parseBoolean(props.getProperty(org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN)))) {
         throw ex;
       }
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
@@ -1,0 +1,19 @@
+set hive.query.lifetime.hooks=org.apache.iceberg.mr.hive.HiveIcebergQueryLifeTimeHook;
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+set hive.explain.user=false;
+
+create table source(a int, b string, c int);
+
+insert into source values (1, 'one', 3);
+insert into source values (1, 'two', 4);
+
+explain extended
+create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source;
+
+create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source;
+
+describe formatted tbl_ice;
+
+select * from tbl_ice;

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -1,0 +1,302 @@
+PREHOOK: query: create table source(a int, b string, c int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source
+POSTHOOK: query: create table source(a int, b string, c int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source
+PREHOOK: query: insert into source values (1, 'one', 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source values (1, 'one', 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+POSTHOOK: Lineage: source.a SCRIPT []
+POSTHOOK: Lineage: source.b SCRIPT []
+POSTHOOK: Lineage: source.c SCRIPT []
+PREHOOK: query: insert into source values (1, 'two', 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source values (1, 'two', 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+POSTHOOK: Lineage: source.a SCRIPT []
+POSTHOOK: Lineage: source.b SCRIPT []
+POSTHOOK: Lineage: source.c SCRIPT []
+PREHOOK: query: explain extended
+create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@source
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain extended
+create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@source
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+OPTIMIZED SQL: SELECT `a`, `b`, `c`
+FROM `default`.`source`
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-3 depends on stages: Stage-0, Stage-2
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: source
+                  Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      bucketingVersion: 2
+                      compressed: false
+                      GlobalTableId: 1
+                      directory: hdfs://### HDFS PATH ###
+                      NumFilesPerFileSink: 1
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                      Stats Publishing Key Prefix: hdfs://### HDFS PATH ###
+                      table:
+                          input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                          jobProperties:
+                            bucketing_version -1
+                            columns a,b,c
+                            columns.types int:string:int
+                            created_with_ctas hdfs://### HDFS PATH ###
+                            format-version 2
+                            iceberg.mr.operation.type.default.tbl_ice OTHER
+                            iceberg.mr.serialized.table.default.tbl_ice rO0ABXA=
+                            iceberg.mr.table.identifier default.tbl_ice
+                            iceberg.mr.table.location hdfs://### HDFS PATH ###
+                            iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
+                            mapred.output.committer.class org.apache.iceberg.mr.hive.HiveIcebergStorageHandler$HiveIcebergNoJobCommitter
+                            name default.tbl_ice
+                            serialization.format 1
+                            serialization.lib org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            storage_handler org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+                            write.format.default orc
+                          output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                          properties:
+                            bucketing_version -1
+                            columns a,b,c
+                            columns.types int:string:int
+                            format-version 2
+                            iceberg.mr.operation.type.default.tbl_ice OTHER
+                            iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
+                            name default.tbl_ice
+                            serialization.format 1
+                            serialization.lib org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            storage_handler org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+                            write.format.default orc
+                          serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                          name: default.tbl_ice
+                      TotalFiles: 1
+                      GatherStats: true
+                      MultiFileSpray: false
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                      outputColumnNames: col1, col2, col3
+                      Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(col1), max(col1), count(1), count(col1), compute_bit_vector_hll(col1), max(length(col2)), avg(COALESCE(length(col2),0)), count(col2), compute_bit_vector_hll(col2), min(col3), max(col3), count(col3), compute_bit_vector_hll(col3)
+                        minReductionHashAggr: 0.5
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                        Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          bucketingVersion: 2
+                          null sort order: 
+                          numBuckets: -1
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: COMPLETE
+                          tag: -1
+                          value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary), _col9 (type: int), _col10 (type: int), _col11 (type: bigint), _col12 (type: binary)
+                          auto parallelism: false
+            Path -> Alias:
+              hdfs://### HDFS PATH ### [source]
+            Path -> Partition:
+              hdfs://### HDFS PATH ### 
+                Partition
+                  base file name: source
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  properties:
+                    bucket_count -1
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns a,b,c
+                    columns.types int:string:int
+#### A masked pattern was here ####
+                    location hdfs://### HDFS PATH ###
+                    name default.source
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns a,b,c
+                      columns.comments 
+                      columns.types int:string:int
+#### A masked pattern was here ####
+                      location hdfs://### HDFS PATH ###
+                      name default.source
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.source
+                  name: default.source
+            Truncated Path -> Alias:
+              /source [source]
+        Reducer 2 
+            Needs Tagging: false
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), max(VALUE._col5), avg(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8), min(VALUE._col9), max(VALUE._col10), count(VALUE._col11), compute_bit_vector_hll(VALUE._col12)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                Statistics: Num rows: 1 Data size: 492 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'LONG' (type: string), UDFToLong(_col0) (type: bigint), UDFToLong(_col1) (type: bigint), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'STRING' (type: string), UDFToLong(COALESCE(_col5,0)) (type: bigint), COALESCE(_col6,0) (type: double), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary), 'LONG' (type: string), UDFToLong(_col9) (type: bigint), UDFToLong(_col10) (type: bigint), (_col2 - _col11) (type: bigint), COALESCE(ndv_compute_bit_vector(_col12),0) (type: bigint), _col12 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17
+                  Statistics: Num rows: 1 Data size: 794 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    bucketingVersion: 2
+                    compressed: false
+                    GlobalTableId: 0
+                    directory: hdfs://### HDFS PATH ###
+                    NumFilesPerFileSink: 1
+                    Statistics: Num rows: 1 Data size: 794 Basic stats: COMPLETE Column stats: COMPLETE
+                    Stats Publishing Key Prefix: hdfs://### HDFS PATH ###
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        properties:
+                          bucketing_version -1
+                          columns _col0,_col1,_col2,_col3,_col4,_col5,_col6,_col7,_col8,_col9,_col10,_col11,_col12,_col13,_col14,_col15,_col16,_col17
+                          columns.types string:bigint:bigint:bigint:bigint:binary:string:bigint:double:bigint:bigint:binary:string:bigint:bigint:bigint:bigint:binary
+                          escape.delim \
+                          hive.serialization.extend.additional.nesting.levels true
+                          serialization.escape.crlf true
+                          serialization.format 1
+                          serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    TotalFiles: 1
+                    GatherStats: false
+                    MultiFileSpray: false
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+          Stats Aggregation Key Prefix: hdfs://### HDFS PATH ###
+      Column Stats Desc:
+          Columns: a, b, c
+          Column Types: int, string, int
+          Table: default.tbl_ice
+          Is Table Level Stats: true
+
+  Stage: Stage-0
+    Move Operator
+      files:
+          hdfs directory: true
+          source: hdfs://### HDFS PATH ###
+          destination: hdfs://### HDFS PATH ###
+
+PREHOOK: query: create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@source
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create external table tbl_ice partitioned by spec (bucket(16, a), truncate(3, b)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select a, b, c from source
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@source
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: describe formatted tbl_ice
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@tbl_ice
+POSTHOOK: query: describe formatted tbl_ice
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@tbl_ice
+# col_name            	data_type           	comment             
+a                   	int                 	                    
+b                   	string              	                    
+c                   	int                 	                    
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+a                   	BUCKET[16]          	 
+b                   	TRUNCATE[3]         	 
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	2147483647          	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	-1                  
+	engine.hive.enabled 	true                
+	iceberg.orc.files.only	true                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	2                   
+	numRows             	2                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	812                 
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	write.format.default	orc                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: select * from tbl_ice
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from tbl_ice
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one	3
+1	two	4

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -84,10 +84,9 @@ STAGE PLANS:
                             bucketing_version -1
                             columns a,b,c
                             columns.types int:string:int
-                            created_with_ctas hdfs://### HDFS PATH ###
+                            created_with_ctas true
                             format-version 2
                             iceberg.mr.operation.type.default.tbl_ice OTHER
-                            iceberg.mr.serialized.table.default.tbl_ice rO0ABXA=
                             iceberg.mr.table.identifier default.tbl_ice
                             iceberg.mr.table.location hdfs://### HDFS PATH ###
                             iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
@@ -134,6 +133,7 @@ STAGE PLANS:
                           tag: -1
                           value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary), _col9 (type: int), _col10 (type: int), _col11 (type: bigint), _col12 (type: binary)
                           auto parallelism: false
+            Execution mode: vectorized
             Path -> Alias:
               hdfs://### HDFS PATH ### [source]
             Path -> Partition:
@@ -174,6 +174,7 @@ STAGE PLANS:
             Truncated Path -> Alias:
               /source [source]
         Reducer 2 
+            Execution mode: vectorized
             Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -103,6 +103,7 @@ STAGE PLANS:
                             columns.types int:string:int
                             format-version 2
                             iceberg.mr.operation.type.default.tbl_ice OTHER
+                            iceberg.mr.table.partition.spec {"spec-id":0,"fields":[{"name":"a_bucket","transform":"bucket[16]","source-id":1,"field-id":1000},{"name":"b_trunc","transform":"truncate[3]","source-id":2,"field-id":1001}]}
                             iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
                             name default.tbl_ice
                             serialization.format 1

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hive.ql.ddl.table.create;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
 
 /**
  * DDL task description for CREATE TABLE commands.
@@ -521,7 +520,7 @@ public class CreateTableDesc implements DDLDesc, Serializable {
   @Explain(displayName = "table properties")
   public Map<String, String> getTblPropsExplain() { // only for displaying plan
     return PlanUtils.getPropertiesExplain(tblProps,
-            IS_EXPLAIN, hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
+            IS_EXPLAIN_PLAN, hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -73,6 +73,8 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+
 /**
  * DDL task description for CREATE TABLE commands.
  */
@@ -519,7 +521,7 @@ public class CreateTableDesc implements DDLDesc, Serializable {
   @Explain(displayName = "table properties")
   public Map<String, String> getTblPropsExplain() { // only for displaying plan
     return PlanUtils.getPropertiesExplain(tblProps,
-            "explain", hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
+            IS_EXPLAIN, hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -519,7 +519,7 @@ public class CreateTableDesc implements DDLDesc, Serializable {
 
   @Explain(displayName = "table properties")
   public Map<String, String> getTblPropsExplain() { // only for displaying plan
-    return PlanUtils.getPropertiesExplain(tblProps,
+    return PlanUtils.getPropertiesForExplain(tblProps,
             IS_EXPLAIN_PLAN, hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -518,10 +518,8 @@ public class CreateTableDesc implements DDLDesc, Serializable {
 
   @Explain(displayName = "table properties")
   public Map<String, String> getTblPropsExplain() { // only for displaying plan
-    HashMap<String, String> copy = new HashMap<>(tblProps);
-    copy.remove(hive_metastoreConstants.TABLE_IS_CTAS);
-    copy.remove(hive_metastoreConstants.TABLE_BUCKETING_VERSION);
-    return copy;
+    return PlanUtils.getPropertiesExplain(tblProps,
+            "explain", hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -72,7 +72,7 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
+import static org.apache.hadoop.hive.conf.Constants.EXPLAIN_CTAS_LOCATION;
 
 /**
  * DDL task description for CREATE TABLE commands.
@@ -520,7 +520,9 @@ public class CreateTableDesc implements DDLDesc, Serializable {
   @Explain(displayName = "table properties")
   public Map<String, String> getTblPropsExplain() { // only for displaying plan
     return PlanUtils.getPropertiesForExplain(tblProps,
-            IS_EXPLAIN_PLAN, hive_metastoreConstants.TABLE_IS_CTAS, hive_metastoreConstants.TABLE_BUCKETING_VERSION);
+            EXPLAIN_CTAS_LOCATION,
+            hive_metastoreConstants.TABLE_IS_CTAS,
+            hive_metastoreConstants.TABLE_BUCKETING_VERSION);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7760,7 +7760,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
               // no metastore.metadata.transformer.class was set
               tblDesc.getTblProps().put(TABLE_IS_CTAS, new Warehouse(conf).getDefaultTablePath(
                       destinationTable.getDbName(),
-                      destinationTable.getDbName(),
+                      destinationTable.getTableName(),
                       Boolean.parseBoolean(destinationTable.getParameters().get("EXTERNAL"))).toString());
             } else {
               tblDesc.getTblProps().put(TABLE_IS_CTAS, destinationTable.getDataLocation().toString());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7756,11 +7756,18 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         } else {
           destinationTable = db.getTranslateTableDryrun(tblDesc.toTable(conf).getTTable());
           if (tblDesc.getTblProps().containsKey(TABLE_IS_CTAS)) {
+            if (destinationTable.getDataLocation() == null) {
+              // no metastore.metadata.transformer.class was set
+              destinationTable.setDataLocation(new Warehouse(conf).getDefaultTablePath(
+                  destinationTable.getDbName(),
+                  destinationTable.getDbName(),
+                  Boolean.parseBoolean(destinationTable.getParameters().get("EXTERNAL"))));
+            }
             tblDesc.getTblProps().put(TABLE_IS_CTAS, destinationTable.getDataLocation().toString());
           }
           tableDescriptor = PlanUtils.getTableDesc(tblDesc, cols, colTypes);
         }
-      } catch (HiveException e) {
+      } catch (HiveException | MetaException e) {
         throw new SemanticException(e);
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7758,12 +7758,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           if (tblDesc.getTblProps().containsKey(TABLE_IS_CTAS)) {
             if (destinationTable.getDataLocation() == null) {
               // no metastore.metadata.transformer.class was set
-              destinationTable.setDataLocation(new Warehouse(conf).getDefaultTablePath(
-                  destinationTable.getDbName(),
-                  destinationTable.getDbName(),
-                  Boolean.parseBoolean(destinationTable.getParameters().get("EXTERNAL"))));
+              tblDesc.getTblProps().put(TABLE_IS_CTAS, new Warehouse(conf).getDefaultTablePath(
+                      destinationTable.getDbName(),
+                      destinationTable.getDbName(),
+                      Boolean.parseBoolean(destinationTable.getParameters().get("EXTERNAL"))).toString());
+            } else {
+              tblDesc.getTblProps().put(TABLE_IS_CTAS, destinationTable.getDataLocation().toString());
             }
-            tblDesc.getTblProps().put(TABLE_IS_CTAS, destinationTable.getDataLocation().toString());
           }
           tableDescriptor = PlanUtils.getTableDesc(tblDesc, cols, colTypes);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.ql.parse;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE;
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONCONVERT;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEARCHIVEENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_DEFAULT_STORAGE_HANDLER;
@@ -14020,7 +14020,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       isExt = isExternalTableChanged(tblProps, isTransactional, isExt, isDefaultTableTypeChanged);
       tblProps.put(TABLE_IS_CTAS, "true");
       if (ctx.isExplainPlan()) {
-        tblProps.put(IS_EXPLAIN, "true");
+        tblProps.put(IS_EXPLAIN_PLAN, "true");
       }
       addDbAndTabToOutputs(new String[] {qualifiedTabName.getDb(), qualifiedTabName.getTable()},
           TableType.MANAGED_TABLE, isTemporary, tblProps, storageFormat);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.parse;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE;
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONCONVERT;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEARCHIVEENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_DEFAULT_STORAGE_HANDLER;
@@ -14019,7 +14020,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       isExt = isExternalTableChanged(tblProps, isTransactional, isExt, isDefaultTableTypeChanged);
       tblProps.put(TABLE_IS_CTAS, "true");
       if (ctx.isExplainPlan()) {
-        tblProps.put("explain", "true");
+        tblProps.put(IS_EXPLAIN, "true");
       }
       addDbAndTabToOutputs(new String[] {qualifiedTabName.getDb(), qualifiedTabName.getTable()},
           TableType.MANAGED_TABLE, isTemporary, tblProps, storageFormat);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.ql.parse;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE;
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
+import static org.apache.hadoop.hive.conf.Constants.EXPLAIN_CTAS_LOCATION;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONCONVERT;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEARCHIVEENABLED;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_DEFAULT_STORAGE_HANDLER;
@@ -7762,12 +7762,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
                   !tblDesc.getTblProps().containsKey(META_TABLE_LOCATION)) {
             if (destinationTable.getDataLocation() == null) {
               // no metastore.metadata.transformer.class was set
-              tblDesc.getTblProps().put(META_TABLE_LOCATION, new Warehouse(conf).getDefaultTablePath(
+              tblDesc.getTblProps().put(EXPLAIN_CTAS_LOCATION, new Warehouse(conf).getDefaultTablePath(
                       destinationTable.getDbName(),
                       destinationTable.getTableName(),
                       Boolean.parseBoolean(destinationTable.getParameters().get("EXTERNAL"))).toString());
             } else {
-              tblDesc.getTblProps().put(META_TABLE_LOCATION, destinationTable.getDataLocation().toString());
+              tblDesc.getTblProps().put(EXPLAIN_CTAS_LOCATION, destinationTable.getDataLocation().toString());
             }
           }
           tableDescriptor = PlanUtils.getTableDesc(tblDesc, cols, colTypes);
@@ -14023,7 +14023,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       isExt = isExternalTableChanged(tblProps, isTransactional, isExt, isDefaultTableTypeChanged);
       tblProps.put(TABLE_IS_CTAS, "true");
       if (ctx.isExplainPlan()) {
-        tblProps.put(IS_EXPLAIN_PLAN, "true");
+        tblProps.put(EXPLAIN_CTAS_LOCATION, "");
       }
       addDbAndTabToOutputs(new String[] {qualifiedTabName.getDb(), qualifiedTabName.getTable()},
           TableType.MANAGED_TABLE, isTemporary, tblProps, storageFormat);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PartitionDesc.java
@@ -213,7 +213,7 @@ public class PartitionDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "properties", explainLevels = { Level.EXTENDED })
   public Map getPropertiesExplain() {
-    return PlanUtils.getPropertiesExplain(getProperties());
+    return PlanUtils.getPropertiesForExplain(getProperties());
   }
 
   public void setProperties(final Properties properties) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.plan;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
+import static org.apache.hadoop.hive.conf.Constants.EXPLAIN_CTAS_LOCATION;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hive.common.util.HiveStringUtils.quoteComments;
 
@@ -1222,7 +1222,7 @@ public final class PlanUtils {
     return LazySimpleSerDe.class;
   }
 
-  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, IS_EXPLAIN_PLAN};
+  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, EXPLAIN_CTAS_LOCATION};
 
   /**
    * Get a Map of table or partition properties to be used in explain extended output.

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.plan;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hive.common.util.HiveStringUtils.quoteComments;
 
@@ -27,14 +27,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JavaUtils;
@@ -1224,7 +1222,7 @@ public final class PlanUtils {
     return LazySimpleSerDe.class;
   }
 
-  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, IS_EXPLAIN};
+  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, IS_EXPLAIN_PLAN};
 
   /**
    * Get a Map of table or partition properties to be used in explain extended output.

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -1228,7 +1228,7 @@ public final class PlanUtils {
    * Get a Map of table or partition properties to be used in explain extended output.
    * Do some filtering to make output readable and/or concise.
    */
-  static Map getPropertiesForExplain(Properties properties) {
+  static Map<Object, Object> getPropertiesForExplain(Properties properties) {
     if (properties != null) {
       Map<Object, Object> clone = null;
       String value = properties.getProperty("columns.comments");
@@ -1262,7 +1262,7 @@ public final class PlanUtils {
 
   public static Map<String, String> getPropertiesForExplain(Map<String, String> properties, String... propertiesToRemove) {
     if (properties == null) {
-      return null;
+      return Collections.emptyMap();
     }
 
     Map<String, String> clone = new HashMap<>(properties);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.plan;
 
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hive.common.util.HiveStringUtils.quoteComments;
 
@@ -1223,7 +1224,7 @@ public final class PlanUtils {
     return LazySimpleSerDe.class;
   }
 
-  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, "explain"};
+  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, IS_EXPLAIN};
 
   /**
    * Get a Map of table or partition properties to be used in explain extended output.

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -1228,7 +1228,7 @@ public final class PlanUtils {
    * Get a Map of table or partition properties to be used in explain extended output.
    * Do some filtering to make output readable and/or concise.
    */
-  static Map getPropertiesExplain(Properties properties) {
+  static Map getPropertiesForExplain(Properties properties) {
     if (properties != null) {
       Map<Object, Object> clone = null;
       String value = properties.getProperty("columns.comments");
@@ -1260,7 +1260,7 @@ public final class PlanUtils {
     return properties;
   }
 
-  public static Map<String, String> getPropertiesExplain(Map<String, String> properties, String... propertiesToRemove) {
+  public static Map<String, String> getPropertiesForExplain(Map<String, String> properties, String... propertiesToRemove) {
     if (properties == null) {
       return null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -1223,6 +1223,8 @@ public final class PlanUtils {
     return LazySimpleSerDe.class;
   }
 
+  private static final String[] FILTER_OUT_FROM_EXPLAIN = {TABLE_IS_CTAS, "explain"};
+
   /**
    * Get a Map of table or partition properties to be used in explain extended output.
    * Do some filtering to make output readable and/or concise.
@@ -1244,16 +1246,31 @@ public final class PlanUtils {
         }
         clone.remove(StatsSetupConst.NUM_ERASURE_CODED_FILES);
       }
-      if (properties.containsKey(TABLE_IS_CTAS)) {
-        if (clone == null) {
-          clone = new HashMap<>(properties);
+      for (String key : FILTER_OUT_FROM_EXPLAIN) {
+        if (properties.containsKey(key)) {
+          if (clone == null) {
+            clone = new HashMap<>(properties);
+          }
+          clone.remove(key);
         }
-        clone.remove(TABLE_IS_CTAS);
       }
       if (clone != null) {
         return clone;
       }
     }
     return properties;
+  }
+
+  public static Map<String, String> getPropertiesExplain(Map<String, String> properties, String... propertiesToRemove) {
+    if (properties == null) {
+      return null;
+    }
+
+    Map<String, String> clone = new HashMap<>(properties);
+    for (String key : propertiesToRemove) {
+      clone.remove(key);
+    }
+
+    return clone;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -143,7 +143,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobProperties() {
-    return jobProperties;
+    return PlanUtils.getPropertiesExplain(jobProperties, "explain");
   }
 
   public void setJobSecrets(Map<String, String> jobSecrets) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -37,7 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
+import static org.apache.hadoop.hive.conf.Constants.EXPLAIN_CTAS_LOCATION;
 
 /**
  * TableDesc.
@@ -145,7 +145,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobPropertiesExplain() {
-    return PlanUtils.getPropertiesForExplain(jobProperties, IS_EXPLAIN_PLAN);
+    return PlanUtils.getPropertiesForExplain(jobProperties, EXPLAIN_CTAS_LOCATION);
   }
 
   public void setJobSecrets(Map<String, String> jobSecrets) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -26,14 +26,10 @@ import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hive.common.util.ReflectionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.Enumeration;
@@ -41,7 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN_PLAN;
 
 /**
  * TableDesc.
@@ -149,7 +145,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobPropertiesExplain() {
-    return PlanUtils.getPropertiesExplain(jobProperties, IS_EXPLAIN);
+    return PlanUtils.getPropertiesExplain(jobProperties, IS_EXPLAIN_PLAN);
   }
 
   public void setJobSecrets(Map<String, String> jobSecrets) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -41,6 +41,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.hadoop.hive.conf.Constants.IS_EXPLAIN;
+
 /**
  * TableDesc.
  *
@@ -147,7 +149,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobPropertiesExplain() {
-    return PlanUtils.getPropertiesExplain(jobProperties, "explain");
+    return PlanUtils.getPropertiesExplain(jobProperties, IS_EXPLAIN);
   }
 
   public void setJobSecrets(Map<String, String> jobSecrets) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -127,7 +127,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "properties", explainLevels = { Level.EXTENDED })
   public Map getPropertiesExplain() {
-    return PlanUtils.getPropertiesExplain(getProperties());
+    return PlanUtils.getPropertiesForExplain(getProperties());
   }
 
   public void setProperties(final Properties properties) {
@@ -145,7 +145,7 @@ public class TableDesc implements Serializable, Cloneable {
 
   @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobPropertiesExplain() {
-    return PlanUtils.getPropertiesExplain(jobProperties, IS_EXPLAIN_PLAN);
+    return PlanUtils.getPropertiesForExplain(jobProperties, IS_EXPLAIN_PLAN);
   }
 
   public void setJobSecrets(Map<String, String> jobSecrets) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -141,8 +141,12 @@ public class TableDesc implements Serializable, Cloneable {
     this.jobProperties = jobProperties;
   }
 
-  @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobProperties() {
+    return jobProperties;
+  }
+
+  @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
+  public Map<String, String> getJobPropertiesExplain() {
     return PlanUtils.getPropertiesExplain(jobProperties, "explain");
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
* Pass a flag to jobConfig to indicate if we are in an explain command and do not create Iceberg tables in case of explain ctas.
* Add the newly created table path to the ctas property and use this value when overlaying jobProperties in IcebergStorageHandler

### Why are the changes needed?
Explain command should not make changes in the catalog. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=ctas_iceberg_partitioned_orc.q -pl itests/qtest-iceberg -Piceberg -Pitests
```