### PR TITLE
HIVE-26843: Filter all dependency module descriptors from shaded jars.

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -256,21 +256,17 @@
               </transformers>
               <filters>
                 <filter>
-                  <!--
-                  Shading signed JARs will fail without this.
-                  http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
-                  -->
                   <artifact>*:*</artifact>
                   <excludes>
+                    <!--
+                    Shading signed JARs will fail without this.
+                    http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                    -->
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>com.zaxxer:HikariCP</artifact>
-                  <excludes>
-                    <exclude>META-INF/versions/11/module-info.class</exclude>
+                    <!-- Exclude dependency module descriptors, which would be incorrect in a Hive jar. -->
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -202,20 +202,21 @@
                     <filter>
                       <artifact>*:*</artifact>
                       <excludes>
+                        <!--
+                        Shading signed JARs will fail without this.
+                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                        -->
                         <exclude>META-INF/*.SF</exclude>
                         <exclude>META-INF/*.DSA</exclude>
                         <exclude>META-INF/*.RSA</exclude>
+                        <!-- Exclude irrelevant webapp files of dependencies. -->
                         <exclude>core-default.xml</exclude>
                         <exclude>webapps/</exclude>
                         <exclude>hive-webapps/</exclude>
                         <exclude>hbase-webapps/</exclude>
                         <exclude>static/</exclude>
-                      </excludes>
-                    </filter>
-                    <filter>
-                      <artifact>com.zaxxer:HikariCP</artifact>
-                      <excludes>
-                        <exclude>META-INF/versions/11/module-info.class</exclude>
+                        <!-- Exclude dependency module descriptors, which would be incorrect in a Hive jar. -->
+                        <exclude>META-INF/versions/*/module-info.class</exclude>
                       </excludes>
                     </filter>
                   </filters>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1108,15 +1108,17 @@
                 <filter>
                   <artifact>org.apache.calcite.avatica:avatica</artifact>
                   <excludes>
+                    <!-- Exclude Avatica bundled SLF4J, because Hive manages its own SLF4J version. -->
                     <exclude>org/slf4j/**</exclude>
                     <exclude>META-INF/maven/org.slf4j/**</exclude>
                     <exclude>META-INF/licenses/slf4j*/**</exclude>
                   </excludes>
                 </filter>
                 <filter>
-                  <artifact>com.zaxxer:HikariCP</artifact>
+                  <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>META-INF/versions/11/module-info.class</exclude>
+                    <!-- Exclude dependency module descriptors, which would be incorrect in a Hive jar. -->
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Filter all dependency module descriptors from shaded jars.

### Why are the changes needed?

[HIVE-26813](https://issues.apache.org/jira/browse/HIVE-26813) upgraded HikariCP from 2.6.1 to 4.0.3. During review of PR #3839, we discussed the need to omit its module descriptor (module-info.class) from shaded jars. However, it turns out there are also existing instances of module-info.class files from other dependencies like Jackson and Log4J leaking into the shaded jars. We can update the shading filters with wildcards to exclude these and also make it future-proof against any other dependencies that start including a module descriptor.

### Does this PR introduce _any_ user-facing change?

Shaded jars will stop including module-info.class files from Jackson, Log4J and any other dependencies. As discussed in the prior PR, it's incorrect for Hive to include these files:

https://github.com/apache/hive/pull/3839#discussion_r1042642131

### How was this patch tested?

I ran a build locally:

```
mvn -Piceberg clean package -DskipTests
```

Then, I ran the following to iterate through all built jars and check for the presence of module-info.class. It didn't find anything. Prior to this patch, the beeline and JDBC jars contained module-info.class files from Jackson and Log4J.

```
for x in $(find . -name '*.jar'); do echo $x && jar tf $x | grep 'module-info'; done
```
