### PR TITLE
HIVE-26922: Deadlock when rebuilding Materialized view stored by Iceberg

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
@@ -22,3 +22,12 @@ select * from mat1;
 
 explain cbo
 select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+insert into tbl_ice values (10, 'ten', 60);
+
+explain cbo
+alter materialized view mat1 rebuild;
+
+alter materialized view mat1 rebuild;
+
+select * from mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
@@ -1,4 +1,4 @@
--- MV data is stored by iceberg
+-- MV data is stored by iceberg v1
 -- SORT_QUERY_RESULTS
 
 set hive.explain.user=false;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc3.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc3.q
@@ -1,0 +1,19 @@
+-- MV data is stored by iceberg v2
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+drop materialized view if exists mat1;
+drop table if exists tbl_ice;
+
+create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2');
+insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54);
+
+create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+delete from tbl_ice where a = 4;
+
+alter materialized view mat1 rebuild;
+
+select * from mat1;

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
@@ -185,3 +185,45 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 CBO PLAN:
 HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
 
+PREHOOK: query: insert into tbl_ice values (10, 'ten', 60)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (10, 'ten', 60)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: explain cbo
+alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: explain cbo
+alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(b=[$1], c=[$2])
+  HiveFilter(condition=[>($2, 52)])
+    HiveTableScan(table=[[default, tbl_ice]], table:alias=[tbl_ice])
+
+PREHOOK: query: alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+five	54
+four	53
+ten	60

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc3.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc3.q.out
@@ -1,0 +1,65 @@
+PREHOOK: query: drop materialized view if exists mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: query: drop materialized view if exists mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: query: drop table if exists tbl_ice
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists tbl_ice
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: Lineage: mat1.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat1.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: delete from tbl_ice where a = 4
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: delete from tbl_ice where a = 4
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+five	54

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -3029,12 +3029,15 @@ public class AcidUtils {
       case INSERT_OVERWRITE:
         assert t != null;
         if (AcidUtils.isTransactionalTable(t)) {
-          if (conf.getBoolVar(HiveConf.ConfVars.TXN_OVERWRITE_X_LOCK) && !sharedWrite 
-              && !isLocklessReadsEnabled) {
+          if (conf.getBoolVar(HiveConf.ConfVars.TXN_OVERWRITE_X_LOCK) && !sharedWrite
+                  && !isLocklessReadsEnabled) {
             compBuilder.setExclusive();
           } else {
             compBuilder.setExclWrite();
           }
+          compBuilder.setOperationType(DataOperationType.UPDATE);
+        } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
+          compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
           compBuilder.setOperationType(DataOperationType.UPDATE);
         } else {
           compBuilder.setExclusive();
@@ -3063,15 +3066,7 @@ public class AcidUtils {
             break;
           }
         } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
-          final HiveStorageHandler storageHandler = Preconditions.checkNotNull(t.getStorageHandler(),
-              "Thought all the non native tables have an instance of storage handler");
-          LockType lockType = storageHandler.getLockType(output);
-          if (null == LockType.findByValue(lockType.getValue())) {
-            throw new IllegalArgumentException(String
-                .format("Lock type [%s] for Database.Table [%s.%s] is unknown", lockType, t.getDbName(),
-                    t.getTableName()));
-          }
-          compBuilder.setLock(lockType);
+          compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
         } else {
           if (conf.getBoolVar(HiveConf.ConfVars.HIVE_TXN_STRICT_LOCKING_MODE)) {
             compBuilder.setExclusive();
@@ -3122,7 +3117,19 @@ public class AcidUtils {
     }
     return lockComponents;
   }
-  
+
+  private static LockType getLockTypeFromStorageHandler(WriteEntity output, Table t) {
+    final HiveStorageHandler storageHandler = Preconditions.checkNotNull(t.getStorageHandler(),
+        "Thought all the non native tables have an instance of storage handler");
+    LockType lockType = storageHandler.getLockType(output);
+    if (null == LockType.findByValue(lockType.getValue())) {
+      throw new IllegalArgumentException(String
+          .format("Lock type [%s] for Database.Table [%s.%s] is unknown", lockType, t.getDbName(),
+              t.getTableName()));
+    }
+    return lockType;
+  }
+
   public static boolean isExclusiveCTASEnabled(Configuration conf) {
     return HiveConf.getBoolVar(conf, ConfVars.TXN_CTAS_X_LOCK);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -3037,7 +3037,7 @@ public class AcidUtils {
           }
           compBuilder.setOperationType(DataOperationType.UPDATE);
         } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
-          compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
+          compBuilder.setLock(t.getStorageHandler().getLockType(output));
           compBuilder.setOperationType(DataOperationType.UPDATE);
         } else {
           compBuilder.setExclusive();
@@ -3066,7 +3066,7 @@ public class AcidUtils {
             break;
           }
         } else if (MetaStoreUtils.isNonNativeTable(t.getTTable())) {
-          compBuilder.setLock(getLockTypeFromStorageHandler(output, t));
+          compBuilder.setLock(t.getStorageHandler().getLockType(output));
         } else {
           if (conf.getBoolVar(HiveConf.ConfVars.HIVE_TXN_STRICT_LOCKING_MODE)) {
             compBuilder.setExclusive();
@@ -3116,18 +3116,6 @@ public class AcidUtils {
       lockComponents.add(comp);
     }
     return lockComponents;
-  }
-
-  private static LockType getLockTypeFromStorageHandler(WriteEntity output, Table t) {
-    final HiveStorageHandler storageHandler = Preconditions.checkNotNull(t.getStorageHandler(),
-        "Non-native tables must have an instance of storage handler.");
-    LockType lockType = storageHandler.getLockType(output);
-    if (null == LockType.findByValue(lockType.getValue())) {
-      throw new IllegalArgumentException(String
-          .format("Lock type [%s] for Database.Table [%s.%s] is unknown", lockType, t.getDbName(),
-              t.getTableName()));
-    }
-    return lockType;
   }
 
   public static boolean isExclusiveCTASEnabled(Configuration conf) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -3120,7 +3120,7 @@ public class AcidUtils {
 
   private static LockType getLockTypeFromStorageHandler(WriteEntity output, Table t) {
     final HiveStorageHandler storageHandler = Preconditions.checkNotNull(t.getStorageHandler(),
-        "Thought all the non native tables have an instance of storage handler");
+        "Non-native tables must have an instance of storage handler.");
     LockType lockType = storageHandler.getLockType(output);
     if (null == LockType.findByValue(lockType.getValue())) {
       throw new IllegalArgumentException(String

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
@@ -65,12 +65,11 @@ public class StorageHandlerMock extends DefaultStorageHandler {
     };
   }
 
-  @Override public LockType getLockType(WriteEntity writeEntity
-  ) {
+  @Override public LockType getLockType(WriteEntity writeEntity) {
     if (writeEntity.getWriteType().equals(WriteEntity.WriteType.INSERT)) {
       return LockType.SHARED_READ;
     }
-    return LockType.EXCLUSIVE;
+    return super.getLockType(writeEntity);
   }
 
   @Override public Class<? extends OutputFormat> getOutputFormatClass() {

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
@@ -70,7 +70,7 @@ public class StorageHandlerMock extends DefaultStorageHandler {
     if (writeEntity.getWriteType().equals(WriteEntity.WriteType.INSERT)) {
       return LockType.SHARED_READ;
     }
-    return LockType.SHARED_WRITE;
+    return LockType.EXCLUSIVE;
   }
 
   @Override public Class<? extends OutputFormat> getOutputFormatClass() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Set the lock type based in the table's storage handler in case of non native tables when creating LockComponent's for output tables.

### Why are the changes needed?
Iceberg table writes does not require exclusive lock since Iceberg handles the concurrency. However locking is necessary when committing the Iceberg change and updating the metadata file at Hive side. Originally for insert overwrite an exclusive lock was acquired in the beginning of the transaction to the target table and a second write lock was requested for the Iceberg commit in the same transaction but this second one was never been acquired because the two lock request caused a deadlock.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=mv_iceberg_orc2.q -pl itests/qtest-iceberg -Piceberg -Pitests -Drat.skip
```