### PR TITLE
HIVE-26793: Create a new configuration to override 'no compaction' for tables

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics2.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.hive.metastore.HMSMetricsListener;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.metrics.Metrics;
+import org.apache.hadoop.hive.metastore.metrics.MetricsConstants;
+import org.apache.hadoop.hive.metastore.txn.TxnUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class TestCompactionMetrics2 extends CompactorTest {
+  @Test
+  public void testWritesToDisabledCompactionDatabase() throws Exception {
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS, HMSMetricsListener.class.getName());
+    txnHandler = TxnUtils.getTxnStore(conf);
+
+    String dbName = "test";
+    Map<String, String> dbParams = new HashMap<String, String>(1);
+    dbParams.put("NO_AUTO_COMPACTION", "true");
+    ms.createDatabase(new Database(dbName, "", null, dbParams));
+
+    Map<String, String> params = new HashMap<>();
+    params.put(hive_metastoreConstants.NO_AUTO_COMPACT, "false");
+    Table t =  newTable(dbName, "comp_disabled", false, params);
+    burnThroughTransactions(dbName, t.getTableName(), 1, null, null);
+    burnThroughTransactions(dbName, t.getTableName(), 1, null, new HashSet<>(
+        Collections.singletonList(2L)));
+
+    Assert.assertEquals(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE + " value incorrect",
+        2, Metrics.getOrCreateGauge(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE).intValue());
+  }
+
+  @Test
+  public void testWritesToEnabledCompactionDatabase() throws Exception {
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS, HMSMetricsListener.class.getName());
+    txnHandler = TxnUtils.getTxnStore(conf);
+
+    String dbName = "test1";
+    Map<String, String> dbParams = new HashMap<String, String>(1);
+    dbParams.put("no_auto_compaction", "false");
+    ms.createDatabase(new Database(dbName, "", null, dbParams));
+
+    Map<String, String> params = new HashMap<>();
+    params.put(hive_metastoreConstants.NO_AUTO_COMPACT, "true");
+    Table t =  newTable(dbName, "comp_enabled", false, params);
+    burnThroughTransactions(dbName, t.getTableName(), 1, null, null);
+    burnThroughTransactions(dbName, t.getTableName(), 1, null, new HashSet<>(
+        Collections.singletonList(2L)));
+
+    Assert.assertEquals(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE + " value incorrect",
+        0, Metrics.getOrCreateGauge(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE).intValue());
+  }
+
+  @Override
+  boolean useHive130DeltaDirName() {
+    return false;
+  }
+}

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactorBase.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactorBase.java
@@ -180,8 +180,5 @@ class TestCompactorBase {
         writer.close();
       }
     }
-
   }
-
-
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator2.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestInitiator2 extends CompactorTest {
+  @Test
+  public void dbNoAutoCompactSetTrue() throws Exception {
+    String dbName = "test";
+    Map<String, String> dbParams = new HashMap<String, String>(1);
+    dbParams.put("no_auto_compaction", "true");
+    Database db = new Database(dbName, "", null, dbParams);
+    ms.createDatabase(db);
+    Map<String, String> parameters = new HashMap<>(1);
+    parameters.put("no_auto_compaction", "true");
+    Table t = newTable(dbName, "dbnacst", false, parameters);
+
+    HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 10);
+
+    for (int i = 0; i < 11; i++) {
+      long txnid = openTxn();
+      LockComponent comp = new LockComponent(LockType.SHARED_WRITE, LockLevel.TABLE, dbName);
+      comp.setTablename("dbnacst");
+      comp.setOperationType(DataOperationType.UPDATE);
+      List<LockComponent> components = new ArrayList<LockComponent>(1);
+      components.add(comp);
+      LockRequest req = new LockRequest(components, "me", "localhost");
+      req.setTxnid(txnid);
+      txnHandler.lock(req);
+      txnHandler.abortTxn(new AbortTxnRequest(txnid));
+    }
+
+    startInitiator();
+
+    ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(0, rsp.getCompactsSize());
+  }
+
+  @Test
+  public void dbNoAutoCompactSetFalseUpperCase() throws Exception {
+    String dbName = "test1";
+    Map<String, String> params = new HashMap<String, String>(1);
+    params.put("NO_AUTO_COMPACTION", "false");
+    Database db = new Database(dbName, "", null, params);
+    ms.createDatabase(db);
+    Map<String, String> parameters = new HashMap<>(1);
+    parameters.put("no_auto_compaction", "true");
+    Table t = newTable(dbName, "dbnacsf", false, parameters);
+
+    HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 10);
+
+    for (int i = 0; i < 11; i++) {
+      long txnid = openTxn();
+      LockComponent comp = new LockComponent(LockType.SHARED_WRITE, LockLevel.TABLE, dbName);
+      comp.setTablename("dbnacsf");
+      comp.setOperationType(DataOperationType.UPDATE);
+      List<LockComponent> components = new ArrayList<LockComponent>(1);
+      components.add(comp);
+      LockRequest req = new LockRequest(components, "me", "localhost");
+      req.setTxnid(txnid);
+      txnHandler.lock(req);
+      txnHandler.abortTxn(new AbortTxnRequest(txnid));
+    }
+
+    startInitiator();
+
+    ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(1, rsp.getCompactsSize());
+  }
+
+  @Override
+  boolean useHive130DeltaDirName() {
+    return false;
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -835,7 +835,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     String dbName = "default";
 
     Map<String, String> params = new HashMap<>();
-    params.put(hive_metastoreConstants.TABLE_NO_AUTO_COMPACT, "true");
+    params.put(hive_metastoreConstants.NO_AUTO_COMPACT, "true");
     Table disabledTbl = newTable(dbName, "comp_disabled", false, params);
     burnThroughTransactions(disabledTbl.getDbName(), disabledTbl.getTableName(), 1, null, null);
     burnThroughTransactions(disabledTbl.getDbName(), disabledTbl.getTableName(), 1, null, new HashSet<>(

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/hive_metastoreConstants.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/hive_metastoreConstants.java
@@ -63,7 +63,7 @@ package org.apache.hadoop.hive.metastore.api;
 
   public static final java.lang.String TABLE_IS_TRANSACTIONAL = "transactional";
 
-  public static final java.lang.String TABLE_NO_AUTO_COMPACT = "no_auto_compaction";
+  public static final java.lang.String NO_AUTO_COMPACT = "no_auto_compaction";
 
   public static final java.lang.String TABLE_TRANSACTIONAL_PROPERTIES = "transactional_properties";
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -1143,15 +1143,30 @@ public class MetaStoreUtils {
   /**
    * Because TABLE_NO_AUTO_COMPACT was originally assumed to be NO_AUTO_COMPACT and then was moved
    * to no_auto_compact, we need to check it in both cases.
+   * Check the database level no_auto_compact , if present it is given priority else table level no_auto_compact is considered.
    */
-  public static boolean isNoAutoCompactSet(Map<String, String> parameters) {
-    String noAutoCompact =
-            parameters.get(hive_metastoreConstants.TABLE_NO_AUTO_COMPACT);
-    if (noAutoCompact == null) {
-      noAutoCompact =
-              parameters.get(hive_metastoreConstants.TABLE_NO_AUTO_COMPACT.toUpperCase());
+  public static boolean isNoAutoCompactSet(Map<String, String> dbParameters, Map<String, String> tblParameters) {
+    String dbNoAutoCompact = getNoAutoCompact(dbParameters);
+    if (dbNoAutoCompact == null) {
+      LOG.debug("Using table configuration '" + hive_metastoreConstants.NO_AUTO_COMPACT + "' for compaction");
+      String noAutoCompact = getNoAutoCompact(tblParameters);
+      return Boolean.parseBoolean(noAutoCompact);
     }
-    return noAutoCompact != null && noAutoCompact.equalsIgnoreCase("true");
+    LOG.debug("Using database configuration '" + hive_metastoreConstants.NO_AUTO_COMPACT + "' for compaction");
+    return Boolean.parseBoolean(dbNoAutoCompact);
+  }
+
+  /**
+   * Get no_auto_compact property by checking in both lower and upper cases
+   * @param parameters
+   * @return true/false if set, null if there is no NO_AUTO_COMPACT set in database level config,
+   */
+  public static String getNoAutoCompact(Map<String, String> parameters) {
+    String noAutoCompact = parameters.get(hive_metastoreConstants.NO_AUTO_COMPACT);
+    if (noAutoCompact == null) {
+      return parameters.get(hive_metastoreConstants.NO_AUTO_COMPACT.toUpperCase());
+    }
+    return noAutoCompact;
   }
 
   public static String getHostFromId(String id) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSMetricsListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSMetricsListener.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore;
 import com.codahale.metrics.Counter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.util.Map;
 
 /**
  * Report metrics of metadata added, deleted by this Hive Metastore.
@@ -97,30 +99,37 @@ public class HMSMetricsListener extends MetaStoreEventListener {
 
   @Override
   public void onAllocWriteId(AllocWriteIdEvent allocWriteIdEvent, Connection dbConn, SQLGenerator sqlGenerator) throws MetaException {
-    if (MetastoreConf.getBoolVar(getConf(), MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_EXT_ON)) {
-      Table table = getTable(allocWriteIdEvent);
-      // In the case of CTAS, the table is created after write ids are allocated, so we'll skip metrics collection.
-      if (table != null && MetaStoreUtils.isNoAutoCompactSet(table.getParameters())) {
-        int noAutoCompactSet =
-            Metrics.getOrCreateGauge(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE).incrementAndGet();
-        if (noAutoCompactSet >=
-            MetastoreConf.getIntVar(getConf(),
-                MetastoreConf.ConfVars.COMPACTOR_NUMBER_OF_DISABLED_COMPACTION_TABLES_THRESHOLD)) {
-          LOGGER.warn("There has been a write to table " + table.getDbName() + "." + table.getTableName() +
-              " where auto-compaction is disabled (tblproperties (\"no_auto_compact\"=\"true\")).");
-        }
+    if (MetastoreConf.getBoolVar(getConf(), MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_EXT_ON) && isNoAutoCompactSet(allocWriteIdEvent)) {
+      int numOfWritesToDisabledCompactionTable = Metrics.getOrCreateGauge(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE).incrementAndGet();
+      if (numOfWritesToDisabledCompactionTable >= MetastoreConf.getIntVar(getConf(), MetastoreConf.ConfVars.COMPACTOR_NUMBER_OF_DISABLED_COMPACTION_TABLES_THRESHOLD)) {
+        LOGGER.warn("There has been a write to table " + allocWriteIdEvent.getDbName() + "." + allocWriteIdEvent.getTableName() + " where auto-compaction is disabled \"no_auto_compact\"=\"true\".");
       }
     }
   }
 
-  private Table getTable(AllocWriteIdEvent allocWriteIdEvent) throws MetaException {
+  private Boolean isNoAutoCompactSet(AllocWriteIdEvent allocWriteIdEvent) throws MetaException {
     String catalog = MetaStoreUtils.getDefaultCatalog(getConf());
     String dbName = allocWriteIdEvent.getDbName();
     String tableName = allocWriteIdEvent.getTableName();
+
+    RawStore rawStore;
     if (allocWriteIdEvent.getIHMSHandler() != null) {
-      return allocWriteIdEvent.getIHMSHandler().getMS().getTable(catalog, dbName, tableName);
+      rawStore = allocWriteIdEvent.getIHMSHandler().getMS();
     } else {
-      return HMSHandler.getMSForConf(getConf()).getTable(catalog, dbName, tableName);
+      rawStore = HMSHandler.getMSForConf(getConf());
     }
+    Map<String, String> dbParameters;
+    try {
+      dbParameters = rawStore.getDatabase(catalog, dbName).getParameters();
+    } catch (NoSuchObjectException e) {
+      LOGGER.error("Unable to find database " + dbName + ", " + e.getMessage());
+      throw new MetaException(String.valueOf(e));
+    }
+    Table table = rawStore.getTable(catalog, dbName, tableName);
+    // In the case of CTAS, the table is created after write ids are allocated, so we'll skip metrics collection.
+    if (table != null) {
+      return MetaStoreUtils.isNoAutoCompactSet(dbParameters, table.getParameters());
+    }
+    return false;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
no_auto_compaction configuration should be allowed to overridden on a database level: adding no_auto_compaction=false should override the table level setting forcing the initiator to schedule compaction for all tables.

### Why are the changes needed?
Currently a simple user can create a table with no_auto_compaction=true table property and create an aborted write transaction writing to this table. This way a malicious user can prevent cleaning up data for the aborted transaction, creating performance degradation.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests 
itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator2.java
itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics2.java
