### PR TITLE
HIVE-26796: Tests in modules dependent on curator-test are skipped silently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,18 @@
         <version>${calcite.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-test</artifactId>
+        <version>${curator.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.apache.datasketches</groupId>
         <artifactId>datasketches-hive</artifactId>
         <version>${datasketches.version}</version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -449,6 +449,12 @@
         <artifactId>curator-test</artifactId>
         <version>${curator.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What changes were proposed and why?

The junit-jupiter-api dependency coming from curator-test comes in conflict with the one used by the surefire plugin and the one used in Hive causing many problems with the discovery of tests in many modules.

Excluding the junit-jupiter-api dependency from curator remedies the problem for now.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
cd itests/hive-unit && mvn test
mvn test -Dtest=StartMiniHS2Cluster
```