### PR TITLE
HIVE-26697: Create vectorized Hive DeleteFilter for Iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -908,7 +908,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   /**
    * If any of the following checks is true we fall back to non vectorized mode:
    * <ul>
-   *   <li>iceberg format-version is "2"</li>
    *   <li>fileformat is set to avro</li>
    *   <li>querying metadata tables</li>
    *   <li>fileformat is set to ORC, and table schema has time type column</li>
@@ -918,8 +917,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    */
   private void fallbackToNonVectorizedModeBasedOnProperties(Properties tableProps) {
     Schema tableSchema = SchemaParser.fromJson(tableProps.getProperty(InputFormatConfig.TABLE_SCHEMA));
-    if ("2".equals(tableProps.get(TableProperties.FORMAT_VERSION)) ||
-        FileFormat.AVRO.name().equalsIgnoreCase(tableProps.getProperty(TableProperties.DEFAULT_FILE_FORMAT)) ||
+    if (FileFormat.AVRO.name().equalsIgnoreCase(tableProps.getProperty(TableProperties.DEFAULT_FILE_FORMAT)) ||
         (tableProps.containsKey("metaTable") && isValidMetadataTable(tableProps.getProperty("metaTable"))) ||
         hasOrcTimeInSchema(tableProps, tableSchema) ||
         !hasParquetNestedTypeWithinListOrMap(tableProps, tableSchema)) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveDeleteFilter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveDeleteFilter.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.vector;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.NoSuchElementException;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+
+/**
+ * Delete filter implementation which is consuming HiveRow instances.
+ */
+public class HiveDeleteFilter extends DeleteFilter<HiveRow> {
+
+  private final FileIO io;
+  private final HiveStructLike asStructLike;
+
+  public HiveDeleteFilter(FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
+    super((task.file()).path().toString(), task.deletes(), tableSchema, requestedSchema);
+    this.io = io;
+    this.asStructLike = new HiveStructLike(this.requiredSchema().asStruct());
+  }
+
+  @Override
+  protected StructLike asStructLike(HiveRow record) {
+    return asStructLike.wrap(record);
+  }
+
+  @Override
+  protected long pos(HiveRow record) {
+    return (long) record.get(MetadataColumns.ROW_POSITION.fieldId());
+  }
+
+  @Override
+  protected void markRowDeleted(HiveRow row) {
+    row.setDeleted(true);
+  }
+
+  @Override
+  protected InputFile getInputFile(String location) {
+    return this.io.newInputFile(location);
+  }
+
+  /**
+   * Adjusts the pipeline of incoming VRBs so that for each batch every row goes through the delete filter.
+   * @param batches iterable of HiveBatchContexts i.e. VRBs and their meta information
+   * @return the adjusted iterable of HiveBatchContexts
+   */
+  public CloseableIterable<HiveBatchContext> filterBatch(CloseableIterable<HiveBatchContext> batches) {
+
+    // Delete filter pipeline setup logic:
+    // A HiveRow iterable (deleteInputIterable) is provided as input iterable for the DeleteFilter.
+    // The content in deleteInputIterable is provided by row iterators from the incoming VRBs i.e. on the arrival of
+    // a new batch the underlying iterator gets swapped.
+    SwappableHiveRowIterable deleteInputIterable = new SwappableHiveRowIterable();
+
+    // Output iterable of DeleteFilter, and its iterator
+    CloseableIterable<HiveRow> deleteOutputIterable = filter(deleteInputIterable);
+    CloseableIterator<HiveRow> deleteOutputIterator = deleteOutputIterable.iterator();
+
+    return new CloseableIterable<HiveBatchContext>() {
+
+      @Override
+      public CloseableIterator<HiveBatchContext> iterator() {
+
+        CloseableIterator<HiveBatchContext> srcIterator = batches.iterator();
+
+        return new CloseableIterator<HiveBatchContext>() {
+
+          @Override
+          public boolean hasNext() {
+            return srcIterator.hasNext();
+          }
+
+          @Override
+          public HiveBatchContext next() {
+            try {
+              if (!hasNext()) {
+                throw new NoSuchElementException();
+              }
+              HiveBatchContext currentBatchContext = srcIterator.next();
+              deleteInputIterable.currentRowIterator = currentBatchContext.rowIterator();
+              VectorizedRowBatch batch = currentBatchContext.getBatch();
+
+              int oldSize = batch.size;
+              int newSize = 0;
+
+              // Apply delete filtering and adjust the selected array so that undeleted row indices are filled with it.
+              while (deleteOutputIterator.hasNext()) {
+                HiveRow row = deleteOutputIterator.next();
+                if (!row.isDeleted()) {
+                  batch.selected[newSize++] = row.physicalBatchIndex();
+                }
+              }
+
+              if (newSize < oldSize) {
+                batch.size = newSize;
+                batch.selectedInUse = true;
+              }
+              return currentBatchContext;
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          }
+
+          @Override
+          public void close() throws IOException {
+            srcIterator.close();
+          }
+        };
+      }
+
+      @Override
+      public void close() throws IOException {
+        batches.close();
+      }
+    };
+  }
+
+  // HiveRow iterable that wraps an interchangeable source HiveRow iterable
+  static class SwappableHiveRowIterable implements CloseableIterable<HiveRow> {
+
+    private CloseableIterator<HiveRow> currentRowIterator;
+
+    @Override
+    public CloseableIterator<HiveRow> iterator() {
+
+      return new CloseableIterator<HiveRow>() {
+
+        @Override
+        public boolean hasNext() {
+          return currentRowIterator.hasNext();
+        }
+
+        @Override
+        public HiveRow next() {
+          return currentRowIterator.next();
+        }
+
+        @Override
+        public void close() throws IOException {
+          currentRowIterator.close();
+        }
+      };
+    }
+
+    @Override
+    public void close() throws IOException {
+      currentRowIterator.close();
+    }
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -221,11 +221,13 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       if (MetastoreUtil.hive3PresentOnClasspath()) {
         HIVE_VECTORIZED_READER_BUILDER = DynMethods.builder("reader")
             .impl(HIVE_VECTORIZED_READER_CLASS,
+                Table.class,
                 Path.class,
                 FileScanTask.class,
                 Map.class,
                 TaskAttemptContext.class,
-                Expression.class)
+                Expression.class,
+                Schema.class)
             .buildStatic();
       } else {
         HIVE_VECTORIZED_READER_BUILDER = null;
@@ -326,8 +328,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       Expression residual = HiveIcebergInputFormat.residualForTask(task, context.getConfiguration());
 
       // TODO: We have to take care of the EncryptionManager when LLAP and vectorization is used
-      CloseableIterable<T> iterator = HIVE_VECTORIZED_READER_BUILDER.invoke(path, task,
-          idToConstant, context, residual);
+      CloseableIterable<T> iterator = HIVE_VECTORIZED_READER_BUILDER.invoke(table, path, task,
+          idToConstant, context, residual, readSchema);
 
       return applyResidualFiltering(iterator, residual, readSchema);
     }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -638,7 +638,7 @@ public abstract class TestTables {
     }
   }
 
-  enum TestTableType {
+  public enum TestTableType {
     HADOOP_TABLE {
       @Override
       public TestTables instance(Configuration conf, TemporaryFolder temporaryFolder, String catalogName) {

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_orc.q.out
@@ -90,6 +90,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
         Map 6 
             Map Operator Tree:
                 TableScan
@@ -202,6 +203,7 @@ STAGE PLANS:
                           Statistics: Num rows: 4 Data size: 644 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col4 (type: bigint)
         Reducer 3 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
@@ -216,6 +218,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 4 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
@@ -230,6 +233,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 5 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
                 aggregations: count(VALUE._col0)

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_partitioned_orc.q.out
@@ -92,6 +92,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: int)
+            Execution mode: vectorized
         Map 8 
             Map Operator Tree:
                 TableScan
@@ -202,6 +203,7 @@ STAGE PLANS:
                           Statistics: Num rows: 4 Data size: 644 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col4 (type: bigint)
         Reducer 3 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
@@ -216,6 +218,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 4 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: bigint), KEY.reducesinkkey2 (type: string), KEY.reducesinkkey3 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int)
@@ -230,6 +233,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 5 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int), KEY.iceberg_bucket(_col0, 16) (type: int), KEY._col1 (type: string)
@@ -244,6 +248,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 6 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: int), KEY.iceberg_bucket(_col0, 16) (type: int), KEY._col1 (type: string)
@@ -258,6 +263,7 @@ STAGE PLANS:
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
         Reducer 7 
+            Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
                 aggregations: count(VALUE._col0)


### PR DESCRIPTION
Implement a DeleteFilter that changes an Iterable of VectorizedRowBatches in a way that whenever a new batch is seen in the next() method, we iterate its rows and apply the original Iceberg DeleteFilter on it. In VRBs we can utilize the selected array to mark rows as selected (not deleted), so essentially we're going to implement the markRowDeleted method.