### PR TITLE
HIVE-26794: Explore retiring TxnHandler#connPoolMutex idle connections

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -113,6 +113,14 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     objectPool.setSoftMinEvictableIdleTimeMillis(softMinEvictableIdleTimeMillis);
     objectPool.setLifo(lifo);
 
+    if ("mutex".equalsIgnoreCase(poolName)) {
+      if (timeBetweenEvictionRuns < 0) {
+        objectPool.setTimeBetweenEvictionRunsMillis(30 * 1000);
+      }
+      if (softMinEvictableIdleTimeMillis < 0) {
+        objectPool.setSoftMinEvictableIdleTimeMillis(600 * 1000);
+      }
+    }
     String stmt = dbProduct.getPrepareTxnStmt();
     if (stmt != null) {
       poolableConnFactory.setConnectionInitSql(Arrays.asList(stmt));

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.metastore.datasource;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -114,7 +115,7 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
 
     String stmt = dbProduct.getPrepareTxnStmt();
     if (stmt != null) {
-      poolableConnFactory.setValidationQuery(stmt);
+      poolableConnFactory.setConnectionInitSql(Arrays.asList(stmt));
     }
     return new PoolingDataSource(objectPool);
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hive.metastore.datasource;
 
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -113,8 +113,13 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     objectPool.setSoftMinEvictableIdleTimeMillis(softMinEvictableIdleTimeMillis);
     objectPool.setLifo(lifo);
 
+    // Enable TxnHandler#connPoolMutex to release the idle connection if possible,
+    // TxnHandler#connPoolMutex is mostly used for MutexAPI that is primarily designed to
+    // provide coarse-grained mutex support to maintenance tasks running inside the Metastore,
+    // this will make Metastore more scalable especially if there is a leader in the warehouse.
     if ("mutex".equalsIgnoreCase(poolName)) {
       if (timeBetweenEvictionRuns < 0) {
+        // When timeBetweenEvictionRunsMillis non-positive, no idle object evictor thread runs
         objectPool.setTimeBetweenEvictionRunsMillis(30 * 1000);
       }
       if (softMinEvictableIdleTimeMillis < 0) {
@@ -123,7 +128,7 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     }
     String stmt = dbProduct.getPrepareTxnStmt();
     if (stmt != null) {
-      poolableConnFactory.setConnectionInitSql(Arrays.asList(stmt));
+      poolableConnFactory.setConnectionInitSql(Collections.singletonList(stmt));
     }
     return new PoolingDataSource(objectPool);
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -75,12 +75,11 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     // It's kind of a waste to create a fixed size connection pool as same as the TxnHandler#connPool,
     // TxnHandler#connPoolMutex is mostly used for MutexAPI that is primarily designed to
     // provide coarse-grained mutex support to maintenance tasks running inside the Metastore,
-    // add minimumIdle=2 and idleTimeout=5min to the pool, so that the connection pool can retire
-    // the idle connection aggressively, this will make Metastore more scalable especially if
-    // there is a leader in the warehouse.
+    // add minimumIdle=2 and idleTimeout=10min(default, can be set by hikaricp.idleTimeout) to the pool,
+    // so that the connection pool can retire the idle connection aggressively,
+    // this will make Metastore more scalable especially if there is a leader in the warehouse.
     if ("mutex".equals(poolName)) {
       config.setMinimumIdle(Math.min(maxPoolSize, 2));
-      config.setIdleTimeout(300 * 1000);
     }
 
     //https://github.com/brettwooldridge/HikariCP

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -72,6 +72,17 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
       config.setPoolName(poolName);
     }
 
+    // It's kind of a waste to create a fixed size connection pool as same as the TxnHandler#connPool,
+    // TxnHandler#connPoolMutex is mostly used for MutexAPI that is primarily designed to
+    // provide coarse-grained mutex support to maintenance tasks running inside the Metastore,
+    // add minimumIdle=2 and idleTimeout=5min to the pool, so that the connection pool can retire
+    // the idle connection aggressively, this will make Metastore more scalable especially if
+    // there is a leader in the warehouse.
+    if ("mutex".equals(poolName)) {
+      config.setMinimumIdle(Math.min(maxPoolSize, 2));
+      config.setIdleTimeout(300 * 1000);
+    }
+
     //https://github.com/brettwooldridge/HikariCP
     config.setConnectionTimeout(connectionTimeout);
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/HikariCPDataSourceProvider.java
@@ -79,7 +79,8 @@ public class HikariCPDataSourceProvider implements DataSourceProvider {
     // so that the connection pool can retire the idle connection aggressively,
     // this will make Metastore more scalable especially if there is a leader in the warehouse.
     if ("mutex".equals(poolName)) {
-      config.setMinimumIdle(Math.min(maxPoolSize, 2));
+      int minimumIdle = Integer.valueOf(hdpConfig.get(HIKARI + ".minimumIdle", "2"));
+      config.setMinimumIdle(Math.min(maxPoolSize, minimumIdle));
     }
 
     //https://github.com/brettwooldridge/HikariCP

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -6188,6 +6188,12 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
         connectionProps.setProperty("user", username);
         connectionProps.setProperty("password", password);
         Connection conn = driver.connect(connString, connectionProps);
+        String prepareStmt = dbProduct != null ? dbProduct.getPrepareTxnStmt() : null;
+        if (prepareStmt != null) {
+          try (Statement stmt = conn.createStatement()) {
+            stmt.execute(prepareStmt);
+          }
+        }
         conn.setAutoCommit(false);
         return conn;
       } catch (SQLException e) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.hive.metastore.datasource;
 
 import com.zaxxer.hikari.HikariDataSource;
 
+import com.zaxxer.hikari.HikariPoolMXBean;
 import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.PersistenceManagerProvider;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
@@ -32,8 +34,11 @@ import org.junit.experimental.categories.Category;
 
 import javax.jdo.PersistenceManagerFactory;
 import javax.sql.DataSource;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Category(MetastoreUnitTest.class)
 public class TestDataSourceProviderFactory {
@@ -141,6 +146,62 @@ public class TestDataSourceProviderFactory {
 
     DataSource ds = dsp.create(conf);
     Assert.assertTrue(ds instanceof PoolingDataSource);
+  }
+
+  @Test
+  public void testEvictIdleConnection() throws Exception {
+    String[] dataSourceType = {HikariCPDataSourceProvider.HIKARI, DbCPDataSourceProvider.DBCP};
+    try (DataSourceProvider.DataSourceNameConfigurator configurator =
+             new DataSourceProvider.DataSourceNameConfigurator(conf, "mutex")) {
+      for (final String type: dataSourceType) {
+        MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, type);
+        boolean isHikari = HikariCPDataSourceProvider.HIKARI.equals(type);
+        if (isHikari) {
+          conf.unset("hikaricp.connectionInitSql");
+          // The minimum of idleTimeout is 10s
+          conf.set("hikaricp.idleTimeout", "10000");
+          System.setProperty("com.zaxxer.hikari.housekeeping.periodMs", "1000");
+        } else {
+          conf.set("dbcp.timeBetweenEvictionRunsMillis", "1000");
+          conf.set("dbcp.softMinEvictableIdleTimeMillis", "3000");
+          conf.set("dbcp.maxIdle", "0");
+        }
+        DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+        DataSource ds = dsp.create(conf, 5);
+        List<Connection> connections = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+          connections.add(ds.getConnection());
+        }
+        HikariPoolMXBean poolMXBean = null;
+        GenericObjectPool objectPool = null;
+        if (isHikari) {
+          poolMXBean = ((HikariDataSource) ds).getHikariPoolMXBean();
+          Assert.assertEquals(5, poolMXBean.getTotalConnections());
+          Assert.assertEquals(5, poolMXBean.getActiveConnections());
+        } else {
+          Method getPool = PoolingDataSource.class.getDeclaredMethod("getPool");
+          getPool.setAccessible(true);
+          objectPool = (GenericObjectPool) getPool.invoke(ds);
+          Assert.assertEquals(5, objectPool.getNumActive());
+          Assert.assertEquals(5, objectPool.getMaxTotal());
+        }
+        connections.forEach(connection -> {
+          try {
+            connection.close();
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        });
+        Thread.sleep(isHikari ? 15000 : 7000);
+        if (isHikari) {
+          Assert.assertEquals(2, poolMXBean.getTotalConnections());
+          Assert.assertEquals(2, poolMXBean.getIdleConnections());
+        } else {
+          Assert.assertEquals(0, objectPool.getNumActive());
+          Assert.assertEquals(0, objectPool.getNumIdle());
+        }
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Change the TxnHandler#connPoolMutex from a fixed size connection pool to NoPoolConnectionPool
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
- TxnHandler#MutexAPI is primarily designed to provide coarse-grained mutex support to maintenance tasks running inside the Metastore, now used by Compactor(Initiator/Cleaner), AcidHouseKeeperService, AcidTxnCleanerService, MaterializationsRebuildLockCleanerTask;
- A fixed size connection pool is a waste for other non leaders in the warehouse;
- Explore if we can remove the mutex used in TxnHandler#lockMaterializationRebuild and TxnHandler#compact, as user have a change to call them;

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Tested manually by using existed TestTxnHandler#testMutexAPI against Postgres(docker container), MySQL(remote), Oracle(remote), Mssql(remote) with the proposed fix, worked fine.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
