### PR TITLE
HIVE-26524: Use Calcite to remove sections of a query plan known never produces rows - ADDENDUM

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveValues.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveValues.java
@@ -32,7 +32,7 @@ import java.util.List;
  * Subclass of {@link org.apache.calcite.rel.core.Values}.
  * Specialized to Hive engine.
  */
-public class HiveValues extends Values {
+public class HiveValues extends Values implements HiveRelNode {
 
   public HiveValues(RelOptCluster cluster, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples,
                     RelTraitSet traits) {
@@ -42,5 +42,9 @@ public class HiveValues extends Values {
   @Override
   public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
     return new HiveValues(getCluster(), getRowType(), tuples, getTraitSet());
+  }
+
+  @Override
+  public void implement(Implementor implementor) {
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing `HiveRelNode` interface implementation to `HiveValues`

### Why are the changes needed?
All Hive operators must implement it to ensure Hive calling convetion.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing ptests.