### PR TITLE
HIVE-26876 : Disable flaky Spark Tests in branch-3

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/exec/spark/TestSparkStatistics.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/exec/spark/TestSparkStatistics.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHive
 import org.apache.hadoop.hive.ql.session.SessionState;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 
 public class TestSparkStatistics {
 
+  @Ignore("flaky test")
   @Test
   public void testSparkStatistics() {
     HiveConf conf = new HiveConf();

--- a/spark-client/src/test/java/org/apache/hive/spark/client/rpc/TestRpc.java
+++ b/spark-client/src/test/java/org/apache/hive/spark/client/rpc/TestRpc.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -176,6 +177,7 @@ public class TestRpc {
     serverRpcFuture.cancel(true);
   }
 
+  @Ignore("Flaky test")
   @Test
   public void testServerPort() throws Exception {
     Map<String, String> config = new HashMap<String, String>();


### PR DESCRIPTION
These test are failing with intermittent issues as follows :

Error Incorrect RPC server port configuration for HiveServer2 Stacktrace java.io.IOException: Incorrect RPC server port configuration for HiveServer2 at org.apache.hive.spark.client.rpc.RpcConfiguration.getServerPorts(RpcConfiguration.java:130) at org.apache.hive.spark.client.rpc.RpcServer.bindServerPort(RpcServer.java:131) at org.apache.hive.spark.client.rpc.RpcServer.<init>(RpcServer.java:116) at org.apache.hive.spark.client.rpc.TestRpc.testServerPort(TestRpc.java:211) at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke(Method.java:498) at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271) at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70) at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)

These are temporary issues since Hive Server does not find a port to connect to even if retry logic is in place.