### PR TITLE
HIVE-26758: Allow use scratchdir for staging final job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -266,7 +266,7 @@ fi
             # make parallel-test-execution plugins source scanner happy ~ better results for 1st run
             find . -name '*.java'|grep /Test|grep -v src/test/java|grep org/apache|while read f;do t="`echo $f|sed 's|.*org/apache|happy/src/test/java/org/apache|'`";mkdir -p  "${t%/*}";touch "$t";done
         '''
-        splits = splitTests parallelism: count(Integer.parseInt(params.SPLIT)), generateInclusions: true, estimateTestsFromFiles: true
+        splits = splitTests parallelism: count(Integer.parseInt(params.SPLIT)), generateInclusions: true, estimateTestsFromFiles: false
       }
     }
   }

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5629,7 +5629,7 @@ public class HiveConf extends Configuration {
             "This is a performance optimization that forces the final FileSinkOperator to write to the blobstore.\n" +
             "See HIVE-15121 for details."),
 
-    HIVE_USE_SCRATCHDIR_FOR_STAGING("hive.use.scratchdir_for_staging", false,
+    HIVE_USE_SCRATCHDIR_FOR_STAGING("hive.use.scratchdir.for.staging", false,
         "Use ${hive.exec.scratchdir} for query results instead of ${hive.exec.stagingdir}.\n" +
             "This stages query results in ${hive.exec.scratchdir} before move to final destination."),
 

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5629,6 +5629,10 @@ public class HiveConf extends Configuration {
             "This is a performance optimization that forces the final FileSinkOperator to write to the blobstore.\n" +
             "See HIVE-15121 for details."),
 
+    HIVE_USE_SCRATCHDIR_FOR_STAGING("hive.use.scratchdir_for_staging", false,
+        "Use ${hive.exec.scratchdir} for query results instead of ${hive.exec.stagingdir}.\n" +
+            "This stages query results in ${hive.exec.scratchdir} before move to final destination."),
+
     HIVE_ADDITIONAL_CONFIG_FILES("hive.additional.config.files", "",
             "The names of additional config files, such as ldap-site.xml," +
                     "tez-site.xml, etc in comma separated list.");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -1001,8 +1001,11 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   }
 
   private void createDpDirCheckSrc(final Path dpStagingPath, final Path dpFinalPath) throws IOException {
-    if (!fs.exists(dpStagingPath) && !fs.exists(dpFinalPath)) {
-      fs.mkdirs(dpStagingPath);
+    if (!fs.exists(dpStagingPath)) {
+      FileSystem dpFs = dpFinalPath.getFileSystem(hconf);
+      if (!dpFs.exists(dpFinalPath)) {
+        fs.mkdirs(dpStagingPath);
+      }
       // move task will create dp final path
       if (reporter != null) {
         reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -1005,10 +1005,10 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
       FileSystem dpFs = dpFinalPath.getFileSystem(hconf);
       if (!dpFs.exists(dpFinalPath)) {
         fs.mkdirs(dpStagingPath);
-      }
-      // move task will create dp final path
-      if (reporter != null) {
-        reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
+        // move task will create dp final path
+        if (reporter != null) {
+          reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
+        }
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -393,6 +393,10 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
             }
           }
           else {
+            FileSystem targetFs = targetPath.getFileSystem(conf);
+            if (!targetFs.exists(targetPath.getParent())){
+              targetFs.mkdirs(targetPath.getParent());
+            }
             moveFile(sourcePath, targetPath, lfd.getIsDfsDir());
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
@@ -109,6 +109,8 @@ public class OrcFileMergeOperator extends
 
       if (prevPath == null) {
         prevPath = k.getInputPath();
+      }
+      if (reader == null) {
         reader = OrcFile.createReader(fs, k.getInputPath());
         LOG.info("ORC merge file input path: " + k.getInputPath());
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4917,13 +4917,6 @@ private void constructOneLBLocationMap(FileStatus fSta,
             }
             return true;
           } else {
-            // Create destf parent if it is on scratchdir and not exist
-            if (!destFs.exists(destf.getParent())) {
-              Path scratchDir = new Path(HiveConf.getVar(conf, ConfVars.SCRATCHDIR));
-              if (isSubDir(destf, scratchDir, destFs, destFs, false)) {
-                destFs.mkdirs(destf.getParent());
-              }
-            }
             if (destFs.rename(srcf, destf)) {
               return true;
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2608,7 +2608,6 @@ public class Hive {
            * See: HIVE-1707 and HIVE-2117 for background
            */
           FileSystem oldPartPathFS = oldPartPath.getFileSystem(getConf());
-          //FileSystem loadPathFS = loadPath.getFileSystem(getConf());
           FileSystem tblPathFS = tblDataLocationPath.getFileSystem(getConf());
           if (FileUtils.equalsFileSystem(oldPartPathFS,tblPathFS)) {
             newPartPath = oldPartPath;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -1977,7 +1977,16 @@ public final class GenMapRedUtils {
 
         // Create the required temporary file in the HDFS location if the destination
         // path of the FileSinkOperator table is a blobstore path.
-        Path tmpDir = baseCtx.getTempDirForFinalJobPath(fileSinkDesc.getDestPath());
+        Path tmpDir = null;
+        if (hconf.getBoolVar(ConfVars.HIVE_USE_SCRATCHDIR_FOR_STAGING)){
+          tmpDir = baseCtx.getTempDirForInterimJobPath(fileSinkDesc.getDestPath());
+          DynamicPartitionCtx dpCtx = fileSinkDesc.getDynPartCtx();
+          if (dpCtx != null && dpCtx.getSPPath() != null) {
+            tmpDir = new Path(tmpDir, dpCtx.getSPPath());
+          }
+        } else {
+          tmpDir = baseCtx.getTempDirForFinalJobPath(fileSinkDesc.getDestPath());
+        }
 
         // Change all the linked file sink descriptors
         if (fileSinkDesc.isLinkedFileSink()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -1971,8 +1971,6 @@ public final class GenMapRedUtils {
        * 2. INSERT operation on full ACID table
        */
       if (!isMmTable && !isDirectInsert) {
-        // generate the temporary file
-        // it must be on the same file system as the current destination
         Context baseCtx = parseCtx.getContext();
 
         // Choose location of required temporary file

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -1975,17 +1975,16 @@ public final class GenMapRedUtils {
         // it must be on the same file system as the current destination
         Context baseCtx = parseCtx.getContext();
 
-        // Create the required temporary file in the HDFS location if the destination
-        // path of the FileSinkOperator table is a blobstore path.
+        // Choose location of required temporary file
         Path tmpDir = null;
-        if (hconf.getBoolVar(ConfVars.HIVE_USE_SCRATCHDIR_FOR_STAGING)){
+        if (hconf.getBoolVar(ConfVars.HIVE_USE_SCRATCHDIR_FOR_STAGING)) {
           tmpDir = baseCtx.getTempDirForInterimJobPath(fileSinkDesc.getDestPath());
-          DynamicPartitionCtx dpCtx = fileSinkDesc.getDynPartCtx();
-          if (dpCtx != null && dpCtx.getSPPath() != null) {
-            tmpDir = new Path(tmpDir, dpCtx.getSPPath());
-          }
         } else {
           tmpDir = baseCtx.getTempDirForFinalJobPath(fileSinkDesc.getDestPath());
+        }
+        DynamicPartitionCtx dpCtx = fileSinkDesc.getDynPartCtx();
+        if (dpCtx != null && dpCtx.getSPPath() != null) {
+            tmpDir = new Path(tmpDir, dpCtx.getSPPath());
         }
 
         // Change all the linked file sink descriptors

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7692,6 +7692,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         dpCtx.setRootPath(queryTmpdir);
         isPartitioned = true;
       } else {
+        queryTmpdir = getTmpDir(false, isMmTable, isDirectInsert, qPath, dpCtx);
         ColsAndTypes ct = deriveFileSinkColTypes(
             inputRR, sortColumnNames, distributeColumnNames, fieldSchemas, sortColumns, distributeColumns,
             sortColInfos, distributeColInfos);


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. add a hive configuration hive.use.scratchdir.for.staging

2. for native table, no-mm, no-direct-insert, no-acid, change dynamic partition staging directory layout from
<dest_path>/<static_partition>/<staging_dir>/<dynamic_partition>
to 
<dest_path>/<staging_dir>/<static_partition>/<dynamic_partition>

3. when hive.use.scratchdir.for.staging=true, FileSinkOperator's dirName, DynamicContext's sourcePath change from
<dest_path>/{hive.exec.stagingdir}
to
<hive.exec.scratchdir>


for example for query 
insert into/overwrite table partition(year=2001, season) select...

before the change, the FileSinkOperator conf has
<table_path>/year=2001/.staging_dir/season=xxx

after the change, it has
<table_path>/.staging_dir/year=2001/season=xxx

This change allow to swap <table_path> with another path such as  <hive.exec.scratchdir>, and the moveTask will move into <table_path>

### Why are the changes needed?

In the S3 blobstorage optimization, HIVE-15121 / HIVE-17620 changed interim job path to use hive.exec.scracthdir, final job to use hive.exec.stagingdir. https://issues.apache.org/jira/browse/HIVE-15215 is open whether to use scratch for staging dir for S3. 

However for blobstorage where 'rename' is slow and no encryption, it can help performance to use scratchdir to staging query results and use the MoveTask to copy to blobstorage. This is especially true when there is FileMerge task.
This may also help cross-filesystem when user wants to use local cluster filesystem to staging query results and move the results to destination filesystem.


### Does this PR introduce _any_ user-facing change?
This adds a new hive configuration.


### How was this patch tested?
