### PR TITLE
HIVE-26935: Expose root cause of MetaException to client sides

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/RetryingMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/RetryingMetaStoreClient.java
@@ -264,15 +264,18 @@ public class RetryingMetaStoreClient implements InvocationHandler {
     return ret;
   }
 
+  public static boolean isRecoverableMessage(String exceptionMsg) {
+    if (exceptionMsg == null) {
+      return false;
+    }
+    if (exceptionMsg.contains("java.sql.SQLIntegrityConstraintViolationException")) {
+      return false;
+    }
+    return IO_JDO_TRANSPORT_PROTOCOL_EXCEPTION_PATTERN.matcher(exceptionMsg).matches();
+  }
+
   private static boolean isRecoverableMetaException(MetaException e) {
-    String m = e.getMessage();
-    if (m == null) {
-      return false;
-    }
-    if (m.contains("java.sql.SQLIntegrityConstraintViolationException")) {
-      return false;
-    }
-    return IO_JDO_TRANSPORT_PROTOCOL_EXCEPTION_PATTERN.matcher(m).matches();
+    return isRecoverableMessage(e.getMessage());
   }
 
   /**

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/RetryingMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/RetryingMetaStoreClient.java
@@ -264,18 +264,15 @@ public class RetryingMetaStoreClient implements InvocationHandler {
     return ret;
   }
 
-  public static boolean isRecoverableMessage(String exceptionMsg) {
-    if (exceptionMsg == null) {
-      return false;
-    }
-    if (exceptionMsg.contains("java.sql.SQLIntegrityConstraintViolationException")) {
-      return false;
-    }
-    return IO_JDO_TRANSPORT_PROTOCOL_EXCEPTION_PATTERN.matcher(exceptionMsg).matches();
-  }
-
   private static boolean isRecoverableMetaException(MetaException e) {
-    return isRecoverableMessage(e.getMessage());
+    String m = e.getMessage();
+    if (m == null) {
+      return false;
+    }
+    if (m.contains("java.sql.SQLIntegrityConstraintViolationException")) {
+      return false;
+    }
+    return IO_JDO_TRANSPORT_PROTOCOL_EXCEPTION_PATTERN.matcher(m).matches();
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
@@ -206,7 +206,7 @@ public class RetryingHMSHandler implements InvocationHandler {
       Throwable rootCause = ExceptionUtils.getRootCause(caughtException);
       String errorMessage = ExceptionUtils.getMessage(caughtException) +
               (rootCause == null ? "" : ("\nRoot cause: " + rootCause));
-      if (!RetryingMetaStoreClient.isRecoverableMessage(errorMessage) ||  retryCount >= retryLimit) {
+      if (retryCount >= retryLimit) {
         LOG.error("HMSHandler Fatal error: " + ExceptionUtils.getStackTrace(caughtException));
         throw new MetaException(errorMessage);
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
@@ -204,12 +204,11 @@ public class RetryingHMSHandler implements InvocationHandler {
       }
 
       Throwable rootCause = ExceptionUtils.getRootCause(caughtException);
-      String rootMsg = rootCause == null ? "" : rootCause.toString();
-      if (!RetryingMetaStoreClient.isRecoverableMessage(rootMsg) ||  retryCount >= retryLimit) {
+      String errorMessage = ExceptionUtils.getMessage(caughtException) +
+              (rootCause == null ? "" : ("\nRoot cause: " + rootCause));
+      if (!RetryingMetaStoreClient.isRecoverableMessage(errorMessage) ||  retryCount >= retryLimit) {
         LOG.error("HMSHandler Fatal error: " + ExceptionUtils.getStackTrace(caughtException));
-        MetaException me = new MetaException(caughtException.getMessage() +
-                (rootMsg == "" ? "": "\nRoot cause: ") + rootMsg);
-        throw me;
+        throw new MetaException(errorMessage);
       }
 
       assert (retryInterval >= 0);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
@@ -203,10 +203,12 @@ public class RetryingHMSHandler implements InvocationHandler {
         }
       }
 
-      if (retryCount >= retryLimit) {
+      Throwable rootCause = ExceptionUtils.getRootCause(caughtException);
+      String rootMsg = rootCause == null ? "" : rootCause.toString();
+      if (!RetryingMetaStoreClient.isRecoverableMessage(rootMsg) ||  retryCount >= retryLimit) {
         LOG.error("HMSHandler Fatal error: " + ExceptionUtils.getStackTrace(caughtException));
-        MetaException me = new MetaException(caughtException.toString());
-        me.initCause(caughtException);
+        MetaException me = new MetaException(caughtException.getMessage() +
+                (rootMsg == "" ? "": "\nRoot cause: ") + rootMsg);
         throw me;
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We are trying to expose the root cause of MetaException in the message:
1. Refactor the MetaException message in RetryingHMSHandler with following format:
```sh
MetaException(message:JDOUserException: One or more instances could not be deleted
Root cause: java.sql.SQLIntegrityConstraintViolationException: Cannot delete or update a parent row)
```
~2. Check if the exception can be retry in HMS server.~


### Why are the changes needed?
1. Expose root cause for user troubleshooting.
~2. Root cause in message can help skip some unnecessary retry in both client and server sides.~


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add Unit test.
