### PR TITLE
HIVE-26817: Set column names in result schema when plan has Values root

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveValues.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveValues.java
@@ -57,6 +57,6 @@ public class HiveValues extends Values implements HiveRelNode {
       builder.add(newColumnNames.get(i), getRowType().getFieldList().get(i).getType());
     }
 
-    return new HiveValues(getCluster(), builder.build(), tuples, getTraitSet());
+    return new HiveValues(getCluster(), builder.uniquify().build(), tuples, getTraitSet());
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/PlanModifierForASTConv.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/PlanModifierForASTConv.java
@@ -43,7 +43,6 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Pair;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/PlanModifierForASTConv.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/PlanModifierForASTConv.java
@@ -73,9 +73,7 @@ public class PlanModifierForASTConv {
   public static RelNode convertOpTree(RelNode rel, List<FieldSchema> resultSchema, boolean alignColumns)
       throws CalciteSemanticException {
     if (rel instanceof HiveValues) {
-      RelDataTypeFactory typeFactory = rel.getCluster().getTypeFactory();
       List<String> fieldNames = resultSchema.stream().map(FieldSchema::getName).collect(Collectors.toList());
-      fieldNames = SqlValidatorUtil.uniquify(fieldNames, typeFactory.getTypeSystem().isSchemaCaseSensitive());
       return ((HiveValues) rel).copy(fieldNames);
     }
 

--- a/ql/src/test/queries/clientpositive/empty_result.q
+++ b/ql/src/test/queries/clientpositive/empty_result.q
@@ -11,10 +11,15 @@ explain
 select a1 from t1
 join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
 
+select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1;
+
 explain cbo
 select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0;
 
 explain
+select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0;
+
 select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0;
 
 
@@ -34,3 +39,7 @@ select count(a1) from t1 where 1=0 group by a1 order by a1;
 
 explain cbo
 select min(c1) from t1 where false;
+
+explain cbo
+select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1;
+select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1;

--- a/ql/src/test/results/clientpositive/llap/empty_result.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result.q.out
@@ -57,6 +57,19 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: select a1 from t1
+join (select a2 from t2 where 1 = 0) s on s.a2 = t1.a1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+a1
 PREHOOK: query: explain cbo
 select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0
 PREHOOK: type: QUERY
@@ -92,6 +105,15 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select y + 1 from (select a1 y, b1 z from t1 where b1 > 10) q WHERE 1=0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+_c0
 PREHOOK: query: create view vw1 as (select t1.b1, t2.b2 from t1, t2 WHERE t1.a1 = t2.a2)
 PREHOOK: type: CREATEVIEW
 PREHOOK: Input: default@t1
@@ -202,3 +224,26 @@ CBO PLAN:
 HiveAggregate(group=[{}], agg#0=[min($0)])
   HiveValues(tuples=[[]])
 
+PREHOOK: query: explain cbo
+select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveValues(tuples=[[]])
+
+PREHOOK: query: select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select b1, count(a1) count1 from (select a1, b1 from t1) s where 1=0 group by b1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+b1	count1

--- a/ql/src/test/results/clientpositive/llap/empty_result_outerjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result_outerjoin.q.out
@@ -66,7 +66,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
-a	b	c	d
+s.a	s.b	t2.c	t2.d
 PREHOOK: query: explain cbo
 select * from t1
 left join (select c, d from t2 where 1=0) s on t1.a = s.c
@@ -133,7 +133,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
-a	b	c	d
+s1.a	s1.b	s2.c	s2.d
 PREHOOK: query: explain cbo
 select * from t1
 right join (select c, d from t2 where 1=0) s on t1.a = s.c
@@ -164,7 +164,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
-a	b	c	d
+t1.a	t1.b	s.c	s.d
 PREHOOK: query: explain cbo
 select * from (select a, b from t1 where 0=1) s
 right join t2 on s.a = t2.c
@@ -231,7 +231,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
-a	b	c	d
+s1.a	s1.b	s2.c	s2.d
 PREHOOK: query: explain cbo
 select * from (select a, b from t1 where 0=1) s
 full outer join t2 on s.a = t2.c
@@ -334,7 +334,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
-a	b	c	d
+s1.a	s1.b	s2.c	s2.d
 PREHOOK: query: explain cbo
 select t1.a from t1 left join (select c, d from t2 where 1=0) s on s.c = t1.a where s.c is null
 PREHOOK: type: QUERY


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Set the column names int the root `HiveValues` schema in the logical plan to the ones coming from the result schema.

### Why are the changes needed?
When logical plan is generated the column names in the root operator schema are generated names and does not reflect to the names and aliases specified in the main query's project schema. These are set after logical plan generation but this step is missing when root operator is `HiveValues`.


### Does this PR introduce _any_ user-facing change?
Yes. If
```
set hive.cli.print.header=true;
```
the printed column names may changed.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=empty_result.q -pl itests/qtest -Pitests
```