### PR TITLE
HIVE-26836 : Ensure Green Build for Branch-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <mockito-all.version>1.10.19</mockito-all.version>
     <powermock.version>1.7.4</powermock.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.69.Final</netty.version>
+    <netty.version>4.1.17.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <parquet.version>1.10.0</parquet.version>
     <pig.version>0.16.0</pig.version>


### PR DESCRIPTION
This change involves cherry picks from Open Source branch-3.1 and some additional changes to ensure that the branch-3 has a Green Build. Since these policies did not exist previously, branch-3 was unstable. We have setup a Jenkins pipeline for Branch-3 through this JIRA : https://issues.apache.org/jira/browse/HIVE-26816

Cherry Picks from Branch-3.1:
1. 11279e77 - Revert "HIVE-25709: Upgrading netty binaries to newer release"

Additional Changes: