### PR TITLE
HIVE-26756: Iceberg: Fetch format version from metadata file to avoid conflicts with spark.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -911,6 +911,14 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
   }
 
+  public void setTableProperties(org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+    if (hmsTable != null) {
+      Table tbl = Catalogs.loadTable(conf, getCatalogProperties(hmsTable));
+      String formatVersion = String.valueOf(((BaseTable) tbl).operations().current().formatVersion());
+      hmsTable.getParameters().put(TableProperties.FORMAT_VERSION, formatVersion);
+    }
+  }
+
   private class PreAlterTableProperties {
     private String tableLocation;
     private String format;

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -698,6 +698,23 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
+  public void testFormatVersion() throws IOException {
+    Assume.assumeTrue(testTableType != TestTables.TestTableType.HIVE_CATALOG);
+    TableIdentifier tbl = TableIdentifier.of("default", "customers");
+    // Create the Iceberg table
+    testTables.createIcebergTable(shell.getHiveConf(), "customers", COMPLEX_SCHEMA, FileFormat.PARQUET,
+        Collections.singletonMap("format-version", "2"), Collections.emptyList());
+
+    shell.executeStatement("CREATE EXTERNAL TABLE customers " + "STORED BY ICEBERG " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")) +
+        testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
+
+    String fmt = shell.executeAndStringify("show create table " + TableIdentifier.of("default", "customers"));
+
+    Assert.assertTrue(fmt, fmt.contains("'format-version'='2'"));
+  }
+
+  @Test
   public void testCreatePartitionedTableWithPropertiesAndWithColumnSpecification() {
     PartitionSpec spec =
         PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
@@ -177,4 +177,12 @@ public interface HiveMetaHook {
   default boolean createHMSTableInHook() {
     return false;
   }
+
+  /**
+   *  Set storage handler specific table properties
+   * @param table
+   */
+  default void setTableProperties(Table table) {
+    // Do nothing
+  }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2688,6 +2688,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         getTableRequest.setProcessorIdentifier(processorIdentifier);
 
       Table t = getTableInternal(getTableRequest).getTable();
+      extractTablePropertiesFromHook(t);
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
       long diff = System.currentTimeMillis() - t1;
@@ -2695,6 +2696,13 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         LOG.debug("class={}, method={}, duration={}, comments={}", CLASS_NAME, "getTable",
             diff, "HMS client");
       }
+    }
+  }
+
+  private void extractTablePropertiesFromHook(Table t) throws MetaException {
+    HiveMetaHook hook = getHook(t);
+    if (hook != null) {
+      hook.setTableProperties(t);
     }
   }
 
@@ -2721,6 +2729,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
     req.setProjectionSpec(projectionsSpec);
     List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
+    for (Table tbl : tabs) {
+      extractTablePropertiesFromHook(tbl);
+    }
     return deepCopyTables(FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extract format version from metadata file

### Why are the changes needed?

Support inter operability with Spark

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

UT & Actual Env