### PR TITLE
HIVE-26455: Remove powermock from hive-exec

### DIFF
--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -25,7 +25,6 @@
   <name>Hive Query Language</name>
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <powermock.version>2.0.2</powermock.version>
     <reflections.version>0.10.2</reflections.version>
     <atlas.version>2.1.0</atlas.version>
   </properties>
@@ -814,18 +813,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>${guava.version}</version>
@@ -857,6 +844,12 @@
     <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -1406,7 +1406,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
           for (String tblName : Utils.matchesTbl(hiveDb, dbName, work.replScope)) {
             Table table = null;
             try {
-              HiveWrapper.Tuple<Table> tableTuple = new HiveWrapper(hiveDb, dbName).table(tblName, conf);
+              HiveWrapper.Tuple<Table> tableTuple = createHiveWrapper(hiveDb, dbName).table(tblName, conf);
               table = tableTuple != null ? tableTuple.object : null;
 
               //disable materialized-view replication if not configured
@@ -1803,6 +1803,10 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
       // Just log a debug message and skip it.
       LOG.debug(e.getMessage());
     }
+  }
+
+  HiveWrapper createHiveWrapper(Hive hiveDb, String dbName){
+    return new HiveWrapper(hiveDb, dbName);
   }
 
   private HiveWrapper.Tuple<Function> functionTuple(String functionName, String dbName, Hive hiveDb) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/load/message/CreateFunctionHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/load/message/CreateFunctionHandler.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -40,6 +39,7 @@ import org.apache.hadoop.hive.ql.parse.repl.PathBuilder;
 import org.apache.hadoop.hive.ql.parse.repl.load.MetaData;
 import org.apache.hadoop.hive.ql.plan.CopyWork;
 import org.apache.hadoop.hive.ql.plan.DependencyCollectionWork;
+import org.apache.hadoop.hive.ql.util.TimeUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -154,12 +154,20 @@ public class CreateFunctionHandler extends AbstractMessageHandler {
     private final String functionsRootDir;
     private String destinationDbName;
 
+    private TimeUtil timeUtil;
+
     PrimaryToReplicaResourceFunction(Context context, MetaData metadata,
-        String destinationDbName) {
+        String destinationDbName, TimeUtil timeUtil) {
       this.context = context;
       this.metadata = metadata;
       this.destinationDbName = destinationDbName;
       this.functionsRootDir = context.hiveConf.getVar(HiveConf.ConfVars.REPL_FUNCTIONS_ROOT_DIR);
+      this.timeUtil = timeUtil;
+    }
+
+    PrimaryToReplicaResourceFunction(Context context, MetaData metadata,
+                                     String destinationDbName) {
+      this(context, metadata, destinationDbName, new TimeUtil());
     }
 
     @Override
@@ -187,7 +195,7 @@ public class CreateFunctionHandler extends AbstractMessageHandler {
           pathBuilder
               .addDescendant(destinationDbName.toLowerCase())
               .addDescendant(metadata.function.getFunctionName().toLowerCase())
-              .addDescendant(String.valueOf(System.nanoTime()))
+              .addDescendant(String.valueOf(timeUtil.getNanoSeconds()))
               .addDescendant(split[split.length - 1])
               .build(),
           new Path(functionsRootDir).getFileSystem(context.hiveConf)

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableDesc.java
@@ -137,7 +137,6 @@ public class TableDesc implements Serializable, Cloneable {
     this.jobProperties = jobProperties;
   }
 
-  @Explain(displayName = "jobProperties", explainLevels = { Level.EXTENDED })
   public Map<String, String> getJobProperties() {
     return jobProperties;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllHistogramEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllHistogramEstimator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.udf.datasketches.kll;
+
+import org.apache.datasketches.kll.KllFloatsSketch;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class KllHistogramEstimator {
+
+  private final KllFloatsSketch kll;
+
+  KllHistogramEstimator(int k) {
+    this.kll = new KllFloatsSketch(k);
+  }
+
+  KllHistogramEstimator(KllFloatsSketch kll) {
+    this.kll = kll;
+  }
+
+  public byte[] serialize() {
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try {
+      KllUtils.serializeKll(bos, kll);
+      final byte[] result = bos.toByteArray();
+      bos.close();
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void addToEstimator(long v) {
+    kll.update(v);
+  }
+
+  public void addToEstimator(double d) {
+    kll.update((float) d);
+  }
+
+  public void addToEstimator(HiveDecimal decimal) {
+    kll.update(decimal.floatValue());
+  }
+
+  public void mergeEstimators(KllHistogramEstimator o) {
+    kll.merge(o.kll);
+  }
+
+  public int lengthFor(JavaDataModel model) {
+    return KllUtils.lengthFor(model, kll);
+  }
+
+  public KllFloatsSketch getSketch() {
+    return kll;
+  }
+
+  public int getK() {
+    return kll.getK();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllHistogramEstimatorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllHistogramEstimatorFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hadoop.hive.ql.udf.datasketches.kll;
+
+public class KllHistogramEstimatorFactory {
+
+  private KllHistogramEstimatorFactory() {
+    throw new AssertionError("Suppress default constructor for non instantiation");
+  }
+
+  /**
+   * This function deserializes the serialized KLL histogram estimator from a byte array.
+   * @param buf to deserialize
+   * @param start start index for deserialization
+   * @param len start+len is deserialized
+   * @return KLL histogram estimator
+   */
+  public static KllHistogramEstimator getKllHistogramEstimator(byte[] buf, int start, int len) {
+    return new KllHistogramEstimator(KllUtils.deserializeKll(buf, start, len));
+  }
+
+  /**
+   * This method creates an empty histogram estimator with a KLL sketch of a given k parameter.
+   * @param k the KLL parameter k for initializing the sketch
+   * @return an empty histogram estimator with a KLL sketch of a given k parameter
+   */
+  public static KllHistogramEstimator getEmptyHistogramEstimator(int k) {
+    return new KllHistogramEstimator(k);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/datasketches/kll/KllUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.udf.datasketches.kll;
+
+import org.apache.datasketches.kll.KllFloatsSketch;
+import org.apache.datasketches.memory.Memory;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * KLL serialization utilities.
+ */
+public class KllUtils {
+
+  private KllUtils() {
+    throw new AssertionError("Suppress default constructor for non instantiation");
+  }
+
+  /**
+   * KLL is serialized according to what provided by data-sketches library
+   * @param out output stream to write to
+   * @param kll KLL sketch that needs to be serialized
+   * @throws IOException if an error occurs during serialization
+   */
+  public static void serializeKll(OutputStream out, KllFloatsSketch kll) throws IOException {
+    out.write(kll.toByteArray());
+  }
+
+  /**
+   * This function deserializes the serialized KLL sketch from a stream.
+   * @param in input stream to be deserialized
+   * @return KLL sketch
+   * @throws IOException if errors occur while reading the stream
+   */
+  public static KllFloatsSketch deserializeKll(InputStream in) throws IOException {
+    final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    final byte[] data = new byte[4];
+    int nRead;
+
+    while ((nRead = in.read(data, 0, data.length)) != -1) {
+      buffer.write(data, 0, nRead);
+    }
+
+    buffer.flush();
+    return KllFloatsSketch.heapify(Memory.wrap(buffer.toByteArray()));
+  }
+
+  /**
+   * This function deserializes the serialized KLL sketch from a byte array.
+   * @param buf to deserialize
+   * @param start start index for deserialization
+   * @param len start+len is deserialized
+   * @return KLL sketch
+   */
+  public static KllFloatsSketch deserializeKll(byte[] buf, int start, int len) {
+    InputStream is = new ByteArrayInputStream(buf, start, len);
+    try {
+      KllFloatsSketch result = deserializeKll(is);
+      is.close();
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Returns the length of the given KLL sketch according to the given java data model.
+   * @param model the java data model to compute the length
+   * @param kll the KLL sketch to compute the length for
+   * @return the length of the given KLL sketch according to the given java data model
+   */
+  public static int lengthFor(JavaDataModel model, KllFloatsSketch kll) {
+    return model == null ? KllFloatsSketch.getMaxSerializedSizeBytes(kll.getK(), kll.getN())
+        : (int) model.lengthForByteArrayOfSize(kll.getSerializedSizeBytes());
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/TimeUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/TimeUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.util;
+
+public class TimeUtil {
+    public long getNanoSeconds(){
+        return System.nanoTime();
+    }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -101,7 +101,8 @@ import org.junit.rules.ExpectedException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
+
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -1452,8 +1453,8 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     runStatementOnDriver("INSERT INTO " + tblName +
       (isPartioned ? " PARTITION (p='" + partName + "')" : "") +
       " VALUES (1, 'foo'),(2, 'bar'),(3, 'baz')");
-    runStatementOnDriver("UPDATE " + tblName + " SET b = 'blah' WHERE a = 3");
 
+    runStatementOnDriver("UPDATE " + tblName + " SET b = 'blah' WHERE a = 3");
     //run Worker to execute compaction
     CompactionRequest req = new CompactionRequest("default", tblName, CompactionType.MAJOR);
     if (isPartioned) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -33,10 +33,9 @@ import org.apache.hadoop.hive.ql.parse.repl.metric.ReplicationMetricCollector;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,13 +47,10 @@ import org.slf4j.LoggerFactory;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ Utils.class, ReplDumpTask.class})
-@PowerMockIgnore({ "javax.management.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class TestReplDumpTask {
 
   protected static final Logger LOG = LoggerFactory.getLogger(TestReplDumpTask.class);
@@ -113,47 +109,50 @@ public class TestReplDumpTask {
     String dbRandomKey = "akeytoberandom";
     ReplScope replScope = new ReplScope("default");
 
-    mockStatic(Utils.class);
-    when(Utils.matchesDb(same(hive), eq("default")))
-        .thenReturn(Collections.singletonList("default"));
-    when(Utils.getAllTables(same(hive), eq("default"), eq(replScope))).thenReturn(tableList);
-    when(Utils.setDbBootstrapDumpState(same(hive), eq("default"))).thenReturn(dbRandomKey);
-    when(Utils.matchesTbl(same(hive), eq("default"), eq(replScope))).thenReturn(tableList);
+    try (MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class)){
+        utilsMockedStatic.when(() -> Utils.matchesDb(same(hive), eq("default")))
+                .thenReturn(Collections.singletonList("default"));
+        utilsMockedStatic.when(() -> Utils.getAllTables(same(hive), eq("default"), eq(replScope))).thenReturn(tableList);
+        utilsMockedStatic.when(() -> Utils.setDbBootstrapDumpState(same(hive), eq("default"))).thenReturn(dbRandomKey);
+        utilsMockedStatic.when(() -> Utils.matchesTbl(same(hive), eq("default"), eq(replScope))).thenReturn(tableList);
 
+        when(queryState.getConf()).thenReturn(conf);
+        when(conf.getLong("hive.repl.last.repl.id", -1L)).thenReturn(1L);
+        when(conf.getBoolVar(HiveConf.ConfVars.REPL_INCLUDE_EXTERNAL_TABLES)).thenReturn(false);
+        when(HiveConf.getVar(conf, HiveConf.ConfVars.REPL_BOOTSTRAP_DUMP_OPEN_TXN_TIMEOUT)).thenReturn("1h");
 
-    when(hive.getAllFunctions()).thenReturn(Collections.emptyList());
-    when(queryState.getConf()).thenReturn(conf);
-    when(conf.getLong("hive.repl.last.repl.id", -1L)).thenReturn(1L);
-    when(conf.getBoolVar(HiveConf.ConfVars.REPL_INCLUDE_EXTERNAL_TABLES)).thenReturn(false);
-    when(HiveConf.getVar(conf, HiveConf.ConfVars.REPL_BOOTSTRAP_DUMP_OPEN_TXN_TIMEOUT)).thenReturn("1h");
-    whenNew(HiveWrapper.class).withAnyArguments().thenReturn(mock(HiveWrapper.class));
+        ReplDumpTask task = new StubReplDumpTask() {
+            private int tableDumpCount = 0;
 
-    ReplDumpTask task = new StubReplDumpTask() {
-      private int tableDumpCount = 0;
+            @Override
+            void dumpTable(ExportService exportService, String dbName, String tblName, String validTxnList,
+                           Path dbRootMetadata, Path dbRootData,
+                           long lastReplId, Hive hiveDb,
+                           HiveWrapper.Tuple<Table> tuple, FileList managedTableDirFileList, boolean dataCopyAtLoad)
+                    throws Exception {
+                tableDumpCount++;
+                if (tableDumpCount > 1) {
+                    throw new TestException();
+                }
+            }
 
-      @Override
-      void dumpTable(ExportService exportService, String dbName, String tblName, String validTxnList,
-                     Path dbRootMetadata, Path dbRootData,
-                     long lastReplId, Hive hiveDb,
-                     HiveWrapper.Tuple<Table> tuple, FileList managedTableDirFileList, boolean dataCopyAtLoad)
-          throws Exception {
-        tableDumpCount++;
-        if (tableDumpCount > 1) {
-          throw new TestException();
+            @Override
+            HiveWrapper createHiveWrapper(Hive hiveDb, String dbName){
+                return mock(HiveWrapper.class);
+            }
+        };
+
+        task.initialize(queryState, null, null, null);
+        ReplDumpWork replDumpWork = new ReplDumpWork(replScope, "", "");
+        replDumpWork.setMetricCollector(metricCollector);
+        task.setWork(replDumpWork);
+
+        try {
+            task.bootStrapDump(new Path("mock"), new DumpMetaData(new Path("mock"), conf),
+                    mock(Path.class), hive);
+        } finally {
+            Utils.resetDbBootstrapDumpState(same(hive), eq("default"), eq(dbRandomKey));
         }
-      }
-    };
-
-    task.initialize(queryState, null, null, null);
-    ReplDumpWork replDumpWork = new ReplDumpWork(replScope, "", "");
-    replDumpWork.setMetricCollector(metricCollector);
-    task.setWork(replDumpWork);
-
-    try {
-      task.bootStrapDump(new Path("mock"), new DumpMetaData(new Path("mock"), conf),
-        mock(Path.class), hive);
-    } finally {
-      Utils.resetDbBootstrapDumpState(same(hive), eq("default"), eq(dbRandomKey));
     }
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/TestTaskTracker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/TestTaskTracker.java
@@ -22,14 +22,12 @@ import org.apache.hadoop.hive.ql.exec.repl.util.TaskTracker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.io.Serializable;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
   public class TestTaskTracker {
   @Mock
   private Task<?> task;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/util/TestFileList.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/util/TestFileList.java
@@ -30,8 +30,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,9 +40,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Tests the File List implementation.
  */
-
 @RunWith(MockitoJUnitRunner.class)
-@PrepareForTest({LoggerFactory.class})
 public class TestFileList {
 
   HiveConf conf = new HiveConf();

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/TestCopyUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/TestCopyUtils.java
@@ -30,11 +30,11 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import javax.rmi.CORBA.Util;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,15 +52,13 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit Test class for CopyUtils class.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ CopyUtils.class, FileUtils.class, Utils.class, UserGroupInformation.class, ReplChangeManager.class})
-@PowerMockIgnore({ "javax.management.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class TestCopyUtils {
   /*
   Distcp currently does not copy a single file in a distributed manner hence we dont care about
@@ -68,25 +66,28 @@ public class TestCopyUtils {
    */
   @Test
   public void distcpShouldNotBeCalledOnlyForOneFile() throws Exception {
-    mockStatic(UserGroupInformation.class);
-    when(UserGroupInformation.getCurrentUser()).thenReturn(mock(UserGroupInformation.class));
+    try (MockedStatic<UserGroupInformation> userGroupInformationMockedStatic = mockStatic(UserGroupInformation.class)) {
+      userGroupInformationMockedStatic.when(UserGroupInformation::getCurrentUser).thenReturn(mock(UserGroupInformation.class));
 
-    HiveConf conf = Mockito.spy(new HiveConf());
-    doReturn(1L).when(conf).getLong(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE.varname, 32L * 1024 * 1024);
-    CopyUtils copyUtils = new CopyUtils("", conf, null);
-    long MB_128 = 128 * 1024 * 1024;
-    assertFalse(copyUtils.limitReachedForLocalCopy(MB_128, 1L));
+      HiveConf conf = Mockito.spy(new HiveConf());
+      doReturn(1L).when(conf).getLong(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE.varname, 32L * 1024 * 1024);
+      CopyUtils copyUtils = new CopyUtils("", conf, null);
+      long MB_128 = 128 * 1024 * 1024;
+      assertFalse(copyUtils.limitReachedForLocalCopy(MB_128, 1L));
+    }
   }
 
   @Test
   public void distcpShouldNotBeCalledForSmallerFileSize() throws Exception {
-    mockStatic(UserGroupInformation.class);
-    when(UserGroupInformation.getCurrentUser()).thenReturn(mock(UserGroupInformation.class));
+    try (
+            MockedStatic<UserGroupInformation> userGroupInformationMockedStatic = mockStatic(UserGroupInformation.class)) {
+            userGroupInformationMockedStatic.when(UserGroupInformation::getCurrentUser).thenReturn(mock(UserGroupInformation.class));
 
-    HiveConf conf = Mockito.spy(new HiveConf());
-    CopyUtils copyUtils = new CopyUtils("", conf, null);
-    long MB_16 = 16 * 1024 * 1024;
-    assertFalse(copyUtils.limitReachedForLocalCopy(MB_16, 100L));
+      HiveConf conf = Mockito.spy(new HiveConf());
+      CopyUtils copyUtils = new CopyUtils("", conf, null);
+      long MB_16 = 16 * 1024 * 1024;
+      assertFalse(copyUtils.limitReachedForLocalCopy(MB_16, 100L));
+    }
   }
 
   @Test(expected = IOException.class)
@@ -98,150 +99,163 @@ public class TestCopyUtils {
     HiveConf conf = mock(HiveConf.class);
     CopyUtils copyUtils = Mockito.spy(new CopyUtils(null, conf, fs));
 
-    mockStatic(FileUtils.class);
-    mockStatic(Utils.class);
-    when(destination.getFileSystem(same(conf))).thenReturn(fs);
-    when(source.getFileSystem(same(conf))).thenReturn(fs);
-    when(FileUtils.distCp(same(fs), anyListOf(Path.class), same(destination),
-                          anyBoolean(), eq(null), same(conf),
-                          same(ShimLoader.getHadoopShims())))
-        .thenReturn(false);
-    when(Utils.getUGI()).thenReturn(mock(UserGroupInformation.class));
-    doReturn(false).when(copyUtils).regularCopy(same(fs), anyListOf(ReplChangeManager.FileInfo.class));
+    try (
+            MockedStatic<FileUtils> fileUtilsMockedStatic = mockStatic(FileUtils.class);
+            MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class)) {
 
-    copyUtils.doCopy(destination, srcPaths);
+      fileUtilsMockedStatic.when(() -> FileUtils.distCp(same(fs), anyListOf(Path.class), same(destination),
+                      anyBoolean(), eq(null), same(conf),
+                      same(ShimLoader.getHadoopShims())))
+              .thenReturn(false);
+      utilsMockedStatic.when(Utils::getUGI).thenReturn(mock(UserGroupInformation.class));
+
+      when(source.getFileSystem(same(conf))).thenReturn(fs);
+      doReturn(false).when(copyUtils).regularCopy(same(fs), anyListOf(ReplChangeManager.FileInfo.class));
+
+      copyUtils.doCopy(destination, srcPaths);
+    }
   }
 
   @Test
   public void testFSCallsFailOnParentExceptions() throws Exception {
-    mockStatic(UserGroupInformation.class);
-    mockStatic(ReplChangeManager.class);
-    when(UserGroupInformation.getCurrentUser()).thenReturn(mock(UserGroupInformation.class));
-    HiveConf conf = mock(HiveConf.class);
-    conf.set(HiveConf.ConfVars.REPL_RETRY_INTIAL_DELAY.varname, "1s");
-    FileSystem fs = mock(FileSystem.class);
-    Path source = mock(Path.class);
-    Path destination = mock(Path.class);
-    ContentSummary cs = mock(ContentSummary.class);
+    try (
+            MockedStatic<UserGroupInformation> userGroupInformationMockedStatic = mockStatic(UserGroupInformation.class);
+            MockedStatic<ReplChangeManager> replChangeManagerMockedStatic = mockStatic(ReplChangeManager.class)
+            ) {
 
-    Exception exception = new org.apache.hadoop.fs.PathPermissionException("Failed");
-    when(ReplChangeManager.checksumFor(source, fs)).thenThrow(exception).thenReturn("dummy");
-    when(fs.exists(same(source))).thenThrow(exception).thenReturn(true);
-    when(fs.delete(same(source), anyBoolean())).thenThrow(exception).thenReturn(true);
-    when(fs.mkdirs(same(source))).thenThrow(exception).thenReturn(true);
-    when(fs.rename(same(source), same(destination))).thenThrow(exception).thenReturn(true);
-    when(fs.getContentSummary(same(source))).thenThrow(exception).thenReturn(cs);
+      userGroupInformationMockedStatic.when(UserGroupInformation::getCurrentUser).thenReturn(mock(UserGroupInformation.class));
 
-    CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, fs);
-    CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
-    try {
-      copyUtilsSpy.exists(fs, source);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());
+      HiveConf conf = mock(HiveConf.class);
+      conf.set(HiveConf.ConfVars.REPL_RETRY_INTIAL_DELAY.varname, "1s");
+      FileSystem fs = mock(FileSystem.class);
+      Path source = mock(Path.class);
+      Path destination = mock(Path.class);
+      ContentSummary cs = mock(ContentSummary.class);
+
+      Exception exception = new org.apache.hadoop.fs.PathPermissionException("Failed");
+      replChangeManagerMockedStatic.when(() -> ReplChangeManager.checksumFor(source, fs)).thenThrow(exception).thenReturn("dummy");
+      when(fs.exists(same(source))).thenThrow(exception).thenReturn(true);
+      when(fs.delete(same(source), anyBoolean())).thenThrow(exception).thenReturn(true);
+      when(fs.mkdirs(same(source))).thenThrow(exception).thenReturn(true);
+      when(fs.rename(same(source), same(destination))).thenThrow(exception).thenReturn(true);
+      when(fs.getContentSummary(same(source))).thenThrow(exception).thenReturn(cs);
+
+      CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, fs);
+      CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
+      try {
+        copyUtilsSpy.exists(fs, source);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());
+      }
+      Mockito.verify(fs, Mockito.times(1)).exists(source);
+      try {
+        copyUtils.delete(fs, source, true);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());
+      }
+      Mockito.verify(fs, Mockito.times(1)).delete(source, true);
+      try {
+        copyUtils.mkdirs(fs, source);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());
+      }
+      Mockito.verify(fs, Mockito.times(1)).mkdirs(source);
+      try {
+        copyUtils.rename(fs, source, destination);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());
+      }
+      Mockito.verify(fs, Mockito.times(1)).rename(source, destination);
+      try {
+        copyUtilsSpy.getContentSummary(fs, source);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());;
+      }
+      Mockito.verify(fs, Mockito.times(1)).getContentSummary(source);
+      try {
+        copyUtilsSpy.checkSumFor(source, fs);
+      } catch (Exception e) {
+        assertEquals(exception.getClass(), e.getCause().getClass());
+      }
+      Mockito.verify(copyUtilsSpy, Mockito.times(1)).checkSumFor(source, fs);
     }
-    Mockito.verify(fs, Mockito.times(1)).exists(source);
-    try {
-      copyUtils.delete(fs, source, true);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());
-    }
-    Mockito.verify(fs, Mockito.times(1)).delete(source, true);
-    try {
-      copyUtils.mkdirs(fs, source);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());
-    }
-    Mockito.verify(fs, Mockito.times(1)).mkdirs(source);
-    try {
-      copyUtils.rename(fs, source, destination);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());
-    }
-    Mockito.verify(fs, Mockito.times(1)).rename(source, destination);
-    try {
-      copyUtilsSpy.getContentSummary(fs, source);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());;
-    }
-    Mockito.verify(fs, Mockito.times(1)).getContentSummary(source);
-    try {
-      copyUtilsSpy.checkSumFor(source, fs);
-    } catch (Exception e) {
-      assertEquals(exception.getClass(), e.getCause().getClass());
-    }
-    Mockito.verify(copyUtilsSpy, Mockito.times(1)).checkSumFor(source, fs);
   }
 
   @Test
   public void testRetryableFSCalls() throws Exception {
-    mockStatic(UserGroupInformation.class);
-    mockStatic(ReplChangeManager.class);
-    when(UserGroupInformation.getCurrentUser()).thenReturn(mock(UserGroupInformation.class));
-    HiveConf conf = mock(HiveConf.class);
-    conf.set(HiveConf.ConfVars.REPL_RETRY_INTIAL_DELAY.varname, "1s");
-    FileSystem fs = mock(FileSystem.class);
-    Path source = mock(Path.class);
-    Path destination = mock(Path.class);
-    ContentSummary cs = mock(ContentSummary.class);
+    try (
+            MockedStatic<UserGroupInformation> userGroupInformationMockedStatic = mockStatic(UserGroupInformation.class);
+            MockedStatic<ReplChangeManager> replChangeManagerMockedStatic = mockStatic(ReplChangeManager.class)
+            ) {
 
-    when(ReplChangeManager.checksumFor(source, fs)).thenThrow(new IOException("Failed")).thenReturn("dummy");
-    when(fs.exists(same(source))).thenThrow(new IOException("Failed")).thenReturn(true);
-    when(fs.delete(same(source), anyBoolean())).thenThrow(new IOException("Failed")).thenReturn(true);
-    when(fs.mkdirs(same(source))).thenThrow(new IOException("Failed")).thenReturn(true);
-    when(fs.rename(same(source), same(destination))).thenThrow(new IOException("Failed")).thenReturn(true);
-    when(fs.getContentSummary(same(source))).thenThrow(new IOException("Failed")).thenReturn(cs);
+      userGroupInformationMockedStatic.when(UserGroupInformation::getCurrentUser).thenReturn(mock(UserGroupInformation.class));
+      HiveConf conf = mock(HiveConf.class);
+      conf.set(HiveConf.ConfVars.REPL_RETRY_INTIAL_DELAY.varname, "1s");
+      FileSystem fs = mock(FileSystem.class);
+      Path source = mock(Path.class);
+      Path destination = mock(Path.class);
+      ContentSummary cs = mock(ContentSummary.class);
 
-    CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, fs);
-    CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
-    assertEquals (true, copyUtilsSpy.exists(fs, source));
-    Mockito.verify(fs, Mockito.times(2)).exists(source);
-    assertEquals (true, copyUtils.delete(fs, source, true));
-    Mockito.verify(fs, Mockito.times(2)).delete(source, true);
-    assertEquals (true, copyUtils.mkdirs(fs, source));
-    Mockito.verify(fs, Mockito.times(2)).mkdirs(source);
-    assertEquals (true, copyUtils.rename(fs, source, destination));
-    Mockito.verify(fs, Mockito.times(2)).rename(source, destination);
-    assertEquals (cs, copyUtilsSpy.getContentSummary(fs, source));
-    Mockito.verify(fs, Mockito.times(2)).getContentSummary(source);
-    assertEquals ("dummy", copyUtilsSpy.checkSumFor(source, fs));
+      replChangeManagerMockedStatic.when(() -> ReplChangeManager.checksumFor(source, fs)).thenThrow(new IOException("Failed")).thenReturn("dummy");
+      when(fs.exists(same(source))).thenThrow(new IOException("Failed")).thenReturn(true);
+      when(fs.delete(same(source), anyBoolean())).thenThrow(new IOException("Failed")).thenReturn(true);
+      when(fs.mkdirs(same(source))).thenThrow(new IOException("Failed")).thenReturn(true);
+      when(fs.rename(same(source), same(destination))).thenThrow(new IOException("Failed")).thenReturn(true);
+      when(fs.getContentSummary(same(source))).thenThrow(new IOException("Failed")).thenReturn(cs);
+
+      CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, fs);
+      CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
+      assertEquals (true, copyUtilsSpy.exists(fs, source));
+      Mockito.verify(fs, Mockito.times(2)).exists(source);
+      assertEquals (true, copyUtils.delete(fs, source, true));
+      Mockito.verify(fs, Mockito.times(2)).delete(source, true);
+      assertEquals (true, copyUtils.mkdirs(fs, source));
+      Mockito.verify(fs, Mockito.times(2)).mkdirs(source);
+      assertEquals (true, copyUtils.rename(fs, source, destination));
+      Mockito.verify(fs, Mockito.times(2)).rename(source, destination);
+      assertEquals (cs, copyUtilsSpy.getContentSummary(fs, source));
+      Mockito.verify(fs, Mockito.times(2)).getContentSummary(source);
+      assertEquals ("dummy", copyUtilsSpy.checkSumFor(source, fs));
+    }
   }
 
   @Test
   public void testParallelCopySuccess() throws Exception {
-    mockStatic(UserGroupInformation.class);
-    when(UserGroupInformation.getCurrentUser()).thenReturn(mock(UserGroupInformation.class));
-    HiveConf conf = Mockito.spy(new HiveConf());
-    when(conf.getIntVar(HiveConf.ConfVars.REPL_PARALLEL_COPY_TASKS)).thenReturn(2);
-    when(conf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL)).thenReturn(true);
-    FileSystem destFs = mock(FileSystem.class);
-    when(destFs.exists(Mockito.any())).thenReturn(true);
-    CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, destFs);
-    CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-    ExecutorService mockExecutorService = Mockito.spy(executorService);
-    when(copyUtilsSpy.getExecutorService()).thenReturn(mockExecutorService);
-    Path destination = new Path("dest");
-    Path source = mock(Path.class);
-    FileSystem fs = mock(FileSystem.class);
-    ReplChangeManager.FileInfo srcFileInfo = new ReplChangeManager.FileInfo(fs, source, "path1");
-    List<ReplChangeManager.FileInfo> srcFiles = Arrays.asList(srcFileInfo);
-    doNothing().when(copyUtilsSpy).doCopy(Mockito.any(), Mockito.any(),
-      Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any());
-    copyUtilsSpy.copyAndVerify(destination, srcFiles, source, true, true);
-    Class<Collection<? extends Callable<Void>>> listClass =
-      (Class<Collection<? extends Callable<Void>>>)(Class)List.class;
-    //Thread pool Not invoked as only one target path
-    ArgumentCaptor<Collection<? extends Callable<Void>>> callableCapture = ArgumentCaptor.forClass(listClass);
-    Mockito.verify(mockExecutorService, Mockito.times(0)).invokeAll(callableCapture.capture());
-    ReplChangeManager.FileInfo srcFileInfo1 = new ReplChangeManager.FileInfo(fs, source, "path2");
-    ReplChangeManager.FileInfo srcFileInfo2 = new ReplChangeManager.FileInfo(fs, source, "path3");
-    srcFiles = Arrays.asList(srcFileInfo1, srcFileInfo2);
-    executorService = Executors.newFixedThreadPool(2);
-    mockExecutorService = Mockito.spy(executorService);
-    when(copyUtilsSpy.getExecutorService()).thenReturn(mockExecutorService);
-    copyUtilsSpy.copyAndVerify(destination, srcFiles, source, true, true);
-    //File count is greater than 1 do thread pool invoked
-    Mockito.verify(mockExecutorService,
-      Mockito.times(1)).invokeAll(callableCapture.capture());
+    try (MockedStatic<UserGroupInformation> userGroupInformationMockedStatic = mockStatic(UserGroupInformation.class)) {
+
+      userGroupInformationMockedStatic.when(UserGroupInformation::getCurrentUser).thenReturn(mock(UserGroupInformation.class));
+      HiveConf conf = Mockito.spy(new HiveConf());
+      when(conf.getIntVar(HiveConf.ConfVars.REPL_PARALLEL_COPY_TASKS)).thenReturn(2);
+      when(conf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL)).thenReturn(true);
+      FileSystem destFs = mock(FileSystem.class);
+      CopyUtils copyUtils = new CopyUtils(UserGroupInformation.getCurrentUser().getUserName(), conf, destFs);
+      CopyUtils copyUtilsSpy = Mockito.spy(copyUtils);
+      ExecutorService executorService = Executors.newFixedThreadPool(2);
+      ExecutorService mockExecutorService = Mockito.spy(executorService);
+      when(copyUtilsSpy.getExecutorService()).thenReturn(mockExecutorService);
+      Path destination = new Path("dest");
+      Path source = mock(Path.class);
+      FileSystem fs = mock(FileSystem.class);
+      ReplChangeManager.FileInfo srcFileInfo = new ReplChangeManager.FileInfo(fs, source, "path1");
+      List<ReplChangeManager.FileInfo> srcFiles = Arrays.asList(srcFileInfo);
+      doNothing().when(copyUtilsSpy).doCopy(Mockito.any(), Mockito.any(),
+              Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any());
+      copyUtilsSpy.copyAndVerify(destination, srcFiles, source, true, true);
+      Class<Collection<? extends Callable<Void>>> listClass =
+              (Class<Collection<? extends Callable<Void>>>)(Class)List.class;
+      //Thread pool Not invoked as only one target path
+      ArgumentCaptor<Collection<? extends Callable<Void>>> callableCapture = ArgumentCaptor.forClass(listClass);
+      Mockito.verify(mockExecutorService, Mockito.times(0)).invokeAll(callableCapture.capture());
+      ReplChangeManager.FileInfo srcFileInfo1 = new ReplChangeManager.FileInfo(fs, source, "path2");
+      ReplChangeManager.FileInfo srcFileInfo2 = new ReplChangeManager.FileInfo(fs, source, "path3");
+      srcFiles = Arrays.asList(srcFileInfo1, srcFileInfo2);
+      executorService = Executors.newFixedThreadPool(2);
+      mockExecutorService = Mockito.spy(executorService);
+      when(copyUtilsSpy.getExecutorService()).thenReturn(mockExecutorService);
+      copyUtilsSpy.copyAndVerify(destination, srcFiles, source, true, true);
+      //File count is greater than 1 do thread pool invoked
+      Mockito.verify(mockExecutorService,
+              Mockito.times(1)).invokeAll(callableCapture.capture());
+    }
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/dump/TestExportService.java
@@ -24,8 +24,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.Test;
@@ -35,9 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({LoggerFactory.class, ExportService.class})
-
+@RunWith(MockitoJUnitRunner.class)
 public class TestExportService {
   protected static final Logger LOG = LoggerFactory.getLogger(TestExportService.class);
   @Mock

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/load/message/TestPrimaryToReplicaResourceFunction.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/load/message/TestPrimaryToReplicaResourceFunction.java
@@ -30,12 +30,13 @@ import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.repl.load.MetaData;
+import org.apache.hadoop.hive.ql.util.TimeUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,12 +51,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ PrimaryToReplicaResourceFunction.class, FileSystem.class, ReplCopyTask.class,
-                    System.class })
+@RunWith(MockitoJUnitRunner.class)
 public class TestPrimaryToReplicaResourceFunction {
 
   private PrimaryToReplicaResourceFunction function;
@@ -76,20 +75,27 @@ public class TestPrimaryToReplicaResourceFunction {
         new Context("primaryDb", null, null, null, hiveConf, null, null, logger);
     when(hiveConf.getVar(HiveConf.ConfVars.REPL_FUNCTIONS_ROOT_DIR))
         .thenReturn("/someBasePath/withADir/");
-    function = new PrimaryToReplicaResourceFunction(context, metadata, "replicaDbName");
+    function = new PrimaryToReplicaResourceFunction(context, metadata, "replicaDbName", new TimeUtil(){
+        @Override
+        public long getNanoSeconds(){
+            return 0l;
+        }
+    });
   }
 
   @Test
   public void createDestinationPath() throws IOException, SemanticException, URISyntaxException {
-    mockStatic(FileSystem.class);
-    when(FileSystem.get(any(Configuration.class))).thenReturn(mockFs);
-    when(FileSystem.get(any(URI.class), any(Configuration.class))).thenReturn(mockFs);
+    MockedStatic<FileSystem> fileSystemMockedStatic = mockStatic(FileSystem.class);
+    MockedStatic<ReplCopyTask> ignoredReplCopyTaskMockedStatic = mockStatic(ReplCopyTask.class);
+    MockedStatic<CreateFunctionHandler> createFunctionHandlerMockedStatic = mockStatic(CreateFunctionHandler.class);
+
+    fileSystemMockedStatic.when(() -> FileSystem.get(any(Configuration.class))).thenReturn(mockFs);
+    fileSystemMockedStatic.when(() -> FileSystem.get(any(URI.class), any(Configuration.class))).thenReturn(mockFs);
+
     when(mockFs.getScheme()).thenReturn("hdfs");
     when(mockFs.getUri()).thenReturn(new URI("hdfs", "somehost:9000", null, null, null));
-    mockStatic(System.class);
-//    when(System.nanoTime()).thenReturn(Long.MAX_VALUE);
+
     when(functionObj.getFunctionName()).thenReturn("someFunctionName");
-    mockStatic(ReplCopyTask.class);
     Task mock = mock(Task.class);
     when(ReplCopyTask.getLoadCopyTask(any(ReplicationSpec.class), any(Path.class), any(Path.class),
         any(HiveConf.class), any(), any())).thenReturn(mock);

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
@@ -45,14 +45,13 @@ import org.apache.hadoop.hive.ql.parse.repl.metric.event.Metric;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -62,23 +61,29 @@ import java.util.Arrays;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Unit Test class for In Memory Replication Metric Collection.
  */
 
-@PowerMockIgnore({ "javax.*", "com.sun.*", "org.w3c.*" })
-@PrepareOnlyThisForTest({MetricSink.class})
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class TestReplicationMetricCollector {
 
   HiveConf conf;
+
+  private static MockedStatic<MetricSink> metricSinkMockedStatic;
 
   @Mock
   private FailoverMetaData fmd;
 
   @Mock
   private MetricSink metricSinkInstance;
+
+  @BeforeClass
+  public static void setupClass() {
+    metricSinkMockedStatic = mockStatic(MetricSink.class);
+  }
 
   @Before
   public void setup() throws Exception {
@@ -92,8 +97,7 @@ public class TestReplicationMetricCollector {
   }
 
   private void disableBackgroundThreads() {
-    PowerMockito.mockStatic(MetricSink.class);
-    Mockito.when(MetricSink.getInstance()).thenReturn(metricSinkInstance);
+    metricSinkMockedStatic.when(MetricSink::getInstance).thenReturn(metricSinkInstance);
   }
 
   @After

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionHeartbeatService.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionHeartbeatService.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.junit.After;
@@ -29,46 +30,54 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({HiveMetaStoreUtils.class})
-@PowerMockIgnore("javax.management.*")
+@RunWith(MockitoJUnitRunner.class)
 public class TestCompactionHeartbeatService {
 
   private static Field HEARTBEAT_SINGLETON;
+  private static Field HEARTBEAT_CLIENTPOOL;
   @Mock
   private HiveConf conf;
   @Mock
   private IMetaStoreClient client;
 
+  private ObjectPool<IMetaStoreClient> clientPool;
+
   @BeforeClass
   public static void setupClass() throws NoSuchFieldException {
     HEARTBEAT_SINGLETON = CompactionHeartbeatService.class.getDeclaredField("instance");
     HEARTBEAT_SINGLETON.setAccessible(true);
+
+    HEARTBEAT_CLIENTPOOL = CompactionHeartbeatService.class.getDeclaredField("clientPool");
+    HEARTBEAT_CLIENTPOOL.setAccessible(true);
   }
 
   @Before
   public void setup() throws Exception {
     Mockito.when(conf.get(MetastoreConf.ConfVars.TXN_TIMEOUT.getVarname())).thenReturn("100ms");
     Mockito.when(conf.get(MetastoreConf.ConfVars.COMPACTOR_WORKER_THREADS.getVarname())).thenReturn("4");
-    PowerMockito.mockStatic(HiveMetaStoreUtils.class);
-    PowerMockito.when(HiveMetaStoreUtils.getHiveMetastoreClient(any())).thenReturn(client);
     HEARTBEAT_SINGLETON.set(null,null);
+
+    IMetaStoreClientFactory metaStoreClientFactory = spy((new IMetaStoreClientFactory(conf)));
+    doReturn(client).when(metaStoreClientFactory).create();
+
+    clientPool = Mockito.spy(new GenericObjectPool<>(metaStoreClientFactory));
+
+    CompactionHeartbeatService compactionHeartbeatService = CompactionHeartbeatService.getInstance(conf);
+    HEARTBEAT_CLIENTPOOL.set(compactionHeartbeatService, clientPool);
   }
 
   @After
@@ -148,7 +157,7 @@ public class TestCompactionHeartbeatService {
     // Check if bad clients were closed and new ones were requested
     verify(client, times(3)).heartbeat(0,0);
     verify(client, times(3)).close();
-    PowerMockito.verifyStatic(HiveMetaStoreUtils.class, times(3));
-    HiveMetaStoreUtils.getHiveMetastoreClient(conf);
+
+    verify(clientPool, times(3)).borrowObject();
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -74,7 +74,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the worker thread and its MR jobs.
@@ -1019,7 +1019,7 @@ public class TestWorker extends CompactorTest {
   public void testFindNextCompactThrowsTException() throws Exception {
     Worker worker = Mockito.spy(new Worker());
     IMetaStoreClient msc = Mockito.mock(IMetaStoreClient.class);
-    Mockito.when(msc.findNextCompact(Mockito.any(FindNextCompactRequest.class))).thenThrow(MetaException.class);
+    when(msc.findNextCompact(Mockito.any(FindNextCompactRequest.class))).thenThrow(MetaException.class);
     worker.msc = msc;
 
     worker.findNextCompactionAndExecute(true, true);


### PR DESCRIPTION
### What changes were proposed in this pull request?

PowerMockito is a mockito extension that introduces some painful points. 

The main intention behind that is to be able to do static mocking. Since its release, mockito-inline has been released, as a part of the mockito-core. 
It doesn't require vintage test runner to be able to run and it can mock objects with their own thread. 


### Why are the changes needed?
PowerMock allows some crazy things that shouldn't be allowed. Like mocking constructors, and core libraries (like System package). 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I ran the affected tests manually on my local computer. And let the apache infrastructure to run all the tests on the PR. 
