### PR TITLE
HIVE-26887 Make sure dirPath has the correct permissions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -582,6 +582,9 @@ public class Context {
             throw new RuntimeException("Cannot make directory: "
                 + dirPath.toString());
           }
+          if (!fsPermission.equals(fsPermission.applyUMask(FsPermission.getUMask(conf)))) {
+            fs.setPermission(dirPath, fsPermission);
+          }
           if (isHDFSCleanup) {
             fs.deleteOnExit(dirPath);
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
@@ -371,6 +371,9 @@ public final class QueryResultsCache {
     FsPermission fsPermission = new FsPermission("700");
     fs.mkdirs(cacheDirPath, fsPermission);
 
+    if (!fsPermission.equals(fsPermission.applyUMask(FsPermission.getUMask(conf)))) {
+        fs.setPermission(cacheDirPath, fsPermission);
+    }
     // Create non-existent path for 0-row results
     zeroRowsPath = new Path(cacheDirPath, "dummy_zero_rows");
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
@@ -372,7 +372,7 @@ public final class QueryResultsCache {
     fs.mkdirs(cacheDirPath, fsPermission);
 
     if (!fsPermission.equals(fsPermission.applyUMask(FsPermission.getUMask(conf)))) {
-        fs.setPermission(cacheDirPath, fsPermission);
+      fs.setPermission(cacheDirPath, fsPermission);
     }
     // Create non-existent path for 0-row results
     zeroRowsPath = new Path(cacheDirPath, "dummy_zero_rows");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -796,6 +796,9 @@ public class TezSessionState {
     FileSystem fs = tezDir.getFileSystem(conf);
     FsPermission fsPermission = new FsPermission(HiveConf.getVar(conf, HiveConf.ConfVars.SCRATCHDIRPERMISSION));
     fs.mkdirs(tezDir, fsPermission);
+    if (!fsPermission.equals(fsPermission.applyUMask(FsPermission.getUMask(conf)))) {
+       fs.setPermission(tezDir, fsPermission);
+    }
     // Make sure the path is normalized (we expect validation to pass since we just created it).
     tezDir = DagUtils.validateTargetDir(tezDir, conf).getPath();
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -853,6 +853,9 @@ public class SessionState implements ISessionAuthState{
       if (!fs.mkdirs(path, fsPermission)) {
         throw new IOException("Failed to create directory " + path + " on fs " + fs.getUri());
       }
+      if (!fsPermission.equals(fsPermission.applyUMask(FsPermission.getUMask(conf)))) {
+        fs.setPermission(path, fsPermission);
+      }
       String dirType = isLocal ? "local" : "HDFS";
       LOG.info("Created " + dirType + " directory: " + path.toString());
     }


### PR DESCRIPTION
HIVE-26887 In the QueryResultsCache function of class QueryResultsCache, there is the following code segment

```java
  private QueryResultsCache(HiveConf configuration) throws IOException {
    ......
    FileSystem fs = cacheDirPath.getFileSystem(conf);
    FsPermission fsPermission = new FsPermission("700");
    fs.mkdirs(cacheDirPath, fsPermission);
    ......
}
```
It can be seen that the function will use the mkdirs to create cacheDirPath, and the parameters passed in include the path variable cacheDirPath and a permission 700. But we haven't confirmed whether the permission is correctly assigned to the file.

The above question is raised because there are two mkdir functions of hadoop,`mkdirs(Path f, FsPermission permission)` with `mkdirs(FileSystem fs, Path dir, FsPermission permission)`and the first one is used here. The permissions of this function will be affected by the underlying umask. Although 700 here will hardly be affected by umask, but I think from a rigorous point of view, we should have one more permission check and permission grant here. So I judge whether the file permission is correctly granted by detecting the influence of umask on the permission, and if not, give it the correct permission through setPermission.

```java
    if (!permission.equals(permission.applyUMask(FsPermission.getUMask(conf)))) {
        fs.setPermission(dir, permission);
    }
```

And I find same issue in other three methods here.
In class Context
```java
private Path getScratchDir(String scheme, String authority,
      boolean mkdir, String scratchDir) {
          ......
          FileSystem fs = dirPath.getFileSystem(conf);
          dirPath = new Path(fs.makeQualified(dirPath).toString());
          FsPermission fsPermission = new FsPermission(scratchDirPermission);

          if (!fs.mkdirs(dirPath, fsPermission)) {
            throw new RuntimeException("Cannot make directory: "
                + dirPath.toString());
          ......
  }
```
In class SessionState
```java
  static void createPath(HiveConf conf, Path path, String permission, boolean isLocal,
      boolean isCleanUp) throws IOException {
    FsPermission fsPermission = new FsPermission(permission);
    FileSystem fs;
    ......
    if (!fs.mkdirs(path, fsPermission)) {
      throw new IOException("Failed to create directory " + path + " on fs " + fs.getUri());
    }
    ......
  }
```

and in class TezSessionState
```java
private Path createTezDir(String sessionId, String suffix) throws IOException {
    ......
    Path tezDir = new Path(hdfsScratchDir, TEZ_DIR);
    FileSystem fs = tezDir.getFileSystem(conf);
    FsPermission fsPermission = new FsPermission(HiveConf.getVar(conf, HiveConf.ConfVars.SCRATCHDIRPERMISSION));
    fs.mkdirs(tezDir, fsPermission);
    ......
  }
```