### PR TITLE
HIVE-26787: Pushdown Timestamp data type to metastore via directsql/JDO

### DIFF
--- a/ql/src/test/results/clientpositive/llap/temp_table_partition_timestamp.q.out
+++ b/ql/src/test/results/clientpositive/llap/temp_table_partition_timestamp.q.out
@@ -96,95 +96,45 @@ POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/r
 PREHOOK: query: select * from partition_timestamp_1_temp where dt = '2000-01-01 01:00:00' and region = '2' order by key,value
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select * from partition_timestamp_1_temp where dt = '2000-01-01 01:00:00' and region = '2' order by key,value
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 01:00:00'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 01:00:00'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 10
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = '2000-01-01 01:00:00'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = '2000-01-01 01:00:00'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 10
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 02:00:00' and region = '2'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 02:00:00' and region = '2'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 5
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2001-01-01 03:00:00' and region = '10'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2001-01-01 03:00:00' and region = '10'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 11
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where region = '1'
@@ -199,153 +149,73 @@ POSTHOOK: Input: default@partition_timestamp_1_temp
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 01:00:00' and region = '3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '2000-01-01 01:00:00' and region = '3'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 0
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '1999-01-01 01:00:00'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt = timestamp '1999-01-01 01:00:00'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 0
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt > timestamp '2000-01-01 01:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt > timestamp '2000-01-01 01:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 20
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt < timestamp '2000-01-02 01:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt < timestamp '2000-01-02 01:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 10
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt >= timestamp '2000-01-02 01:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt >= timestamp '2000-01-02 01:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 20
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt <= timestamp '2000-01-01 01:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt <= timestamp '2000-01-01 01:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 10
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt <> timestamp '2000-01-01 01:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt <> timestamp '2000-01-01 01:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 20
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where dt between timestamp '1999-12-30 12:00:00' and timestamp '2000-01-03 12:00:00' and region = '1'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_timestamp_1_temp
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-PREHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from partition_timestamp_1_temp where dt between timestamp '1999-12-30 12:00:00' and timestamp '2000-01-03 12:00:00' and region = '1'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@partition_timestamp_1_temp
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 01%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2000-01-01 02%3A00%3A00/region=2
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 01%3A00%3A00/region=2020-20-20
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 02%3A00%3A00/region=1
-POSTHOOK: Input: default@partition_timestamp_1_temp@dt=2001-01-01 03%3A00%3A00/region=10
 #### A masked pattern was here ####
 10
 PREHOOK: query: select count(*) from partition_timestamp_1_temp where region = '2020-20-20'

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -25,6 +25,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,6 +84,14 @@ public class MetaStoreUtils {
       val.setTimeZone(TimeZone.getTimeZone("UTC"));
       return val;
     }
+  };
+  public static final ThreadLocal<DateTimeFormatter> PARTITION_TIMESTAMP_FORMAT =
+      new ThreadLocal<DateTimeFormatter>() {
+        @Override
+        protected DateTimeFormatter initialValue() {
+          return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").
+              withZone(TimeZone.getTimeZone("UTC").toZoneId());
+        }
   };
   // Indicates a type was derived from the deserializer rather than Hive's metadata.
   public static final String TYPE_FROM_DESERIALIZER = "<derived from deserializer>";

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -247,6 +247,14 @@ public class DatabaseProduct implements Configurable {
     }
   }
 
+  protected String toTimestamp(String tableValue) {
+    if (isORACLE()) {
+      return "TO_TIMESTAMP(" + tableValue + ", 'YYYY-MM-DD HH:mm:ss')";
+    } else {
+      return "cast(" + tableValue + " as TIMESTAMP)";
+    }
+  }
+
   /**
    * Returns db-specific logic to be executed at the beginning of a transaction.
    * Used in pooled connections.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.metastore.parser;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -456,19 +457,22 @@ public class ExpressionTree {
       boolean isIntegralSupported = canPushDownIntegral && canJdoUseStringsWithIntegral();
       String colType = partitionKeys.get(partColIndex).getType();
       // Can only support partitions whose types are string, or maybe integers
-      // Date data type value is considered as string hence pushing down to JDO.
-      if (!colType.equals(ColumnType.STRING_TYPE_NAME) && !colType.equals(ColumnType.DATE_TYPE_NAME)
+      // Date/Timestamp data type value is considered as string hence pushing down to JDO.
+      if (!ColumnType.STRING_TYPE_NAME.equalsIgnoreCase(colType) && !ColumnType.DATE_TYPE_NAME.equalsIgnoreCase(colType)
+          && !ColumnType.TIMESTAMP_TYPE_NAME.equalsIgnoreCase(colType)
           && (!isIntegralSupported || !ColumnType.IntegralTypes.contains(colType))) {
         filterBuilder.setError("Filtering is supported only on partition keys of type " +
             "string" + (isIntegralSupported ? ", or integral types" : ""));
         return null;
       }
 
-      // There's no support for date cast in JDO. Let's convert it to string; the date
+      // There's no support for date or timestamp cast in JDO. Let's convert it to string; the date
       // columns have been excluded above, so it will either compare w/string or fail.
       Object val = value;
-      if (value instanceof Date) {
+      if (colType.equals("date") && value instanceof Date) {
         val = MetaStoreUtils.PARTITION_DATE_FORMAT.get().format((Date)value);
+      } else if (colType.equals("timestamp") && value instanceof Timestamp) {
+        val = MetaStoreUtils.PARTITION_TIMESTAMP_FORMAT.get().format(((Timestamp)value).toLocalDateTime());
       }
       boolean isStringValue = val instanceof String;
       if (!isStringValue && (!isIntegralSupported || !(val instanceof Long))) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Change the filter parser to process the new timestamp data type filter generated by CBO to be pushed down the filter predicate to the metastore

### Why are the changes needed?
In my testing setup of table having 10k partitions in the table. When we do a select query on one of the partitions without the change it was 300 ms and after the change it was 14 ms.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
1. Manual testing
2. Existing automated tests
