### PR TITLE
HIVE-26890 : Disable TestSSL#testConnectionWrongCertCN (Done as part of HIVE-22621 in master)

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestSSL.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestSSL.java
@@ -386,6 +386,7 @@ public class TestSSL {
    * Opening a new connection with this wrong certificate should fail
    * @throws Exception
    */
+  @Ignore
   @Test
   public void testConnectionWrongCertCN() throws Exception {
     // This call sets the default ssl params including the correct keystore in the server config


### PR DESCRIPTION
This was done as part of [HIVE-22621](https://issues.apache.org/jira/browse/HIVE-22621) on oss/master. This test also fails with the same error in Hive-3.1.3 release. So we can safely ignore this test from branch-3. Please find the JIRA link : https://issues.apache.org/jira/browse/HIVE-26890