### PR TITLE
HIVE-26745: HPL unable to handle Decimal or null values in hplsql mode

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Var.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Var.java
@@ -255,11 +255,11 @@ public class Var {
       cast(new Var(queryResult.column(idx, String.class)));
     } else if (type == java.sql.Types.INTEGER || type == java.sql.Types.BIGINT ||
             type == java.sql.Types.SMALLINT || type == java.sql.Types.TINYINT) {
-      cast(new Var(Long.valueOf(queryResult.column(idx, Long.class))));
+      cast(new Var(queryResult.column(idx, Long.class)));
     } else if (type == java.sql.Types.DECIMAL || type == java.sql.Types.NUMERIC) {
       cast(new Var(queryResult.column(idx, BigDecimal.class)));
     } else if (type == java.sql.Types.FLOAT || type == java.sql.Types.DOUBLE) {
-      cast(new Var(Double.valueOf(queryResult.column(idx, Double.class))));
+      cast(new Var(queryResult.column(idx, Double.class)));
     }
     return this;
   }

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
@@ -63,7 +63,7 @@ import org.junit.Test;
  *
  */
   public class TestBeeLineWithArgs {
-  private enum OutStream {
+  enum OutStream {
     ERR, OUT
   }
 
@@ -158,7 +158,7 @@ import org.junit.Test;
    * @return The stderr and stdout from running the script
    * @throws Throwable
    */
-  private static String testCommandLineScript(List<String> argList, InputStream inputStream,
+  static String testCommandLineScript(List<String> argList, InputStream inputStream,
       OutStream streamType)
       throws Throwable {
     BeeLine beeLine = new BeeLine();

--- a/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
@@ -138,7 +138,8 @@ public class HplSqlQueryExecutor implements QueryExecutor {
           if (type == Byte.class)
               return type.cast(((Number) current[columnIndex]).byteValue());
         }
-        // RowSet can never return BigDecimal or HiveDecimal instances, they'd get converted to String
+        // RowSet can never return the HiveDecimal instances created on Hive side, nor its BigDecimal representation.
+        // Instead, it gets converted into String object in ColumnBasedSet.addRow()...
         if (type == BigDecimal.class &&
             serdeConstants.DECIMAL_TYPE_NAME.equalsIgnoreCase(metadata(handle).columnTypeName(columnIndex))) {
           return (T) new BigDecimal((String) current[columnIndex]);

--- a/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlQueryExecutor.java
@@ -20,6 +20,7 @@
 
 package org.apache.hive.service.cli.operation.hplsql;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hive.hplsql.executor.ColumnMeta;
 import org.apache.hive.hplsql.executor.Metadata;
 import org.apache.hive.hplsql.executor.QueryException;
@@ -120,6 +122,9 @@ public class HplSqlQueryExecutor implements QueryExecutor {
 
     @Override
     public <T> T get(int columnIndex, Class<T> type) {
+      if (current[columnIndex] == null) {
+        return null;
+      }
       if (type.isInstance(current[columnIndex])) {
         return (T) current[columnIndex];
       } else {
@@ -132,6 +137,11 @@ public class HplSqlQueryExecutor implements QueryExecutor {
               return type.cast(((Number) current[columnIndex]).shortValue());
           if (type == Byte.class)
               return type.cast(((Number) current[columnIndex]).byteValue());
+        }
+        // RowSet can never return BigDecimal or HiveDecimal instances, they'd get converted to String
+        if (type == BigDecimal.class &&
+            serdeConstants.DECIMAL_TYPE_NAME.equalsIgnoreCase(metadata(handle).columnTypeName(columnIndex))) {
+          return (T) new BigDecimal((String) current[columnIndex]);
         }
         throw new ClassCastException(current[columnIndex].getClass() + " cannot be casted to " + type);
       }


### PR DESCRIPTION
Decimal or null values coming from Hive service side are not handled properly in HPL.

When we're using beeline in HPL mode then the results of queries such as SELECT CAST are returned in RowSet objects directly from HS2 code. This is due to HplSqlQueryExecutor expecting RowSet type in OperationRowResult. For this RowSet interface, a ColumnBasedSet class brings the imlementation which holds a ColumnBuffer list to hold the result data.

The internal representation however cannot hold BigDecimal values, as seen here: https://github.com/apache/hive/blob/master/serde/src/java/org/apache/hadoop/hive/serde2/thrift/ColumnBuffer.java#L396 so while the SELECT CAST query will produce a HiveBigDecimal instance, it will be converted to String at https://github.com/apache/hive/blob/master/service/src/java/org/apache/hive/service/cli/ColumnBasedSet.java#L110-L112 before we add this piece of data to the result set.

Further down the line we will see class java.lang.String cannot be casted to class java.math.BigDecimal.

ColumnBuffer seems like a pretty commonly used code and I don't think we would want to try and extend this with the ability the carry decimal types. Perhaps we could create a Jira to recreate the BigDecimal value from the String representation arriving on the HPL side.

Since the two issues are both about value conversion I'm aiming to fix these in one go.