### PR TITLE
Hive-26731: Truncate UDF returns incorrect output for higher values

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
@@ -63,16 +63,15 @@ import org.apache.hive.common.util.DateParser;
 
 /**
  * GenericUDFTrunc.
- *
+ * <p>
  * Returns the first day of the month which the date belongs to. The time part of the date will be
  * ignored.
- *
  */
 @Description(name = "trunc", value = "_FUNC_(date, fmt) / _FUNC_(N,D) - Returns If input is date returns date with the time portion of the day truncated "
-    + "to the unit specified by the format model fmt. If you omit fmt, then date is truncated to "
-    + "the nearest day. It currently only supports 'MONTH'/'MON'/'MM', 'QUARTER'/'Q' and 'YEAR'/'YYYY'/'YY' as format."
-    + "If input is a number group returns N truncated to D decimal places. If D is omitted, then N is truncated to 0 places."
-    + "D can be negative to truncate (make zero) D digits left of the decimal point.", extended = "date is a string in the format 'yyyy-MM-dd HH:mm:ss' or 'yyyy-MM-dd'."
+        + "to the unit specified by the format model fmt. If you omit fmt, then date is truncated to "
+        + "the nearest day. It currently only supports 'MONTH'/'MON'/'MM', 'QUARTER'/'Q' and 'YEAR'/'YYYY'/'YY' as format."
+        + "If input is a number group returns N truncated to D decimal places. If D is omitted, then N is truncated to 0 places."
+        + "D can be negative to truncate (make zero) D digits left of the decimal point.", extended = "date is a string in the format 'yyyy-MM-dd HH:mm:ss' or 'yyyy-MM-dd'."
         + " The time part of date is ignored.\n" + "Example:\n "
         + " > SELECT _FUNC_('2009-02-12', 'MM');\n" + "OK\n" + " '2009-02-01'" + "\n"
         + " > SELECT _FUNC_('2017-03-15', 'Q');\n" + "OK\n" + " '2017-01-01'" + "\n"
@@ -81,417 +80,434 @@ import org.apache.hive.common.util.DateParser;
         + " > SELECT _FUNC_(1234567891.1234567891,-4);\n" + "OK\n" + " 1234560000"
         + " > SELECT _FUNC_(1234567891.1234567891,0);\n" + "OK\n" + " 1234567891" + "\n"
         + " > SELECT _FUNC_(1234567891.1234567891);\n" + "OK\n" + " 1234567891")
-@VectorizedExpressions({ TruncDateFromTimestamp.class, TruncDateFromString.class,
-    TruncDateFromDate.class, TruncFloat.class, TruncFloatNoScale.class, TruncDecimal.class, TruncDecimalNoScale.class})
+@VectorizedExpressions({TruncDateFromTimestamp.class, TruncDateFromString.class,
+        TruncDateFromDate.class, TruncFloat.class, TruncFloatNoScale.class, TruncDecimal.class, TruncDecimalNoScale.class})
 public class GenericUDFTrunc extends GenericUDF {
 
-  private transient TimestampConverter timestampConverter;
-  private transient Converter textConverter1;
-  private transient Converter textConverter2;
-  private transient Converter dateWritableConverter;
-  private transient Converter byteConverter;
-  private transient Converter shortConverter;
-  private transient Converter intConverter;
-  private transient Converter longConverter;
-  private transient PrimitiveCategory inputType1;
-  private transient PrimitiveCategory inputType2;
-  private final Date date = new Date();
-  private final Text output = new Text();
-  private transient String fmtInput;
-  private transient PrimitiveObjectInspector inputOI;
-  private transient PrimitiveObjectInspector inputScaleOI;
-  private int scale = 0;
-  private boolean inputSacleConst;
-  private boolean dateTypeArg;
+    private transient TimestampConverter timestampConverter;
+    private transient Converter textConverter1;
+    private transient Converter textConverter2;
+    private transient Converter dateWritableConverter;
+    private transient Converter byteConverter;
+    private transient Converter shortConverter;
+    private transient Converter intConverter;
+    private transient Converter longConverter;
+    private transient PrimitiveCategory inputType1;
+    private transient PrimitiveCategory inputType2;
+    private final Date date = new Date();
+    private final Text output = new Text();
+    private transient String fmtInput;
+    private transient PrimitiveObjectInspector inputOI;
+    private transient PrimitiveObjectInspector inputScaleOI;
+    private int scale = 0;
+    private boolean inputSacleConst;
+    private boolean dateTypeArg;
 
-  @Override
-  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
-    if (arguments.length == 2) {
-      inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-      inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
-      if ((PrimitiveObjectInspectorUtils
-          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.DATE_GROUP
-          || PrimitiveObjectInspectorUtils
-              .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.STRING_GROUP)
-          && PrimitiveObjectInspectorUtils
-              .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.STRING_GROUP) {
-        dateTypeArg = true;
-        return initializeDate(arguments);
-      } else if (PrimitiveObjectInspectorUtils
-          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP
-          && PrimitiveObjectInspectorUtils
-              .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.NUMERIC_GROUP) {
-        dateTypeArg = false;
-        return initializeNumber(arguments);
-      }
-      throw new UDFArgumentException("Got wrong argument types : first argument type : "
-          + arguments[0].getTypeName() + ", second argument type : " + arguments[1].getTypeName());
-    } else if (arguments.length == 1) {
-      inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-      if (PrimitiveObjectInspectorUtils
-          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP) {
-        dateTypeArg = false;
-        return initializeNumber(arguments);
-      } else {
-        throw new UDFArgumentException(
-            "Only primitive type arguments are accepted, when arguments length is one, got "
-                + arguments[0].getTypeName());
-      }
-    }
-    throw new UDFArgumentException("TRUNC requires one or two argument, got " + arguments.length);
-  }
-
-  private ObjectInspector initializeNumber(ObjectInspector[] arguments)
-      throws UDFArgumentException {
-    if (arguments.length < 1 || arguments.length > 2) {
-      throw new UDFArgumentLengthException(
-          "TRUNC requires one or two argument, got " + arguments.length);
-    }
-
-    if (arguments[0].getCategory() != Category.PRIMITIVE) {
-      throw new UDFArgumentTypeException(0,
-          "TRUNC input only takes primitive types, got " + arguments[0].getTypeName());
-    }
-    inputOI = (PrimitiveObjectInspector) arguments[0];
-
-    if (arguments.length == 2) {
-      if (arguments[1].getCategory() != Category.PRIMITIVE) {
-        throw new UDFArgumentTypeException(1,
-            "TRUNC second argument only takes primitive types, got " + arguments[1].getTypeName());
-      }
-
-      inputScaleOI = (PrimitiveObjectInspector) arguments[1];
-      inputSacleConst = arguments[1] instanceof ConstantObjectInspector;
-      if (inputSacleConst) {
-        try {
-          Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
-          fmtInput = obj != null ? obj.toString() : null;
-          scale = Integer.parseInt(fmtInput);
-        } catch (Exception e) {
-          throw new UDFArgumentException("TRUNC input only takes integer values, got " + fmtInput);
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+        if (arguments.length == 2) {
+            inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+            inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
+            if ((PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.DATE_GROUP
+                    || PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.STRING_GROUP)
+                    && PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.STRING_GROUP) {
+                dateTypeArg = true;
+                return initializeDate(arguments);
+            } else if (PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP
+                    && PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.NUMERIC_GROUP) {
+                dateTypeArg = false;
+                return initializeNumber(arguments);
+            }
+            throw new UDFArgumentException("Got wrong argument types : first argument type : "
+                    + arguments[0].getTypeName() + ", second argument type : " + arguments[1].getTypeName());
+        } else if (arguments.length == 1) {
+            inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+            if (PrimitiveObjectInspectorUtils
+                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP) {
+                dateTypeArg = false;
+                return initializeNumber(arguments);
+            } else {
+                throw new UDFArgumentException(
+                        "Only primitive type arguments are accepted, when arguments length is one, got "
+                                + arguments[0].getTypeName());
+            }
         }
-      } else {
-        switch (inputScaleOI.getPrimitiveCategory()) {
-        case BYTE:
-          byteConverter = ObjectInspectorConverters.getConverter(arguments[1],
-              PrimitiveObjectInspectorFactory.writableByteObjectInspector);
-          break;
-        case SHORT:
-          shortConverter = ObjectInspectorConverters.getConverter(arguments[1],
-              PrimitiveObjectInspectorFactory.writableShortObjectInspector);
-          break;
-        case INT:
-          intConverter = ObjectInspectorConverters.getConverter(arguments[1],
-              PrimitiveObjectInspectorFactory.writableIntObjectInspector);
-          break;
-        case LONG:
-          longConverter = ObjectInspectorConverters.getConverter(arguments[1],
-              PrimitiveObjectInspectorFactory.writableLongObjectInspector);
-          break;
-        default:
-          throw new UDFArgumentTypeException(1,
-              getFuncName().toUpperCase() + " second argument only takes integer values");
+        throw new UDFArgumentException("TRUNC requires one or two argument, got " + arguments.length);
+    }
+
+    private ObjectInspector initializeNumber(ObjectInspector[] arguments)
+            throws UDFArgumentException {
+        if (arguments.length < 1 || arguments.length > 2) {
+            throw new UDFArgumentLengthException(
+                    "TRUNC requires one or two argument, got " + arguments.length);
         }
-      }
-    }
 
-    inputType1 = inputOI.getPrimitiveCategory();
-    ObjectInspector outputOI = null;
-    switch (inputType1) {
-    case DECIMAL:
-      int outputScale = scale > 0 ? scale : 0;
-      int outputPrecision = ((PrimitiveObjectInspector) arguments[0]).precision() - ((PrimitiveObjectInspector) arguments[0]).scale() + outputScale;
-      DecimalTypeInfo t = new DecimalTypeInfo(outputPrecision, outputScale);
-      outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(t);
-      break;
-    case VOID:
-    case BYTE:
-    case SHORT:
-    case INT:
-    case LONG:
-    case FLOAT:
-    case DOUBLE:
-      outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(inputType1);
-      break;
-    default:
-      throw new UDFArgumentTypeException(0,
-          "Only numeric or string group data types are allowed for TRUNC function. Got "
-              + inputType1.name());
-    }
-
-    return outputOI;
-  }
-
-  private ObjectInspector initializeDate(ObjectInspector[] arguments)
-      throws UDFArgumentLengthException, UDFArgumentTypeException {
-    if (arguments.length != 2) {
-      throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
-    }
-
-    if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
-      throw new UDFArgumentTypeException(0, "Only primitive type arguments are accepted but "
-          + arguments[0].getTypeName() + " is passed. as first arguments");
-    }
-
-    if (arguments[1].getCategory() != ObjectInspector.Category.PRIMITIVE) {
-      throw new UDFArgumentTypeException(1, "Only primitive type arguments are accepted but "
-          + arguments[1].getTypeName() + " is passed. as second arguments");
-    }
-
-    ObjectInspector outputOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
-    inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-    switch (inputType1) {
-    case STRING:
-    case VARCHAR:
-    case CHAR:
-    case VOID:
-      inputType1 = PrimitiveCategory.STRING;
-      textConverter1 = ObjectInspectorConverters.getConverter(arguments[0],
-          PrimitiveObjectInspectorFactory.writableStringObjectInspector);
-      break;
-    case TIMESTAMP:
-      timestampConverter = new TimestampConverter((PrimitiveObjectInspector) arguments[0],
-          PrimitiveObjectInspectorFactory.writableTimestampObjectInspector);
-      break;
-    case DATE:
-      dateWritableConverter = ObjectInspectorConverters.getConverter(arguments[0],
-          PrimitiveObjectInspectorFactory.writableDateObjectInspector);
-      break;
-    default:
-      throw new UDFArgumentTypeException(0,
-          "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types as first argument, got "
-              + inputType1);
-    }
-
-    inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
-    if (PrimitiveObjectInspectorUtils
-        .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.STRING_GROUP
-        && PrimitiveObjectInspectorUtils
-            .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.VOID_GROUP) {
-      throw new UDFArgumentTypeException(1,
-          "trunc() only takes STRING/CHAR/VARCHAR types as second argument, got " + inputType2);
-    }
-
-    inputType2 = PrimitiveCategory.STRING;
-
-    if (arguments[1] instanceof ConstantObjectInspector) {
-      Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
-      fmtInput = obj != null ? obj.toString() : null;
-    } else {
-      textConverter2 = ObjectInspectorConverters.getConverter(arguments[1],
-          PrimitiveObjectInspectorFactory.writableStringObjectInspector);
-    }
-    return outputOI;
-  }
-
-  @Override
-  public Object evaluate(DeferredObject[] arguments) throws HiveException {
-    if (dateTypeArg) {
-      return evaluateDate(arguments);
-    } else {
-      return evaluateNumber(arguments);
-    }
-  }
-
-  private Object evaluateDate(DeferredObject[] arguments) throws UDFArgumentLengthException,
-      HiveException, UDFArgumentTypeException, UDFArgumentException {
-    if (arguments.length != 2) {
-      throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
-    }
-
-    if (arguments[0].get() == null || arguments[1].get() == null) {
-      return null;
-    }
-
-    if (textConverter2 != null) {
-      fmtInput = textConverter2.convert(arguments[1].get()).toString();
-    }
-
-    Date d;
-    switch (inputType1) {
-    case STRING:
-      String dateString = textConverter1.convert(arguments[0].get()).toString();
-      d = DateParser.parseDate(dateString);
-      if (d == null) {
-        return null;
-      }
-      break;
-    case TIMESTAMP:
-      Timestamp ts =
-          ((TimestampWritableV2) timestampConverter.convert(arguments[0].get())).getTimestamp();
-      d = Date.ofEpochMilli(ts.toEpochMilli());
-      break;
-    case DATE:
-      DateWritableV2 dw = (DateWritableV2) dateWritableConverter.convert(arguments[0].get());
-      d = dw.get();
-      break;
-    default:
-      throw new UDFArgumentTypeException(0,
-          "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types, got " + inputType1);
-    }
-
-    if (evalDate(d) == null) {
-      return null;
-    }
-
-    output.set(date.toString());
-    return output;
-  }
-
-  private Object evaluateNumber(DeferredObject[] arguments)
-      throws HiveException, UDFArgumentTypeException {
-
-    if (arguments[0] == null) {
-      return null;
-    }
-
-    Object input = arguments[0].get();
-    if (input == null) {
-      return null;
-    }
-
-    if (arguments.length == 2 && arguments[1] != null && arguments[1].get() != null
-        && !inputSacleConst) {
-      Object scaleObj = null;
-      switch (inputScaleOI.getPrimitiveCategory()) {
-      case BYTE:
-        scaleObj = byteConverter.convert(arguments[1].get());
-        scale = ((ByteWritable) scaleObj).get();
-        break;
-      case SHORT:
-        scaleObj = shortConverter.convert(arguments[1].get());
-        scale = ((ShortWritable) scaleObj).get();
-        break;
-      case INT:
-        scaleObj = intConverter.convert(arguments[1].get());
-        scale = ((IntWritable) scaleObj).get();
-        break;
-      case LONG:
-        scaleObj = longConverter.convert(arguments[1].get());
-        long l = ((LongWritable) scaleObj).get();
-        if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
-          throw new UDFArgumentException(
-              getFuncName().toUpperCase() + " scale argument out of allowed range");
+        if (arguments[0].getCategory() != Category.PRIMITIVE) {
+            throw new UDFArgumentTypeException(0,
+                    "TRUNC input only takes primitive types, got " + arguments[0].getTypeName());
         }
-        scale = (int) l;
-      default:
-        break;
-      }
+        inputOI = (PrimitiveObjectInspector) arguments[0];
+
+        if (arguments.length == 2) {
+            if (arguments[1].getCategory() != Category.PRIMITIVE) {
+                throw new UDFArgumentTypeException(1,
+                        "TRUNC second argument only takes primitive types, got " + arguments[1].getTypeName());
+            }
+
+            inputScaleOI = (PrimitiveObjectInspector) arguments[1];
+            inputSacleConst = arguments[1] instanceof ConstantObjectInspector;
+            if (inputSacleConst) {
+                try {
+                    Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
+                    fmtInput = obj != null ? obj.toString() : null;
+                    scale = Integer.parseInt(fmtInput);
+                } catch (Exception e) {
+                    throw new UDFArgumentException("TRUNC input only takes integer values, got " + fmtInput);
+                }
+            } else {
+                switch (inputScaleOI.getPrimitiveCategory()) {
+                    case BYTE:
+                        byteConverter = ObjectInspectorConverters.getConverter(arguments[1],
+                                PrimitiveObjectInspectorFactory.writableByteObjectInspector);
+                        break;
+                    case SHORT:
+                        shortConverter = ObjectInspectorConverters.getConverter(arguments[1],
+                                PrimitiveObjectInspectorFactory.writableShortObjectInspector);
+                        break;
+                    case INT:
+                        intConverter = ObjectInspectorConverters.getConverter(arguments[1],
+                                PrimitiveObjectInspectorFactory.writableIntObjectInspector);
+                        break;
+                    case LONG:
+                        longConverter = ObjectInspectorConverters.getConverter(arguments[1],
+                                PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+                        break;
+                    default:
+                        throw new UDFArgumentTypeException(1,
+                                getFuncName().toUpperCase() + " second argument only takes integer values");
+                }
+            }
+        }
+
+        inputType1 = inputOI.getPrimitiveCategory();
+        ObjectInspector outputOI = null;
+        switch (inputType1) {
+            case DECIMAL:
+                int outputScale = scale > 0 ? scale : 0;
+                int outputPrecision = ((PrimitiveObjectInspector) arguments[0]).precision() - ((PrimitiveObjectInspector) arguments[0]).scale() + outputScale;
+                DecimalTypeInfo t = new DecimalTypeInfo(outputPrecision, outputScale);
+                outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(t);
+                break;
+            case VOID:
+            case BYTE:
+            case SHORT:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(inputType1);
+                break;
+            default:
+                throw new UDFArgumentTypeException(0,
+                        "Only numeric or string group data types are allowed for TRUNC function. Got "
+                                + inputType1.name());
+        }
+
+        return outputOI;
     }
 
-    switch (inputType1) {
-    case VOID:
-      return null;
-    case DECIMAL:
-      HiveDecimalWritable decimalWritable =
-          (HiveDecimalWritable) inputOI.getPrimitiveWritableObject(input);
-      HiveDecimal dec = trunc(decimalWritable.getHiveDecimal(), scale);
-      if (dec == null) {
-        return null;
-      }
-      return new HiveDecimalWritable(dec);
-    case BYTE:
-      ByteWritable byteWritable = (ByteWritable) inputOI.getPrimitiveWritableObject(input);
-      if (scale >= 0) {
-        return byteWritable;
-      } else {
-        return new ByteWritable((byte) trunc(byteWritable.get(), scale));
-      }
-    case SHORT:
-      ShortWritable shortWritable = (ShortWritable) inputOI.getPrimitiveWritableObject(input);
-      if (scale >= 0) {
-        return shortWritable;
-      } else {
-        return new ShortWritable((short) trunc(shortWritable.get(), scale));
-      }
-    case INT:
-      IntWritable intWritable = (IntWritable) inputOI.getPrimitiveWritableObject(input);
-      if (scale >= 0) {
-        return intWritable;
-      } else {
-        return new IntWritable((int) trunc(intWritable.get(), scale));
-      }
-    case LONG:
-      LongWritable longWritable = (LongWritable) inputOI.getPrimitiveWritableObject(input);
-      if (scale >= 0) {
-        return longWritable;
-      } else {
-        return new LongWritable(trunc(longWritable.get(), scale));
-      }
-    case FLOAT:
-      float f = ((FloatWritable) inputOI.getPrimitiveWritableObject(input)).get();
-      return new FloatWritable((float) trunc(f, scale));
-    case DOUBLE:
-      return trunc(((DoubleWritable) inputOI.getPrimitiveWritableObject(input)), scale);
-    default:
-      throw new UDFArgumentTypeException(0,
-          "Only numeric or string group data types are allowed for TRUNC function. Got "
-              + inputType1.name());
+    private ObjectInspector initializeDate(ObjectInspector[] arguments)
+            throws UDFArgumentLengthException, UDFArgumentTypeException {
+        if (arguments.length != 2) {
+            throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
+        }
+
+        if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
+            throw new UDFArgumentTypeException(0, "Only primitive type arguments are accepted but "
+                    + arguments[0].getTypeName() + " is passed. as first arguments");
+        }
+
+        if (arguments[1].getCategory() != ObjectInspector.Category.PRIMITIVE) {
+            throw new UDFArgumentTypeException(1, "Only primitive type arguments are accepted but "
+                    + arguments[1].getTypeName() + " is passed. as second arguments");
+        }
+
+        ObjectInspector outputOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+        inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+        switch (inputType1) {
+            case STRING:
+            case VARCHAR:
+            case CHAR:
+            case VOID:
+                inputType1 = PrimitiveCategory.STRING;
+                textConverter1 = ObjectInspectorConverters.getConverter(arguments[0],
+                        PrimitiveObjectInspectorFactory.writableStringObjectInspector);
+                break;
+            case TIMESTAMP:
+                timestampConverter = new TimestampConverter((PrimitiveObjectInspector) arguments[0],
+                        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector);
+                break;
+            case DATE:
+                dateWritableConverter = ObjectInspectorConverters.getConverter(arguments[0],
+                        PrimitiveObjectInspectorFactory.writableDateObjectInspector);
+                break;
+            default:
+                throw new UDFArgumentTypeException(0,
+                        "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types as first argument, got "
+                                + inputType1);
+        }
+
+        inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
+        if (PrimitiveObjectInspectorUtils
+                .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.STRING_GROUP
+                && PrimitiveObjectInspectorUtils
+                .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.VOID_GROUP) {
+            throw new UDFArgumentTypeException(1,
+                    "trunc() only takes STRING/CHAR/VARCHAR types as second argument, got " + inputType2);
+        }
+
+        inputType2 = PrimitiveCategory.STRING;
+
+        if (arguments[1] instanceof ConstantObjectInspector) {
+            Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
+            fmtInput = obj != null ? obj.toString() : null;
+        } else {
+            textConverter2 = ObjectInspectorConverters.getConverter(arguments[1],
+                    PrimitiveObjectInspectorFactory.writableStringObjectInspector);
+        }
+        return outputOI;
     }
-  }
 
-  @Override
-  public String getDisplayString(String[] children) {
-    return getStandardDisplayString("trunc", children);
-  }
-
-  private Date evalDate(Date d) throws UDFArgumentException {
-    date.setTimeInDays(d.toEpochDay());
-    if ("MONTH".equals(fmtInput) || "MON".equals(fmtInput) || "MM".equals(fmtInput)) {
-      date.setDayOfMonth(1);
-      return date;
-    } else if ("QUARTER".equals(fmtInput) || "Q".equals(fmtInput)) {
-      int month = date.getMonth() - 1;
-      int quarter = month / 3;
-      int monthToSet = quarter * 3 + 1;
-      date.setMonth(monthToSet);
-      date.setDayOfMonth(1);
-      return date;
-    } else if ("YEAR".equals(fmtInput) || "YYYY".equals(fmtInput) || "YY".equals(fmtInput)) {
-      date.setMonth(1);
-      date.setDayOfMonth(1);
-      return date;
-    } else {
-      return null;
+    @Override
+    public Object evaluate(DeferredObject[] arguments) throws HiveException {
+        if (dateTypeArg) {
+            return evaluateDate(arguments);
+        } else {
+            return evaluateNumber(arguments);
+        }
     }
-  }
 
-  protected HiveDecimal trunc(HiveDecimal input, int scale) {
-    BigDecimal bigDecimal = trunc(input.bigDecimalValue(), scale);
-    return HiveDecimal.create(bigDecimal);
-  }
+    private Object evaluateDate(DeferredObject[] arguments) throws UDFArgumentLengthException,
+            HiveException, UDFArgumentTypeException, UDFArgumentException {
+        if (arguments.length != 2) {
+            throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
+        }
 
-  protected long trunc(long input, int scale) {
-    return trunc(BigDecimal.valueOf(input), scale).longValue();
-  }
+        if (arguments[0].get() == null || arguments[1].get() == null) {
+            return null;
+        }
 
-  protected double trunc(double input, int scale) {
-    return trunc(BigDecimal.valueOf(input), scale).doubleValue();
-  }
+        if (textConverter2 != null) {
+            fmtInput = textConverter2.convert(arguments[1].get()).toString();
+        }
 
-  protected DoubleWritable trunc(DoubleWritable input, int scale) {
-    BigDecimal bigDecimal = new BigDecimal(input.get());
-    BigDecimal trunc = trunc(bigDecimal, scale);
-    DoubleWritable doubleWritable = new DoubleWritable(trunc.doubleValue());
-    return doubleWritable;
-  }
+        Date d;
+        switch (inputType1) {
+            case STRING:
+                String dateString = textConverter1.convert(arguments[0].get()).toString();
+                d = DateParser.parseDate(dateString);
+                if (d == null) {
+                    return null;
+                }
+                break;
+            case TIMESTAMP:
+                Timestamp ts =
+                        ((TimestampWritableV2) timestampConverter.convert(arguments[0].get())).getTimestamp();
+                d = Date.ofEpochMilli(ts.toEpochMilli());
+                break;
+            case DATE:
+                DateWritableV2 dw = (DateWritableV2) dateWritableConverter.convert(arguments[0].get());
+                d = dw.get();
+                break;
+            default:
+                throw new UDFArgumentTypeException(0,
+                        "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types, got " + inputType1);
+        }
 
-  protected BigDecimal trunc(BigDecimal input, int scale) {
-    BigDecimal output = new BigDecimal(0);
-    BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.abs(scale)));
-    if (scale >= 0) {
-      pow = BigDecimal.valueOf(Math.pow(10, scale));
-      if (scale != 0) {
-        long longValue = input.multiply(pow).longValue();
-        output = BigDecimal.valueOf(longValue).divide(pow);
-      } else {
-        output = BigDecimal.valueOf(input.longValue());
-      }
-    } else {
-      long longValue2 = input.divide(pow).longValue();
-      output = BigDecimal.valueOf(longValue2).multiply(pow);
+        if (evalDate(d) == null) {
+            return null;
+        }
+
+        output.set(date.toString());
+        return output;
     }
-    return output;
-  }
+
+    private Object evaluateNumber(DeferredObject[] arguments)
+            throws HiveException, UDFArgumentTypeException {
+
+        if (arguments[0] == null) {
+            return null;
+        }
+
+        Object input = arguments[0].get();
+        if (input == null) {
+            return null;
+        }
+
+        if (arguments.length == 2 && arguments[1] != null && arguments[1].get() != null
+                && !inputSacleConst) {
+            Object scaleObj = null;
+            switch (inputScaleOI.getPrimitiveCategory()) {
+                case BYTE:
+                    scaleObj = byteConverter.convert(arguments[1].get());
+                    scale = ((ByteWritable) scaleObj).get();
+                    break;
+                case SHORT:
+                    scaleObj = shortConverter.convert(arguments[1].get());
+                    scale = ((ShortWritable) scaleObj).get();
+                    break;
+                case INT:
+                    scaleObj = intConverter.convert(arguments[1].get());
+                    scale = ((IntWritable) scaleObj).get();
+                    break;
+                case LONG:
+                    scaleObj = longConverter.convert(arguments[1].get());
+                    long l = ((LongWritable) scaleObj).get();
+                    if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
+                        throw new UDFArgumentException(
+                                getFuncName().toUpperCase() + " scale argument out of allowed range");
+                    }
+                    scale = (int) l;
+                default:
+                    break;
+            }
+        }
+
+        switch (inputType1) {
+            case VOID:
+                return null;
+            case DECIMAL:
+                HiveDecimalWritable decimalWritable =
+                        (HiveDecimalWritable) inputOI.getPrimitiveWritableObject(input);
+                HiveDecimal dec = trunc(decimalWritable.getHiveDecimal(), scale);
+                if (dec == null) {
+                    return null;
+                }
+                return new HiveDecimalWritable(dec);
+            case BYTE:
+                ByteWritable byteWritable = (ByteWritable) inputOI.getPrimitiveWritableObject(input);
+                if (scale >= 0) {
+                    return byteWritable;
+                } else {
+                    return new ByteWritable((byte) trunc(byteWritable.get(), scale));
+                }
+            case SHORT:
+                ShortWritable shortWritable = (ShortWritable) inputOI.getPrimitiveWritableObject(input);
+                if (scale >= 0) {
+                    return shortWritable;
+                } else {
+                    return new ShortWritable((short) trunc(shortWritable.get(), scale));
+                }
+            case INT:
+                IntWritable intWritable = (IntWritable) inputOI.getPrimitiveWritableObject(input);
+                if (scale >= 0) {
+                    return intWritable;
+                } else {
+                    return new IntWritable((int) trunc(intWritable.get(), scale));
+                }
+            case LONG:
+                LongWritable longWritable = (LongWritable) inputOI.getPrimitiveWritableObject(input);
+                if (scale >= 0) {
+                    return longWritable;
+                } else {
+                    return new LongWritable(trunc(longWritable.get(), scale));
+                }
+            case FLOAT:
+                float f = ((FloatWritable) inputOI.getPrimitiveWritableObject(input)).get();
+                return new FloatWritable((float) trunc(f, scale));
+            case DOUBLE:
+                return trunc(((DoubleWritable) inputOI.getPrimitiveWritableObject(input)), scale);
+            default:
+                throw new UDFArgumentTypeException(0,
+                        "Only numeric or string group data types are allowed for TRUNC function. Got "
+                                + inputType1.name());
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return getStandardDisplayString("trunc", children);
+    }
+
+    private Date evalDate(Date d) throws UDFArgumentException {
+        date.setTimeInDays(d.toEpochDay());
+        if ("MONTH".equals(fmtInput) || "MON".equals(fmtInput) || "MM".equals(fmtInput)) {
+            date.setDayOfMonth(1);
+            return date;
+        } else if ("QUARTER".equals(fmtInput) || "Q".equals(fmtInput)) {
+            int month = date.getMonth() - 1;
+            int quarter = month / 3;
+            int monthToSet = quarter * 3 + 1;
+            date.setMonth(monthToSet);
+            date.setDayOfMonth(1);
+            return date;
+        } else if ("YEAR".equals(fmtInput) || "YYYY".equals(fmtInput) || "YY".equals(fmtInput)) {
+            date.setMonth(1);
+            date.setDayOfMonth(1);
+            return date;
+        } else {
+            return null;
+        }
+    }
+
+    protected HiveDecimal trunc(HiveDecimal input, int scale) {
+        BigDecimal bigDecimal = trunc(input.bigDecimalValue(), scale);
+        return HiveDecimal.create(bigDecimal);
+    }
+
+    protected long trunc(long input, int scale) {
+        return trunc(BigDecimal.valueOf(input), scale).longValue();
+    }
+
+    protected double trunc(double input, int scale) {
+        return trunc(BigDecimal.valueOf(input), scale).doubleValue();
+    }
+
+    protected DoubleWritable trunc(DoubleWritable input, int scale) {
+        BigDecimal bigDecimal = new BigDecimal(input.get());
+        BigDecimal trunc = trunc(bigDecimal, scale);
+        DoubleWritable doubleWritable = new DoubleWritable(trunc.doubleValue());
+        return doubleWritable;
+    }
+
+    protected BigDecimal trunc(BigDecimal input, int scale) {
+        if (input.scale() < scale) {
+            return input;
+        } else {
+            BigDecimal intPart = new BigDecimal(input.toBigInteger());
+            BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.abs(scale)));
+            if (scale > 0) {
+                // scale is +ve , truncate only the decimal part by value of position
+                pow = BigDecimal.valueOf(Math.pow(10, scale));
+                BigDecimal decimalPart = input.remainder(BigDecimal.ONE);
+                // To avoid overflow while multiplication, extract decimal part first,
+                // truncate it and then add it to whole part
+                // eg: input 123.456, scale 2, result 123.45
+                if (BigDecimal.ZERO.compareTo(decimalPart) == 0) {
+                    return intPart;
+                } else {
+                    BigDecimal newRemainder = new BigDecimal(decimalPart.multiply(pow).toBigInteger());
+                    return intPart.add(newRemainder.divide(pow));
+                }
+            } else if (scale == 0) {
+                // position is 0, extract whole part
+                // eg: input 123.456, scale 0, result 123
+                return intPart;
+            } else {
+                // position is -ve, truncate the whole part by absolute value of position
+                // eg: input 123.456, scale -2, result 100
+                if (BigDecimal.ZERO.compareTo(intPart) == 0) {
+                    return intPart;
+                } else {
+                    return BigDecimal.valueOf(input.divide(pow).longValue()).multiply(pow);
+                }
+            }
+        }
+    }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
@@ -63,9 +63,10 @@ import org.apache.hive.common.util.DateParser;
 
 /**
  * GenericUDFTrunc.
- * <p>
+ *
  * Returns the first day of the month which the date belongs to. The time part of the date will be
  * ignored.
+ *
  */
 @Description(name = "trunc", value = "_FUNC_(date, fmt) / _FUNC_(N,D) - Returns If input is date returns date with the time portion of the day truncated "
         + "to the unit specified by the format model fmt. If you omit fmt, then date is truncated to "
@@ -80,7 +81,7 @@ import org.apache.hive.common.util.DateParser;
         + " > SELECT _FUNC_(1234567891.1234567891,-4);\n" + "OK\n" + " 1234560000"
         + " > SELECT _FUNC_(1234567891.1234567891,0);\n" + "OK\n" + " 1234567891" + "\n"
         + " > SELECT _FUNC_(1234567891.1234567891);\n" + "OK\n" + " 1234567891")
-@VectorizedExpressions({TruncDateFromTimestamp.class, TruncDateFromString.class,
+@VectorizedExpressions({ TruncDateFromTimestamp.class, TruncDateFromString.class,
         TruncDateFromDate.class, TruncFloat.class, TruncFloatNoScale.class, TruncDecimal.class, TruncDecimalNoScale.class})
 public class GenericUDFTrunc extends GenericUDF {
 
@@ -509,5 +510,7 @@ public class GenericUDFTrunc extends GenericUDF {
             }
         }
     }
+
+
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
@@ -69,10 +69,10 @@ import org.apache.hive.common.util.DateParser;
  *
  */
 @Description(name = "trunc", value = "_FUNC_(date, fmt) / _FUNC_(N,D) - Returns If input is date returns date with the time portion of the day truncated "
-        + "to the unit specified by the format model fmt. If you omit fmt, then date is truncated to "
-        + "the nearest day. It currently only supports 'MONTH'/'MON'/'MM', 'QUARTER'/'Q' and 'YEAR'/'YYYY'/'YY' as format."
-        + "If input is a number group returns N truncated to D decimal places. If D is omitted, then N is truncated to 0 places."
-        + "D can be negative to truncate (make zero) D digits left of the decimal point.", extended = "date is a string in the format 'yyyy-MM-dd HH:mm:ss' or 'yyyy-MM-dd'."
+    + "to the unit specified by the format model fmt. If you omit fmt, then date is truncated to "
+    + "the nearest day. It currently only supports 'MONTH'/'MON'/'MM', 'QUARTER'/'Q' and 'YEAR'/'YYYY'/'YY' as format."
+    + "If input is a number group returns N truncated to D decimal places. If D is omitted, then N is truncated to 0 places."
+    + "D can be negative to truncate (make zero) D digits left of the decimal point.", extended = "date is a string in the format 'yyyy-MM-dd HH:mm:ss' or 'yyyy-MM-dd'."
         + " The time part of date is ignored.\n" + "Example:\n "
         + " > SELECT _FUNC_('2009-02-12', 'MM');\n" + "OK\n" + " '2009-02-01'" + "\n"
         + " > SELECT _FUNC_('2017-03-15', 'Q');\n" + "OK\n" + " '2017-01-01'" + "\n"
@@ -82,407 +82,407 @@ import org.apache.hive.common.util.DateParser;
         + " > SELECT _FUNC_(1234567891.1234567891,0);\n" + "OK\n" + " 1234567891" + "\n"
         + " > SELECT _FUNC_(1234567891.1234567891);\n" + "OK\n" + " 1234567891")
 @VectorizedExpressions({ TruncDateFromTimestamp.class, TruncDateFromString.class,
-        TruncDateFromDate.class, TruncFloat.class, TruncFloatNoScale.class, TruncDecimal.class, TruncDecimalNoScale.class})
+    TruncDateFromDate.class, TruncFloat.class, TruncFloatNoScale.class, TruncDecimal.class, TruncDecimalNoScale.class})
 public class GenericUDFTrunc extends GenericUDF {
 
-    private transient TimestampConverter timestampConverter;
-    private transient Converter textConverter1;
-    private transient Converter textConverter2;
-    private transient Converter dateWritableConverter;
-    private transient Converter byteConverter;
-    private transient Converter shortConverter;
-    private transient Converter intConverter;
-    private transient Converter longConverter;
-    private transient PrimitiveCategory inputType1;
-    private transient PrimitiveCategory inputType2;
-    private final Date date = new Date();
-    private final Text output = new Text();
-    private transient String fmtInput;
-    private transient PrimitiveObjectInspector inputOI;
-    private transient PrimitiveObjectInspector inputScaleOI;
-    private int scale = 0;
-    private boolean inputSacleConst;
-    private boolean dateTypeArg;
+  private transient TimestampConverter timestampConverter;
+  private transient Converter textConverter1;
+  private transient Converter textConverter2;
+  private transient Converter dateWritableConverter;
+  private transient Converter byteConverter;
+  private transient Converter shortConverter;
+  private transient Converter intConverter;
+  private transient Converter longConverter;
+  private transient PrimitiveCategory inputType1;
+  private transient PrimitiveCategory inputType2;
+  private final Date date = new Date();
+  private final Text output = new Text();
+  private transient String fmtInput;
+  private transient PrimitiveObjectInspector inputOI;
+  private transient PrimitiveObjectInspector inputScaleOI;
+  private int scale = 0;
+  private boolean inputSacleConst;
+  private boolean dateTypeArg;
 
-    @Override
-    public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
-        if (arguments.length == 2) {
-            inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-            inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
-            if ((PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.DATE_GROUP
-                    || PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.STRING_GROUP)
-                    && PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.STRING_GROUP) {
-                dateTypeArg = true;
-                return initializeDate(arguments);
-            } else if (PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP
-                    && PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.NUMERIC_GROUP) {
-                dateTypeArg = false;
-                return initializeNumber(arguments);
-            }
-            throw new UDFArgumentException("Got wrong argument types : first argument type : "
-                    + arguments[0].getTypeName() + ", second argument type : " + arguments[1].getTypeName());
-        } else if (arguments.length == 1) {
-            inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-            if (PrimitiveObjectInspectorUtils
-                    .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP) {
-                dateTypeArg = false;
-                return initializeNumber(arguments);
-            } else {
-                throw new UDFArgumentException(
-                        "Only primitive type arguments are accepted, when arguments length is one, got "
-                                + arguments[0].getTypeName());
-            }
-        }
-        throw new UDFArgumentException("TRUNC requires one or two argument, got " + arguments.length);
+  @Override
+  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+    if (arguments.length == 2) {
+      inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+      inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
+      if ((PrimitiveObjectInspectorUtils
+          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.DATE_GROUP
+          || PrimitiveObjectInspectorUtils
+              .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.STRING_GROUP)
+          && PrimitiveObjectInspectorUtils
+              .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.STRING_GROUP) {
+        dateTypeArg = true;
+        return initializeDate(arguments);
+      } else if (PrimitiveObjectInspectorUtils
+          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP
+          && PrimitiveObjectInspectorUtils
+              .getPrimitiveGrouping(inputType2) == PrimitiveGrouping.NUMERIC_GROUP) {
+        dateTypeArg = false;
+        return initializeNumber(arguments);
+      }
+      throw new UDFArgumentException("Got wrong argument types : first argument type : "
+          + arguments[0].getTypeName() + ", second argument type : " + arguments[1].getTypeName());
+    } else if (arguments.length == 1) {
+      inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+      if (PrimitiveObjectInspectorUtils
+          .getPrimitiveGrouping(inputType1) == PrimitiveGrouping.NUMERIC_GROUP) {
+        dateTypeArg = false;
+        return initializeNumber(arguments);
+      } else {
+        throw new UDFArgumentException(
+            "Only primitive type arguments are accepted, when arguments length is one, got "
+                + arguments[0].getTypeName());
+      }
+    }
+    throw new UDFArgumentException("TRUNC requires one or two argument, got " + arguments.length);
+  }
+
+  private ObjectInspector initializeNumber(ObjectInspector[] arguments)
+      throws UDFArgumentException {
+    if (arguments.length < 1 || arguments.length > 2) {
+      throw new UDFArgumentLengthException(
+          "TRUNC requires one or two argument, got " + arguments.length);
     }
 
-    private ObjectInspector initializeNumber(ObjectInspector[] arguments)
-            throws UDFArgumentException {
-        if (arguments.length < 1 || arguments.length > 2) {
-            throw new UDFArgumentLengthException(
-                    "TRUNC requires one or two argument, got " + arguments.length);
+    if (arguments[0].getCategory() != Category.PRIMITIVE) {
+      throw new UDFArgumentTypeException(0,
+          "TRUNC input only takes primitive types, got " + arguments[0].getTypeName());
+    }
+    inputOI = (PrimitiveObjectInspector) arguments[0];
+
+    if (arguments.length == 2) {
+      if (arguments[1].getCategory() != Category.PRIMITIVE) {
+        throw new UDFArgumentTypeException(1,
+            "TRUNC second argument only takes primitive types, got " + arguments[1].getTypeName());
+      }
+
+      inputScaleOI = (PrimitiveObjectInspector) arguments[1];
+      inputSacleConst = arguments[1] instanceof ConstantObjectInspector;
+      if (inputSacleConst) {
+        try {
+          Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
+          fmtInput = obj != null ? obj.toString() : null;
+          scale = Integer.parseInt(fmtInput);
+        } catch (Exception e) {
+          throw new UDFArgumentException("TRUNC input only takes integer values, got " + fmtInput);
         }
-
-        if (arguments[0].getCategory() != Category.PRIMITIVE) {
-            throw new UDFArgumentTypeException(0,
-                    "TRUNC input only takes primitive types, got " + arguments[0].getTypeName());
+      } else {
+        switch (inputScaleOI.getPrimitiveCategory()) {
+        case BYTE:
+          byteConverter = ObjectInspectorConverters.getConverter(arguments[1],
+              PrimitiveObjectInspectorFactory.writableByteObjectInspector);
+          break;
+        case SHORT:
+          shortConverter = ObjectInspectorConverters.getConverter(arguments[1],
+              PrimitiveObjectInspectorFactory.writableShortObjectInspector);
+          break;
+        case INT:
+          intConverter = ObjectInspectorConverters.getConverter(arguments[1],
+              PrimitiveObjectInspectorFactory.writableIntObjectInspector);
+          break;
+        case LONG:
+          longConverter = ObjectInspectorConverters.getConverter(arguments[1],
+              PrimitiveObjectInspectorFactory.writableLongObjectInspector);
+          break;
+        default:
+          throw new UDFArgumentTypeException(1,
+              getFuncName().toUpperCase() + " second argument only takes integer values");
         }
-        inputOI = (PrimitiveObjectInspector) arguments[0];
-
-        if (arguments.length == 2) {
-            if (arguments[1].getCategory() != Category.PRIMITIVE) {
-                throw new UDFArgumentTypeException(1,
-                        "TRUNC second argument only takes primitive types, got " + arguments[1].getTypeName());
-            }
-
-            inputScaleOI = (PrimitiveObjectInspector) arguments[1];
-            inputSacleConst = arguments[1] instanceof ConstantObjectInspector;
-            if (inputSacleConst) {
-                try {
-                    Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
-                    fmtInput = obj != null ? obj.toString() : null;
-                    scale = Integer.parseInt(fmtInput);
-                } catch (Exception e) {
-                    throw new UDFArgumentException("TRUNC input only takes integer values, got " + fmtInput);
-                }
-            } else {
-                switch (inputScaleOI.getPrimitiveCategory()) {
-                    case BYTE:
-                        byteConverter = ObjectInspectorConverters.getConverter(arguments[1],
-                                PrimitiveObjectInspectorFactory.writableByteObjectInspector);
-                        break;
-                    case SHORT:
-                        shortConverter = ObjectInspectorConverters.getConverter(arguments[1],
-                                PrimitiveObjectInspectorFactory.writableShortObjectInspector);
-                        break;
-                    case INT:
-                        intConverter = ObjectInspectorConverters.getConverter(arguments[1],
-                                PrimitiveObjectInspectorFactory.writableIntObjectInspector);
-                        break;
-                    case LONG:
-                        longConverter = ObjectInspectorConverters.getConverter(arguments[1],
-                                PrimitiveObjectInspectorFactory.writableLongObjectInspector);
-                        break;
-                    default:
-                        throw new UDFArgumentTypeException(1,
-                                getFuncName().toUpperCase() + " second argument only takes integer values");
-                }
-            }
-        }
-
-        inputType1 = inputOI.getPrimitiveCategory();
-        ObjectInspector outputOI = null;
-        switch (inputType1) {
-            case DECIMAL:
-                int outputScale = scale > 0 ? scale : 0;
-                int outputPrecision = ((PrimitiveObjectInspector) arguments[0]).precision() - ((PrimitiveObjectInspector) arguments[0]).scale() + outputScale;
-                DecimalTypeInfo t = new DecimalTypeInfo(outputPrecision, outputScale);
-                outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(t);
-                break;
-            case VOID:
-            case BYTE:
-            case SHORT:
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-                outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(inputType1);
-                break;
-            default:
-                throw new UDFArgumentTypeException(0,
-                        "Only numeric or string group data types are allowed for TRUNC function. Got "
-                                + inputType1.name());
-        }
-
-        return outputOI;
+      }
     }
 
-    private ObjectInspector initializeDate(ObjectInspector[] arguments)
-            throws UDFArgumentLengthException, UDFArgumentTypeException {
-        if (arguments.length != 2) {
-            throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
-        }
-
-        if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
-            throw new UDFArgumentTypeException(0, "Only primitive type arguments are accepted but "
-                    + arguments[0].getTypeName() + " is passed. as first arguments");
-        }
-
-        if (arguments[1].getCategory() != ObjectInspector.Category.PRIMITIVE) {
-            throw new UDFArgumentTypeException(1, "Only primitive type arguments are accepted but "
-                    + arguments[1].getTypeName() + " is passed. as second arguments");
-        }
-
-        ObjectInspector outputOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
-        inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
-        switch (inputType1) {
-            case STRING:
-            case VARCHAR:
-            case CHAR:
-            case VOID:
-                inputType1 = PrimitiveCategory.STRING;
-                textConverter1 = ObjectInspectorConverters.getConverter(arguments[0],
-                        PrimitiveObjectInspectorFactory.writableStringObjectInspector);
-                break;
-            case TIMESTAMP:
-                timestampConverter = new TimestampConverter((PrimitiveObjectInspector) arguments[0],
-                        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector);
-                break;
-            case DATE:
-                dateWritableConverter = ObjectInspectorConverters.getConverter(arguments[0],
-                        PrimitiveObjectInspectorFactory.writableDateObjectInspector);
-                break;
-            default:
-                throw new UDFArgumentTypeException(0,
-                        "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types as first argument, got "
-                                + inputType1);
-        }
-
-        inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
-        if (PrimitiveObjectInspectorUtils
-                .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.STRING_GROUP
-                && PrimitiveObjectInspectorUtils
-                .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.VOID_GROUP) {
-            throw new UDFArgumentTypeException(1,
-                    "trunc() only takes STRING/CHAR/VARCHAR types as second argument, got " + inputType2);
-        }
-
-        inputType2 = PrimitiveCategory.STRING;
-
-        if (arguments[1] instanceof ConstantObjectInspector) {
-            Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
-            fmtInput = obj != null ? obj.toString() : null;
-        } else {
-            textConverter2 = ObjectInspectorConverters.getConverter(arguments[1],
-                    PrimitiveObjectInspectorFactory.writableStringObjectInspector);
-        }
-        return outputOI;
+    inputType1 = inputOI.getPrimitiveCategory();
+    ObjectInspector outputOI = null;
+    switch (inputType1) {
+    case DECIMAL:
+      int outputScale = scale > 0 ? scale : 0;
+      int outputPrecision = ((PrimitiveObjectInspector) arguments[0]).precision() - ((PrimitiveObjectInspector) arguments[0]).scale() + outputScale;
+      DecimalTypeInfo t = new DecimalTypeInfo(outputPrecision, outputScale);
+      outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(t);
+      break;
+    case VOID:
+    case BYTE:
+    case SHORT:
+    case INT:
+    case LONG:
+    case FLOAT:
+    case DOUBLE:
+      outputOI = PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(inputType1);
+      break;
+    default:
+      throw new UDFArgumentTypeException(0,
+          "Only numeric or string group data types are allowed for TRUNC function. Got "
+              + inputType1.name());
     }
 
-    @Override
-    public Object evaluate(DeferredObject[] arguments) throws HiveException {
-        if (dateTypeArg) {
-            return evaluateDate(arguments);
-        } else {
-            return evaluateNumber(arguments);
-        }
+    return outputOI;
+  }
+
+  private ObjectInspector initializeDate(ObjectInspector[] arguments)
+      throws UDFArgumentLengthException, UDFArgumentTypeException {
+    if (arguments.length != 2) {
+      throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
     }
 
-    private Object evaluateDate(DeferredObject[] arguments) throws UDFArgumentLengthException,
-            HiveException, UDFArgumentTypeException, UDFArgumentException {
-        if (arguments.length != 2) {
-            throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
-        }
-
-        if (arguments[0].get() == null || arguments[1].get() == null) {
-            return null;
-        }
-
-        if (textConverter2 != null) {
-            fmtInput = textConverter2.convert(arguments[1].get()).toString();
-        }
-
-        Date d;
-        switch (inputType1) {
-            case STRING:
-                String dateString = textConverter1.convert(arguments[0].get()).toString();
-                d = DateParser.parseDate(dateString);
-                if (d == null) {
-                    return null;
-                }
-                break;
-            case TIMESTAMP:
-                Timestamp ts =
-                        ((TimestampWritableV2) timestampConverter.convert(arguments[0].get())).getTimestamp();
-                d = Date.ofEpochMilli(ts.toEpochMilli());
-                break;
-            case DATE:
-                DateWritableV2 dw = (DateWritableV2) dateWritableConverter.convert(arguments[0].get());
-                d = dw.get();
-                break;
-            default:
-                throw new UDFArgumentTypeException(0,
-                        "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types, got " + inputType1);
-        }
-
-        if (evalDate(d) == null) {
-            return null;
-        }
-
-        output.set(date.toString());
-        return output;
+    if (arguments[0].getCategory() != ObjectInspector.Category.PRIMITIVE) {
+      throw new UDFArgumentTypeException(0, "Only primitive type arguments are accepted but "
+          + arguments[0].getTypeName() + " is passed. as first arguments");
     }
 
-    private Object evaluateNumber(DeferredObject[] arguments)
-            throws HiveException, UDFArgumentTypeException {
+    if (arguments[1].getCategory() != ObjectInspector.Category.PRIMITIVE) {
+      throw new UDFArgumentTypeException(1, "Only primitive type arguments are accepted but "
+          + arguments[1].getTypeName() + " is passed. as second arguments");
+    }
 
-        if (arguments[0] == null) {
-            return null;
+    ObjectInspector outputOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+    inputType1 = ((PrimitiveObjectInspector) arguments[0]).getPrimitiveCategory();
+    switch (inputType1) {
+    case STRING:
+    case VARCHAR:
+    case CHAR:
+    case VOID:
+      inputType1 = PrimitiveCategory.STRING;
+      textConverter1 = ObjectInspectorConverters.getConverter(arguments[0],
+          PrimitiveObjectInspectorFactory.writableStringObjectInspector);
+      break;
+    case TIMESTAMP:
+      timestampConverter = new TimestampConverter((PrimitiveObjectInspector) arguments[0],
+          PrimitiveObjectInspectorFactory.writableTimestampObjectInspector);
+      break;
+    case DATE:
+      dateWritableConverter = ObjectInspectorConverters.getConverter(arguments[0],
+          PrimitiveObjectInspectorFactory.writableDateObjectInspector);
+      break;
+    default:
+      throw new UDFArgumentTypeException(0,
+          "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types as first argument, got "
+              + inputType1);
+    }
+
+    inputType2 = ((PrimitiveObjectInspector) arguments[1]).getPrimitiveCategory();
+    if (PrimitiveObjectInspectorUtils
+        .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.STRING_GROUP
+        && PrimitiveObjectInspectorUtils
+            .getPrimitiveGrouping(inputType2) != PrimitiveGrouping.VOID_GROUP) {
+      throw new UDFArgumentTypeException(1,
+          "trunc() only takes STRING/CHAR/VARCHAR types as second argument, got " + inputType2);
+    }
+
+    inputType2 = PrimitiveCategory.STRING;
+
+    if (arguments[1] instanceof ConstantObjectInspector) {
+      Object obj = ((ConstantObjectInspector) arguments[1]).getWritableConstantValue();
+      fmtInput = obj != null ? obj.toString() : null;
+    } else {
+      textConverter2 = ObjectInspectorConverters.getConverter(arguments[1],
+          PrimitiveObjectInspectorFactory.writableStringObjectInspector);
+    }
+    return outputOI;
+  }
+
+  @Override
+  public Object evaluate(DeferredObject[] arguments) throws HiveException {
+    if (dateTypeArg) {
+      return evaluateDate(arguments);
+    } else {
+      return evaluateNumber(arguments);
+    }
+  }
+
+  private Object evaluateDate(DeferredObject[] arguments) throws UDFArgumentLengthException,
+      HiveException, UDFArgumentTypeException, UDFArgumentException {
+    if (arguments.length != 2) {
+      throw new UDFArgumentLengthException("trunc() requires 2 argument, got " + arguments.length);
+    }
+
+    if (arguments[0].get() == null || arguments[1].get() == null) {
+      return null;
+    }
+
+    if (textConverter2 != null) {
+      fmtInput = textConverter2.convert(arguments[1].get()).toString();
+    }
+
+    Date d;
+    switch (inputType1) {
+    case STRING:
+      String dateString = textConverter1.convert(arguments[0].get()).toString();
+      d = DateParser.parseDate(dateString);
+      if (d == null) {
+        return null;
+      }
+      break;
+    case TIMESTAMP:
+      Timestamp ts =
+          ((TimestampWritableV2) timestampConverter.convert(arguments[0].get())).getTimestamp();
+      d = Date.ofEpochMilli(ts.toEpochMilli());
+      break;
+    case DATE:
+      DateWritableV2 dw = (DateWritableV2) dateWritableConverter.convert(arguments[0].get());
+      d = dw.get();
+      break;
+    default:
+      throw new UDFArgumentTypeException(0,
+          "TRUNC() only takes STRING/TIMESTAMP/DATEWRITABLE types, got " + inputType1);
+    }
+
+    if (evalDate(d) == null) {
+      return null;
+    }
+
+    output.set(date.toString());
+    return output;
+  }
+
+  private Object evaluateNumber(DeferredObject[] arguments)
+      throws HiveException, UDFArgumentTypeException {
+
+    if (arguments[0] == null) {
+      return null;
+    }
+
+    Object input = arguments[0].get();
+    if (input == null) {
+      return null;
+    }
+
+    if (arguments.length == 2 && arguments[1] != null && arguments[1].get() != null
+        && !inputSacleConst) {
+      Object scaleObj = null;
+      switch (inputScaleOI.getPrimitiveCategory()) {
+      case BYTE:
+        scaleObj = byteConverter.convert(arguments[1].get());
+        scale = ((ByteWritable) scaleObj).get();
+        break;
+      case SHORT:
+        scaleObj = shortConverter.convert(arguments[1].get());
+        scale = ((ShortWritable) scaleObj).get();
+        break;
+      case INT:
+        scaleObj = intConverter.convert(arguments[1].get());
+        scale = ((IntWritable) scaleObj).get();
+        break;
+      case LONG:
+        scaleObj = longConverter.convert(arguments[1].get());
+        long l = ((LongWritable) scaleObj).get();
+        if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
+          throw new UDFArgumentException(
+              getFuncName().toUpperCase() + " scale argument out of allowed range");
         }
-
-        Object input = arguments[0].get();
-        if (input == null) {
-            return null;
-        }
-
-        if (arguments.length == 2 && arguments[1] != null && arguments[1].get() != null
-                && !inputSacleConst) {
-            Object scaleObj = null;
-            switch (inputScaleOI.getPrimitiveCategory()) {
-                case BYTE:
-                    scaleObj = byteConverter.convert(arguments[1].get());
-                    scale = ((ByteWritable) scaleObj).get();
-                    break;
-                case SHORT:
-                    scaleObj = shortConverter.convert(arguments[1].get());
-                    scale = ((ShortWritable) scaleObj).get();
-                    break;
-                case INT:
-                    scaleObj = intConverter.convert(arguments[1].get());
-                    scale = ((IntWritable) scaleObj).get();
-                    break;
-                case LONG:
-                    scaleObj = longConverter.convert(arguments[1].get());
-                    long l = ((LongWritable) scaleObj).get();
-                    if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
-                        throw new UDFArgumentException(
-                                getFuncName().toUpperCase() + " scale argument out of allowed range");
-                    }
-                    scale = (int) l;
-                default:
-                    break;
-            }
-        }
-
-        switch (inputType1) {
-            case VOID:
-                return null;
-            case DECIMAL:
-                HiveDecimalWritable decimalWritable =
-                        (HiveDecimalWritable) inputOI.getPrimitiveWritableObject(input);
-                HiveDecimal dec = trunc(decimalWritable.getHiveDecimal(), scale);
-                if (dec == null) {
-                    return null;
-                }
-                return new HiveDecimalWritable(dec);
-            case BYTE:
-                ByteWritable byteWritable = (ByteWritable) inputOI.getPrimitiveWritableObject(input);
-                if (scale >= 0) {
-                    return byteWritable;
-                } else {
-                    return new ByteWritable((byte) trunc(byteWritable.get(), scale));
-                }
-            case SHORT:
-                ShortWritable shortWritable = (ShortWritable) inputOI.getPrimitiveWritableObject(input);
-                if (scale >= 0) {
-                    return shortWritable;
-                } else {
-                    return new ShortWritable((short) trunc(shortWritable.get(), scale));
-                }
-            case INT:
-                IntWritable intWritable = (IntWritable) inputOI.getPrimitiveWritableObject(input);
-                if (scale >= 0) {
-                    return intWritable;
-                } else {
-                    return new IntWritable((int) trunc(intWritable.get(), scale));
-                }
-            case LONG:
-                LongWritable longWritable = (LongWritable) inputOI.getPrimitiveWritableObject(input);
-                if (scale >= 0) {
-                    return longWritable;
-                } else {
-                    return new LongWritable(trunc(longWritable.get(), scale));
-                }
-            case FLOAT:
-                float f = ((FloatWritable) inputOI.getPrimitiveWritableObject(input)).get();
-                return new FloatWritable((float) trunc(f, scale));
-            case DOUBLE:
-                return trunc(((DoubleWritable) inputOI.getPrimitiveWritableObject(input)), scale);
-            default:
-                throw new UDFArgumentTypeException(0,
-                        "Only numeric or string group data types are allowed for TRUNC function. Got "
-                                + inputType1.name());
-        }
+        scale = (int) l;
+      default:
+        break;
+      }
     }
 
-    @Override
-    public String getDisplayString(String[] children) {
-        return getStandardDisplayString("trunc", children);
+    switch (inputType1) {
+    case VOID:
+      return null;
+    case DECIMAL:
+      HiveDecimalWritable decimalWritable =
+          (HiveDecimalWritable) inputOI.getPrimitiveWritableObject(input);
+      HiveDecimal dec = trunc(decimalWritable.getHiveDecimal(), scale);
+      if (dec == null) {
+        return null;
+      }
+      return new HiveDecimalWritable(dec);
+    case BYTE:
+      ByteWritable byteWritable = (ByteWritable) inputOI.getPrimitiveWritableObject(input);
+      if (scale >= 0) {
+        return byteWritable;
+      } else {
+        return new ByteWritable((byte) trunc(byteWritable.get(), scale));
+      }
+    case SHORT:
+      ShortWritable shortWritable = (ShortWritable) inputOI.getPrimitiveWritableObject(input);
+      if (scale >= 0) {
+        return shortWritable;
+      } else {
+        return new ShortWritable((short) trunc(shortWritable.get(), scale));
+      }
+    case INT:
+      IntWritable intWritable = (IntWritable) inputOI.getPrimitiveWritableObject(input);
+      if (scale >= 0) {
+        return intWritable;
+      } else {
+        return new IntWritable((int) trunc(intWritable.get(), scale));
+      }
+    case LONG:
+      LongWritable longWritable = (LongWritable) inputOI.getPrimitiveWritableObject(input);
+      if (scale >= 0) {
+        return longWritable;
+      } else {
+        return new LongWritable(trunc(longWritable.get(), scale));
+      }
+    case FLOAT:
+      float f = ((FloatWritable) inputOI.getPrimitiveWritableObject(input)).get();
+      return new FloatWritable((float) trunc(f, scale));
+    case DOUBLE:
+      return trunc(((DoubleWritable) inputOI.getPrimitiveWritableObject(input)), scale);
+    default:
+      throw new UDFArgumentTypeException(0,
+          "Only numeric or string group data types are allowed for TRUNC function. Got "
+              + inputType1.name());
     }
+  }
 
-    private Date evalDate(Date d) throws UDFArgumentException {
-        date.setTimeInDays(d.toEpochDay());
-        if ("MONTH".equals(fmtInput) || "MON".equals(fmtInput) || "MM".equals(fmtInput)) {
-            date.setDayOfMonth(1);
-            return date;
-        } else if ("QUARTER".equals(fmtInput) || "Q".equals(fmtInput)) {
-            int month = date.getMonth() - 1;
-            int quarter = month / 3;
-            int monthToSet = quarter * 3 + 1;
-            date.setMonth(monthToSet);
-            date.setDayOfMonth(1);
-            return date;
-        } else if ("YEAR".equals(fmtInput) || "YYYY".equals(fmtInput) || "YY".equals(fmtInput)) {
-            date.setMonth(1);
-            date.setDayOfMonth(1);
-            return date;
-        } else {
-            return null;
-        }
+  @Override
+  public String getDisplayString(String[] children) {
+    return getStandardDisplayString("trunc", children);
+  }
+
+  private Date evalDate(Date d) throws UDFArgumentException {
+    date.setTimeInDays(d.toEpochDay());
+    if ("MONTH".equals(fmtInput) || "MON".equals(fmtInput) || "MM".equals(fmtInput)) {
+      date.setDayOfMonth(1);
+      return date;
+    } else if ("QUARTER".equals(fmtInput) || "Q".equals(fmtInput)) {
+      int month = date.getMonth() - 1;
+      int quarter = month / 3;
+      int monthToSet = quarter * 3 + 1;
+      date.setMonth(monthToSet);
+      date.setDayOfMonth(1);
+      return date;
+    } else if ("YEAR".equals(fmtInput) || "YYYY".equals(fmtInput) || "YY".equals(fmtInput)) {
+      date.setMonth(1);
+      date.setDayOfMonth(1);
+      return date;
+    } else {
+      return null;
     }
+  }
 
-    protected HiveDecimal trunc(HiveDecimal input, int scale) {
-        BigDecimal bigDecimal = trunc(input.bigDecimalValue(), scale);
-        return HiveDecimal.create(bigDecimal);
-    }
+  protected HiveDecimal trunc(HiveDecimal input, int scale) {
+    BigDecimal bigDecimal = trunc(input.bigDecimalValue(), scale);
+    return HiveDecimal.create(bigDecimal);
+  }
 
-    protected long trunc(long input, int scale) {
-        return trunc(BigDecimal.valueOf(input), scale).longValue();
-    }
+  protected long trunc(long input, int scale) {
+    return trunc(BigDecimal.valueOf(input), scale).longValue();
+  }
 
-    protected double trunc(double input, int scale) {
-        return trunc(BigDecimal.valueOf(input), scale).doubleValue();
-    }
+  protected double trunc(double input, int scale) {
+    return trunc(BigDecimal.valueOf(input), scale).doubleValue();
+  }
 
-    protected DoubleWritable trunc(DoubleWritable input, int scale) {
-        BigDecimal bigDecimal = new BigDecimal(input.get());
-        BigDecimal trunc = trunc(bigDecimal, scale);
-        DoubleWritable doubleWritable = new DoubleWritable(trunc.doubleValue());
-        return doubleWritable;
-    }
+  protected DoubleWritable trunc(DoubleWritable input, int scale) {
+    BigDecimal bigDecimal = new BigDecimal(input.get());
+    BigDecimal trunc = trunc(bigDecimal, scale);
+    DoubleWritable doubleWritable = new DoubleWritable(trunc.doubleValue());
+    return doubleWritable;
+  }
 
-    protected BigDecimal trunc(BigDecimal input, int scale) {
-        if (input.scale() < scale) {
-            return input;
-        } else {
-            BigDecimal intPart = new BigDecimal(input.toBigInteger());
-            BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.abs(scale)));
-            if (scale > 0) {
+  protected BigDecimal trunc(BigDecimal input, int scale) {
+      if (input.scale() < scale) {
+          return input;
+      } else {
+          BigDecimal intPart = new BigDecimal(input.toBigInteger());
+          BigDecimal pow = BigDecimal.valueOf(Math.pow(10, Math.abs(scale)));
+          if (scale > 0) {
                 // scale is +ve , truncate only the decimal part by value of position
                 pow = BigDecimal.valueOf(Math.pow(10, scale));
                 BigDecimal decimalPart = input.remainder(BigDecimal.ONE);
@@ -495,11 +495,11 @@ public class GenericUDFTrunc extends GenericUDF {
                     BigDecimal newRemainder = new BigDecimal(decimalPart.multiply(pow).toBigInteger());
                     return intPart.add(newRemainder.divide(pow));
                 }
-            } else if (scale == 0) {
+          } else if (scale == 0) {
                 // position is 0, extract whole part
                 // eg: input 123.456, scale 0, result 123
                 return intPart;
-            } else {
+          } else {
                 // position is -ve, truncate the whole part by absolute value of position
                 // eg: input 123.456, scale -2, result 100
                 if (BigDecimal.ZERO.compareTo(intPart) == 0) {
@@ -507,8 +507,8 @@ public class GenericUDFTrunc extends GenericUDF {
                 } else {
                     return BigDecimal.valueOf(input.divide(pow).longValue()).multiply(pow);
                 }
-            }
-        }
-    }
+          }
+      }
+  }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTrunc.java
@@ -511,6 +511,4 @@ public class GenericUDFTrunc extends GenericUDF {
         }
     }
 
-
-
 }

--- a/ql/src/test/queries/clientpositive/udf_trunc_number.q
+++ b/ql/src/test/queries/clientpositive/udf_trunc_number.q
@@ -72,3 +72,83 @@ DROP TABLE sampletable2;
 DROP TABLE sampletable3;
 
 DROP TABLE sampletable4;
+
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 8);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 7);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 6);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 5);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 4);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 3);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 2);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 1);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 0);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -1);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -2);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -3);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -4);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -5);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -6);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -7);
+select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -8);
+
+
+-- trunc double
+select trunc(CAST('123456789.123456789' AS DOUBLE), 8);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 7);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 6);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 5);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 4);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 3);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 2);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 1);
+select trunc(CAST('123456789.123456789' AS DOUBLE), 0);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -1);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -2);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -3);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -4);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -5);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -6);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -7);
+select trunc(CAST('123456789.123456789' AS DOUBLE), -8);
+
+-- trunc float
+select trunc(CAST('1234567.1' AS FLOAT), 1);
+select trunc(CAST('1234567.1' AS FLOAT), 0);
+select trunc(CAST('1234567.1' AS FLOAT));
+select trunc(CAST('1234567.1' AS FLOAT), -1);
+select trunc(CAST('1234567.1' AS FLOAT), -2);
+select trunc(CAST('1234567.1' AS FLOAT), -3);
+select trunc(CAST('1234567.1' AS FLOAT), -4);
+select trunc(CAST('1234567.1' AS FLOAT), -5);
+select trunc(CAST('1234567.1' AS FLOAT), -6);
+select trunc(CAST('1234567.1' AS FLOAT), -7);
+select trunc(CAST('1234567.1' AS FLOAT), -8);
+
+-- trunc longCAST('
+select trunc(CAST('123456789' AS BIGINT), 2);
+select trunc(CAST('123456789' AS BIGINT), 2);
+select trunc(CAST('123456789' AS BIGINT), 1);
+select trunc(CAST('123456789' AS BIGINT), 0);
+select trunc(CAST('123456789' AS BIGINT), -1);
+select trunc(CAST('123456789' AS BIGINT), -2);
+select trunc(CAST('123456789' AS BIGINT), -3);
+select trunc(CAST('123456789' AS BIGINT), -4);
+select trunc(CAST('123456789' AS BIGINT), -5);
+select trunc(CAST('123456789' AS BIGINT), -6);
+select trunc(CAST('123456789' AS BIGINT), -7);
+select trunc(CAST('123456789' AS BIGINT), -8);
+
+
+-- trunc Int
+select trunc(CAST('123456789' AS INT), 3);
+select trunc(CAST('123456789' AS INT), 2);
+select trunc(CAST('123456789' AS INT), 1);
+select trunc(CAST('123456789' AS INT), 0);
+select trunc(CAST('123456789' AS INT), -1);
+select trunc(CAST('123456789' AS INT), -2);
+select trunc(CAST('123456789' AS INT), -3);
+select trunc(CAST('123456789' AS INT), -4);
+select trunc(CAST('123456789' AS INT), -5);
+select trunc(CAST('123456789' AS INT), -6);
+select trunc(CAST('123456789' AS INT), -7);
+select trunc(CAST('123456789' AS INT), -8);

--- a/ql/src/test/results/clientpositive/llap/udf_trunc_number.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_trunc_number.q.out
@@ -369,3 +369,624 @@ POSTHOOK: query: DROP TABLE sampletable4
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@sampletable4
 POSTHOOK: Output: default@sampletable4
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.12345678
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.1234567
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.123456
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.12345
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.1234
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.123
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.12
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789.1
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456780
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456700
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123450000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123400000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123000000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+120000000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), -8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+100000000
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2345678912345679E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.234567891234567E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.23456789123456E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2345678912345E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.234567891234E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.23456789123E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2345678912E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.234567891E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.23456789E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2345678E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.234567E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.23456E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2345E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.234E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.23E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.2E8
+PREHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789.123456789' AS DOUBLE), -8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1.0E8
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234567.1
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234567.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234567.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234560.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234500.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1234000.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1230000.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1200000.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1000000.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+0.0
+PREHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('1234567.1' AS FLOAT), -8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+0.0
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456780
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456700
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456000
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123450000
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123400000
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123000000
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+120000000
+PREHOOK: query: select trunc(CAST('123456789' AS BIGINT), -8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS BIGINT), -8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+100000000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS INT), 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS INT), 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS INT), 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456789
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456780
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456700
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123456000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123450000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123400000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+123000000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+120000000
+PREHOOK: query: select trunc(CAST('123456789' AS INT), -8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select trunc(CAST('123456789' AS INT), -8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+100000000


### PR DESCRIPTION


### What changes were proposed in this pull request?

The truncate UDF returns incorrect output for higher values
Ex:
select trunc(CAST('123456789.123456789' AS DECIMAL(18,9)), 8);

input = 123456711889.122345897
pow = 10,00000000

result = input * pow = 12345671188912234589.7 <-- overflowing

New Logic 

input = 123456711889.122345897
IntegerPart = 123456711889
decimalPart = 122345897

decResult = decimalPart * pow = 12234589.7

newDecimal = decResult.longValue * pow / pow = 0.12234589

result = IntegerPart + newDecimal


### Why are the changes needed?

Fixing the UDF TRUNC


### Does this PR introduce _any_ user-facing change?
Yes, the output of the truncate udf changes.


### How was this patch tested?
With q files and manual tests.
