### PR TITLE
HIVE-26798: Revert HIVE-26763

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,10 +203,10 @@
     <velocity.version>2.3</velocity.version>
     <xerces.version>2.12.2</xerces.version>
     <xmlsec.version>2.3.0</xmlsec.version>
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <zookeeper.version>3.5.5</zookeeper.version>
     <jpam.version>1.1</jpam.version>
     <felix.version>2.4.0</felix.version>
-    <curator.version>5.2.0</curator.version>
+    <curator.version>4.2.0</curator.version>
     <jsr305.version>3.0.0</jsr305.version>
     <gson.version>2.9.0</gson.version>
     <jjwt.version>0.10.5</jjwt.version>

--- a/ql/src/test/org/apache/hive/testutils/MiniZooKeeperCluster.java
+++ b/ql/src/test/org/apache/hive/testutils/MiniZooKeeperCluster.java
@@ -311,7 +311,7 @@ public class MiniZooKeeperCluster {
       serverCnxnFactory = ServerCnxnFactory.createFactory();
       serverCnxnFactory.configure(new InetSocketAddress(currentClientPort),
           configuration.getInt(HConstants.ZOOKEEPER_MAX_CLIENT_CNXNS, HConstants.DEFAULT_ZOOKEPER_MAX_CLIENT_CNXNS),
-          -1,true);
+          true);
     } else {
       serverCnxnFactory = ServerCnxnFactory.createFactory();
       serverCnxnFactory.configure(new InetSocketAddress(currentClientPort),

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -94,8 +94,8 @@
     <storage-api.version>4.0.0-SNAPSHOT</storage-api.version>
     <beanutils.version>1.9.4</beanutils.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <curator.version>5.2.0</curator.version>
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <curator.version>4.2.0</curator.version>
+    <zookeeper.version>3.5.5</zookeeper.version>
     <cron-utils.version>9.1.6</cron-utils.version>
     <spotbugs.version>4.0.3</spotbugs.version>
     <caffeine.version>2.8.4</caffeine.version>


### PR DESCRIPTION
… (Aman Raj, reviewed by Stamatis Zampetakis, Zhihua Deng)"

This reverts commit 81909f3ed294a5c095797346d26d1d1917d42c3a.

Reason: https://issues.apache.org/jira/browse/HIVE-26796

### What changes were proposed in this pull request?
Package updates rolled back.

### Why are the changes needed?
See the related ticket.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran StartMiniHS2SCluster manually. 
