### PR TITLE
HIVE-26866 : Backport of HIVE-25795

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
@@ -188,7 +188,7 @@ public class TestOperationLoggingLayout {
     Map<String, Appender> appendersMap = loggerConfig.getAppenders();
     RoutingAppender routingAppender = (RoutingAppender) appendersMap.get(routingAppenderName);
     Assert.assertNotNull(msg + "could not find routingAppender " + routingAppenderName, routingAppender);
-    Field defaultsField = RoutingAppender.class.getDeclaredField("appenders");
+    Field defaultsField = RoutingAppender.class.getDeclaredField("createdAppenders");
     defaultsField.setAccessible(true);
     ConcurrentHashMap appenders = (ConcurrentHashMap) defaultsField.get(routingAppender);
     AppenderControl appenderControl = (AppenderControl) appenders.get(queryId);
@@ -219,7 +219,7 @@ public class TestOperationLoggingLayout {
     Map<String, Appender> appendersMap = loggerConfig.getAppenders();
     RoutingAppender routingAppender = (RoutingAppender) appendersMap.get(routingAppenderName);
     Assert.assertNotNull("could not find routingAppender " + routingAppenderName, routingAppender);
-    Field defaultsField = RoutingAppender.class.getDeclaredField("appenders");
+    Field defaultsField = RoutingAppender.class.getDeclaredField("createdAppenders");
     defaultsField.setAccessible(true);
     ConcurrentHashMap appenders = (ConcurrentHashMap) defaultsField.get(routingAppender);
     AppenderControl appenderControl = (AppenderControl) appenders.get(queryId);


### PR DESCRIPTION
Backport of HIVE-25795: [addendum] Unit test failures from upgrade to log4j 2.16.0. This would resolve test failures from itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java and ensure we are closer to branch-3 clean build. To be compared with http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-3850/1/tests/ for this test success.