### PR TITLE
HIVE-26910: Backport HIVE-19104: Use independent warehouse directories in test metastores.

### DIFF
--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestPermsGrp.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestPermsGrp.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.Type;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -62,7 +63,6 @@ import junit.framework.TestCase;
 public class TestPermsGrp extends TestCase {
 
   private boolean isServerRunning = false;
-  private int msPort;
   private HiveConf hcatConf;
   private Warehouse clientWH;
   private HiveMetaStoreClient msc;
@@ -80,7 +80,8 @@ public class TestPermsGrp extends TestCase {
       return;
     }
 
-    msPort = MetaStoreTestUtils.startMetaStoreWithRetry();
+    hcatConf = new HiveConf(this.getClass());
+    MetaStoreTestUtils.startMetaStoreWithRetry(hcatConf);
 
     isServerRunning = true;
 
@@ -88,8 +89,6 @@ public class TestPermsGrp extends TestCase {
     System.setSecurityManager(new NoExitSecurityManager());
     Policy.setPolicy(new DerbyPolicy());
 
-    hcatConf = new HiveConf(this.getClass());
-    hcatConf.setVar(HiveConf.ConfVars.METASTOREURIS, "thrift://127.0.0.1:" + msPort);
     hcatConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES, 3);
     hcatConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES, 3);
 
@@ -102,6 +101,12 @@ public class TestPermsGrp extends TestCase {
     msc = new HiveMetaStoreClient(hcatConf);
     System.setProperty(HiveConf.ConfVars.PREEXECHOOKS.varname, " ");
     System.setProperty(HiveConf.ConfVars.POSTEXECHOOKS.varname, " ");
+    System.setProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.WAREHOUSE));
+    System.setProperty(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.CONNECT_URL_KEY));
+    System.setProperty(HiveConf.ConfVars.METASTOREURIS.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.THRIFT_URIS));
   }
 
   public void testCustomPerms() throws Exception {

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatMultiOutputFormat.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatMultiOutputFormat.java
@@ -90,9 +90,6 @@ public class TestHCatMultiOutputFormat {
   private static HiveConf hiveConf;
   private static File workDir;
 
-  private static int msPort;
-  private static Thread t;
-
   static {
     schemaMap.put(tableNames[0], new HCatSchema(ColumnHolder.hCattest1Cols));
     schemaMap.put(tableNames[1], new HCatSchema(ColumnHolder.hCattest2Cols));
@@ -162,7 +159,7 @@ public class TestHCatMultiOutputFormat {
     metastoreConf.setVar(HiveConf.ConfVars.METASTOREWAREHOUSE, warehousedir.toString());
 
     // Run hive metastore server
-    msPort = MetaStoreTestUtils.startMetaStoreWithRetry(metastoreConf);
+    MetaStoreTestUtils.startMetaStoreWithRetry(metastoreConf);
     // Read the warehouse dir, which can be changed so multiple MetaStore tests could be run on
     // the same server
     warehousedir = new Path(MetastoreConf.getVar(metastoreConf, MetastoreConf.ConfVars.WAREHOUSE));
@@ -178,15 +175,14 @@ public class TestHCatMultiOutputFormat {
       new JobConf(conf));
     mrConf = mrCluster.createJobConf();
 
-    initializeSetup();
+    initializeSetup(metastoreConf);
 
     warehousedir.getFileSystem(conf).mkdirs(warehousedir);
   }
 
-  private static void initializeSetup() throws Exception {
+  private static void initializeSetup(HiveConf metastoreConf) throws Exception {
 
-    hiveConf = new HiveConf(mrConf, TestHCatMultiOutputFormat.class);
-    hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, "thrift://localhost:" + msPort);
+    hiveConf = new HiveConf(metastoreConf, TestHCatMultiOutputFormat.class);
     hiveConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES, 3);
     hiveConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES, 3);
     hiveConf.set(HiveConf.ConfVars.SEMANTIC_ANALYZER_HOOK.varname,
@@ -196,6 +192,12 @@ public class TestHCatMultiOutputFormat {
     hiveConf.set(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY.varname, "false");
     System.setProperty(HiveConf.ConfVars.PREEXECHOOKS.varname, " ");
     System.setProperty(HiveConf.ConfVars.POSTEXECHOOKS.varname, " ");
+    System.setProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+        MetastoreConf.getVar(hiveConf, MetastoreConf.ConfVars.WAREHOUSE));
+    System.setProperty(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+        MetastoreConf.getVar(hiveConf, MetastoreConf.ConfVars.CONNECT_URL_KEY));
+    System.setProperty(HiveConf.ConfVars.METASTOREURIS.varname,
+        MetastoreConf.getVar(hiveConf, MetastoreConf.ConfVars.THRIFT_URIS));
 
     hiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehousedir.toString());
     try {

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatPartitionPublish.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatPartitionPublish.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileOutputFormat;
@@ -73,7 +74,6 @@ public class TestHCatPartitionPublish {
   private static FileSystem fs = null;
   private static MiniMRCluster mrCluster = null;
   private static boolean isServerRunning = false;
-  private static int msPort;
   private static HiveConf hcatConf;
   private static HiveMetaStoreClient msc;
   private static SecurityManager securityManager;
@@ -112,17 +112,14 @@ public class TestHCatPartitionPublish {
       return;
     }
 
-    msPort = MetaStoreTestUtils.startMetaStoreWithRetry();
+    hcatConf = new HiveConf(TestHCatPartitionPublish.class);
+    MetaStoreTestUtils.startMetaStoreWithRetry(hcatConf);
 
-    Thread.sleep(10000);
     isServerRunning = true;
     securityManager = System.getSecurityManager();
     System.setSecurityManager(new NoExitSecurityManager());
     Policy.setPolicy(new DerbyPolicy());
 
-    hcatConf = new HiveConf(TestHCatPartitionPublish.class);
-    hcatConf.setVar(HiveConf.ConfVars.METASTOREURIS, "thrift://localhost:"
-        + msPort);
     hcatConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES, 3);
     hcatConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES, 3);
     hcatConf.setTimeVar(HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT, 120, TimeUnit.SECONDS);
@@ -135,6 +132,12 @@ public class TestHCatPartitionPublish {
     msc = new HiveMetaStoreClient(hcatConf);
     System.setProperty(HiveConf.ConfVars.PREEXECHOOKS.varname, " ");
     System.setProperty(HiveConf.ConfVars.POSTEXECHOOKS.varname, " ");
+    System.setProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.WAREHOUSE));
+    System.setProperty(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.CONNECT_URL_KEY));
+    System.setProperty(HiveConf.ConfVars.METASTOREURIS.varname,
+        MetastoreConf.getVar(hcatConf, MetastoreConf.ConfVars.THRIFT_URIS));
   }
 
   @AfterClass

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -147,7 +147,7 @@ public class WarehouseInstance implements Closeable {
     System.setProperty(HiveConf.ConfVars.POSTEXECHOOKS.varname, " ");
 
     HiveConf hiveConfCopy = new HiveConf(hiveConf);
-    MetaStoreTestUtils.startMetaStoreWithRetry(hiveConfCopy);
+    MetaStoreTestUtils.startMetaStoreWithRetry(hiveConfCopy, true);
 
     Path testPath = new Path(hiveWarehouseLocation);
     FileSystem testPathFileSystem = FileSystem.get(testPath.toUri(), hiveConf);

--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.llap.LlapItUtils;
 import org.apache.hadoop.hive.llap.daemon.MiniLlapCluster;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.util.ZooKeeperHiveHelper;
 import org.apache.hadoop.hive.shims.HadoopShims.MiniDFSShim;
@@ -288,9 +289,6 @@ public class MiniHS2 extends AbstractHiveService {
       hiveConf.setVar(ConfVars.HIVE_SERVER2_AUTHENTICATION, authType);
     }
 
-    String metaStoreURL = "jdbc:derby:;databaseName=" + baseDir.getAbsolutePath() + File.separator
-        + "test_metastore;create=true";
-
     if (isMetastoreSecure) {
       hiveConf.setVar(ConfVars.METASTORE_KERBEROS_PRINCIPAL, metastoreServerPrincipal);
       hiveConf.setVar(ConfVars.METASTORE_KERBEROS_KEYTAB_FILE, metastoreKeyTab);
@@ -304,8 +302,6 @@ public class MiniHS2 extends AbstractHiveService {
 
     fs.mkdirs(wareHouseDir);
     setWareHouseDir(wareHouseDir.toString());
-    System.setProperty(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname, metaStoreURL);
-    hiveConf.setVar(HiveConf.ConfVars.METASTORECONNECTURLKEY, metaStoreURL);
     if (!usePortsFromConf) {
       // reassign a new port, just in case if one of the MR services grabbed the last one
       setBinaryPort(MetaStoreTestUtils.findFreePort());
@@ -344,6 +340,7 @@ public class MiniHS2 extends AbstractHiveService {
   public void start(Map<String, String> confOverlay) throws Exception {
     if (isMetastoreRemote) {
       MetaStoreTestUtils.startMetaStoreWithRetry(getHiveConf());
+      setWareHouseDir(MetastoreConf.getVar(getHiveConf(), MetastoreConf.ConfVars.WAREHOUSE));
     }
 
     // Set confOverlay parameters

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1138,8 +1138,10 @@ public class MetastoreConf {
   }
 
   public static Configuration newMetastoreConf() {
+    return newMetastoreConf(new Configuration());
+  }
 
-    Configuration conf = new Configuration();
+  public static Configuration newMetastoreConf(Configuration conf) {
 
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     if (classLoader == null) {

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -101,7 +101,7 @@ import static org.junit.Assert.fail;
 public abstract class TestHiveMetaStore {
   private static final Logger LOG = LoggerFactory.getLogger(TestHiveMetaStore.class);
   protected static HiveMetaStoreClient client;
-  protected static Configuration conf;
+  protected static Configuration conf = MetastoreConf.newMetastoreConf();
   protected static Warehouse warehouse;
   protected static boolean isThriftClient = false;
 
@@ -114,7 +114,6 @@ public abstract class TestHiveMetaStore {
 
   @Before
   public void setUp() throws Exception {
-    conf = MetastoreConf.newMetastoreConf();
     warehouse = new Warehouse(conf);
 
     // set some values to use for getting conf. vars
@@ -2929,18 +2928,18 @@ public abstract class TestHiveMetaStore {
   @Test
   public void testRetriableClientWithConnLifetime() throws Exception {
 
-    Configuration conf = MetastoreConf.newMetastoreConf();
-    MetastoreConf.setTimeVar(conf, ConfVars.CLIENT_SOCKET_LIFETIME, 4, TimeUnit.SECONDS);
-    MetaStoreTestUtils.setConfForStandloneMode(conf);
+    Configuration newConf = MetastoreConf.newMetastoreConf(new Configuration(this.conf));
+    MetastoreConf.setTimeVar(newConf, ConfVars.CLIENT_SOCKET_LIFETIME, 4, TimeUnit.SECONDS);
+    MetaStoreTestUtils.setConfForStandloneMode(newConf);
     long timeout = 5 * 1000; // Lets use a timeout more than the socket lifetime to simulate a reconnect
 
     // Test a normal retriable client
-    IMetaStoreClient client = RetryingMetaStoreClient.getProxy(conf, getHookLoader(), HiveMetaStoreClient.class.getName());
+    IMetaStoreClient client = RetryingMetaStoreClient.getProxy(newConf, getHookLoader(), HiveMetaStoreClient.class.getName());
     client.getAllDatabases();
     client.close();
 
     // Connect after the lifetime, there should not be any failures
-    client = RetryingMetaStoreClient.getProxy(conf, getHookLoader(), HiveMetaStoreClient.class.getName());
+    client = RetryingMetaStoreClient.getProxy(newConf, getHookLoader(), HiveMetaStoreClient.class.getName());
     Thread.sleep(timeout);
     client.getAllDatabases();
     client.close();

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/TestRemoteHiveMetaStore.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/TestRemoteHiveMetaStore.java
@@ -43,7 +43,6 @@ public class TestRemoteHiveMetaStore extends TestHiveMetaStore {
 
     if (isServerStarted) {
       Assert.assertNotNull("Unable to connect to the MetaStore server", client);
-      MetastoreConf.setVar(conf, ConfVars.THRIFT_URIS, "thrift://localhost:" + port);
       return;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TestHS2ImpersonationWithRemoteMS` fails on branch-3. It makes assertions about the state of the warehouse directory, but it doesn't account for a part of metastore initialization that updates the warehouse directory to parameterize it by port number for test isolation.

`MetaStoreTestUtils#startMetaStoreWithRetry` sets the warehouse directory as the new `metastore.warehouse.dir` property. `AbstractHiveService#get/setWareHouseDir` later works with the deprecated `hive.metastore.warehouse.dir` property. `MetastoreConf` will take care of resolving requests for the new property to values under the old property, but not vice versa.

On master, [HIVE-19104](https://issues.apache.org/jira/browse/HIVE-19104) included an additional line in `MiniHs2` to make sure these 2 properties would stay in sync for test runs. This is a slightly modified backport of that patch to branch-3.

There is only one significant difference compared to the master patch. I needed to resolve a merge conflict in `WarehouseInstance`. This code is different on branch-3, because it clones a copy of the `HiveConf` before starting the metastore. (On master, it doesn't make a clone.) I traced this difference to [HIVE-19812](https://issues.apache.org/jira/browse/HIVE-19812), in which slightly different patches were committed to master and branch-3:

* master: 9bc90f28cf4406d74f9597837c2b72c809b582e6
* branch-3: 369798d90367187714ba68ff55784cff1342b020

Only the branch-3 patch had a `WarehouseInstance` change. I reviewed comments on HIVE-19812 / #365, but I couldn't find any record of why branch-3 needed this change. I have decided to preserve the behavior of cloning a copy.

### Why are the changes needed?

This patch is required as part of getting a clean CI run on branch-3 in preparation for a 3.2.0 release.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Without this patch, `TestHS2ImpersonationWithRemoteMS`fails locally. After applying the patch, the test passes. I also confirmed successful runs of all other test suites altered in this patch.