### PR TITLE
Hive 26941

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -6977,7 +6977,7 @@ public class HiveConf extends Configuration {
   }
 
   public static String generateIgnoredConfigWarning(String key) {
-    return String.format("Configuration {} is ignored and may not be set during runtime.", key);
+    return String.format("Configuration %s is ignored and cannot be set during runtime.", key);
   }
 
   public static String generateMrDeprecationWarning() {

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -6880,6 +6880,7 @@ public class HiveConf extends Configuration {
     restrictList.add(ConfVars.HIVE_IN_TEST.varname);
     restrictList.add(ConfVars.HIVE_CONF_RESTRICTED_LIST.varname);
     restrictList.add(ConfVars.HIVE_CONF_HIDDEN_LIST.varname);
+    restrictList.add(ConfVars.HIVE_CONF_IGNORE_LIST.varname);
     restrictList.add(ConfVars.HIVE_CONF_INTERNAL_VARIABLE_LIST.varname);
   }
 

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
@@ -81,19 +81,38 @@ public class HiveConfUtil {
   }
 
   /**
+   * Getting a set of strings from a configuration
+   * @param configuration The original configuration
+   * @param configName configuration name which may have multiple comma separated values
+   * @return The set of strings with the configuration values
+   */
+  public static Set<String> getConfigAsSet(Configuration configuration, String configName) {
+    Set<String> configSet = new HashSet<String>();
+    String configListStr = HiveConf.getVar(configuration, HiveConf.getConfVars(configName));
+    if (configListStr != null) {
+      for (String entry : configListStr.split(",")) {
+        configSet.add(entry.trim());
+      }
+    }
+    return configSet;
+  }
+
+  /**
+   * Getting the set of the ignored configurations
+   * @param configuration The original configuration
+   * @return The list of the configuration values to hide
+   */
+  public static Set<String> getIgnoreSet(Configuration configuration) {
+    return getConfigAsSet(configuration, ConfVars.HIVE_CONF_IGNORE_LIST.varname);
+  }
+
+  /**
    * Getting the set of the hidden configurations
    * @param configuration The original configuration
    * @return The list of the configuration values to hide
    */
   public static Set<String> getHiddenSet(Configuration configuration) {
-    Set<String> hiddenSet = new HashSet<String>();
-    String hiddenListStr = HiveConf.getVar(configuration, HiveConf.ConfVars.HIVE_CONF_HIDDEN_LIST);
-    if (hiddenListStr != null) {
-      for (String entry : hiddenListStr.split(",")) {
-        hiddenSet.add(entry.trim());
-      }
-    }
-    return hiddenSet;
+    return getConfigAsSet(configuration, HiveConf.ConfVars.HIVE_CONF_HIDDEN_LIST.varname);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
@@ -254,6 +254,12 @@ public class SetProcessor implements CommandProcessor {
         throw new IllegalArgumentException("hive configuration " + key + " does not exists.");
       }
     }
+    if (conf.isIgnoredConfig(key)) {
+      result = HiveConf.generateIgnoredConfigWarning(key);
+      ss.out.println(result);
+      LOG.warn(result);
+      return result;
+    }
     conf.verifyAndSet(key, value);
     if (HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname.equals(key)) {
       if ("mr".equals(value)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
@@ -256,8 +256,8 @@ public class SetProcessor implements CommandProcessor {
     }
     if (conf.isIgnoredConfig(key)) {
       result = HiveConf.generateIgnoredConfigWarning(key);
-      ss.out.println(result);
       LOG.warn(result);
+      ss.out.println(result);
       return result;
     }
     conf.verifyAndSet(key, value);

--- a/ql/src/test/org/apache/hadoop/hive/ql/processors/TestSetProcessorWithIgnoreList.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/processors/TestSetProcessorWithIgnoreList.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.processors;
+
+import org.apache.hadoop.hive.common.io.SessionStream;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.SystemVariables;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.*;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestSetProcessorWithIgnoreList {
+
+  private ByteArrayOutputStream baos;
+  private static SessionState state;
+  private SetProcessor processor;
+
+  @BeforeClass
+  public static void before() throws Exception {
+    HiveConf conf = new HiveConf();
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_CONF_IGNORE_LIST, "hive.execution.engine");
+    HiveConf conf2 = new HiveConf(conf, conf.getClass()); //workaround - this will populate the ignoreSet internally
+    SessionState.start(conf2);
+    state = SessionState.get();
+  }
+
+  @Before
+  public void setupTest() throws Exception {
+    baos = new ByteArrayOutputStream();
+    state.out = new SessionStream(baos);
+    processor = new SetProcessor();
+  }
+
+  @Test
+  public void testIgnoredConfigOutputMessage() throws Exception {
+    runSetProcessor(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname+"=mr");
+    String output = baos.toString();
+    Assert.assertTrue(output.contains("ignored"));
+  }
+
+  @Test
+  public void testIgnoredConfig() throws Exception {
+    runSetProcessor(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname);
+    String output = baos.toString();
+
+    baos.close();
+    baos = new ByteArrayOutputStream();
+    state.out = new SessionStream(baos);
+
+    String defaultValue = HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.defaultStrVal;
+    String nonDefaultValue = "tez".equals(defaultValue) ? "mr" : "tez";
+    runSetProcessor(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname+"="+nonDefaultValue);
+
+    baos.close();
+    baos = new ByteArrayOutputStream();
+    state.out = new SessionStream(baos);
+
+    runSetProcessor(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname);
+    String outputAfterSetCommand = baos.toString();
+
+    Assert.assertTrue(output.equals(outputAfterSetCommand));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    baos.close();
+  }
+
+  /*
+   * Simulates the set <command>;
+   */
+  private void runSetProcessor(String command) throws CommandProcessorException {
+    processor.run(command);
+    state.out.flush();
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this jira proposing:
- adding a new config "hive.conf.ignored.variable.list"
- accepts strings, comma separated list of variables (made a small change to parse values in the same way as it is with HIVE_CONF_HIDDEN_LIST)
- the config is empty by default, it can be set in hive-site.xml only
- adding the "hive.conf.ignored.variable.list" to the restricted list ("hive.conf.restricted.list") internally - so it cannot be modified during runtime
- adding tests for the changes


### Why are the changes needed?
In certain environments (usually after upgrades) we need to restrict users from changing some Hive configurations during runtime, for example "mapreduce.job.queuename" or "hive.execution.engine" should not be changed in an environment, however notifying all users and asking them to change all of their jobs is not possible.


### Does this PR introduce _any_ user-facing change?
- Yes, new config "hive.conf.ignored.variable.list" which may need to be documented.
- Trying to set such an ignored variable will result in that the "set" request is ignored and the user gets

> Configuration xxxx is ignored and cannot be set during runtime.

instead of the "No rows affected" (successful) setting.


### How was this patch tested?
- Added a new unit test TestSetProcessorWithIgnoreList to test this feature
- Started a local HS2 instance with a modified "hive-site.xml" to test if the setting is populated properly and works as above explained