### PR TITLE
HIVE-26952 - set the value of metastore.storage.schema.reader.impl  t…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
@@ -43,7 +43,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TestStorageSchemaReader {
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.metastore;
 
 import org.apache.hadoop.hive.conf.HiveConf;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestStorageSchemaReader.java
@@ -1,0 +1,160 @@
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.hbase.HBaseSerDe;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
+import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.apache.hive.storage.jdbc.JdbcSerDe;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class TestStorageSchemaReader {
+
+  protected HiveConf hiveConf;
+  protected HiveMetaStoreClient client;
+  protected String dbName;
+  protected Map<String, String> avroTableParams = new HashMap<>();
+  Map<String, String> hbaseTableParams = new HashMap<>();
+  Map<String, String> hbaseSerdeParams = new HashMap<>();
+  Map<String, String> jdbcTableParams = new HashMap<>();
+  Map<String, String> jdbcSerdeParams = new HashMap<>();
+
+  @Before @BeforeEach public void setUp() throws Exception {
+    dbName = "sampleDb";
+    hiveConf = new HiveConf(this.getClass());
+    new DatabaseBuilder().setName(dbName).create(new HiveMetaStoreClient(hiveConf), hiveConf);
+    avroTableParams.put("avro.schema.literal",
+        "{\"name\":\"nullable\", \"type\":\"record\", \"fields\":[{\"name\":\"id\", \"type\":\"int\"}, {\"name\":\"value\", \"type\":\"int\"}]}");
+
+    hbaseTableParams.put("storage_handler", "org.apache.hadoop.hive.hbase.HBaseStorageHandler");
+    hbaseTableParams.put("hbase.table.name", "t_hive");
+    hbaseTableParams.put("hbase.table.default.storage.type", "binary");
+    hbaseTableParams.put("external.table.purge", "true");
+
+    hbaseSerdeParams.put("hbase.zookeeper.quorum", "test_host");
+    hbaseSerdeParams.put("hbase.zookeeper.property.clientPort", "8765");
+    hbaseSerdeParams.put("hbase.table.name", "my#tbl");
+    hbaseSerdeParams.put("hbase.columns.mapping", "cf:string");
+
+    jdbcTableParams.put("hive.sql.database.type", "METASTORE");
+    jdbcTableParams.put("hive.sql.query", "SELECT \"SERDE_ID\", \"NAME\", \"SLIB\" FROM \"SERDES\"");
+
+    jdbcSerdeParams.put("serialization.format", "1");
+    jdbcTableParams.put("storage_handler", "org.apache.hive.storage.jdbc.JdbcStorageHandler");
+  }
+
+  @After @AfterEach public void tearDown() throws Exception {
+    new HiveMetaStoreClient(hiveConf).dropDatabase(dbName, true, true, true);
+  }
+
+  private Table createTable(String tblName, String serdeClass, String inputFormatClass, String outputFormatClass,
+      Map<String, String> tableParams, Map<String, String> serdeParams) throws TException {
+    client = new HiveMetaStoreClient(hiveConf);
+    return new TableBuilder().setDbName(dbName).setTableName(tblName).addCol("id", "int", "comment for " + tblName)
+        .addCol("value", "int", "comment for " + tblName).setSerdeLib(serdeClass).setInputFormat(inputFormatClass)
+        .setOutputFormat(outputFormatClass).setTableParams(tableParams)
+        .addStorageDescriptorParam("test_param_1", "Use this for comments etc").setSerdeParams(serdeParams)
+        .create(client, hiveConf);
+  }
+
+  private void checkSchema(String tblName, Table tbl) throws TException {
+    List<FieldSchema> fieldSchemasFull = client.getSchema(dbName, tblName);
+    assertNotNull(fieldSchemasFull);
+    assertEquals(fieldSchemasFull.size(), tbl.getSd().getCols().size());
+    checkFields(tbl.getSd().getCols(), fieldSchemasFull);
+  }
+
+  private void checkFields(List<FieldSchema> fieldSchemas, List<FieldSchema> fieldSchemasFromHMS) {
+    for (int i = 0; i < fieldSchemas.size(); i++) {
+      assertTrue(
+          fieldSchemas.get(i).getName().equals(fieldSchemasFromHMS.get(i).getName()) && fieldSchemas.get(i).getType()
+              .equals(fieldSchemasFromHMS.get(i).getType()));
+    }
+  }
+
+  @Test public void testAvroTableWithDefaultSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader");
+    String tblName = "avroTable";
+    createTable(tblName, AvroSerDe.class.getName(), AvroContainerInputFormat.class.getName(),
+        AvroContainerOutputFormat.class.getName(), avroTableParams, new HashMap<>());
+    assertThrows("Storage schema reading not supported", MetaException.class, () -> client.getSchema(dbName, tblName));
+  }
+
+  @Test public void testAvroTableWithSerdeSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader");
+    String tblName = "avroTable";
+    Table tbl = createTable(tblName, AvroSerDe.class.getName(), AvroContainerInputFormat.class.getName(),
+        AvroContainerOutputFormat.class.getName(), avroTableParams, new HashMap<>());
+    checkSchema(tblName, tbl);
+  }
+
+  @Test public void testHbaseTableWithDefaultSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader");
+    String tblName = "jdbcTable";
+
+    createTable(tblName, HBaseSerDe.class.getName(), null, null, hbaseTableParams, hbaseSerdeParams);
+    assertThrows("Storage schema reading not supported", MetaException.class, () -> client.getSchema(dbName, tblName));
+  }
+
+  @Test public void testHbaseTableWithSerdeSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader");
+    String tblName = "jdbcTable";
+
+    Table table =
+        createTable(tblName, "org.apache.hadoop.hive.hbase.HBaseSerDe", null, null, hbaseTableParams, hbaseSerdeParams);
+    checkSchema(tblName, table);
+  }
+
+  @Test public void testJdbcTableWithDefaultSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader");
+    String tblName = "jdbcTable";
+
+    createTable(tblName, JdbcSerDe.class.getName(), null, null, jdbcTableParams, jdbcSerdeParams);
+    assertThrows("Storage schema reading not supported", MetaException.class, () -> client.getSchema(dbName, tblName));
+  }
+
+  @Test public void testJdbcTableWithSerdeSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader");
+    String tblName = "jdbcTable";
+
+    Table table = createTable(tblName, JdbcSerDe.class.getName(), null, null, jdbcTableParams, jdbcSerdeParams);
+    checkSchema(tblName, table);
+  }
+
+  @Test public void testOrcTableWithDefaultSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader");
+    String tblName = "orcTable2";
+    Table tbl =
+        createTable(tblName, OrcSerde.class.getName(), OrcInputFormat.class.getName(), OrcOutputFormat.class.getName(),
+              new HashMap<>(), new HashMap<>());
+    checkSchema(tblName, tbl);
+  }
+
+  @Test public void testOrcTableWithSerdeSSR() throws Exception {
+    hiveConf.set("metastore.storage.schema.reader.impl", "org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader");
+    String tblName = "orcTable";
+    Table tbl =
+        createTable(tblName, OrcSerde.class.getName(), OrcInputFormat.class.getName(), OrcOutputFormat.class.getName(),
+            new HashMap<>(), new HashMap<>());
+    checkSchema(tblName, tbl);
+  }
+}

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -67,6 +67,9 @@ public class MetastoreConf {
   static final String DEFAULT_STORAGE_SCHEMA_READER_CLASS =
       "org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader";
   @VisibleForTesting
+  static final String SERDE_STORAGE_SCHEMA_READER_CLASS =
+      "org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader";
+  @VisibleForTesting
   static final String HIVE_ALTER_HANDLE_CLASS =
       "org.apache.hadoop.hive.metastore.HiveAlterHandler";
   @VisibleForTesting
@@ -1363,7 +1366,7 @@ public class MetastoreConf {
         "hive.metastore.stats.auto.analyze.worker.count", 1,
         "Number of parallel analyze commands to run for background stats update."),
     STORAGE_SCHEMA_READER_IMPL("metastore.storage.schema.reader.impl", "metastore.storage.schema.reader.impl",
-        DEFAULT_STORAGE_SCHEMA_READER_CLASS,
+        SERDE_STORAGE_SCHEMA_READER_CLASS,
         "The class to use to read schemas from storage.  It must implement " +
         "org.apache.hadoop.hive.metastore.StorageSchemaReader"),
     STORE_MANAGER_TYPE("datanucleus.storeManagerType", "datanucleus.storeManagerType", "rdbms", "metadata store type"),

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -31,6 +31,12 @@
       <version>4.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>4.0.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
       <exclusions>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -42,6 +42,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader;
+import org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader;
 import org.apache.hadoop.hive.metastore.HiveAlterHandler;
 import org.apache.hadoop.hive.metastore.MaterializationsRebuildLockCleanerTask;
 import org.apache.hadoop.hive.metastore.MetastoreTaskThread;
@@ -482,6 +483,8 @@ public class TestMetastoreConf {
   public void testClassNames() {
     Assert.assertEquals(MetastoreConf.DEFAULT_STORAGE_SCHEMA_READER_CLASS,
         DefaultStorageSchemaReader.class.getName());
+    Assert.assertEquals(MetastoreConf.SERDE_STORAGE_SCHEMA_READER_CLASS,
+        SerDeStorageSchemaReader.class.getName());
     Assert.assertEquals(MetastoreConf.HIVE_ALTER_HANDLE_CLASS,
         HiveAlterHandler.class.getName());
     Assert.assertEquals(MetastoreConf.MATERIALZIATIONS_REBUILD_LOCK_CLEANER_TASK_CLASS,


### PR DESCRIPTION
…o org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader as default

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
set the value of the config metastore.storage.schema.reader.impl  to org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader as default. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Previously it was set to DefaultStorageSchemaReader with default message as "Storage schema reading not supported". SerDeStorageSchemaReader was introduced with implementation that can help read schema from storage. So proposing to make it as default value to avoid setting this config by users in future releases

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
There is no functionality change introduced, so existing test cases should not be failing with these config value changes