### PR TITLE
HIVE-26717: Query based Rebalance compaction on insert-only tables

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
@@ -102,9 +102,13 @@ class CompactorTestUtil {
    */
   static List<String> getBucketFileNames(FileSystem fs, Table table, String partitionName, String deltaName)
       throws IOException {
+    boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
     Path path = partitionName == null ? new Path(table.getSd().getLocation(), deltaName) : new Path(
         new Path(table.getSd().getLocation()), new Path(partitionName, deltaName));
-    return Arrays.stream(fs.listStatus(path, AcidUtils.bucketFileFilter)).map(FileStatus::getPath).map(Path::getName).sorted()
+    return Arrays.stream(fs.listStatus(path, insertOnly? AcidUtils.originalBucketFilter : AcidUtils.bucketFileFilter))
+        .map(FileStatus::getPath)
+        .map(Path::getName)
+        .sorted()
         .collect(Collectors.toList());
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -537,7 +537,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Assert.assertEquals("Wrong compactor were chosen.", MmMajorQueryCompactor.class, reference.get().getClass());
 
     //Check if the compaction succeed
-    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+    List<ShowCompactResponseElement> compactions = verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+    Assert.assertTrue("no senor", compactions.get(0).getErrorMessage()
+        .contains("Falling back to MAJOR compaction as REBALANCE compaction is supported only on full-acid tables."));
 
     // Verify buckets and their content after rebalance
     basePath = new Path(table.getSd().getLocation(), "base_0000007_v0000017");

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
@@ -77,6 +78,7 @@ import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.FieldSetter;
 
 import static org.apache.hadoop.hive.ql.TxnCommandsBaseForTests.runWorker;
@@ -453,6 +455,110 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     for(int i = 0; i < expectedBuckets.length; i++) {
       Assert.assertEquals("rebalanced bucket " + i, Arrays.asList(expectedBuckets[i]),
           testDataProvider.getBucketData(tableName, BucketCodec.V1.encode(options.bucket(i)) + ""));
+    }
+  }
+
+  @Test
+  public void testMMRebalanceCompactionOfNotPartitionedImplicitlyBucketedTable() throws Exception {
+    conf.setBoolVar(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, true);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, false);
+    conf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
+
+    //set grouping size to have 3 buckets, and re-create driver with the new config
+    conf.set("tez.grouping.min-size", "200");
+    conf.set("tez.grouping.max-size", "80000");
+    driver = new Driver(conf);
+
+    final String stageTableName = "stage_rebalance_test";
+    final String tableName = "rebalance_test";
+
+    TestDataProvider testDataProvider = new TestDataProvider();
+    testDataProvider.createFullAcidTable(stageTableName, true, false);
+    testDataProvider.insertTestDataPartitioned(stageTableName);
+
+    executeStatementOnDriver("drop table if exists " + tableName, driver);
+    executeStatementOnDriver("CREATE TABLE " + tableName + "(a string, b int) " +
+        "STORED AS ORC TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only')", driver);
+    executeStatementOnDriver("INSERT OVERWRITE TABLE " + tableName + " select a, b from " + stageTableName, driver);
+
+    //do some single inserts to have more data in the first bucket.
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('12',12)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('13',13)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('14',14)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('15',15)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('16',16)", driver);
+    executeStatementOnDriver("INSERT INTO TABLE " + tableName + " values ('17',17)", driver);
+
+    Table table = msClient.getTable("default", tableName);
+    FileSystem fs = FileSystem.get(conf);
+
+    // Verify buckets and their content before rebalance
+    Path basePath = new Path(table.getSd().getLocation(), "base_0000001");
+    List<String> bucketFileNames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001");
+
+    Assert.assertEquals("Test setup does not match the expected: different buckets",
+        Arrays.asList("000000_0", "000001_0", "000002_0", "000003_0", "000004_0", "000005_0", "000006_0"),
+        bucketFileNames);
+
+    Map<String, Integer> expectedRowCount = new HashMap<String, Integer>() {{
+      put("000000_0", 4);
+      put("000001_0", 2);
+      put("000002_0", 1);
+      put("000003_0", 2);
+      put("000004_0", 1);
+      put("000005_0", 1);
+      put("000006_0", 1);
+    }};
+    for (String bucketFileName : bucketFileNames) {
+      try(Reader reader = OrcFile.createReader(new Path(basePath, bucketFileName), OrcFile.readerOptions(conf))) {
+        Assert.assertEquals("Row count in bucket " + bucketFileName + " does not match before compaction",
+            (int) expectedRowCount.get(bucketFileName), (int) reader.getNumberOfRows());
+      }
+    }
+
+    //Try to do a rebalancing compaction
+    executeStatementOnDriver("ALTER TABLE " + tableName + " COMPACT 'rebalance'", driver);
+
+    CompactorFactory factory = Mockito.spy(CompactorFactory.getInstance());
+    AtomicReference<QueryCompactor> reference = new AtomicReference<>();
+    doAnswer(invocation -> {
+      QueryCompactor result = (QueryCompactor)invocation.callRealMethod();
+      reference.set(result);
+      return result;
+    }).when(factory).getCompactor(any(), any(), any(), any());
+
+
+    Worker worker = new Worker(factory);
+    worker.setConf(conf);
+    worker.init(new AtomicBoolean(true));
+    worker.run();
+
+    //Check if MmMajorQueryCompactor was used as fallback.
+    Assert.assertEquals("Wrong compactor were chosen.", MmMajorQueryCompactor.class, reference.get().getClass());
+
+    //Check if the compaction succeed
+    verifyCompaction(1, TxnStore.CLEANING_RESPONSE);
+
+    // Verify buckets and their content after rebalance
+    basePath = new Path(table.getSd().getLocation(), "base_0000007_v0000017");
+    bucketFileNames = CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000007_v0000017");
+
+    Assert.assertEquals("Buckets does not match after compaction",
+        Arrays.asList("000000_0", "000001_0", "000002_0", "000003_0", "000004_0"),
+        bucketFileNames);
+
+    expectedRowCount = new HashMap<String, Integer>() {{
+      put("000000_0", 4);
+      put("000001_0", 4);
+      put("000002_0", 4);
+      put("000003_0", 4);
+      put("000004_0", 2);
+    }};
+    for (String bucketFileName : bucketFileNames) {
+      try(Reader reader = OrcFile.createReader(new Path(basePath, bucketFileName), OrcFile.readerOptions(conf))) {
+        Assert.assertEquals("Row count in bucket " + bucketFileName + " does not match before compaction",
+            (int) expectedRowCount.get(bucketFileName), (int) reader.getNumberOfRows());
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
@@ -106,9 +106,11 @@ public final class CompactorFactory {
           // however users can request it. In these cases we simply fall back to MAJOR compaction
           return new MmMajorQueryCompactor();
       }
+    } else {
+      throw new HiveException("Only transactional tables can be compacted, " + table.getTableName() + "is not suitable " +
+          "for compaction!");
     }
-    throw new HiveException("Only transactional tables can be compacted, " + table.getTableName() + "is not suitable " +
-        "for compaction!");
+    throw new HiveException("No suitable compactor found for table: " + table.getTableName());
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
@@ -99,10 +99,12 @@ public final class CompactorFactory {
         case MINOR:
           return new MmMinorQueryCompactor();
         case MAJOR:
+        case REBALANCE:
+          // REBALANCE COMPACTION on an insert-only table is simply a MAJOR compaction. Since there is no ACID row data,
+          // there is no acid row order to keep, and the number of buckets cannot be set at all (it will be calculated
+          // and created by TEZ dynamically). Initiator won't schedule REBALANCE compactions for insert-only tables,
+          // however users can request it. In these cases we simply fall back to MAJOR compaction
           return new MmMajorQueryCompactor();
-        default:
-          throw new HiveException(
-              compactionInfo.type.name() + " compaction is not supported on insert only tables.");
       }
     }
     throw new HiveException("Only transactional tables can be compacted, " + table.getTableName() + "is not suitable " +

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -547,9 +547,8 @@ public class Initiator extends MetaStoreCompactorThread {
     // bucket size calculation can be resource intensive if there are numerous deltas, so we check for rebalance
     // compaction only if the table is in an acceptable shape: no major compaction required. This means the number of
     // files shouldn't be too high
-    if ("tez".equalsIgnoreCase(HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE)) &&
-        HiveConf.getBoolVar(conf, HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED) &&
-        AcidUtils.isFullAcidTable(tblproperties)) {
+    if (AcidUtils.isFullAcidTable(tblproperties)) {
+      // We check only full-acid tables, for insert-only tables a MAJOR compaction will also rebalance bucket data.
       long totalSize = baseSize + deltaSize;
       long minimumSize = MetastoreConf.getLongVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_REBALANCE_MINIMUM_SIZE);
       if (totalSize > minimumSize) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
-import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.txn.CompactionInfo;
 import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -315,13 +315,15 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         return false;
       }
 
-      boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
-      if (LOG.isWarnEnabled() && ci.type.equals(CompactionType.REBALANCE) && insertOnly) {
-        LOG.warn("REBALANCE compaction requested on an insert-only table ({}). Falling back to MAJOR compaction as " +
-            "REBALANCE compaction is supported only on full-acid tables", table.getTableName());
-        if (ci.numberOfBuckets > 0) {
+      if (LOG.isWarnEnabled()) {
+        boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
+        if (ci.type.equals(CompactionType.REBALANCE) && insertOnly) {
+          LOG.warn("REBALANCE compaction requested on an insert-only table ({}). Falling back to MAJOR compaction as " +
+              "REBALANCE compaction is supported only on full-acid tables", table.getTableName());
+        }
+        if ((!ci.type.equals(CompactionType.REBALANCE) || insertOnly) && ci.numberOfBuckets > 0) {
           LOG.warn("Only REBALANCE compaction on a full-acid table accepts the number of buckets clause " +
-              "(CLUSTERED INTO {N} BUCKETS). Since the compaction request is {} and the table is {}, it will be ignored.",
+                  "(CLUSTERED INTO {N} BUCKETS). Since the compaction request is {} and the table is {}, it will be ignored.",
               ci.type, insertOnly ? "insert-only" : "full-acid");
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -268,6 +268,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       findNextCompactRequest.setWorkerVersion(runtimeVersion);
       findNextCompactRequest.setPoolName(this.getPoolName());
       ci = CompactionInfo.optionalCompactionInfoStructToInfo(msc.findNextCompact(findNextCompactRequest));
+      ci.errorMessage = "";
       LOG.info("Processing compaction request {}", ci);
 
       if (ci == null) {
@@ -318,10 +319,13 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       if (LOG.isWarnEnabled()) {
         boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
         if (ci.type.equals(CompactionType.REBALANCE) && insertOnly) {
+          ci.errorMessage += "Falling back to MAJOR compaction as REBALANCE compaction is supported only on full-acid tables. ";
           LOG.warn("REBALANCE compaction requested on an insert-only table ({}). Falling back to MAJOR compaction as " +
               "REBALANCE compaction is supported only on full-acid tables", table.getTableName());
         }
         if ((!ci.type.equals(CompactionType.REBALANCE) || insertOnly) && ci.numberOfBuckets > 0) {
+          ci.errorMessage += "Only REBALANCE compaction on a full-acid table accepts the number of buckets clause. " +
+              "(CLUSTERED INTO {N} BUCKETS).";
           LOG.warn("Only REBALANCE compaction on a full-acid table accepts the number of buckets clause " +
                   "(CLUSTERED INTO {N} BUCKETS). Since the compaction request is {} and the table is {}, it will be ignored.",
               ci.type, insertOnly ? "insert-only" : "full-acid");

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -315,10 +315,14 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         return false;
       }
 
-      if (!ci.type.equals(CompactionType.REBALANCE) && ci.numberOfBuckets > 0) {
-        if (LOG.isWarnEnabled()) {
-          LOG.warn("Only the REBALANCE compaction accepts the number of buckets clause (CLUSTERED INTO {N} BUCKETS). " +
-              "Since the compaction request is {}, it will be ignored.", ci.type);
+      boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
+      if (LOG.isWarnEnabled() && ci.type.equals(CompactionType.REBALANCE) && insertOnly) {
+        LOG.warn("REBALANCE compaction requested on an insert-only table ({}). Falling back to MAJOR compaction as " +
+            "REBALANCE compaction is supported only on full-acid tables", table.getTableName());
+        if (ci.numberOfBuckets > 0) {
+          LOG.warn("Only REBALANCE compaction on a full-acid table accepts the number of buckets clause " +
+              "(CLUSTERED INTO {N} BUCKETS). Since the compaction request is {} and the table is {}, it will be ignored.",
+              ci.type, insertOnly ? "insert-only" : "full-acid");
         }
       }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -342,15 +342,17 @@ class CompactionTxnHandler extends TxnHandler {
   public void markCompacted(CompactionInfo info) throws MetaException {
     try {
       Connection dbConn = null;
-      Statement stmt = null;
+      PreparedStatement pstmt = null;
       try {
         dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED, connPoolCompaction);
-        stmt = dbConn.createStatement();
-        String s = "UPDATE \"COMPACTION_QUEUE\" SET \"CQ_STATE\" = '" + READY_FOR_CLEANING + "', "
-            + "\"CQ_WORKER_ID\" = NULL"
-            + " WHERE \"CQ_ID\" = " + info.id;
-        LOG.debug("Going to execute update <{}>", s);
-        int updCnt = stmt.executeUpdate(s);
+        String sql = "UPDATE \"COMPACTION_QUEUE\" SET \"CQ_STATE\" = ?, "
+            + "\"CQ_WORKER_ID\" = NULL, \"CQ_ERROR_MESSAGE\" = ? WHERE \"CQ_ID\" = ?";
+        pstmt = dbConn.prepareStatement(sql);
+        pstmt.setString(1, Character.toString(READY_FOR_CLEANING));
+        pstmt.setString(2, StringUtils.isNotBlank(info.errorMessage) ? info.errorMessage : null);
+        pstmt.setLong(3, info.id);
+        LOG.debug("Going to execute update <{}>", sql);
+        int updCnt = pstmt.executeUpdate();
         if (updCnt != 1) {
           LOG.error("Unable to set cq_state={} for compaction record: {}. updCnt={}", READY_FOR_CLEANING, info, updCnt);
           LOG.debug("Going to rollback");
@@ -366,7 +368,7 @@ class CompactionTxnHandler extends TxnHandler {
         throw new MetaException("Unable to connect to transaction database " +
           e.getMessage());
       } finally {
-        closeStmt(stmt);
+        closeStmt(pstmt);
         closeDbConn(dbConn);
       }
     } catch (RetryException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
For rebalance compaction requests on inert-only tables, a MAJOR 
compaction will run as a fallback. For details see: https://issues.apache.org/jira/browse/HIVE-26674 (limitations section)

### Why are the changes needed?
To allow the users to request rebalance compactions on insert-only tables.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually, and through unit tests
