### PR TITLE
HIVE-26884: Iceberg: V2 Vectorization returns wrong results with deletes.

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/vector/TestHiveIcebergVectorization.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/vector/TestHiveIcebergVectorization.java
@@ -229,7 +229,7 @@ public class TestHiveIcebergVectorization extends HiveIcebergStorageHandlerWithE
     List<Object[]> postUpdateResult = shell.executeStatement(
         "select * from vectordelete where date_col=date'2022-04-29' OR date_col=date'2022-04-30'");
 
-    Assert.assertNotEquals(0, results.size());
+    Assert.assertNotEquals(0, postUpdateResult.size());
 
     // Do an update on the column, and check if the count is 0, since we changed the value for that column
     shell.executeStatement("update vectordelete set date_col=date'2022-04-30' where date_col=date'2022-04-29'");

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedParquetRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedParquetRecordReader.java
@@ -233,11 +233,11 @@ public class VectorizedParquetRecordReader extends ParquetRecordReaderBase
     long allRowsInFile = 0;
     int blockIndex = 0;
     for (BlockMetaData block : parquetMetadata.getBlocks()) {
-      rowGroupNumToRowPos.put(blockIndex++, allRowsInFile);
-      allRowsInFile += block.getRowCount();
       if (offsets.contains(block.getStartingPos())) {
+        rowGroupNumToRowPos.put(blockIndex++, allRowsInFile);
         blocks.add(block);
       }
+      allRowsInFile += block.getRowCount();
     }
     // verify we found them all
     if (blocks.size() != rowGroupOffsets.length) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix Row Number calculation in Parquet Vectorized V2 reads.

### Why are the changes needed?

Vectorized V2 reads with multiple blocks and some getting filtered leads to wrong positions being calculated, messing up with the PositionalDeleteFilter

### Does this PR introduce _any_ user-facing change?

Yes, Correct Results with Parquet V2 reads

### How was this patch tested?

On Local Env with subset of data from the actual Env. & UT