### PR TITLE
HIVE-26687: INSERT query with array<smallint> type failing with SemanticException

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -8723,11 +8723,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       conversion.set(true);
       if (tableFieldTypeInfo.getCategory() != Category.PRIMITIVE) {
         // handle array in case of complex types
-        String array_type_prefix = "array<";
-        if (tableFieldTypeInfo.getTypeName().startsWith(array_type_prefix)) {
+        String arrayTypePrefix = "array<";
+        if (tableFieldTypeInfo.getTypeName().startsWith(arrayTypePrefix)) {
           // If number of nested array is unequal, then the implicit conversion cannot be done
-          if (StringUtils.countMatches(tableFieldTypeInfo.getTypeName(), array_type_prefix) !=
-                  StringUtils.countMatches(rowFieldTypeInfo.getTypeName(), array_type_prefix)) {
+          if (StringUtils.countMatches(tableFieldTypeInfo.getTypeName(), arrayTypePrefix) !=
+                  StringUtils.countMatches(rowFieldTypeInfo.getTypeName(), arrayTypePrefix)) {
             column = null;
           }
         } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -8722,8 +8722,18 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       // need to do some conversions here
       conversion.set(true);
       if (tableFieldTypeInfo.getCategory() != Category.PRIMITIVE) {
-        // cannot convert to complex types
-        column = null;
+        // handle array in case of complex types
+        String array_type_prefix = "array<";
+        if (tableFieldTypeInfo.getTypeName().startsWith(array_type_prefix)) {
+          // If number of nested array is unequal, then the implicit conversion cannot be done
+          if (StringUtils.countMatches(tableFieldTypeInfo.getTypeName(), array_type_prefix) !=
+                  StringUtils.countMatches(rowFieldTypeInfo.getTypeName(), array_type_prefix)) {
+            column = null;
+          }
+        } else {
+          // any other complex types cannot be converted
+          column = null;
+        }
       } else {
         column = ExprNodeTypeCheck.getExprNodeDefaultExprProcessor()
             .createConversionCast(column, (PrimitiveTypeInfo)tableFieldTypeInfo);

--- a/ql/src/test/queries/clientnegative/array_implicit_conversion_negative.q
+++ b/ql/src/test/queries/clientnegative/array_implicit_conversion_negative.q
@@ -1,0 +1,5 @@
+drop table if exists aic_tab;
+create table aic_tab (c1 array<array<smallint>>);
+insert into aic_tab(c1) values (array(55,54));
+select * from aic_tab;
+

--- a/ql/src/test/queries/clientpositive/array_implicit_conversion.q
+++ b/ql/src/test/queries/clientpositive/array_implicit_conversion.q
@@ -1,0 +1,24 @@
+drop table if exists aic_tab;
+create table aic_tab(array_type array <char(10)>);
+insert into table aic_tab select array(cast ('a' as char(10)));
+select * from aic_tab;
+
+drop table if exists aic_tab;
+create table aic_tab (c1 array<smallint>);
+insert into aic_tab(c1) values (array(55,54));
+select * from aic_tab;
+
+drop table if exists aic_tab;
+create table aic_tab (c1 array<array<smallint>>);
+insert into aic_tab(c1) values (array(array(44,45),array(44,45)));
+select * from aic_tab;
+
+drop table if exists aic_tab;
+create table aic_tab (c1 array<date>);
+insert into aic_tab(c1) values(array('2006-09-25','1980-07-19','1992-02-11'));
+select * from aic_tab;
+
+drop table if exists aic_tab;
+create table aic_tab (c1 array<date>);
+insert into aic_tab(c1) values(array('2002-hi-25','1980-07-19','1992-pi-11'));
+select * from aic_tab;

--- a/ql/src/test/results/clientnegative/array_implicit_conversion_negative.q.out
+++ b/ql/src/test/results/clientnegative/array_implicit_conversion_negative.q.out
@@ -1,0 +1,13 @@
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table aic_tab (c1 array<array<smallint>>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab (c1 array<array<smallint>>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+FAILED: SemanticException Line 0:-1 Cannot insert into target table because column number/types are different 'TOK_TMP_FILE': Cannot convert column 0 from array<int> to array<array<smallint>>.

--- a/ql/src/test/results/clientpositive/llap/array_implicit_conversion.q.out
+++ b/ql/src/test/results/clientpositive/llap/array_implicit_conversion.q.out
@@ -1,0 +1,166 @@
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table aic_tab(array_type array <char(10)>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab(array_type array <char(10)>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: insert into table aic_tab select array(cast ('a' as char(10)))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: insert into table aic_tab select array(cast ('a' as char(10)))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@aic_tab
+POSTHOOK: Lineage: aic_tab.array_type EXPRESSION []
+PREHOOK: query: select * from aic_tab
+PREHOOK: type: QUERY
+PREHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+POSTHOOK: query: select * from aic_tab
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+["a         "]
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@aic_tab
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@aic_tab
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: create table aic_tab (c1 array<smallint>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab (c1 array<smallint>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: insert into aic_tab(c1) values (array(55,54))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: insert into aic_tab(c1) values (array(55,54))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@aic_tab
+POSTHOOK: Lineage: aic_tab.c1 SCRIPT []
+PREHOOK: query: select * from aic_tab
+PREHOOK: type: QUERY
+PREHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+POSTHOOK: query: select * from aic_tab
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+[55,54]
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@aic_tab
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@aic_tab
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: create table aic_tab (c1 array<array<smallint>>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab (c1 array<array<smallint>>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: insert into aic_tab(c1) values (array(array(44,45),array(44,45)))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: insert into aic_tab(c1) values (array(array(44,45),array(44,45)))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@aic_tab
+POSTHOOK: Lineage: aic_tab.c1 SCRIPT []
+PREHOOK: query: select * from aic_tab
+PREHOOK: type: QUERY
+PREHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+POSTHOOK: query: select * from aic_tab
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+[[44,45],[44,45]]
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@aic_tab
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@aic_tab
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: create table aic_tab (c1 array<date>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab (c1 array<date>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: insert into aic_tab(c1) values(array('2006-09-25','1980-07-19','1992-02-11'))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: insert into aic_tab(c1) values(array('2006-09-25','1980-07-19','1992-02-11'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@aic_tab
+POSTHOOK: Lineage: aic_tab.c1 SCRIPT []
+PREHOOK: query: select * from aic_tab
+PREHOOK: type: QUERY
+PREHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+POSTHOOK: query: select * from aic_tab
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+["2006-09-25","1980-07-19","1992-02-11"]
+PREHOOK: query: drop table if exists aic_tab
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@aic_tab
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: drop table if exists aic_tab
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@aic_tab
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: create table aic_tab (c1 array<date>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: create table aic_tab (c1 array<date>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@aic_tab
+PREHOOK: query: insert into aic_tab(c1) values(array('2002-hi-25','1980-07-19','1992-pi-11'))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@aic_tab
+POSTHOOK: query: insert into aic_tab(c1) values(array('2002-hi-25','1980-07-19','1992-pi-11'))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@aic_tab
+POSTHOOK: Lineage: aic_tab.c1 SCRIPT []
+PREHOOK: query: select * from aic_tab
+PREHOOK: type: QUERY
+PREHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+POSTHOOK: query: select * from aic_tab
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@aic_tab
+#### A masked pattern was here ####
+[null,"1980-07-19",null]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Array type should handle implicit conversion


### Why are the changes needed?
The queries were throwing SemanticException


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested locally, added a qfile for the same in the patch
