### PR TITLE
HIVE-26789: Add UserName in CallerContext for queries.

### DIFF
--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -256,7 +256,7 @@ public class CliDriver {
           response = qp.run(cmd);
         } catch (CommandProcessorException e) {
           qp.close();
-          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId());
+          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId() + "_User:" + ss.getUserName());
           throw e;
         }
 
@@ -293,7 +293,7 @@ public class CliDriver {
           throw new CommandProcessorException(1);
         } finally {
           qp.close();
-          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId());
+          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId() + "_User:" + ss.getUserName());
 
           if (out instanceof FetchConverter) {
             ((FetchConverter) out).fetchFinished();

--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -251,7 +251,7 @@ public class CliDriver {
 
         // Set HDFS CallerContext to queryId and reset back to sessionId after the query is done
         ShimLoader.getHadoopShims()
-            .setHadoopQueryContext(qp.getQueryState().getQueryId() + " User: " + ss.getUserName());
+            .setHadoopQueryContext(qp.getQueryState().getQueryId() + "_User:" + ss.getUserName());
         try {
           response = qp.run(cmd);
         } catch (CommandProcessorException e) {

--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -250,7 +250,8 @@ public class CliDriver {
         }
 
         // Set HDFS CallerContext to queryId and reset back to sessionId after the query is done
-        ShimLoader.getHadoopShims().setHadoopQueryContext(qp.getQueryState().getQueryId());
+        ShimLoader.getHadoopShims()
+            .setHadoopQueryContext(qp.getQueryState().getQueryId() + " User: " + ss.getUserName());
         try {
           response = qp.run(cmd);
         } catch (CommandProcessorException e) {

--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.cli;
 
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
 import static org.apache.hadoop.util.StringUtils.stringifyException;
 
 import java.io.BufferedReader;
@@ -251,12 +252,13 @@ public class CliDriver {
 
         // Set HDFS CallerContext to queryId and reset back to sessionId after the query is done
         ShimLoader.getHadoopShims()
-            .setHadoopQueryContext(qp.getQueryState().getQueryId() + "_User:" + ss.getUserName());
+            .setHadoopQueryContext(String.format(USER_ID, qp.getQueryState().getQueryId(), ss.getUserName()));
         try {
           response = qp.run(cmd);
         } catch (CommandProcessorException e) {
           qp.close();
-          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId() + "_User:" + ss.getUserName());
+          ShimLoader.getHadoopShims()
+              .setHadoopSessionContext(String.format(USER_ID, ss.getSessionId(), ss.getUserName()));
           throw e;
         }
 
@@ -293,7 +295,8 @@ public class CliDriver {
           throw new CommandProcessorException(1);
         } finally {
           qp.close();
-          ShimLoader.getHadoopShims().setHadoopSessionContext(ss.getSessionId() + "_User:" + ss.getUserName());
+          ShimLoader.getHadoopShims()
+              .setHadoopSessionContext(String.format(USER_ID, ss.getSessionId(), ss.getUserName()));
 
           if (out instanceof FetchConverter) {
             ((FetchConverter) out).fetchFinished();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -198,7 +198,7 @@ public class TezTask extends Task<TezWork> {
       // TODO: we could perhaps reuse the same directory for HiveResources?
       Path scratchDir = utils.createTezDir(ctx.getMRScratchDir(), conf);
       CallerContext callerContext =
-          CallerContext.create("HIVE", queryPlan.getQueryId() + " User: " + userName, "HIVE_QUERY_ID",
+          CallerContext.create("HIVE", queryPlan.getQueryId() + "_User:" + userName, "HIVE_QUERY_ID",
               queryPlan.getQueryStr());
 
       perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.TEZ_GET_SESSION);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -94,6 +94,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
+
 /**
  *
  * TezTask handles the execution of TezWork. Currently it executes a graph of map and reduce work
@@ -198,7 +200,7 @@ public class TezTask extends Task<TezWork> {
       // TODO: we could perhaps reuse the same directory for HiveResources?
       Path scratchDir = utils.createTezDir(ctx.getMRScratchDir(), conf);
       CallerContext callerContext =
-          CallerContext.create("HIVE", queryPlan.getQueryId() + "_User:" + userName, "HIVE_QUERY_ID",
+          CallerContext.create("HIVE", String.format(USER_ID, queryPlan.getQueryId(), userName), "HIVE_QUERY_ID",
               queryPlan.getQueryStr());
 
       perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.TEZ_GET_SESSION);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -197,8 +197,9 @@ public class TezTask extends Task<TezWork> {
       // DAG scratch dir. We get a session from the pool so it may be different from Tez one.
       // TODO: we could perhaps reuse the same directory for HiveResources?
       Path scratchDir = utils.createTezDir(ctx.getMRScratchDir(), conf);
-      CallerContext callerContext = CallerContext.create(
-          "HIVE", queryPlan.getQueryId(), "HIVE_QUERY_ID", queryPlan.getQueryStr());
+      CallerContext callerContext =
+          CallerContext.create("HIVE", queryPlan.getQueryId() + " User: " + userName, "HIVE_QUERY_ID",
+              queryPlan.getQueryStr());
 
       perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.TEZ_GET_SESSION);
       session = sessionRef.value = WorkloadManagerFederation.getSession(

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.session;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
 
 import java.io.Closeable;
 import java.io.File;
@@ -470,7 +471,7 @@ public class SessionState implements ISessionAuthState{
     killQuery = new NullKillQuery();
     this.cleanupService = cleanupService;
 
-    ShimLoader.getHadoopShims().setHadoopSessionContext(getSessionId() + "_User:" + userName);
+    ShimLoader.getHadoopShims().setHadoopSessionContext(String.format(USER_ID, getSessionId(), userName));
   }
 
   public Map<String, String> getHiveVariables() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -470,7 +470,7 @@ public class SessionState implements ISessionAuthState{
     killQuery = new NullKillQuery();
     this.cleanupService = cleanupService;
 
-    ShimLoader.getHadoopShims().setHadoopSessionContext(getSessionId());
+    ShimLoader.getHadoopShims().setHadoopSessionContext(getSessionId() + "_User:" + userName);
   }
 
   public Map<String, String> getHiveVariables() {

--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
+
 public abstract class Operation {
   protected final HiveSession parentSession;
   protected boolean embedded;
@@ -238,7 +240,7 @@ public abstract class Operation {
    */
   protected void beforeRun() {
     ShimLoader.getHadoopShims()
-        .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSession.getUserName());
+        .setHadoopQueryContext(String.format(USER_ID, queryState.getQueryId(), parentSession.getUserName()));
     if (!embedded) {
       createOperationLog();
       LogUtils.registerLoggingContext(queryState.getConf());
@@ -265,7 +267,7 @@ public abstract class Operation {
     }
     // Reset back to session context after the query is done
     ShimLoader.getHadoopShims().setHadoopSessionContext(
-        parentSession.getSessionState().getSessionId() + "_User:" + parentSession.getUserName());
+        String.format(USER_ID, parentSession.getSessionState().getSessionId(), parentSession.getUserName()));
   }
 
   /**

--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.session.OperationLog;
 import org.apache.hadoop.hive.shims.ShimLoader;
-import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hive.service.cli.FetchOrientation;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
@@ -238,9 +237,8 @@ public abstract class Operation {
    * Set up some preconditions, or configurations.
    */
   protected void beforeRun() {
-    CallerContext.setCurrent(new CallerContext.Builder("Check").build());
     ShimLoader.getHadoopShims()
-        .setHadoopQueryContext(queryState.getQueryId() + " User: " + parentSession.getUserName());
+        .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSession.getUserName());
     if (!embedded) {
       createOperationLog();
       LogUtils.registerLoggingContext(queryState.getConf());

--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.session.OperationLog;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hive.service.cli.FetchOrientation;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
@@ -237,7 +238,9 @@ public abstract class Operation {
    * Set up some preconditions, or configurations.
    */
   protected void beforeRun() {
-    ShimLoader.getHadoopShims().setHadoopQueryContext(queryState.getQueryId());
+    CallerContext.setCurrent(new CallerContext.Builder("Check").build());
+    ShimLoader.getHadoopShims()
+        .setHadoopQueryContext(queryState.getQueryId() + " User: " + parentSession.getUserName());
     if (!embedded) {
       createOperationLog();
       LogUtils.registerLoggingContext(queryState.getConf());

--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -264,7 +264,8 @@ public abstract class Operation {
       LogUtils.unregisterLoggingContext();
     }
     // Reset back to session context after the query is done
-    ShimLoader.getHadoopShims().setHadoopSessionContext(parentSession.getSessionState().getSessionId());
+    ShimLoader.getHadoopShims().setHadoopSessionContext(
+        parentSession.getSessionState().getSessionId() + "_User:" + parentSession.getUserName());
   }
 
   /**

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -329,7 +329,7 @@ public class SQLOperation extends ExecuteStatementOperation {
             LogUtils.registerLoggingContext(queryState.getConf());
           }
           ShimLoader.getHadoopShims()
-              .setHadoopQueryContext(queryState.getQueryId() + " User:" + parentSessionState.getUserName());
+              .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSessionState.getUserName());
 
           try {
             if (asyncPrepare) {

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -328,7 +328,8 @@ public class SQLOperation extends ExecuteStatementOperation {
           if (!embedded) {
             LogUtils.registerLoggingContext(queryState.getConf());
           }
-          ShimLoader.getHadoopShims().setHadoopQueryContext(queryState.getQueryId());
+          ShimLoader.getHadoopShims()
+              .setHadoopQueryContext(queryState.getQueryId() + " User:" + parentSessionState.getUserName());
 
           try {
             if (asyncPrepare) {

--- a/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -82,6 +82,8 @@ import org.apache.hive.service.cli.TableSchema;
 import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.server.ThreadWithGarbageCleanup;
 
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
+
 /**
  * SQLOperation.
  */
@@ -329,7 +331,7 @@ public class SQLOperation extends ExecuteStatementOperation {
             LogUtils.registerLoggingContext(queryState.getConf());
           }
           ShimLoader.getHadoopShims()
-              .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSessionState.getUserName());
+              .setHadoopQueryContext(String.format(USER_ID, queryState.getQueryId(), parentSessionState.getUserName()));
 
           try {
             if (asyncPrepare) {

--- a/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlOperation.java
@@ -199,7 +199,8 @@ public class HplSqlOperation extends ExecuteStatementOperation implements Result
         SessionState.setCurrentSessionState(parentSessionState);
         PerfLogger.setPerfLogger(SessionState.getPerfLogger());
         LogUtils.registerLoggingContext(queryState.getConf());
-        ShimLoader.getHadoopShims().setHadoopQueryContext(queryState.getQueryId());
+        ShimLoader.getHadoopShims()
+            .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSessionState.getUserName());
         try {
           interpret();
         } catch (HiveSQLException e) {

--- a/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/hplsql/HplSqlOperation.java
@@ -49,6 +49,8 @@ import org.apache.hive.service.cli.operation.ExecuteStatementOperation;
 import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.server.ThreadWithGarbageCleanup;
 
+import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
+
 public class HplSqlOperation extends ExecuteStatementOperation implements ResultListener {
   private final Exec exec;
   private final boolean runInBackground;
@@ -200,7 +202,7 @@ public class HplSqlOperation extends ExecuteStatementOperation implements Result
         PerfLogger.setPerfLogger(SessionState.getPerfLogger());
         LogUtils.registerLoggingContext(queryState.getConf());
         ShimLoader.getHadoopShims()
-            .setHadoopQueryContext(queryState.getQueryId() + "_User:" + parentSessionState.getUserName());
+            .setHadoopQueryContext(String.format(USER_ID, queryState.getQueryId(), parentSessionState.getUserName()));
         try {
           interpret();
         } catch (HiveSQLException e) {

--- a/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
@@ -72,6 +72,8 @@ import org.apache.hadoop.util.Progressable;
  */
 public interface HadoopShims {
 
+  String USER_ID = "%s_User:%s";
+
   /**
    * Constructs and Returns TaskAttempt Logger Url
    * or null if the TaskLogServlet is not available


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add UserName in CallerContext for HDFS Audit logs to pick.

### Why are the changes needed?

With Impersonation turned off, every call shows from Hive User, So, to allow tracking the actual user.

### Does this PR introduce _any_ user-facing change?

Nopes,

### How was this patch tested?

Tried a Query in Actual Cluster.