### PR TITLE
HIVE-26065: fix incorrect metric active_calls_alter_partitions and active_calls_alter_partition

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5987,7 +5987,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
           .defaultMetaException();
     } finally {
       tableLock.unlock();
-      endFunction("alter_partition", oldParts != null, ex, tbl_name);
+      endFunction("alter_partitions", oldParts != null, ex, tbl_name);
     }
   }
 


### PR DESCRIPTION
In our production environment, we found that the value of the metric "active_calls_alter_partition" was negative. This is very confusing.
After checking the HMSHandler.class, we found that the method alter_partitions_with_environment_context called()
startTableFunction("alter_partitions", catName, db_name, tbl_name);
...
endFunction("alter_partition", oldParts != null, ex, tbl_name);
So the metric "active_calls_alter_partition" will be decremented by one after the "alter_partitions" function execution ends, causing the value become a negative number