### PR TITLE
HIVE-26871: TestCrudCompactorOnTez is flaky after HIVE-26479

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
@@ -107,7 +107,9 @@ public class TestMmCompactorOnTez extends CompactorOnTezTest {
     testDataProvider.dropTable(tableName);
 
     if (isTez(conf)) {
-      ProtoMessageReader<HiveHookEvents.HiveHookEventProto> reader = TestHiveProtoLoggingHook.getTestReader(conf, tmpFolder);
+      List<ProtoMessageReader<HiveHookEvents.HiveHookEventProto>> readers = TestHiveProtoLoggingHook.getTestReader(conf, tmpFolder);
+      Assert.assertEquals(readers.size(), 1);
+      ProtoMessageReader<HiveHookEvents.HiveHookEventProto> reader = readers.get(0);
       HiveHookEvents.HiveHookEventProto event = reader.readEvent();
       while (ExecutionMode.TEZ != ExecutionMode.valueOf(event.getExecutionMode())) {
         event = reader.readEvent();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
@@ -108,7 +108,7 @@ public class TestMmCompactorOnTez extends CompactorOnTezTest {
 
     if (isTez(conf)) {
       List<ProtoMessageReader<HiveHookEvents.HiveHookEventProto>> readers = TestHiveProtoLoggingHook.getTestReader(conf, tmpFolder);
-      Assert.assertEquals(readers.size(), 1);
+      Assert.assertEquals(1, readers.size());
       ProtoMessageReader<HiveHookEvents.HiveHookEventProto> reader = readers.get(0);
       HiveHookEvents.HiveHookEventProto event = reader.readEvent();
       while (ExecutionMode.TEZ != ExecutionMode.valueOf(event.getExecutionMode())) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHiveProtoLoggingHook.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHiveProtoLoggingHook.java
@@ -166,7 +166,7 @@ public class TestHiveProtoLoggingHook {
     evtLogger.shutdown();
 
     List<ProtoMessageReader<HiveHookEventProto>> readers = getTestReader(conf, tmpFolder);
-    Assert.assertEquals(readers.size(), 1);
+    Assert.assertEquals(1, readers.size());
     ProtoMessageReader<HiveHookEventProto> reader = readers.get(0);
 
     HiveHookEventProto event = reader.readEvent();
@@ -196,7 +196,7 @@ public class TestHiveProtoLoggingHook {
     evtLogger.handle(context);
     evtLogger.shutdown();
     List<ProtoMessageReader<HiveHookEventProto>> readers = getTestReader(conf, tmpFolder);
-    Assert.assertEquals(readers.size(), 1);
+    Assert.assertEquals(1, readers.size());
     ProtoMessageReader<HiveHookEventProto> reader = readers.get(0);
     reader.readEvent();
     reader.readEvent();
@@ -217,7 +217,7 @@ public class TestHiveProtoLoggingHook {
     evtLogger.shutdown();
 
     List<ProtoMessageReader<HiveHookEventProto>> readers = getTestReader(conf, tmpFolder);
-    Assert.assertEquals(readers.size(), 1);
+    Assert.assertEquals(1, readers.size());
     ProtoMessageReader<HiveHookEventProto> reader = readers.get(0);
     HiveHookEventProto event = reader.readEvent();
     Assert.assertNotNull("Pre hook event not found", event);
@@ -326,7 +326,7 @@ public class TestHiveProtoLoggingHook {
 
   private HiveHookEventProto loadEvent(HiveConf conf, String tmpFolder) throws IOException {
     List<ProtoMessageReader<HiveHookEventProto>> readers = getTestReader(conf, tmpFolder);
-    Assert.assertEquals(readers.size(), 1);
+    Assert.assertEquals(1, readers.size());
     ProtoMessageReader<HiveHookEventProto> reader = readers.get(0);
     HiveHookEventProto event = reader.readEvent();
     Assert.assertNotNull(event);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The 3 tests in TestCrudCompactorOnTez which use the ProtoLoggingHook run at different times. Unfortunately, the 3 tests are run at the following times as described in the logs - 
Test 1 - 
`INFO [main] compactor.TestCrudCompactorOnTez: Current time: 2022-12-15T23:57:44 `
Test 2 - 
`INFO [main] compactor.TestCrudCompactorOnTez: Current time: 2022-12-16T00:00:32 `
Test 3 - 
`INFO [main] compactor.TestCrudCompactorOnTez: Current time: 2022-12-16T00:04:12 `
As we can see, the tests are run on 2 different dates. Therefore, HiveProtoLoggingHook generates a unique event logs for every unique date. This is the behaviour of HiveProtoLoggingHook.
https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/hooks/HiveProtoLoggingHook.java#L296-L310

However the expectation from the test side, while generating the log readers is that there must be a single file in the log folder defined.
https://github.com/apache/hive/blob/master/ql/src/test/org/apache/hadoop/hive/ql/hooks/TestHiveProtoLoggingHook.java#L310 

Unfortunately, since there are 2 files which are generated (as mentioned in the logs as well), the following tests fail - 

```
INFO [main] hooks.TestHiveProtoLoggingHook: List of paths: 
INFO [main] hooks.TestHiveProtoLoggingHook: file:/home/jenkins/agent/workspace/internal-hive-flaky-check/itests/hive-unit/target/tmp/junit441259831997042392/junit3438435196942546140/date=2022-12-15
INFO [main] hooks.TestHiveProtoLoggingHook: file:/home/jenkins/agent/workspace/internal-hive-flaky-check/itests/hive-unit/target/tmp/junit441259831997042392/junit3438435196942546140/date=2022-12-16 
```
The solution is to make getTestReader() in TestHiveProtoLoggingHook more compatible with multiple event log file scenario and be able to generate multiple readers for all files present in the folder instead of fixating on a single file clause.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix this flakiness in TestCrudCompactorOnTez

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests are sufficient