### PR TITLE
HIVE-26757: Add sfs+ofs support

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SingleFileSystem.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SingleFileSystem.java
@@ -80,6 +80,9 @@ public abstract class SingleFileSystem extends FileSystem {
   public static class O3FS extends SingleFileSystem {
   }
 
+  public static class OFS extends SingleFileSystem {
+  }
+
   public static class PFILE extends SingleFileSystem {
   }
 

--- a/ql/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/ql/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -23,3 +23,4 @@ org.apache.hadoop.hive.ql.io.SingleFileSystem$FILE
 org.apache.hadoop.hive.ql.io.SingleFileSystem$PFILE
 org.apache.hadoop.hive.ql.io.SingleFileSystem$GS
 org.apache.hadoop.hive.ql.io.SingleFileSystem$O3FS
+org.apache.hadoop.hive.ql.io.SingleFileSystem$OFS


### PR DESCRIPTION
Adds sfs+ofs support to mirror sfs+o3fs. ofs is a newer protocol by Ozone that's meant to replace o3fs.