### PR TITLE
HIVE-26905: Backport HIVE-25173 to 3.2.0: Exclude pentaho-aggdesigner-algorithm from upgrade-acid build.

### DIFF
--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>hive-exec</artifactId>
             <version>2.3.3</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.pentaho</groupId>
+                <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude pentaho-aggdesigner-algorithm from upgrade-acid build.

### Why are the changes needed?

In the current branch-3, upgrade-acid has a dependency on an old hive-exec version that has a transitive dependency to org.pentaho:pentaho-aggdesigner-algorithm. This artifact is no longer available in commonly supported Maven repositories, which causes a build failure. We can safely exclude the dependency, as was originally done in [HIVE-25173](https://issues.apache.org/jira/browse/HIVE-25173).

Differences from the master patch branch are:
1. On master, this applied to the pre-upgrade sub-module. This sub-module doesn't exist in branch-3, so the patch was rebased to the parent upgrade-acid module.
2. Additionally, the pom.xml code had changed quite a bit on master. This is just applying the equivalent exclusion from the HIVE-25173 diff: a1d4c8a6b3cf8465ac1ae074748a8f5a04bb473f.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I can run a full local build from branch-3 after applying this patch.

```
mvn -B -T 8 clean install -Pitests -DskipTests
```

Prior to this patch, my build failed while trying to download the org.pentaho:pentaho-aggdesigner-algorithm artifact.