### PR TITLE
HIVE-26813: Upgrade HikariCP from 2.6.1 to 4.0.3.

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -267,6 +267,12 @@
                     <exclude>META-INF/*.RSA</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>com.zaxxer:HikariCP</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/11/module-info.class</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -212,6 +212,12 @@
                         <exclude>static/</exclude>
                       </excludes>
                     </filter>
+                    <filter>
+                      <artifact>com.zaxxer:HikariCP</artifact>
+                      <excludes>
+                        <exclude>META-INF/versions/11/module-info.class</exclude>
+                      </excludes>
+                    </filter>
                   </filters>
                   <artifactSet>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <hppc.version>0.7.2</hppc.version>
     <!-- required for logging test to avoid including hbase which pulls disruptor transitively -->
     <disruptor.version>3.3.7</disruptor.version>
-    <hikaricp.version>2.6.1</hikaricp.version>
+    <hikaricp.version>4.0.3</hikaricp.version>
     <!-- httpcomponents are not always in version sync -->
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1113,6 +1113,12 @@
                     <exclude>META-INF/licenses/slf4j*/**</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>com.zaxxer:HikariCP</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/11/module-info.class</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <relocations>
                 <relocation>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -76,7 +76,7 @@
     <dropwizard.version>3.1.0</dropwizard.version>
     <guava.version>19.0</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
-    <hikaricp.version>2.6.1</hikaricp.version>
+    <hikaricp.version>4.0.3</hikaricp.version>
     <jackson.version>2.12.7</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade HikariCP from 2.6.1 to 4.0.3.

### Why are the changes needed?

The Hive Metastore currently integrates with HikariCP 2.6.1 for database connection pooling. This version was released in 2017. The most recent Java 8-compatible release is 4.0.3, released earlier this year. This bug proposes to upgrade so that we can include the past few years of development and bug fixes in the 4.0.0 GA release.

### Does this PR introduce _any_ user-facing change?

Yes, in that users will now see a newer version of the bundled HikariCP library. Functionality is backward-compatible.

### How was this patch tested?

* I ran `mvn clean test` for all tests in standalone-metastore. All tests passed.
* I ran `mvn clean package -DskipTests` and inspected the contents of ql/target/hive-exec-4.0.0-SNAPSHOT.jar to confirm that shading isn't accidentally bundling the new HikariCP version's module descriptor as if it belonged to hive-exec.