### PR TITLE
HIVE-26885: Iceberg: Parquet Vectorized V2 reads fails with NPE.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveBatchIterator.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/vector/HiveBatchIterator.java
@@ -65,7 +65,7 @@ public final class HiveBatchIterator implements CloseableIterator<HiveBatchConte
           batch.size = 0;
         }
 
-        if (recordReader instanceof RowPositionAwareVectorizedRecordReader) {
+        if (batch.size != 0 && recordReader instanceof RowPositionAwareVectorizedRecordReader) {
           rowOffset = ((RowPositionAwareVectorizedRecordReader) recordReader).getRowNumber();
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix NPE while reading Iceberg V2 Parquet V2 table in case of empty batches.

### Why are the changes needed?

NPE while reading Parquet V2 table

### Does this PR introduce _any_ user-facing change?

Yep, Query passes without NPE


### How was this patch tested?

UT, On top on HIVE-26884 (Would require a rebase for the UT to give correct result, but won’t give NPE)