### PR TITLE
HIVE-26702: Backport HIVE-17317 (DBCP and HikariCP property configuration support) to 3.2.0.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4377,7 +4377,8 @@ public class HiveConf extends Configuration {
             "bonecp.,"+
             "hive.druid.broker.address.default,"+
             "hive.druid.coordinator.address.default,"+
-            "hikari.,"+
+            "hikaricp.," +
+            "dbcp.," +
             "hadoop.bin.path,"+
             "yarn.bin.path,"+
             "spark.home",

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestRestrictedList.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestRestrictedList.java
@@ -95,7 +95,8 @@ public class TestRestrictedList {
     addToExpectedRestrictedMap("bonecp.test");
     addToExpectedRestrictedMap("hive.druid.broker.address.default");
     addToExpectedRestrictedMap("hive.druid.coordinator.address.default");
-    addToExpectedRestrictedMap("hikari.test");
+    addToExpectedRestrictedMap("hikaricp.test");
+    addToExpectedRestrictedMap("dbcp.test");
     addToExpectedRestrictedMap("hadoop.bin.path");
     addToExpectedRestrictedMap("yarn.bin.path");
     addToExpectedRestrictedMap("hive.spark.client.connect.timeout");

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/DataSourceProviderFactory.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/DataSourceProviderFactory.java
@@ -29,7 +29,8 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 public abstract  class DataSourceProviderFactory {
   private static final ImmutableList<DataSourceProvider> FACTORIES = ImmutableList.of(
     new HikariCPDataSourceProvider(),
-    new BoneCPDataSourceProvider());
+    new BoneCPDataSourceProvider(),
+    new DbCPDataSourceProvider());
 
   /**
    * The data source providers declare if they are supported or not based on the config.

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.datasource;
+
+import org.apache.commons.dbcp.ConnectionFactory;
+import org.apache.commons.dbcp.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp.PoolableConnectionFactory;
+import org.apache.commons.dbcp.PoolingDataSource;
+import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+/**
+ * DataSourceProvider for the dbcp connection pool.
+ */
+public class DbCPDataSourceProvider implements DataSourceProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DbCPDataSourceProvider.class);
+
+  static final String DBCP = "dbcp";
+  private static final String CONNECTION_TIMEOUT_PROPERTY = DBCP + ".maxWait";
+  private static final String CONNECTION_MAX_IDLE_PROPERTY = DBCP + ".maxIdle";
+  private static final String CONNECTION_MIN_IDLE_PROPERTY = DBCP + ".minIdle";
+  private static final String CONNECTION_TEST_BORROW_PROPERTY = DBCP + ".testOnBorrow";
+  private static final String CONNECTION_MIN_EVICT_MILLIS_PROPERTY = DBCP + ".minEvictableIdleTimeMillis";
+  private static final String CONNECTION_TEST_IDLEPROPERTY = DBCP + ".testWhileIdle";
+  private static final String CONNECTION_TIME_BETWEEN_EVICTION_RUNS_MILLIS = DBCP + ".timeBetweenEvictionRunsMillis";
+  private static final String CONNECTION_NUM_TESTS_PER_EVICTION_RUN = DBCP + ".numTestsPerEvictionRun";
+  private static final String CONNECTION_TEST_ON_RETURN = DBCP + ".testOnReturn";
+  private static final String CONNECTION_SOFT_MIN_EVICTABLE_IDLE_TIME = DBCP + ".softMinEvictableIdleTimeMillis";
+  private static final String CONNECTION_LIFO = DBCP + ".lifo";
+
+  @Override
+  public DataSource create(Configuration hdpConfig) throws SQLException {
+
+    LOG.debug("Creating dbcp connection pool for the MetaStore");
+
+    String driverUrl = DataSourceProvider.getMetastoreJdbcDriverUrl(hdpConfig);
+    String user = DataSourceProvider.getMetastoreJdbcUser(hdpConfig);
+    String passwd = DataSourceProvider.getMetastoreJdbcPasswd(hdpConfig);
+    int maxPoolSize = hdpConfig.getInt(
+            MetastoreConf.ConfVars.CONNECTION_POOLING_MAX_CONNECTIONS.getVarname(),
+            ((Long) MetastoreConf.ConfVars.CONNECTION_POOLING_MAX_CONNECTIONS.getDefaultVal()).intValue());
+    long connectionTimeout = hdpConfig.getLong(CONNECTION_TIMEOUT_PROPERTY, 30000L);
+    int connectionMaxIlde = hdpConfig.getInt(CONNECTION_MAX_IDLE_PROPERTY, GenericObjectPool.DEFAULT_MAX_IDLE);
+    int connectionMinIlde = hdpConfig.getInt(CONNECTION_MIN_IDLE_PROPERTY, GenericObjectPool.DEFAULT_MIN_IDLE);
+    boolean testOnBorrow = hdpConfig.getBoolean(CONNECTION_TEST_BORROW_PROPERTY,
+            GenericObjectPool.DEFAULT_TEST_ON_BORROW);
+    long evictionTimeMillis = hdpConfig.getLong(CONNECTION_MIN_EVICT_MILLIS_PROPERTY,
+            GenericObjectPool.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+    boolean testWhileIdle = hdpConfig.getBoolean(CONNECTION_TEST_IDLEPROPERTY,
+            GenericObjectPool.DEFAULT_TEST_WHILE_IDLE);
+    long timeBetweenEvictionRuns = hdpConfig.getLong(CONNECTION_TIME_BETWEEN_EVICTION_RUNS_MILLIS,
+            GenericObjectPool.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS);
+    int numTestsPerEvictionRun = hdpConfig.getInt(CONNECTION_NUM_TESTS_PER_EVICTION_RUN,
+            GenericObjectPool.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
+    boolean testOnReturn = hdpConfig.getBoolean(CONNECTION_TEST_ON_RETURN, GenericObjectPool.DEFAULT_TEST_ON_RETURN);
+    long softMinEvictableIdleTimeMillis = hdpConfig.getLong(CONNECTION_SOFT_MIN_EVICTABLE_IDLE_TIME,
+            GenericObjectPool.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+    boolean lifo = hdpConfig.getBoolean(CONNECTION_LIFO, GenericObjectPool.DEFAULT_LIFO);
+
+    GenericObjectPool objectPool = new GenericObjectPool();
+    objectPool.setMaxActive(maxPoolSize);
+    objectPool.setMaxWait(connectionTimeout);
+    objectPool.setMaxIdle(connectionMaxIlde);
+    objectPool.setMinIdle(connectionMinIlde);
+    objectPool.setTestOnBorrow(testOnBorrow);
+    objectPool.setTestWhileIdle(testWhileIdle);
+    objectPool.setMinEvictableIdleTimeMillis(evictionTimeMillis);
+    objectPool.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRuns);
+    objectPool.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
+    objectPool.setTestOnReturn(testOnReturn);
+    objectPool.setSoftMinEvictableIdleTimeMillis(softMinEvictableIdleTimeMillis);
+    objectPool.setLifo(lifo);
+
+    ConnectionFactory connFactory = new DriverManagerConnectionFactory(driverUrl, user, passwd);
+    // This doesn't get used, but it's still necessary, see
+    // https://git1-us-west.apache.org/repos/asf?p=commons-dbcp.git;a=blob;f=doc/ManualPoolingDataSourceExample.java;
+    // h=f45af2b8481f030b27364e505984c0eef4f35cdb;hb=refs/heads/DBCP_1_5_x_BRANCH
+    new PoolableConnectionFactory(connFactory, objectPool, null, null, false, true);
+
+    return new PoolingDataSource(objectPool);
+  }
+
+  @Override
+  public boolean mayReturnClosedConnection() {
+    // Only BoneCP should return true
+    return false;
+  }
+
+  @Override
+  public String getPoolingType() {
+    return DBCP;
+  }
+}

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -37,8 +37,8 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(HikariCPDataSourceProvider.class);
 
-  static final String HIKARI = "hikari";
-  private static final String CONNECTION_TIMEOUT_PROPERTY= "hikari.connectionTimeout";
+  public static final String HIKARI = "hikaricp";
+  private static final String CONNECTION_TIMEOUT_PROPERTY= HIKARI + ".connectionTimeout";
 
   @Override
   public DataSource create(Configuration hdpConfig) throws SQLException {

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -51,13 +51,8 @@ import java.util.regex.Pattern;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp.ConnectionFactory;
-import org.apache.commons.dbcp.DriverManagerConnectionFactory;
-import org.apache.commons.dbcp.PoolableConnectionFactory;
-import org.apache.commons.dbcp.PoolingDataSource;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.commons.pool.impl.GenericObjectPool;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -74,9 +69,8 @@ import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
 import org.apache.hadoop.hive.metastore.api.*;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
-import org.apache.hadoop.hive.metastore.datasource.BoneCPDataSourceProvider;
 import org.apache.hadoop.hive.metastore.datasource.DataSourceProvider;
-import org.apache.hadoop.hive.metastore.datasource.HikariCPDataSourceProvider;
+import org.apache.hadoop.hive.metastore.datasource.DataSourceProviderFactory;
 import org.apache.hadoop.hive.metastore.events.AbortTxnEvent;
 import org.apache.hadoop.hive.metastore.events.AllocWriteIdEvent;
 import org.apache.hadoop.hive.metastore.events.CommitTxnEvent;
@@ -4757,32 +4751,18 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
 
   private static synchronized DataSource setupJdbcConnectionPool(Configuration conf, int maxPoolSize, long getConnectionTimeoutMs) {
     try {
-      String driverUrl = DataSourceProvider.getMetastoreJdbcDriverUrl(conf);
-      String user = DataSourceProvider.getMetastoreJdbcUser(conf);
-      String passwd = DataSourceProvider.getMetastoreJdbcPasswd(conf);
-      String connectionPooler = MetastoreConf.getVar(conf, ConfVars.CONNECTION_POOLING_TYPE).toLowerCase();
-
-      if ("bonecp".equals(connectionPooler)) {
-        doRetryOnConnPool = true;  // Enable retries to work around BONECP bug.
-        return new BoneCPDataSourceProvider().create(conf);
-      } else if ("dbcp".equals(connectionPooler)) {
-        GenericObjectPool objectPool = new GenericObjectPool();
-        //https://commons.apache.org/proper/commons-pool/api-1.6/org/apache/commons/pool/impl/GenericObjectPool.html#setMaxActive(int)
-        objectPool.setMaxActive(maxPoolSize);
-        objectPool.setMaxWait(getConnectionTimeoutMs);
-        ConnectionFactory connFactory = new DriverManagerConnectionFactory(driverUrl, user, passwd);
-        // This doesn't get used, but it's still necessary, see
-        // http://svn.apache.org/viewvc/commons/proper/dbcp/branches/DBCP_1_4_x_BRANCH/doc/ManualPoolingDataSourceExample.java?view=markup
-        PoolableConnectionFactory poolConnFactory =
-                new PoolableConnectionFactory(connFactory, objectPool, null, null, false, true);
-        return new PoolingDataSource(objectPool);
-      } else if ("hikaricp".equals(connectionPooler)) {
-        return new HikariCPDataSourceProvider().create(conf);
-      } else if ("none".equals(connectionPooler)) {
-        LOG.info("Choosing not to pool JDBC connections");
-        return new NoPoolConnectionPool(conf);
+      DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+      if (dsp != null) {
+        doRetryOnConnPool = dsp.mayReturnClosedConnection();
+        return dsp.create(conf);
       } else {
-        throw new RuntimeException("Unknown JDBC connection pooling " + connectionPooler);
+        String connectionPooler = MetastoreConf.getVar(conf, ConfVars.CONNECTION_POOLING_TYPE).toLowerCase();
+        if ("none".equals(connectionPooler)) {
+          LOG.info("Choosing not to pool JDBC connections");
+          return new NoPoolConnectionPool(conf);
+        } else {
+          throw new RuntimeException("Unknown JDBC connection pooling " + connectionPooler);
+        }
       }
     } catch (SQLException e) {
       LOG.error("Unable to instantiate JDBC connection pooling", e);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport [HIVE-17317](https://issues.apache.org/jira/browse/HIVE-17317). This patch introduced support for DBCP as a connection pool for the metastore database. It also corrected HIkariCP configuration by changing a pooling type constant from `"hikari"` to `"hikaricp"`.

As compared to the original HIVE-17317 patch, here are the differences in this backport:
* Changes in `ObjectStore` are no longer required, because the relevant logic was later refactored into `PersistenceManagerProvider` on branch-3.
* Similarly, there are no changes required in `BoneCPDataSourceProvider` on branch-3.
* `DataSourceProviderFactory` has minor cosmetic differences on how the `FACTORIES` list is defined, and some other changes are no longer required.
* `HikariCPDataSourceProvider` only needs the change of the pooling type from `"hikari"` to `"hikaricp"`.
* Changes in `TxnHandler` look different because 1) `DataSourceProviderFactory#getDataSourceProvider` is now called `tryGetDataSourceProviderOrNull` on branch-3, and 2) the logic was subsequently wrapped in a try-catch for `SQLException`.
* `TestDataSourceProviderFactory` changes are smaller, because the original included several tests that are no longer relevant to the current state of the code on branch-3.

### Why are the changes needed?

DBCP will give Hive 3.2 users another connection pooling option. Correction of the HikariCP pooling type constant makes the feature consistent with the state of the master branch and documentation.

### Does this PR introduce _any_ user-facing change?

Users of Hive 3.2 will be able to use DBCP or stick with the default of HikariCP and use the `hikaricp.` configuration property prefix to pass through any HikariCP configuration properties.

### How was this patch tested?

All unit tests in standalone-metastore are passing. A new unit test covers usage of the new DBCP option. I also manually inspected and confirmed correct passthrough of `hikaricp.` properties.