### PR TITLE
HIVE-26924: Alter materialized view enable rewrite throws SemanticException for source iceberg table

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc.q
@@ -12,11 +12,13 @@ create external table tbl_ice_v2(d int, e string, f int) stored by iceberg store
 
 insert into tbl_ice_v2 values (1, 'one v2', 50), (4, 'four v2', 53), (5, 'five v2', 54);
 
-create materialized view mat1 as
+create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52;
 
 -- view should be empty
 select * from mat1;
+
+alter materialized view mat1 enable rewrite;
 
 -- view is up-to-date, use it
 explain cbo

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc.q.out
@@ -30,14 +30,14 @@ POSTHOOK: query: insert into tbl_ice_v2 values (1, 'one v2', 50), (4, 'four v2',
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_v2
-PREHOOK: query: create materialized view mat1 as
+PREHOOK: query: create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_v2
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
-POSTHOOK: query: create materialized view mat1 as
+POSTHOOK: query: create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@tbl_ice
@@ -55,6 +55,14 @@ POSTHOOK: query: select * from mat1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: alter materialized view mat1 enable rewrite
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 enable rewrite
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
 PREHOOK: query: explain cbo
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 PREHOOK: type: QUERY

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
@@ -68,10 +68,12 @@ public class AlterMaterializedViewRewriteAnalyzer extends BaseSemanticAnalyzer {
     Table materializedViewTable = getTable(tableName, true);
 
     // One last test: if we are enabling the rewrite, we need to check that query
-    // only uses transactional (MM and ACID) tables
+    // only uses transactional (MM and ACID and Iceberg) tables
     if (rewriteEnable) {
       for (SourceTable sourceTable : materializedViewTable.getMVMetadata().getSourceTables()) {
-        if (!AcidUtils.isTransactionalTable(sourceTable.getTable())) {
+        Table table = new Table(sourceTable.getTable());
+        if (!AcidUtils.isTransactionalTable(sourceTable.getTable()) &&
+                !(table.isNonNative() && table.getStorageHandler().areSnapshotsSupported())) {
           throw new SemanticException("Automatic rewriting for materialized view cannot be enabled if the " +
               "materialized view uses non-transactional tables");
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Check whether non-native source tables of a materialized view supports snapshots when enabling the mv for automatic query rewrites.

### Why are the changes needed?
Allow such mvs to be used in automatic query rewrites.

### Does this PR introduce _any_ user-facing change?
Yes. Enabling for rewrite is successful.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=mv_iceberg_orc.q -pl itests/qtest-iceberg -Piceberg -Pitests -Drat.skip
```
