### PR TITLE
HIVE-26785: Remove explicit protobuf-java dependency from blobstore and minikdc modules

### DIFF
--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -32,15 +32,9 @@
     <execute.beeline.tests>false</execute.beeline.tests>
     <active.hadoop.version>${hadoop.version}</active.hadoop.version>
     <test.dfs.mkdir>-mkdir -p</test.dfs.mkdir>
-    <!-- Required by Calcite Avatica -->
-    <protobuf.version>3.3.0</protobuf.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-common</artifactId>

--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -26,15 +26,9 @@
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
     <exclude.tests>None</exclude.tests>
-    <!-- Required by Calcite Avatica -->
-    <protobuf.version>3.3.0</protobuf.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-common</artifactId>


### PR DESCRIPTION
The modules do not directly need protobuf dependency so it is misleading to declare it explicitly.

Moreover, these modules use a different protobuf version (3.3.0) than the rest of the project (3.21.4) which can lead to compatibility problems, incosistent behavior in tests, and undesired transitive propagation to other modules.