### PR TITLE
HIVE-26868: Iceberg: Allow IOW on empty table with Partition Evolution.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -583,7 +583,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     if (sinkDesc.getInsertOverwrite()) {
       Table table = IcebergTableUtil.getTable(conf, sinkDesc.getTableInfo().getProperties());
       if (table.currentSnapshot() != null &&
-          "0" .equalsIgnoreCase(table.currentSnapshot().summary().get(SnapshotSummary.TOTAL_RECORDS_PROP))) {
+          Long.parseLong(table.currentSnapshot().summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)) == 0) {
         // If the table is empty we don't have any danger that some data can get lost.
         return;
       }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergInserts.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.TestHelper;
@@ -503,5 +506,105 @@ public class TestHiveIcebergInserts extends HiveIcebergStorageHandlerWithEngineB
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
     HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+  }
+
+  @Test
+  public void testInsertOverwriteOnEmptyV1Table() throws IOException {
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Insert some data.
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "ABC", "DBAK")
+        .add(1L, "XYZ", "RDBS")
+        .build();
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, false));
+
+    // Change the partition and then insert some more data.
+    shell.executeStatement("ALTER TABLE target SET PARTITION SPEC(TRUNCATE(2, last_name))");
+    newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(2L, "Mike", "Taylor")
+        .add(3L, "Christy", "Hubert")
+        .build();
+
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, false));
+
+    // Truncate the table
+    shell.executeStatement("TRUNCATE TABLE target");
+
+    newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Mike", "Taylor")
+        .add(3L, "ABC", "DBAK")
+        .add(4L, "APL", "DBAM")
+        .build();
+
+    // Do an insert-overwrite and this should be successful because the table is empty.
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
+
+    HiveIcebergTestUtils.validateData(table, newRecords, 0);
+  }
+
+  @Test
+  public void testInsertOverwriteOnEmptyV2Table() throws IOException {
+    // Create a V2 table with merge-on-read.
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    Map<String, String> opTypes = ImmutableMap.of(
+        TableProperties.DELETE_MODE, "merge-on-read",
+        TableProperties.MERGE_MODE, "merge-on-read",
+        TableProperties.UPDATE_MODE, "merge-on-read");
+
+    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2, opTypes);
+
+    // Insert some data.
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(3L, "ABC", "DBAK")
+        .add(4L, "XYZ", "RDBS")
+        .add(5L, "CBO", "HIVE")
+        .add(6L, "HADOOP", "HDFS")
+        .build();
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, false));
+
+    // Perform some deletes & updates.
+    shell.executeStatement("update target set first_name='WXYZ' where customer_id=1");
+    shell.executeStatement("delete from target where customer_id%2=0");
+
+    // Change the partition and then insert some more data.
+    shell.executeStatement("ALTER TABLE target SET PARTITION SPEC(TRUNCATE(2, last_name))");
+    newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(7L, "Mike", "Taylor")
+        .add(8L, "Christy", "Hubert")
+        .add(9L, "RDBMS", "Talk")
+        .add(10L, "Notification", "Hub")
+        .add(11L, "Vector", "HDFS")
+        .build();
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, false));
+
+    // Perform some deletes & updates.
+    shell.executeStatement("update target set first_name='RDBMSV2' where customer_id=9");
+    shell.executeStatement("delete from target where customer_id%2=0 AND customer_id>6");
+
+    Table icebergTable = testTables.loadTable(target);
+    // There should be some delete files, due to our delete & update operations.
+    Assert.assertNotEquals("0", icebergTable.currentSnapshot().summary().get(SnapshotSummary.TOTAL_DELETE_FILES_PROP));
+
+    long preTruncateSnapshotId = icebergTable.currentSnapshot().snapshotId();
+    List<Object[]> result =
+        shell.executeStatement(String.format("SELECT * FROM %s order by customer_id", target.name()));
+
+    // Truncate the table
+    shell.executeStatement("TRUNCATE TABLE target");
+
+    // Do an insert-overwrite and this should be successful because the table is empty.
+    shell.executeStatement(
+        "INSERT OVERWRITE TABLE target select * from target FOR SYSTEM_VERSION AS OF " + preTruncateSnapshotId);
+
+    HiveIcebergTestUtils.validateData(table,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, result), 0);
+    icebergTable = testTables.loadTable(target);
+
+    // There should be no delete files, they should have been merged with the data files
+    Assert.assertEquals("0", icebergTable.currentSnapshot().summary().get(SnapshotSummary.TOTAL_DELETE_FILES_PROP));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow IOW on empty iceberg tables.

### Why are the changes needed?

Helps with compactions

### Does this PR introduce _any_ user-facing change?

Yes, IOW can be performed on empty tables.

### How was this patch tested?

UT