### PR TITLE
HIVE-26880: Upgrade Apache Directory Server to 1.5.7 for release 3.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,7 @@
     <activemq.version>5.5.0</activemq.version>
     <ant.version>1.9.1</ant.version>
     <antlr.version>3.5.2</antlr.version>
-    <apache-directory-server.version>1.5.6</apache-directory-server.version>
-    <apache-directory-clientapi.version>0.1</apache-directory-clientapi.version>
+    <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
     <arrow.version>0.8.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -292,13 +292,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.directory.client.ldap</groupId>
-      <artifactId>ldap-client-api</artifactId>
-      <version>${apache-directory-clientapi.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.directory.server</groupId>
       <artifactId>apacheds-server-integ</artifactId>
       <version>${apache-directory-server.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

branch-3 uses Apache Directory Server in some tests. It currently uses version 1.5.6. This version has a transitive dependency to a SNAPSHOT, making it awkward to build and release. We can upgrade to 1.5.7 to remove the SNAPSHOT dependency.

### Why are the changes needed?

SNAPSHOT dependencies make local builds awkward and release build policies typically don't allow them.

### Does this PR introduce _any_ user-facing change?

No, Apache Directory Server is only used for tests.

### How was this patch tested?

I built locally and confirmed tests.