### PR TITLE
HIVE-26849: Nightly build fails in master (build 1533 onwards)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <maven.build-helper.plugin.version>1.12</maven.build-helper.plugin.version>
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
     <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
+    <maven.setversion.plugin.version>2.13.0</maven.setversion.plugin.version>
     <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <!-- Library Dependency Versions -->
@@ -1437,6 +1438,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven.checkstyle.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${maven.setversion.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -54,6 +54,7 @@
     <!-- Plugin versions -->
     <ant.contrib.version>1.0b3</ant.contrib.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
+    <maven.setversion.plugin.version>2.13.0</maven.setversion.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <!-- Dependency versions -->
     <antlr.version>3.5.2</antlr.version>
@@ -488,6 +489,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${maven.setversion.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -36,6 +36,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
+    <maven.setversion.plugin.version>2.13.0</maven.setversion.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
   </properties>
   <dependencies>
@@ -163,6 +164,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven.checkstyle.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${maven.setversion.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -40,6 +40,7 @@
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <junit.vintage.version>5.6.2</junit.vintage.version>
+    <maven.setversion.plugin.version>2.13.0</maven.setversion.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
   </properties>
   <modules>
@@ -56,6 +57,11 @@
           <propertyExpansion>config_loc=${checkstyle.conf.dir}</propertyExpansion>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${maven.setversion.plugin.version}</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
Freeze versions-maven-plugin to avoid problems such as the one reported here caused by the most recent (2.14.0) version.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

```
mvn versions:set versions:commit -DgenerateBackupPoms=false -DnewVersion=4.0.0-nightly-89bf37bb45-20221214_191135
```
The command finishes without any errors, contrary to what is happening when we use the most recent version.