### PR TITLE
HIVE-26723: Configurable canonical name checking.

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -99,6 +99,7 @@ public class Utils {
     public static final String AUTH_PASSWD = "password";
     public static final String AUTH_KERBEROS_AUTH_TYPE = "kerberosAuthType";
     public static final String AUTH_KERBEROS_AUTH_TYPE_FROM_SUBJECT = "fromSubject";
+    public static final String AUTH_KERBEROS_ENABLE_CANONICAL_HOSTNAME_CHECK = "kerberosEnableCanonicalHostnameCheck";
     public static final String AUTH_TYPE_JWT = "jwt";
     public static final String AUTH_TYPE_JWT_KEY = "jwt";
     public static final String AUTH_JWT_ENV = "JWT";


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hive JDBC client validates the host name by its canonical name by default. This behaviour leads to `SSLHandshakeExcpetion` when trying to connect using alias name with Kerberos authentication. To solve this issue a new connection property is introduced to be able disabling canonical host name check: `enableCanonicalHostnameCheck` having default value `true`.

When the property is not given in connection string (or its value is true) then the original behaviour is applied i.e. checking canonical host name.


### Why are the changes needed?

It is not possible to create SSL connection with Kerberos authentication when the server certificate is not issued to the canonical host name but to an alternative domain name.

See details about the exception and steps for reproducing in the [JIRA#26723](https://issues.apache.org/jira/browse/HIVE-26723)

### Does this PR introduce _any_ user-facing change?

A new JDBC connection URL property has been introduced: `enableCanonicalHostnameCheck` to be able to turn off the canonical host name checking. Its default value is `true` so if it is not set the canonical host name is checked when building up the SSL connection.

To turn off the canonical host name checking just add this property to the connection string, i.e:
```bash
./beeline -u "jdbc:hive2://hs2.subdomain.example.com:443/default;transportMode=http;httpPath=cliservice;socketTimeout=60;ssl=true;retries=1;principal=myhiveprincipal/mydomain.example.com;enableCanonicalHostnameCheck=false;"
```
 
### How was this patch tested?

There are no new unit tests because the fix is in the `HiveConnection` constructor which contains lot of logic inside and also builds new SSL connections. 
IMO it would have been far too much effort to mock the whole environment for creating unit tests against this tiny change. :(

There wasn't any already existing test against `HiveConnection` that could be extended with this new feature/bugfix. It is misleading that there is a class having name `TestHiveConnection` but there is no any tests that would test the class `HiveConnection` itself.

BTW It was tested manually: after this fix when the steps in JIRA are executed again using the new JARs then the SSL connection is created successfully, and I was able to execute queries.
 
