### PR TITLE
WIP: Improve branch-3 build time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
@@ -99,7 +99,6 @@
     <datanucleus.maven.plugin.version>3.3.0-release</datanucleus.maven.plugin.version>
     <maven.test.jvm.args>-Xmx2048m</maven.test.jvm.args>
     <maven.antrun.plugin.version>1.7</maven.antrun.plugin.version>
-    <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
     <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
@@ -1009,7 +1008,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>${maven.assembly.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
     <relativePath></relativePath>
   </parent>
 
@@ -38,7 +38,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <maven.repo.local>${settings.localRepository}</maven.repo.local>
-    <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
     <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
 
     <!-- Test Properties -->
@@ -618,7 +617,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven.assembly.plugin.version}</version>
         <executions>
           <execution>
             <id>assemble</id>
@@ -628,11 +626,15 @@
             </goals>
             <configuration>
               <finalName>apache-hive-metastore-${project.version}</finalName>
+              <!-- <formats> -->
+              <!--   <format>tar.gz</format> -->
+              <!-- </formats> -->
               <descriptors>
                 <descriptor>src/assembly/bin.xml</descriptor>
                 <descriptor>src/assembly/src.xml</descriptor>
               </descriptors>
               <tarLongFileMode>gnu</tarLongFileMode>
+              <!-- <tarLongFileMode>posix</tarLongFileMode> -->
             </configuration>
           </execution>
         </executions>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
     <relativePath></relativePath>
   </parent>
 

--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -20,7 +20,7 @@
         <!--disconnected from hive root pom since this module needs 2.x jars -->
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>23</version>
         <relativePath></relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -38,7 +38,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
         <maven.repo.local>${settings.localRepository}</maven.repo.local>
-        <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <hive.path.to.root>..</hive.path.to.root>
         <!-- Plugin versions -->
@@ -80,6 +79,12 @@
             <artifactId>hive-exec</artifactId>
             <version>2.3.3</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.pentaho</groupId>
+                <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

**DRAFT**, not ready for review.

Upgrade maven-assembly-plugin used in branch-3 build.

### Why are the changes needed?

Improve branch-3 full package build times for modules like standalone-metastore that use maven-assembly-plugin.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `mvn -B -T 8 -Pitests clean install -DskipTests` locally and measured reduction in build time from ~40 minutes to ~13 minutes.