### PR TITLE
HIVE-26767: Fix HIVE-24120 to work for custom databases

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -77,8 +77,15 @@ public class DatabaseProduct implements Configurable {
       Configuration conf) {
     DbType dbt;
 
+    // Check if we are using an external database product
+    boolean isExternal = MetastoreConf.getBoolVar(conf, ConfVars.USE_CUSTOM_RDBMS);
+
     if (theDatabaseProduct != null) {
-      Preconditions.checkState(theDatabaseProduct.dbType == getDbType(productName));
+      dbt = getDbType(productName);
+      if (isExternal) {
+        dbt = DbType.CUSTOM;
+      }
+      Preconditions.checkState(theDatabaseProduct.dbType == dbt);
       return theDatabaseProduct;
     }
 
@@ -93,10 +100,6 @@ public class DatabaseProduct implements Configurable {
 
       // Check for null again in case of race condition
       if (theDatabaseProduct == null) {
-        Preconditions.checkNotNull(conf, "Configuration is null");
-        // Check if we are using an external database product
-        boolean isExternal = MetastoreConf.getBoolVar(conf, ConfVars.USE_CUSTOM_RDBMS);
-
         if (isExternal) {
           // The DatabaseProduct will be created by instantiating an external class via
           // reflection. The external class can override any method in the current class

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -77,6 +77,7 @@ public class DatabaseProduct implements Configurable {
       Configuration conf) {
     DbType dbt;
 
+    Preconditions.checkNotNull(conf, "Configuration is null");
     // Check if we are using an external database product
     boolean isExternal = MetastoreConf.getBoolVar(conf, ConfVars.USE_CUSTOM_RDBMS);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR assumes that if ConfVars.USE_CUSTOM_RDBMS is set that we will expect DbType.CUSTOM, therefore, it will not use DbType.UNDEFINED to compare to the database type set in theDatabaseProduct.

### Why are the changes needed?
getDbType(productName) returns DbType.UNDEFINED
But when theDatabaseProduct == null and ConfVars.USE_CUSTOM_RDBMS is set  theDatabaseProduct.dbType is initialized to DbType.CUSTOM.  DbType.UNDEFINED will never equal  DbType.CUSTOM

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I compile the code, added a subclass of DatabaseProduct for Db2 and installed Hive Metastore using a backend Db2 database.
