### PR TITLE
HIVE-26864: Incremental rebuild of non-transaction materialized view fails

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2024,9 +2024,7 @@ public class Hive {
    * (false), or it cannot be determined (null). The latest case may happen e.g. when the
    * materialized view definition uses external tables.
    */
-  public Boolean isOutdatedMaterializedView(HiveTxnManager txnManager, TableName tableName) throws HiveException {
-
-    Table table = getTable(tableName.getDb(), tableName.getTable());
+  public Boolean isOutdatedMaterializedView(HiveTxnManager txnManager, Table table) throws HiveException {
 
     String validTxnsList = conf.get(ValidTxnList.VALID_TXNS_KEY);
     if (validTxnsList == null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
@@ -54,11 +54,13 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
 
 
   private boolean containsAggregate;
+  private boolean fullAcidView;
   private boolean rewritingAllowed;
   private int countIndex;
 
   public MaterializedViewRewritingRelVisitor() {
     this.containsAggregate = false;
+    this.fullAcidView = false;
     this.rewritingAllowed = false;
     this.countIndex = -1;
   }
@@ -127,7 +129,8 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
             // If it is not a materialized view, we do not rewrite it
             throw new ReturnedValue(false);
           }
-          if (containsAggregate && !AcidUtils.isFullAcidTable(hiveTable.getHiveTableMD())) {
+          fullAcidView = AcidUtils.isFullAcidTable(hiveTable.getHiveTableMD());
+          if (containsAggregate && !fullAcidView) {
             // If it contains an aggregate and it is not a full acid table,
             // we do not rewrite it (we need MERGE support)
             throw new ReturnedValue(false);
@@ -159,6 +162,10 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
 
   public boolean isContainsAggregate() {
     return containsAggregate;
+  }
+
+  public boolean isFullAcidView() {
+    return fullAcidView;
   }
 
   public boolean isRewritingAllowed() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
@@ -26,15 +26,11 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ControlFlowException;
-import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class is a helper to check whether a materialized view rebuild

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/MaterializedViewRewritingRelVisitor.java
@@ -58,9 +58,9 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
   private boolean rewritingAllowed;
   private int countIndex;
 
-  public MaterializedViewRewritingRelVisitor() {
+  public MaterializedViewRewritingRelVisitor(boolean fullAcidView) {
     this.containsAggregate = false;
-    this.fullAcidView = false;
+    this.fullAcidView = fullAcidView;
     this.rewritingAllowed = false;
     this.countIndex = -1;
   }
@@ -129,7 +129,6 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
             // If it is not a materialized view, we do not rewrite it
             throw new ReturnedValue(false);
           }
-          fullAcidView = AcidUtils.isFullAcidTable(hiveTable.getHiveTableMD());
           if (containsAggregate && !fullAcidView) {
             // If it contains an aggregate and it is not a full acid table,
             // we do not rewrite it (we need MERGE support)
@@ -162,10 +161,6 @@ public class MaterializedViewRewritingRelVisitor extends RelVisitor {
 
   public boolean isContainsAggregate() {
     return containsAggregate;
-  }
-
-  public boolean isFullAcidView() {
-    return fullAcidView;
   }
 
   public boolean isRewritingAllowed() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -402,8 +402,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   // whether this is a mv rebuild rewritten expression
   protected MaterializationRebuildMode mvRebuildMode = MaterializationRebuildMode.NONE;
-  protected String mvRebuildDbName; // Db name for materialization to rebuild
-  protected String mvRebuildName; // Name for materialization to rebuild
 
   protected volatile boolean disableJoinMerge = false;
   protected final boolean defaultJoinMerge;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_10.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_10.q
@@ -1,0 +1,29 @@
+-- Try to run incremental on a non-transactional MV in presence of delete operations
+-- Compiler should fall back to full rebuild.
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+set hive.stats.autogather=false;
+
+create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into t1 values (1,1), (2,1), (3,3);
+
+create materialized view mv1 as
+select a, b from t1 where b = 1;
+
+delete from t1 where a = 2;
+
+explain cbo
+alter materialized view mv1 rebuild;
+
+explain
+alter materialized view mv1 rebuild;
+
+alter materialized view mv1 rebuild;
+
+explain cbo
+select a, b from t1 where b = 1;
+
+select a, b from t1 where b = 1;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_10.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_10.q.out
@@ -1,0 +1,154 @@
+PREHOOK: query: create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (a int, b int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1 values (1,1), (2,1), (3,3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 values (1,1), (2,1), (3,3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+PREHOOK: query: create materialized view mv1 as
+select a, b from t1 where b = 1
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv1
+POSTHOOK: query: create materialized view mv1 as
+select a, b from t1 where b = 1
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv1
+POSTHOOK: Lineage: mv1.a SIMPLE [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv1.b SIMPLE []
+PREHOOK: query: delete from t1 where a = 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@t1
+POSTHOOK: query: delete from t1 where a = 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@t1
+PREHOOK: query: explain cbo
+alter materialized view mv1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mv1
+POSTHOOK: query: explain cbo
+alter materialized view mv1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mv1
+CBO PLAN:
+HiveProject(a=[$0], b=[CAST(1):INTEGER])
+  HiveFilter(condition=[=($1, 1)])
+    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain
+alter materialized view mv1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mv1
+POSTHOOK: query: explain
+alter materialized view mv1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mv1
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (b = 1) (type: boolean)
+                  Statistics: Num rows: 69 Data size: 13590 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (b = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: a (type: int), 1 (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
+                        table:
+                            input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                            serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                            name: default.mv1
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: true
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mv1
+
+  Stage: Stage-3
+    Materialized View Update
+      name: default.mv1
+      update creation metadata: true
+
+PREHOOK: query: alter materialized view mv1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mv1
+POSTHOOK: query: alter materialized view mv1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mv1
+POSTHOOK: Lineage: mv1.a SIMPLE [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mv1.b SIMPLE []
+PREHOOK: query: explain cbo
+select a, b from t1 where b = 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select a, b from t1 where b = 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveTableScan(table=[[default, mv1]], table:alias=[default.mv1])
+
+PREHOOK: query: select a, b from t1 where b = 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: select a, b from t1 where b = 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When rebuilding a non-transactional MV in presence of delete operations fall back to full rebuild.

### Why are the changes needed?
Exception was thrown.


### Does this PR introduce _any_ user-facing change?
Yes. Rebuild is successful.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite_10.q -pl itests/qtest -Pitests
```