### PR TITLE
HIVE-26821: Fetch task caching should only depend on fetch task conversion

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryPlan;
@@ -70,7 +71,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
     super.initialize(queryState, queryPlan, taskQueue, context);
     work.initializeForFetch(context.getOpContext());
 
-    cachingEnabled = HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVEFETCHTASKCACHING);
+    cachingEnabled = work.isCachingEnabled();
     fetchedData = new ArrayList<>();
 
     try {
@@ -236,4 +237,8 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
     ExecMapper.setDone(false);
   }
 
+  @VisibleForTesting
+  public boolean isCachingEnabled() {
+    return cachingEnabled;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.QueryState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -143,7 +143,7 @@ public class SimpleFetchOptimizer extends Transform {
     if (fetch != null && checkThreshold(fetch, limit, pctx)) {
       FetchWork fetchWork = fetch.convertToWork();
       FetchTask fetchTask = (FetchTask) TaskFactory.get(fetchWork);
-      fetchWork.setCachingEnabled(HiveConf.getBoolVar(pctx.getConf(),
+      fetchTask.setCachingEnabled(HiveConf.getBoolVar(pctx.getConf(),
               HiveConf.ConfVars.HIVEFETCHTASKCACHING));
       fetchWork.setSink(fetch.completed(pctx, fetchWork));
       fetchWork.setSource(source);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -143,6 +143,8 @@ public class SimpleFetchOptimizer extends Transform {
     if (fetch != null && checkThreshold(fetch, limit, pctx)) {
       FetchWork fetchWork = fetch.convertToWork();
       FetchTask fetchTask = (FetchTask) TaskFactory.get(fetchWork);
+      fetchWork.setCachingEnabled(HiveConf.getBoolVar(pctx.getConf(),
+              HiveConf.ConfVars.HIVEFETCHTASKCACHING));
       fetchWork.setSink(fetch.completed(pctx, fetchWork));
       fetchWork.setSource(source);
       fetchWork.setLimit(limit);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FetchWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FetchWork.java
@@ -84,6 +84,11 @@ public class FetchWork implements Serializable {
 
   private Set<FileStatus> filesToFetch = null;
 
+  /**
+   * Whether this FetchWork should enable cache
+   */
+  private boolean cachingEnabled = false;
+
   public boolean isHiveServerQuery() {
 	return isHiveServerQuery;
   }
@@ -396,5 +401,13 @@ public class FetchWork implements Serializable {
 
   public Set<FileStatus> getFilesToFetch() {
     return filesToFetch;
+  }
+
+  public boolean isCachingEnabled() {
+    return cachingEnabled;
+  }
+
+  public void setCachingEnabled(boolean cachingEnabled) {
+    this.cachingEnabled = cachingEnabled;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FetchWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FetchWork.java
@@ -84,11 +84,6 @@ public class FetchWork implements Serializable {
 
   private Set<FileStatus> filesToFetch = null;
 
-  /**
-   * Whether this FetchWork should enable cache
-   */
-  private boolean cachingEnabled = false;
-
   public boolean isHiveServerQuery() {
 	return isHiveServerQuery;
   }
@@ -401,13 +396,5 @@ public class FetchWork implements Serializable {
 
   public Set<FileStatus> getFilesToFetch() {
     return filesToFetch;
-  }
-
-  public boolean isCachingEnabled() {
-    return cachingEnabled;
-  }
-
-  public void setCachingEnabled(boolean cachingEnabled) {
-    this.cachingEnabled = cachingEnabled;
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -2511,14 +2511,14 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVEFETCHTASKCACHING, true);
     hiveConf.setVar(HiveConf.ConfVars.HIVEFETCHTASKCONVERSION, "none");
     d.run("select * from fetch_task_table");
-    Assert.assertFalse(d.getFetchTask().getWork().isCachingEnabled());
+    Assert.assertFalse(d.getFetchTask().isCachingEnabled());
     d.getFetchTask().fetch(actualRes);
     Assert.assertEquals(actualRes, expectedRes);
     actualRes.clear();
 
     hiveConf.setVar(HiveConf.ConfVars.HIVEFETCHTASKCONVERSION, "more");
     d.run("select * from fetch_task_table");
-    Assert.assertTrue(d.getFetchTask().getWork().isCachingEnabled());
+    Assert.assertTrue(d.getFetchTask().isCachingEnabled());
     d.getFetchTask().fetch(actualRes);
     Assert.assertEquals(actualRes, expectedRes);
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -2511,14 +2511,14 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVEFETCHTASKCACHING, true);
     hiveConf.setVar(HiveConf.ConfVars.HIVEFETCHTASKCONVERSION, "none");
     d.run("select * from fetch_task_table");
-    Assert.assertFalse(d.getFetchTask().isCachingEnabled());
+    Assert.assertFalse(d.getFetchTask().getWork().isCachingEnabled());
     d.getFetchTask().fetch(actualRes);
     Assert.assertEquals(actualRes, expectedRes);
     actualRes.clear();
 
     hiveConf.setVar(HiveConf.ConfVars.HIVEFETCHTASKCONVERSION, "more");
     d.run("select * from fetch_task_table");
-    Assert.assertTrue(d.getFetchTask().isCachingEnabled());
+    Assert.assertTrue(d.getFetchTask().getWork().isCachingEnabled());
     d.getFetchTask().fetch(actualRes);
     Assert.assertEquals(actualRes, expectedRes);
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, fetch task is caching results irrespective of whether fetch task conversion is enabled or not. This can lead to situation wherein the queries have fetch task conversion disabled but the results are cached. Fetch task must be aware if it is used for fetch task conversion or not. In the latter case, caching should be disabled.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fetch task conversion and fetch task caching must go hand in hand.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests