### PR TITLE
HIVE-25707: SchemaTool may leave the metastore in-between upgrade steps

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
+++ b/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
@@ -75,7 +75,7 @@ public class HiveSchemaTool extends MetastoreSchemaTool {
     // write out the buffer into a file. Add beeline commands for autocommit and close
     FileWriter fstream = new FileWriter(tmpFile.getPath());
     BufferedWriter out = new BufferedWriter(fstream);
-    if (!dbType.equals("hive")) {
+    if (!dbType.equalsIgnoreCase(HiveSchemaHelper.DB_HIVE)) {
       out.write("!autocommit off" + System.getProperty("line.separator"));
       out.write(sqlCommands);
       out.write("!commit" + System.getProperty("line.separator"));

--- a/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
+++ b/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
@@ -75,9 +75,14 @@ public class HiveSchemaTool extends MetastoreSchemaTool {
     // write out the buffer into a file. Add beeline commands for autocommit and close
     FileWriter fstream = new FileWriter(tmpFile.getPath());
     BufferedWriter out = new BufferedWriter(fstream);
-    out.write("!autocommit off" + System.getProperty("line.separator"));
-    out.write(sqlCommands);
-    out.write("!commit" + System.getProperty("line.separator"));
+    if (!dbType.equals("hive")) {
+      out.write("!autocommit off" + System.getProperty("line.separator"));
+      out.write(sqlCommands);
+      out.write("!commit" + System.getProperty("line.separator"));
+    } else {
+      out.write("!autocommit on" + System.getProperty("line.separator"));
+      out.write(sqlCommands);
+    }
     out.write("!closeall" + System.getProperty("line.separator"));
     out.close();
     execSql(tmpFile.getPath());

--- a/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
+++ b/beeline/src/java/org/apache/hive/beeline/schematool/HiveSchemaTool.java
@@ -75,8 +75,9 @@ public class HiveSchemaTool extends MetastoreSchemaTool {
     // write out the buffer into a file. Add beeline commands for autocommit and close
     FileWriter fstream = new FileWriter(tmpFile.getPath());
     BufferedWriter out = new BufferedWriter(fstream);
-    out.write("!autocommit on" + System.getProperty("line.separator"));
+    out.write("!autocommit off" + System.getProperty("line.separator"));
     out.write(sqlCommands);
+    out.write("!commit" + System.getProperty("line.separator"));
     out.write("!closeall" + System.getProperty("line.separator"));
     out.close();
     execSql(tmpFile.getPath());


### PR DESCRIPTION
### What changes were proposed in this pull request?
We only commit when all the changes in schema upgrade is successful.
Otherwise, we do not commit.


### Why are the changes needed?
Currently, as schematool applies schema changes during an upgrade, each change is autocommitted. So if it fails after applying a few changes from an upgrade file, those changes remain in the schema. So re-running the schematool fails at the first line because that change already exists.

Instead, we should create a transactional boundary between each upgrade file, aka commit only after all the changes in an upgrade file are successful.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Maven build and unit test.
