### PR TITLE
HIVE-26740: HS2 makes direct connections to HMS backend DB due to Compaction/StatsUpdater

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -74,7 +74,6 @@ public final class StatsUpdater {
             }
             sb.append(" compute statistics");
             LOG.info(ci + ": running '" + sb + "'");
-            statusUpdaterConf.setVar(HiveConf.ConfVars.METASTOREURIS, "");
             if (compactionQueueName != null && compactionQueueName.length() > 0) {
                 statusUpdaterConf.set(TezConfiguration.TEZ_QUEUE_NAME, compactionQueueName);
             }


### PR DESCRIPTION
HIVE-20172 solved an issue where HMS was running the compaction worker, and StatUpdater thus ran in the very same JVM causing kerberos issues while connecting to "itself". The fix was to update HMS URI setting to empty string. This way HMS wouldn't have to go around itself to connect to itself :)

But.. this is not correct anymore, as Hive doesn't support running the compaction worker on HMS side anymore, but only on HS2. So in any case this code part ends up executed in HS2, where an embedded HMS will be created due to this empty string URIs config, and eventually will open connections directly to HMS backend DB.

We need to remove this setting as it was fixing something that is not relevant anymore.
