### PR TITLE
HIVE-26933: Cleanup dump directory for eventId which was failed in previous dump cycle

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3016,7 +3016,7 @@ public class HiveConf extends Configuration {
     HIVE_TXN_MANAGER("hive.txn.manager",
         "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
         "Set to org.apache.hadoop.hive.ql.lockmgr.DbTxnManager as part of turning on Hive\n" +
-        "transactions, which also requires appropriate settings for hive.compactor.initiator.on,\n" +
+        "transactions, which also requires appropriate settings for hive.compactor.initiator.on,hive.compactor.cleaner.on,\n" +
         "hive.compactor.worker.threads, hive.support.concurrency (true),\n" +
         "and hive.exec.dynamic.partition.mode (nonstrict).\n" +
         "The default DummyTxnManager replicates pre-Hive-0.13 behavior and provides\n" +

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -363,10 +363,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
           db.dropPartitions(hmsTable.getDbName(), hmsTable.getTableName(), EMPTY_FILTER, DROP_OPTIONS);
 
           List<TransformSpec> spec = PartitionTransform.getPartitionTransformSpec(hmsTable.getPartitionKeys());
-          if (!SessionStateUtil.addResource(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC, spec)) {
-            throw new MetaException("Query state attached to Session state must be not null. " +
-                "Partition transform metadata cannot be saved.");
-          }
+          SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC, spec);
           hmsTable.getSd().getCols().addAll(hmsTable.getPartitionKeys());
           hmsTable.setPartitionKeysIsSet(false);
         }

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc.q
@@ -12,11 +12,13 @@ create external table tbl_ice_v2(d int, e string, f int) stored by iceberg store
 
 insert into tbl_ice_v2 values (1, 'one v2', 50), (4, 'four v2', 53), (5, 'five v2', 54);
 
-create materialized view mat1 as
+create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52;
 
 -- view should be empty
 select * from mat1;
+
+alter materialized view mat1 enable rewrite;
 
 -- view is up-to-date, use it
 explain cbo

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
@@ -1,4 +1,4 @@
--- MV data is stored by iceberg
+-- MV data is stored by iceberg v1
 -- SORT_QUERY_RESULTS
 
 set hive.explain.user=false;
@@ -22,3 +22,12 @@ select * from mat1;
 
 explain cbo
 select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+insert into tbl_ice values (10, 'ten', 60);
+
+explain cbo
+alter materialized view mat1 rebuild;
+
+alter materialized view mat1 rebuild;
+
+select * from mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc3.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc3.q
@@ -1,0 +1,19 @@
+-- MV data is stored by iceberg v2
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+drop materialized view if exists mat1;
+drop table if exists tbl_ice;
+
+create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2');
+insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54);
+
+create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+delete from tbl_ice where a = 4;
+
+alter materialized view mat1 rebuild;
+
+select * from mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
@@ -1,0 +1,21 @@
+-- MV data is stored by partitioned iceberg testing the existing Hive syntax (also used by native mv) to specify partition cols.
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- SORT_QUERY_RESULTS
+
+drop materialized view if exists mat1;
+drop table if exists tbl_ice;
+
+create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1');
+insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54);
+
+create materialized view mat1 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+describe formatted mat1;
+
+select * from mat1;
+
+create materialized view mat2 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+describe formatted mat2;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
@@ -1,0 +1,21 @@
+-- MV data is stored by partitioned iceberg with partition spec
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- SORT_QUERY_RESULTS
+
+drop materialized view if exists mat1;
+drop table if exists tbl_ice;
+
+create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1');
+insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54);
+
+create materialized view mat1 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+describe formatted mat1;
+
+select * from mat1;
+
+create materialized view mat2 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+describe formatted mat2;

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc.q.out
@@ -30,14 +30,14 @@ POSTHOOK: query: insert into tbl_ice_v2 values (1, 'one v2', 50), (4, 'four v2',
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_v2
-PREHOOK: query: create materialized view mat1 as
+PREHOOK: query: create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@tbl_ice
 PREHOOK: Input: default@tbl_ice_v2
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
-POSTHOOK: query: create materialized view mat1 as
+POSTHOOK: query: create materialized view mat1 disable rewrite as
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@tbl_ice
@@ -55,6 +55,14 @@ POSTHOOK: query: select * from mat1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: alter materialized view mat1 enable rewrite
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 enable rewrite
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
 PREHOOK: query: explain cbo
 select tbl_ice.b, tbl_ice.c, tbl_ice_v2.e from tbl_ice join tbl_ice_v2 on tbl_ice.a=tbl_ice_v2.d where tbl_ice.c > 52
 PREHOOK: type: QUERY

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
@@ -185,3 +185,45 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 CBO PLAN:
 HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
 
+PREHOOK: query: insert into tbl_ice values (10, 'ten', 60)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (10, 'ten', 60)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: explain cbo
+alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: explain cbo
+alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(b=[$1], c=[$2])
+  HiveFilter(condition=[>($2, 52)])
+    HiveTableScan(table=[[default, tbl_ice]], table:alias=[tbl_ice])
+
+PREHOOK: query: alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+five	54
+four	53
+ten	60

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc3.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc3.q.out
@@ -1,0 +1,65 @@
+PREHOOK: query: drop materialized view if exists mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: query: drop materialized view if exists mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: query: drop table if exists tbl_ice
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists tbl_ice
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: create external table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create materialized view mat1 stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: Lineage: mat1.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat1.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: delete from tbl_ice where a = 4
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: delete from tbl_ice where a = 4
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: alter materialized view mat1 rebuild
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 rebuild
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: default@mat1
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+five	54

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -1,0 +1,173 @@
+PREHOOK: query: drop materialized view if exists mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: query: drop materialized view if exists mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: query: drop table if exists tbl_ice
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists tbl_ice
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: create materialized view mat1 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: create materialized view mat1 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Lineage: mat1.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat1.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: describe formatted mat1
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@mat1
+POSTHOOK: query: describe formatted mat1
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@mat1
+# col_name            	data_type           	comment             
+c                   	int                 	                    
+b                   	string              	                    
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	IDENTITY            	 
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MATERIALIZED_VIEW   	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	format-version      	1                   
+	iceberg.orc.files.only	false               
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	2                   
+	numRows             	2                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1282                
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+	 	 
+# Materialized View Information	 	 
+Original Query:     	select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52	 
+Expanded Query:     	SELECT `c`, `b` FROM (select `tbl_ice`.`b`, `tbl_ice`.`c` from `default`.`tbl_ice` where `tbl_ice`.`c` > 52) `mat1`	 
+Rewrite Enabled:    	Yes                 	 
+Outdated for Rewriting:	Unknown             	 
+	 	 
+# Materialized View Source table information	 	 
+Table name          	I/U/D since last rebuild	 
+hive.default.tbl_ice	0/0/0               	 
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+53	four
+54	five
+PREHOOK: query: create materialized view mat2 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat2
+PREHOOK: Output: default@mat2
+POSTHOOK: query: create materialized view mat2 partitioned on (b) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat2
+POSTHOOK: Output: default@mat2
+POSTHOOK: Lineage: mat2.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat2.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: describe formatted mat2
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@mat2
+POSTHOOK: query: describe formatted mat2
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@mat2
+# col_name            	data_type           	comment             
+c                   	int                 	                    
+b                   	string              	                    
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	IDENTITY            	 
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MATERIALIZED_VIEW   	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	format-version      	2                   
+	iceberg.orc.files.only	false               
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	2                   
+	numRows             	2                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1282                
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	write.delete.mode   	merge-on-read       
+	write.merge.mode    	merge-on-read       
+	write.update.mode   	merge-on-read       
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+	 	 
+# Materialized View Information	 	 
+Original Query:     	select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52	 
+Expanded Query:     	SELECT `c`, `b` FROM (select `tbl_ice`.`b`, `tbl_ice`.`c` from `default`.`tbl_ice` where `tbl_ice`.`c` > 52) `mat2`	 
+Rewrite Enabled:    	Yes                 	 
+Outdated for Rewriting:	Unknown             	 
+	 	 
+# Materialized View Source table information	 	 
+Table name          	I/U/D since last rebuild	 
+hive.default.tbl_ice	0/0/0               	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -1,0 +1,175 @@
+PREHOOK: query: drop materialized view if exists mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: query: drop materialized view if exists mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: query: drop table if exists tbl_ice
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists tbl_ice
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: create table tbl_ice(a int, b string, c int) stored by iceberg stored as orc tblproperties ('format-version'='1')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl_ice
+POSTHOOK: query: insert into tbl_ice values (1, 'one', 50), (2, 'two', 51), (3, 'three', 52), (4, 'four', 53), (5, 'five', 54)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl_ice
+PREHOOK: query: create materialized view mat1 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create materialized view mat1 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='1') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: Lineage: mat1.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat1.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: describe formatted mat1
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@mat1
+POSTHOOK: query: describe formatted mat1
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@mat1
+# col_name            	data_type           	comment             
+b                   	string              	                    
+c                   	int                 	                    
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	BUCKET[16]          	 
+c                   	TRUNCATE[3]         	 
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MATERIALIZED_VIEW   	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	format-version      	1                   
+	iceberg.orc.files.only	false               
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	2                   
+	numRows             	2                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1282                
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+	 	 
+# Materialized View Information	 	 
+Original Query:     	select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52	 
+Expanded Query:     	select `tbl_ice`.`b`, `tbl_ice`.`c` from `default`.`tbl_ice` where `tbl_ice`.`c` > 52	 
+Rewrite Enabled:    	Yes                 	 
+Outdated for Rewriting:	Unknown             	 
+	 	 
+# Materialized View Source table information	 	 
+Table name          	I/U/D since last rebuild	 
+hive.default.tbl_ice	0/0/0               	 
+PREHOOK: query: select * from mat1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from mat1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+five	54
+four	53
+PREHOOK: query: create materialized view mat2 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: create materialized view mat2 partitioned on spec (bucket(16, b), truncate(3, c)) stored by iceberg stored as orc tblproperties ('format-version'='2') as
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: Lineage: mat2.b SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: mat2.c SIMPLE [(tbl_ice)tbl_ice.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: describe formatted mat2
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@mat2
+POSTHOOK: query: describe formatted mat2
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@mat2
+# col_name            	data_type           	comment             
+b                   	string              	                    
+c                   	int                 	                    
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	BUCKET[16]          	 
+c                   	TRUNCATE[3]         	 
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MATERIALIZED_VIEW   	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	format-version      	2                   
+	iceberg.orc.files.only	false               
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	2                   
+	numRows             	2                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1282                
+#### A masked pattern was here ####
+	uuid                	#Masked#
+	write.delete.mode   	merge-on-read       
+	write.merge.mode    	merge-on-read       
+	write.update.mode   	merge-on-read       
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Sort Columns:       	[]                  	 
+	 	 
+# Materialized View Information	 	 
+Original Query:     	select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52	 
+Expanded Query:     	select `tbl_ice`.`b`, `tbl_ice`.`c` from `default`.`tbl_ice` where `tbl_ice`.`c` > 52	 
+Rewrite Enabled:    	Yes                 	 
+Outdated for Rewriting:	Unknown             	 
+	 	 
+# Materialized View Source table information	 	 
+Table name          	I/U/D since last rebuild	 
+hive.default.tbl_ice	0/0/0               	 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/MetastoreHousekeepingLeaderTestBase.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/MetastoreHousekeepingLeaderTestBase.java
@@ -61,6 +61,7 @@ class MetastoreHousekeepingLeaderTestBase {
     MetastoreConf.setVar(conf, ConfVars.METASTORE_HOUSEKEEPING_LEADER_ELECTION,
         configuredLeader ? "host" : "lock");
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
 
     addHouseKeepingThreadConfigs();
 
@@ -115,6 +116,7 @@ class MetastoreHousekeepingLeaderTestBase {
 
   private void addCompactorConfigs() {
     MetastoreConf.setBoolVar(conf, ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(conf, ConfVars.COMPACTOR_CLEANER_ON, true);
     MetastoreConf.setVar(conf, ConfVars.HIVE_METASTORE_RUNWORKER_IN, "metastore");
     MetastoreConf.setLongVar(conf, ConfVars.COMPACTOR_WORKER_THREADS, 1);
     threadClasses.put(Initiator.class, false);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestAcidOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestAcidOnTez.java
@@ -122,6 +122,7 @@ public class TestAcidOnTez {
     hiveConf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER, 
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
     TestTxnDbUtil.setConfValues(hiveConf);
     hiveConf.setInt(MRJobConfig.MAP_MEMORY_MB, 1024);
     hiveConf.setInt(MRJobConfig.REDUCE_MEMORY_MB, 1024);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplWithReadOnlyHook.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplWithReadOnlyHook.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import static org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook.READONLY;
+import static org.apache.hadoop.hive.common.repl.ReplConst.READ_ONLY_HOOK;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.messaging.json.gzip.GzipJSONMessageEncoder;
+import org.apache.hadoop.hive.shims.Utils;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestReplWithReadOnlyHook extends BaseReplicationScenariosAcidTables {
+
+  @BeforeClass
+  public static void classLevelSetup() throws Exception {
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put(MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY.getHiveName(),
+      GzipJSONMessageEncoder.class.getCanonicalName());
+
+    conf = new HiveConf(TestReplWithReadOnlyHook.class);
+    conf.set("hadoop.proxyuser." + Utils.getUGI().getShortUserName() + ".hosts", "*");
+
+    MiniDFSCluster miniDFSCluster =
+      new MiniDFSCluster.Builder(conf).numDataNodes(2).format(true).build();
+
+    Map<String, String> acidEnableConf = new HashMap<String, String>();
+    acidEnableConf.put("fs.defaultFS", miniDFSCluster.getFileSystem().getUri().toString());
+    acidEnableConf.put("hive.support.concurrency", "true");
+    acidEnableConf.put("hive.txn.manager", "org.apache.hadoop.hive.ql.lockmgr.DbTxnManager");
+    acidEnableConf.put("hive.metastore.client.capability.check", "false");
+    acidEnableConf.put("hive.repl.bootstrap.dump.open.txn.timeout", "1s");
+    acidEnableConf.put("hive.exec.dynamic.partition.mode", "nonstrict");
+    acidEnableConf.put("hive.strict.checks.bucketing", "false");
+    acidEnableConf.put("hive.mapred.mode", "nonstrict");
+    acidEnableConf.put("mapred.input.dir.recursive", "true");
+    acidEnableConf.put("hive.metastore.disallow.incompatible.col.type.changes", "false");
+    acidEnableConf.put("metastore.warehouse.tenant.colocation", "true");
+    acidEnableConf.put("hive.in.repl.test", "true");
+    acidEnableConf.put("hive.txn.readonly.enabled", "true");
+    acidEnableConf.put(HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET.varname, "false");
+    acidEnableConf.put(HiveConf.ConfVars.REPL_RETAIN_CUSTOM_LOCATIONS_FOR_DB_ON_TARGET.varname,
+      "false");
+    acidEnableConf.put(HiveConf.ConfVars.PREEXECHOOKS.varname, READ_ONLY_HOOK);
+
+    acidEnableConf.putAll(overrides);
+
+    primary = new WarehouseInstance(LOG, miniDFSCluster, acidEnableConf);
+    acidEnableConf.put(MetastoreConf.ConfVars.REPLDIR.getHiveName(), primary.repldDir);
+
+    replica = new WarehouseInstance(LOG, miniDFSCluster, acidEnableConf);
+    Map<String, String> overridesForHiveConf1 = new HashMap<>();
+    overridesForHiveConf1.put("fs.defaultFS", miniDFSCluster.getFileSystem().getUri().toString());
+    overridesForHiveConf1.put("hive.support.concurrency", "false");
+    overridesForHiveConf1.put("hive.txn.manager", "org.apache.hadoop.hive.ql.lockmgr" +
+      ".DummyTxnManager");
+    overridesForHiveConf1.put("hive.metastore.client.capability.check", "false");
+
+
+    overridesForHiveConf1.put(MetastoreConf.ConfVars.REPLDIR.getHiveName(), primary.repldDir);
+    replicaNonAcid = new WarehouseInstance(LOG, miniDFSCluster, overridesForHiveConf1);
+  }
+
+  @After
+  public void afterTest() throws Throwable {
+    replica.run("alter database " + replicatedDbName + " set dbproperties('readonly'='false')");
+  }
+
+  @Test
+  public void testDbSetToReadOnlyAfterBootstrapLoad() throws Throwable {
+    primary.run("use " + primaryDbName)
+      .run("CREATE TABLE t1(a string) STORED AS TEXTFILE")
+      .dump(primaryDbName);
+    replica.load(replicatedDbName, primaryDbName);
+    Map<String, String> dbParams = replica.getDatabase(replicatedDbName).getParameters();
+    assertEquals("true", dbParams.get(READONLY));
+  }
+
+  @Test
+  public void testDbReadOnlyModeBackWardCompatible() throws Throwable {
+    //do bootstrap
+    primary.run("use " + primaryDbName)
+      .run("CREATE TABLE t1(a string) STORED AS TEXTFILE")
+      .dump(primaryDbName);
+    replica.load(replicatedDbName, primaryDbName);
+
+    // let's toggle 'readonly' of db to simulate the use case
+    replica.run("ALTER DATABASE " + replicatedDbName + " SET DBPROPERTIES('readonly'='false')");
+
+    // perform incremental
+    primary.run("insert into " + primaryDbName +".t1 values(\"AAA\")")
+      .dump(primaryDbName);
+
+    // before REPL LOAD ensure db parameters is not "readonly"
+    String isDbReadOnly = replica.getDatabase(replicatedDbName).getParameters().get(READONLY);
+    assertEquals(Boolean.FALSE.toString() ,isDbReadOnly);
+
+    // perform REPL LOAD
+    replica.load(replicatedDbName, primaryDbName);
+
+    isDbReadOnly = replica.getDatabase(replicatedDbName).getParameters().get(READONLY);
+    assertEquals(Boolean.TRUE.toString() ,isDbReadOnly);
+  }
+}

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOptimisedBootstrap.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationOptimisedBootstrap.java
@@ -55,6 +55,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.QUOTA_DONT_SET;
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.QUOTA_RESET;
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_ENABLE_BACKGROUND_THREAD;
 import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_TARGET_DB_PROPERTY;
 import static org.apache.hadoop.hive.common.repl.ReplConst.TARGET_OF_REPLICATION;
 import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
@@ -1091,5 +1092,61 @@ public class TestReplicationOptimisedBootstrap extends BaseReplicationScenariosA
       }
     }
     return txnHandler.getOpenTxns(txnListExcludingReplCreated).getOpen_txns();
+  }
+
+  @Test
+  public void testDbParametersAfterOptimizedBootstrap() throws Throwable {
+    List<String> withClause = Arrays.asList(
+            String.format("'%s'='%s'", HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET.varname, "false"),
+            String.format("'%s'='%s'", HiveConf.ConfVars.HIVE_REPL_FAILOVER_START.varname, "true")
+    );
+
+    // bootstrap
+    primary.run("use " + primaryDbName)
+            .run("create table t1 (id int) clustered by(id) into 3 buckets stored as orc " +
+                    "tblproperties (\"transactional\"=\"true\")")
+            .run("insert into table t1 values (1),(2)")
+            .dump(primaryDbName, withClause);
+    replica.load(replicatedDbName, primaryDbName, withClause);
+
+    // incremental
+    primary.run("use " + primaryDbName)
+            .run("insert into table t1 values (3)")
+            .dump(primaryDbName, withClause);
+    replica.load(replicatedDbName, primaryDbName, withClause);
+
+    // make some changes on primary
+    primary.run("use " + primaryDbName)
+            .run("insert into table t1 values (4)");
+
+    withClause = Arrays.asList(
+            String.format("'%s'='%s'", HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET.varname, "false")
+    );
+    // 1st cycle of optimized bootstrap
+    replica.dump(replicatedDbName, withClause);
+    primary.load(primaryDbName, replicatedDbName, withClause);
+
+    String[] dbParams = new String[]{
+            TARGET_OF_REPLICATION,
+            CURR_STATE_ID_SOURCE.toString(),
+            CURR_STATE_ID_TARGET.toString(),
+            REPL_TARGET_DB_PROPERTY,
+            REPL_ENABLE_BACKGROUND_THREAD
+    };
+    //verify if all db parameters are set
+    for (String paramKey : dbParams) {
+      assertTrue(replica.getDatabase(replicatedDbName).getParameters().containsKey(paramKey));
+    }
+
+    // 2nd cycle of optimized bootstrap
+    replica.dump(replicatedDbName, withClause);
+    primary.load(primaryDbName, replicatedDbName, withClause);
+
+    for (String paramKey : dbParams) {
+      assertFalse(replica.getDatabase(replicatedDbName).getParameters().containsKey(paramKey));
+    }
+    // ensure optimized bootstrap was successful.
+    primary.run(String.format("select * from %s.t1", primaryDbName))
+            .verifyResults(new String[]{"1", "2", "3"});
   }
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -79,6 +79,9 @@ import java.util.List;
 import java.util.Map;
 
 
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_RESUME_STARTED_AFTER_FAILOVER;
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_TARGET_DATABASE_PROPERTY;
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_TARGET_TABLE_PROPERTY;
 import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
 import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_ENABLE_BACKGROUND_THREAD;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.DUMP_ACKNOWLEDGEMENT;
@@ -3560,5 +3563,29 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
     assertTrue(AcidUtils.isTransactionalTable(replica.getTable(replicatedDbName, tbl)));
     assertFalse(replica.getTable(replicatedDbName, tbl).getTableType().equals(TableType.EXTERNAL_TABLE.toString()));
+  }
+
+  @Test
+  public void testReplTargetLastIdNotUpdatedInCaseOfResume() throws Throwable {
+    Map<String, String> params = new HashMap<>();
+    params.put(REPL_RESUME_STARTED_AFTER_FAILOVER, "true");
+    params.put(REPL_TARGET_TABLE_PROPERTY, "19");
+    params.put(REPL_TARGET_DATABASE_PROPERTY, "15");
+
+    // create database and set the parameters
+    String dbName = "db1";
+    Database db1 = primary.run("create database " + dbName)
+                          .getDatabase(dbName);
+    db1.setParameters(params);
+
+    // let's change 'repl.last.id', now this should not update 'repl.target.last.id' as it finds
+    // 'repl.resume.started' flag
+    primary.run("alter database " + dbName + " set dbproperties('repl.last.id'='21')");
+    Map<String, String> updatedParams = db1.getParameters();
+
+
+    assertEquals(params.get(REPL_TARGET_DATABASE_PROPERTY),
+      updatedParams.get(REPL_TARGET_DATABASE_PROPERTY));
+    assertEquals("15", updatedParams.get(REPL_TARGET_DATABASE_PROPERTY));
   }
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -383,10 +383,6 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(primary.getDatabase(primaryDbName),
             MetaStoreUtils.FailoverEndpoint.SOURCE));
 
-    primary.run("drop database if exists " + primaryDbName + " cascade");
-
-    assertTrue(primary.getDatabase(primaryDbName) == null);
-
     assertFalse(ReplChangeManager.isSourceOfReplication(replica.getDatabase(replicatedDbName)));
 
     WarehouseInstance.Tuple reverseDumpData = replica.run("create table t3 (id int)")
@@ -398,11 +394,15 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     assertTrue(fs.exists(new Path(dumpPath, ReplAck.FAILOVER_READY_MARKER.toString())));
     dumpPath = new Path(reverseDumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
     assertFalse(fs.exists(new Path(dumpPath, ReplAck.FAILOVER_READY_MARKER.toString())));
-    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.BOOTSTRAP);
+    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.INCREMENTAL);
     assertTrue(fs.exists(new Path(dumpPath, DUMP_ACKNOWLEDGEMENT.toString())));
     db = replica.getDatabase(replicatedDbName);
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
-    assertFalse(MetaStoreUtils.isTargetOfReplication(db));
+    assertTrue(MetaStoreUtils.isTargetOfReplication(db));
+    //do a second reverse dump.
+    primary.load(primaryDbName, replicatedDbName);
+    reverseDumpData = replica.dump(replicatedDbName);
+    dumpPath = new Path(reverseDumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
 
     primary.load(primaryDbName, replicatedDbName)
             .run("use " + primaryDbName)
@@ -419,7 +419,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
     Database primaryDb = primary.getDatabase(primaryDbName);
     assertFalse(primaryDb == null);
-    assertTrue(ReplUtils.isFirstIncPending(primaryDb.getParameters()));
+    assertFalse(ReplUtils.isFirstIncPending(primaryDb.getParameters()));
     assertTrue(MetaStoreUtils.isTargetOfReplication(primaryDb));
     assertFalse(MetaStoreUtils.isDbBeingFailedOver(primaryDb));
     assertTrue(fs.exists(new Path(dumpPath, LOAD_ACKNOWLEDGEMENT.toString())));
@@ -531,7 +531,9 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
             "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR + "'='true'",
             "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'");
     List<String> retainPrevDumpDir = Arrays.asList("'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR + "'='true'",
-            "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'");
+            "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'",
+            "'" + HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET + "'='true'"
+    );
     WarehouseInstance.Tuple dumpData = primary.run("use " + primaryDbName)
             .run("create table t1 (id int) clustered by(id) into 3 buckets stored as orc " +
                     "tblproperties (\"transactional\"=\"true\")")
@@ -608,8 +610,6 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
     assertTrue(fs.exists(new Path(dumpPath, ReplAck.LOAD_ACKNOWLEDGEMENT.toString())));
 
-    primary.run("drop database if exists " + primaryDbName + " cascade");
-
     WarehouseInstance.Tuple reverseDumpData = replica.run("use " + replicatedDbName)
             .run("insert into t2 partition(name='Carl') values(12)")
             .run("create table t3 (id int)")
@@ -622,12 +622,16 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     dumpAckFile = new Path(dumpPath, DUMP_ACKNOWLEDGEMENT.toString());
     assertTrue(fs.exists(dumpAckFile));
     assertFalse(fs.exists(new Path(dumpPath, ReplAck.FAILOVER_READY_MARKER.toString())));
-    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.BOOTSTRAP);
+    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.INCREMENTAL);
     db = replica.getDatabase(replicatedDbName);
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
-    assertFalse(MetaStoreUtils.isTargetOfReplication(db));
+    assertTrue(MetaStoreUtils.isTargetOfReplication(db));
+    primary.load(primaryDbName, replicatedDbName, retainPrevDumpDir);
+    //do a second reverse dump.
+    reverseDumpData = replica.dump(replicatedDbName, retainPrevDumpDir);
+    dumpPath = new Path(reverseDumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
 
-    primary.load(primaryDbName, replicatedDbName)
+    primary.load(primaryDbName, replicatedDbName, retainPrevDumpDir)
             .run("use " + primaryDbName)
             .run("show tables")
             .verifyResults(new String[]{"t1", "t2", "t3"})
@@ -642,13 +646,15 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
     assertTrue(fs.exists(new Path(dumpPath, LOAD_ACKNOWLEDGEMENT.toString())));
 
-    reverseDumpData = replica.run("insert into t3 values (15)")
-            .dump(replicatedDbName, retainPrevDumpDir);
+    reverseDumpData = replica.run("use " + replicatedDbName)
+            .run("insert into t3 values (15)")
+            .dump(replicatedDbName);
     dumpPath = new Path(reverseDumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
     fs.exists(new Path(dumpPath, DUMP_ACKNOWLEDGEMENT.toString()));
     assertFalse(MetaStoreUtils.isDbBeingFailedOver(replica.getDatabase(replicatedDbName)));
 
     primary.load(primaryDbName, replicatedDbName)
+            .run("use " + primaryDbName)
             .run("select id from t3")
             .verifyResults(new String[]{"10", "15"});;
     assertTrue(fs.exists(new Path(dumpPath, LOAD_ACKNOWLEDGEMENT.toString())));
@@ -660,7 +666,9 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
             "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR + "'='true'",
             "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'");
     List<String> retainPrevDumpDir = Arrays.asList("'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR + "'='true'",
-            "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'");
+            "'" + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR_COUNT + "'='1'",
+            "'" + HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET + "'='true'"
+    );
     WarehouseInstance.Tuple dumpData = primary.run("use " + primaryDbName)
             .run("create table t1 (id int) clustered by(id) into 3 buckets stored as orc " +
                     "tblproperties (\"transactional\"=\"true\")")
@@ -711,8 +719,6 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
     assertTrue(fs.exists(new Path(dumpPath, ReplAck.LOAD_ACKNOWLEDGEMENT.toString())));
 
-    primary.run("drop database if exists " + primaryDbName + " cascade");
-
     WarehouseInstance.Tuple reverseDumpData = replica.run("use " + replicatedDbName)
             .run("insert into t2 partition(name='Bob') values(20)")
             .run("create table t3 (id int)")
@@ -725,26 +731,29 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     Path dumpAckFile = new Path(dumpPath, DUMP_ACKNOWLEDGEMENT.toString());
     assertTrue(fs.exists(dumpAckFile));
     assertFalse(fs.exists(new Path(dumpPath, ReplAck.FAILOVER_READY_MARKER.toString())));
-    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.BOOTSTRAP);
+    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.INCREMENTAL);
     db = replica.getDatabase(replicatedDbName);
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
-    assertFalse(MetaStoreUtils.isTargetOfReplication(db));
-
+    assertTrue(MetaStoreUtils.isTargetOfReplication(db));
     fs.delete(dumpAckFile, false);
     assertFalse(fs.exists(dumpAckFile));
     WarehouseInstance.Tuple preFailoverDumpData = dumpData;
     dumpData = replica.dump(replicatedDbName, retainPrevDumpDir);
+    dumpPath = new Path(dumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
+    dumpAckFile = new Path(dumpPath, DUMP_ACKNOWLEDGEMENT.toString());
     assertNotEquals(dumpData.dumpLocation, preFailoverDumpData.dumpLocation);
     assertTrue(fs.exists(new Path(preFailoverDumpData.dumpLocation)));
-    assertEquals(reverseDumpData.dumpLocation, dumpData.dumpLocation);
+    assertNotEquals(reverseDumpData.dumpLocation, dumpData.dumpLocation);
     assertFalse(fs.exists(new Path(dumpPath, ReplAck.FAILOVER_READY_MARKER.toString())));
-    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.BOOTSTRAP);
+    assertTrue(new DumpMetaData(dumpPath, conf).getDumpType() == DumpType.INCREMENTAL);
     assertTrue(fs.exists(dumpAckFile));
     db = replica.getDatabase(replicatedDbName);
     assertTrue(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(db, MetaStoreUtils.FailoverEndpoint.TARGET));
-    assertFalse(MetaStoreUtils.isTargetOfReplication(db));
+    assertTrue(MetaStoreUtils.isTargetOfReplication(db));
+    primary.load(primaryDbName, replicatedDbName);
+    dumpData = replica.dump(replicatedDbName, retainPrevDumpDir);
 
-    primary.load(primaryDbName, replicatedDbName)
+    primary.load(primaryDbName, replicatedDbName, retainPrevDumpDir)
             .run("use " + primaryDbName)
             .run("show tables")
             .verifyResults(new String[]{"t1", "t2", "t3"})
@@ -759,7 +768,8 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
     assertTrue(fs.exists(new Path(dumpPath, LOAD_ACKNOWLEDGEMENT.toString())));
 
-    reverseDumpData = replica.run("insert into t3 values (3)")
+    reverseDumpData = replica.run("use " + replicatedDbName)
+            .run("insert into t3 values (3)")
             .run("insert into t2 partition(name='Bob') values(30)")
             .dump(replicatedDbName, retainPrevDumpDir);
     dumpPath = new Path(reverseDumpData.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
@@ -778,7 +788,8 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     assertFalse(MetaStoreUtils.isDbBeingFailedOverAtEndpoint(replica.getDatabase(replicatedDbName),
             MetaStoreUtils.FailoverEndpoint.TARGET));
 
-    primary.load(primaryDbName, replicatedDbName)
+    primary.load(primaryDbName, replicatedDbName, retainPrevDumpDir)
+            .run("use " + primaryDbName)
             .run("select rank from t2 order by rank")
             .verifyResults(new String[]{"11", "20", "30"})
             .run("select id from t3")

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -106,6 +106,7 @@ public abstract class CompactorOnTezTest {
     hiveConf.setVar(HiveConf.ConfVars.HIVEFETCHTASKCONVERSION, "none");
     MetastoreConf.setTimeVar(hiveConf, MetastoreConf.ConfVars.TXN_OPENTXN_TIMEOUT, 2, TimeUnit.SECONDS);
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
 
     TestTxnDbUtil.setConfValues(hiveConf);
     TestTxnDbUtil.cleanDb(hiveConf);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
@@ -102,9 +102,13 @@ class CompactorTestUtil {
    */
   static List<String> getBucketFileNames(FileSystem fs, Table table, String partitionName, String deltaName)
       throws IOException {
+    boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
     Path path = partitionName == null ? new Path(table.getSd().getLocation(), deltaName) : new Path(
         new Path(table.getSd().getLocation()), new Path(partitionName, deltaName));
-    return Arrays.stream(fs.listStatus(path, AcidUtils.bucketFileFilter)).map(FileStatus::getPath).map(Path::getName).sorted()
+    return Arrays.stream(fs.listStatus(path, insertOnly? AcidUtils.originalBucketFilter : AcidUtils.bucketFileFilter))
+        .map(FileStatus::getPath)
+        .map(Path::getName)
+        .sorted()
         .collect(Collectors.toList());
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactorBase.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactorBase.java
@@ -88,6 +88,7 @@ class TestCompactorBase {
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVEOPTIMIZEMETADATAQUERIES, false);
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
 
     TestTxnDbUtil.setConfValues(hiveConf);
     TestTxnDbUtil.cleanDb(hiveConf);

--- a/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniLlapLocalCompactorCliDriver.java
+++ b/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniLlapLocalCompactorCliDriver.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.cli;
+
+import org.apache.hadoop.hive.cli.control.CliAdapter;
+import org.apache.hadoop.hive.cli.control.CliConfigs;
+import org.apache.hadoop.hive.cli.control.SplitSupport;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.txn.compactor.Worker;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RunWith(Parameterized.class)
+public class TestMiniLlapLocalCompactorCliDriver {
+
+  static CliAdapter adapter = new CliConfigs.MiniLlapLocalCompactorCliConfig().getCliAdapter();
+
+  private static int N_SPLITS = 32;
+
+  private static final AtomicBoolean stop = new AtomicBoolean();
+  private static Worker worker;
+  @Parameters(name = "{0}")
+  public static List<Object[]> getParameters() throws Exception {
+    return SplitSupport.process(adapter.getParameters(), TestMiniLlapLocalCompactorCliDriver.class, N_SPLITS);
+  }
+
+  @ClassRule
+  public static TestRule cliClassRule = adapter.buildClassRule();
+
+  @Rule
+  public TestRule cliTestRule = adapter.buildTestRule();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    worker = new Worker();
+    worker.setConf(SessionState.get().getConf());
+    stop.set(false);
+    worker.init(stop);
+    worker.start();
+  }
+
+  @AfterClass
+  public static void tearDown(){
+    stop.set(true);
+  }
+  private String name;
+  private File qfile;
+
+  public TestMiniLlapLocalCompactorCliDriver(String name, File qfile) {
+    this.name = name;
+    this.qfile = qfile;
+  }
+
+  @Test
+  public void testCliDriver() throws Exception {
+    adapter.runTest(name, qfile);
+  }
+}

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -416,3 +416,11 @@ iceberg.llap.query.files=\
 iceberg.llap.only.query.files=\
   llap_iceberg_read_orc.q,\
   llap_iceberg_read_parquet.q
+
+compaction.query.files=\
+  compaction_query_based.q,\
+  compaction_query_based_clustered.q,\
+  compaction_query_based_clustered_minor.q,\
+  compaction_query_based_insert_only.q,\
+  compaction_query_based_insert_only_minor.q,\
+  compaction_query_based_minor.q

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCliConfig.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCliConfig.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -33,6 +34,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QTestSystemProperties;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.MiniClusterType;
@@ -69,6 +71,7 @@ public abstract class AbstractCliConfig {
   // moved...this may change
   private Set<String> includeQueryFileNames;
   private Class<? extends CliAdapter> cliAdapter;
+  private Map<HiveConf.ConfVars, String> customConfigValueMap;
 
   public AbstractCliConfig(Class<? extends CliAdapter> adapter) {
     cliAdapter = adapter;
@@ -414,5 +417,13 @@ public abstract class AbstractCliConfig {
 
   protected void setMetastoreType(String metastoreType) {
     this.metastoreType = metastoreType;
+  }
+
+  protected void setCustomConfigValueMap(Map<HiveConf.ConfVars, String> customConfigValueMap) {
+    this.customConfigValueMap = customConfigValueMap;
+  }
+  
+  public Map<HiveConf.ConfVars, String> getCustomConfigValueMap() {
+    return this.customConfigValueMap;
   }
 }

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.hive.cli.control;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QTestMiniClusters;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.MiniClusterType;
 import org.apache.hadoop.hive.ql.parse.CoreParseNegative;
@@ -222,7 +225,8 @@ public class CliConfigs {
         excludesFrom(testConfigProps, "hive.kafka.query.files");
         excludesFrom(testConfigProps, "erasurecoding.only.query.files");
         excludesFrom(testConfigProps, "beeline.positive.include");
-
+        excludesFrom(testConfigProps, "compaction.query.files");
+        
         setResultsDir("ql/src/test/results/clientpositive/llap");
         setLogDir("itests/qtest/target/qfile-results/clientpositive");
 
@@ -236,7 +240,38 @@ public class CliConfigs {
       }
     }
   }
+  
+  public static class MiniLlapLocalCompactorCliConfig extends AbstractCliConfig {
 
+    public MiniLlapLocalCompactorCliConfig() {
+      super(CoreCliDriver.class);
+      try {
+        setQueryDir("ql/src/test/queries/clientpositive");
+
+        includesFrom(testConfigProps, "compaction.query.files");
+        setResultsDir("ql/src/test/results/clientpositive/llap");
+        setLogDir("itests/qtest/target/qfile-results/clientpositive");
+
+        setInitScript("q_test_init.sql");
+        setCleanupScript("q_test_cleanup.sql");
+
+        setHiveConfDir("data/conf/llap");
+        setClusterType(MiniClusterType.LLAP_LOCAL);
+        setCustomConfigValueMap(createConfVarsStringMap());
+      } catch (Exception e) {
+        throw new RuntimeException("can't construct cliconfig", e);
+      }
+    }
+
+    private static Map<HiveConf.ConfVars, String> createConfVarsStringMap() {
+      Map<HiveConf.ConfVars,String> customConfigValueMap = new HashMap<>();
+      customConfigValueMap.put(HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED, "true");
+      customConfigValueMap.put(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, "true");
+      customConfigValueMap.put(HiveConf.ConfVars.HIVE_TXN_MANAGER, "org.apache.hadoop.hive.ql.lockmgr.DbTxnManager");
+      customConfigValueMap.put(HiveConf.ConfVars.HIVE_COMPACTOR_GATHER_STATS, "false");
+      return customConfigValueMap;
+    }
+  }
   public static class EncryptedHDFSCliConfig extends AbstractCliConfig {
     public EncryptedHDFSCliConfig() {
       super(CoreCliDriver.class);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -71,6 +71,7 @@ public class CoreCliDriver extends CliAdapter {
             .withCleanupScript(cleanupScript)
             .withLlapIo(true)
             .withFsType(cliConfig.getFsType())
+            .withCustomConfigValueMap(this.cliConfig.getCustomConfigValueMap())
             .build());
   }
 

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestArguments.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestArguments.java
@@ -18,8 +18,12 @@
 
 package org.apache.hadoop.hive.ql;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.QTestSetup;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * QTestArguments composite used as arguments holder for QTestUtil initialization.
@@ -35,6 +39,8 @@ public final class QTestArguments {
   private boolean withLlapIo;
   private FsType fsType;
   private QTestSetup qtestSetup;
+
+  private Map<HiveConf.ConfVars,String> customConfigValueMap;
 
   private QTestArguments() {
   }
@@ -111,6 +117,14 @@ public final class QTestArguments {
     this.qtestSetup = qtestSetup;
   }
 
+  private void setCustomConfigValueMap(Map<HiveConf.ConfVars,String> customConfigValueMap){
+    this.customConfigValueMap = customConfigValueMap;
+  }
+
+  public Map<HiveConf.ConfVars, String> getCustomConfs() {
+    return this.customConfigValueMap;
+  }
+
   /**
    * QTestArgumentsBuilder used for QTestArguments construction.
    */
@@ -126,7 +140,9 @@ public final class QTestArguments {
     private FsType fsType;
     private QTestSetup qtestSetup;
 
-    private QTestArgumentsBuilder(){
+    private Map<HiveConf.ConfVars, String> customConfigValueMap;
+
+    private QTestArgumentsBuilder() {
     }
 
     public static QTestArgumentsBuilder instance() {
@@ -178,6 +194,11 @@ public final class QTestArguments {
       return this;
     }
 
+    public QTestArgumentsBuilder withCustomConfigValueMap(Map<HiveConf.ConfVars, String> customConfigValueMap) {
+      this. customConfigValueMap =  customConfigValueMap;
+      return this;
+    }
+
     public QTestArguments build() {
       QTestArguments testArguments = new QTestArguments();
       testArguments.setOutDir(outDir);
@@ -194,6 +215,7 @@ public final class QTestArguments {
       testArguments.setQTestSetup(
           qtestSetup != null ? qtestSetup : new QTestSetup());
 
+      testArguments.setCustomConfigValueMap(customConfigValueMap != null ? customConfigValueMap : new HashMap<>());
       return testArguments;
     }
   }

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -36,6 +36,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -214,6 +215,7 @@ public class QTestUtil {
     System.setProperty("hive.query.max.length", "100Mb");
 
     conf = new HiveConf(IDriver.class);
+    setCustomConfs(conf, testArgs.getCustomConfs());
     setMetaStoreProperties();
 
     final String scriptsDir = getScriptsDir(conf);
@@ -241,6 +243,10 @@ public class QTestUtil {
 
     savedConf = new HiveConf(conf);
 
+  }
+
+  private void setCustomConfs(HiveConf conf, Map<ConfVars,String> customConfigValueMap) {
+    customConfigValueMap.entrySet().forEach(item-> conf.set(item.getKey().varname, item.getValue()));
   }
 
   private void logClassPath() {

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -1685,6 +1685,8 @@ viewPartition
 @after { popMsg(state); }
     : KW_PARTITIONED KW_ON LPAREN columnNameList RPAREN
     -> ^(TOK_VIEWPARTCOLS columnNameList)
+    | KW_PARTITIONED KW_ON KW_SPEC LPAREN (spec = partitionTransformSpec) RPAREN
+    -> ^(TOK_TABLEPARTCOLSBYSPEC $spec)
     ;
 
 viewOrganization

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/DDLUtils.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.hive.ql.ddl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.hadoop.hive.common.TableName;
@@ -26,16 +29,22 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.hooks.Entity.Type;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.PartitionTransform;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.parse.TransformSpec;
 import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hive.common.util.ReflectionUtil;
 import org.slf4j.Logger;
@@ -185,5 +194,27 @@ public final class DDLUtils {
     table.setTableType(type);
     table.setTemporary(isTemporary);
     outputs.add(new WriteEntity(table, WriteEntity.WriteType.DDL_NO_LOCK));
+  }
+
+  public static void setColumnsAndStorePartitionTransformSpecOfTable(
+          List<FieldSchema> columns, List<FieldSchema> partitionColumns,
+          HiveConf conf, Table tbl) {
+    Optional<List<FieldSchema>> cols = Optional.ofNullable(columns);
+    Optional<List<FieldSchema>> partCols = Optional.ofNullable(partitionColumns);
+    HiveStorageHandler storageHandler = tbl.getStorageHandler();
+
+    if (storageHandler != null && storageHandler.alwaysUnpartitioned()) {
+      tbl.getSd().setCols(new ArrayList<>());
+      cols.ifPresent(c -> tbl.getSd().getCols().addAll(c));
+      if (partCols.isPresent() && !partCols.get().isEmpty()) {
+        // Add the partition columns to the normal columns and save the transform to the session state
+        tbl.getSd().getCols().addAll(partCols.get());
+        List<TransformSpec> spec = PartitionTransform.getPartitionTransformSpec(partCols.get());
+        SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC, spec);
+      }
+    } else {
+      cols.ifPresent(tbl::setFields);
+      partCols.ifPresent(tbl::setPartCols);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecAnalyzer.java
@@ -56,11 +56,8 @@ public class AlterTableSetPartitionSpecAnalyzer extends AbstractAlterTableAnalyz
     inputs.add(new ReadEntity(table));
     List<TransformSpec> partitionTransformSpec =
         PartitionTransform.getPartitionTransformSpec(command);
-    if (!SessionStateUtil.addResource(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC,
-        partitionTransformSpec)) {
-      throw new SemanticException("Query state attached to Session state must be not null. " +
-          "Partition transform metadata cannot be saved.");
-    }
+    SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC,
+            partitionTransformSpec);
 
     AlterTableSetPartitionSpecDesc desc = new AlterTableSetPartitionSpecDesc(tableName, partitionSpec);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateMaterializedViewDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateMaterializedViewDesc.java
@@ -45,6 +45,8 @@ import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hive.ql.ddl.DDLUtils.setColumnsAndStorePartitionTransformSpecOfTable;
+
 /**
  * DDL task description for CREATE VIEW commands.
  */
@@ -312,17 +314,13 @@ public class CreateMaterializedViewDesc implements DDLDesc, Serializable {
     tbl.setTableType(TableType.MATERIALIZED_VIEW);
     tbl.setSerializationLib(null);
     tbl.clearSerDeInfo();
-    tbl.setFields(getSchema());
+
     if (getComment() != null) {
       tbl.setProperty("comment", getComment());
     }
 
     if (tblProps != null) {
       tbl.getParameters().putAll(tblProps);
-    }
-
-    if (!CollectionUtils.isEmpty(partCols)) {
-      tbl.setPartCols(partCols);
     }
 
     if (!CollectionUtils.isEmpty(sortColNames)) {
@@ -352,6 +350,8 @@ public class CreateMaterializedViewDesc implements DDLDesc, Serializable {
           getStorageHandler());
     }
     HiveStorageHandler storageHandler = tbl.getStorageHandler();
+
+    setColumnsAndStorePartitionTransformSpecOfTable(getSchema(), getPartCols(), conf, tbl);
 
     /*
      * If the user didn't specify a SerDe, we use the default.

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
@@ -68,10 +68,12 @@ public class AlterMaterializedViewRewriteAnalyzer extends BaseSemanticAnalyzer {
     Table materializedViewTable = getTable(tableName, true);
 
     // One last test: if we are enabling the rewrite, we need to check that query
-    // only uses transactional (MM and ACID) tables
+    // only uses transactional (MM and ACID and Iceberg) tables
     if (rewriteEnable) {
       for (SourceTable sourceTable : materializedViewTable.getMVMetadata().getSourceTables()) {
-        if (!AcidUtils.isTransactionalTable(sourceTable.getTable())) {
+        Table table = new Table(sourceTable.getTable());
+        if (!AcidUtils.isTransactionalTable(sourceTable.getTable()) &&
+                !(table.isNonNative() && table.getStorageHandler().areSnapshotsSupported())) {
           throw new SemanticException("Automatic rewriting for materialized view cannot be enabled if the " +
               "materialized view uses non-transactional tables");
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -122,6 +122,7 @@ import java.util.HashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_RESUME_STARTED_AFTER_FAILOVER;
 import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_TARGET_DB_PROPERTY;
 import static org.apache.hadoop.hive.common.repl.ReplConst.TARGET_OF_REPLICATION;
 import static org.apache.hadoop.hive.conf.Constants.SCHEDULED_QUERY_SCHEDULENAME;
@@ -482,6 +483,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
       dbParams.remove(CURR_STATE_ID_SOURCE.toString());
       dbParams.remove(REPL_TARGET_DB_PROPERTY);
       dbParams.remove(ReplConst.REPL_ENABLE_BACKGROUND_THREAD);
+      dbParams.remove(REPL_RESUME_STARTED_AFTER_FAILOVER);
 
       database.setParameters(dbParams);
       LOG.info("Removing {} property from the database {} after successful optimised bootstrap dump", String.join(",",

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -1087,7 +1087,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
           if (fs.exists(eventRoot)) {
             fs.delete(eventRoot, true);
           }
-        } catch (FileNotFoundException e) {
+          } catch (FileNotFoundException e) {
           // no worries
         }
         return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -874,11 +874,17 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
         LOG.info("Event id {} to {} are already dumped, skipping {} events", work.eventFrom, resumeFrom, dumpedCount);
       }
       cleanFailedEventDirIfExists(dumpRoot, resumeFrom);
+      boolean isStagingDirCheckedForFailedEvents = false;
       while (evIter.hasNext()) {
         NotificationEvent ev = evIter.next();
         lastReplId = ev.getEventId();
         if (ev.getEventId() <= resumeFrom) {
           continue;
+        }
+        // Checking and removing remnant file from staging directory if previous incremental repl dump is failed
+        if (!isStagingDirCheckedForFailedEvents) {
+          cleanFailedEventDirIfExists(dumpRoot, ev.getEventId());
+          isStagingDirCheckedForFailedEvents = true;
         }
 
         //disable materialized-view replication if not configured
@@ -1069,16 +1075,18 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
     return currentEventMaxLimit;
   }
 
-  private void cleanFailedEventDirIfExists(Path dumpDir, long resumeFrom) throws SemanticException {
-    Path nextEventRoot = new Path(dumpDir, String.valueOf(resumeFrom + 1));
+  private void cleanFailedEventDirIfExists(Path dumpDir, long eventId) throws SemanticException {
+    Path eventRoot = new Path(dumpDir, String.valueOf(eventId));
     Retryable retryable = Retryable.builder()
-      .withHiveConf(conf)
-      .withRetryOnException(IOException.class).build();
+            .withHiveConf(conf)
+            .withRetryOnException(IOException.class).build();
     try {
       retryable.executeCallable((Callable<Void>) () -> {
-        FileSystem fs = FileSystem.get(nextEventRoot.toUri(), conf);
         try {
-          fs.delete(nextEventRoot, true);
+          FileSystem fs = FileSystem.get(eventRoot.toUri(), conf);
+          if (fs.exists(eventRoot)) {
+            fs.delete(eventRoot, true);
+          }
         } catch (FileNotFoundException e) {
           // no worries
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -73,6 +73,7 @@ public class ReplDumpWork implements Serializable {
   private ReplLogger replLogger;
   private FailoverMetaData fmd;
   private boolean firstDumpAfterFailover;
+  private boolean secondDumpAfterFailover;
 
   public static void injectNextDumpDirForTest(String dumpDir) {
     injectNextDumpDirForTest(dumpDir, false);
@@ -354,5 +355,13 @@ public class ReplDumpWork implements Serializable {
 
   public void setReplLogger(ReplLogger replLogger) {
     this.replLogger = replLogger;
+  }
+
+  public boolean isSecondDumpAfterFailover() {
+    return secondDumpAfterFailover;
+  }
+
+  public void setSecondDumpAfterFailover(boolean secondDumpAfterFailover) {
+    this.secondDumpAfterFailover = secondDumpAfterFailover;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -721,6 +721,10 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
     Database targetDb = getHive().getDatabase(work.dbNameToLoadIn);
     Map<String, String> props = new HashMap<>();
 
+    if (targetDb == null) {
+      throw new HiveException(ErrorMsg.DATABASE_NOT_EXISTS, work.dbNameToLoadIn);
+    }
+
     // Check if it is a optimised bootstrap failover.
     if (work.isFirstFailover) {
       // Check it should be marked as target of replication & not source of replication.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -99,6 +99,7 @@ import java.util.Set;
 
 import static org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook.READONLY;
 import static org.apache.hadoop.hive.common.repl.ReplConst.READ_ONLY_HOOK;
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_RESUME_STARTED_AFTER_FAILOVER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_SKIP_IMMUTABLE_DATA_COPY;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_SNAPSHOT_DIFF_FOR_EXTERNAL_TABLE_COPY;
 import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
@@ -638,6 +639,7 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
               Database db = hiveDb.getDatabase(work.getTargetDatabase());
               LinkedHashMap<String, String> params = new LinkedHashMap<>(db.getParameters());
               LOG.debug("Database {} properties before removal {}", work.getTargetDatabase(), params);
+              params.remove(REPL_RESUME_STARTED_AFTER_FAILOVER);
               params.remove(SOURCE_OF_REPLICATION);
               db.setParameters(params);
               LOG.info("Removed {} property from database {} after successful optimised bootstrap load.",

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -97,6 +97,8 @@ import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook.READONLY;
+import static org.apache.hadoop.hive.common.repl.ReplConst.READ_ONLY_HOOK;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_SKIP_IMMUTABLE_DATA_COPY;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_SNAPSHOT_DIFF_FOR_EXTERNAL_TABLE_COPY;
 import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
@@ -421,7 +423,38 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
         // Ignore if no file.
       }
     }
+
+    if (isReadOnlyHookRegistered()) {
+      LOG.info("Setting database {} read-only", work.dbNameToLoadIn);
+      setDbReadOnly();
+    }
     return 0;
+  }
+
+  private boolean isReadOnlyHookRegistered() {
+    return conf.get(HiveConf.ConfVars.PREEXECHOOKS.varname) != null &&
+      conf.get(HiveConf.ConfVars.PREEXECHOOKS.varname).contains(READ_ONLY_HOOK);
+  }
+
+  /**
+   * Following hook should be registered before using readonly feature.
+   * 1. SET hive.exec.pre.hooks = "org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook";
+   * If not set 'readonly' has no effect on the database.
+   */
+  private void setDbReadOnly() {
+    Map<String, String> props = new HashMap<>();
+    props.put(READONLY, Boolean.TRUE.toString());
+
+    AlterDatabaseSetPropertiesDesc setTargetReadOnly =
+      new AlterDatabaseSetPropertiesDesc(work.dbNameToLoadIn, props, null);
+    DDLWork alterDbPropWork = new DDLWork(new HashSet<>(), new HashSet<>(), setTargetReadOnly, true,
+      work.dumpDirectory, work.getMetricCollector());
+
+    Task<?> addReadOnlyTargetPropTask = TaskFactory.get(alterDbPropWork, conf);
+    if (this.childTasks == null) {
+      this.childTasks = new ArrayList<>();
+    }
+    this.childTasks.add(addReadOnlyTargetPropTask);
   }
 
   private void addLazyDataCopyTask(TaskTracker loadTaskTracker, ReplLogger replLogger) throws IOException {
@@ -725,6 +758,11 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
       throw new HiveException(ErrorMsg.DATABASE_NOT_EXISTS, work.dbNameToLoadIn);
     }
 
+    // check if db is set READ_ONLY, if not then set it. Basically this ensures backward
+    // compatibility.
+    if (!isDbReadOnly(targetDb) && isReadOnlyHookRegistered()) {
+      setDbReadOnly();
+    }
     // Check if it is a optimised bootstrap failover.
     if (work.isFirstFailover) {
       // Check it should be marked as target of replication & not source of replication.
@@ -875,6 +913,11 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
     ((IncrementalLoadLogger)work.incrementalLoadTasksBuilder().getReplLogger()).initiateEventTimestamp(currentTimestamp);
     LOG.info("REPL_INCREMENTAL_LOAD stage duration : {} ms", currentTimestamp - loadStartTime);
     return 0;
+  }
+
+  private boolean isDbReadOnly(Database db) {
+    Map<String, String> dbParameters = db.getParameters();
+    return dbParameters != null && Boolean.parseBoolean(dbParameters.get(READONLY)) ;
   }
 
   private void abortOpenTxnsForDatabase(HiveTxnManager hiveTxnManager, ValidTxnList validTxnList, String dbName,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13720,15 +13720,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
         break;
       case HiveParser.TOK_TABLEPARTCOLSBYSPEC:
-        List<TransformSpec> partitionTransformSpec =
-            PartitionTransform.getPartitionTransformSpec(child);
-
-        if (!SessionStateUtil.addResource(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC,
-            partitionTransformSpec)) {
-          throw new SemanticException("Query state attached to Session state must be not null. " +
-              "Partition transform metadata cannot be saved.");
-        }
-
+        SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC,
+                PartitionTransform.getPartitionTransformSpec(child));
         partitionTransformSpecExists = true;
         break;
       case HiveParser.TOK_TABLEPARTCOLNAMES:
@@ -13783,30 +13776,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
-    HiveStorageHandler handler;
-    try {
-      handler = HiveUtils.getStorageHandler(conf, storageFormat.getStorageHandler());
-    } catch (HiveException e) {
-      throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
-    }
-
-    if (handler != null) {
-      if (partitionTransformSpecExists && !handler.supportsPartitionTransform()) {
-        throw new SemanticException("Partition transform is not supported for " + handler.getClass().getName());
-      }
-
-      String fileFormatPropertyKey = handler.getFileFormatPropertyKey();
-      if (fileFormatPropertyKey != null) {
-        if (tblProps != null && tblProps.containsKey(fileFormatPropertyKey) && storageFormat.getSerdeProps() != null &&
-            storageFormat.getSerdeProps().containsKey(fileFormatPropertyKey)) {
-          String fileFormat = tblProps.get(fileFormatPropertyKey);
-          throw new SemanticException(
-              "Provide only one of the following: STORED BY " + fileFormat + " or WITH SERDEPROPERTIES('" +
-              fileFormatPropertyKey + "'='" + fileFormat + "') or" + " TBLPROPERTIES('" + fileFormatPropertyKey
-              + "'='" + fileFormat + "')");
-        }
-      }
-    }
+    validateStorageFormat(storageFormat, tblProps, partitionTransformSpecExists);
 
     if (command_type == CREATE_TABLE || command_type == CTLT || command_type == CTT || command_type == CTLF) {
       queryState.setCommandType(HiveOperation.CREATETABLE);
@@ -13926,10 +13896,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           throw new SemanticException(e);
         }
       }
-      if (!SessionStateUtil.addResource(conf, META_TABLE_LOCATION, tblLocation)) {
-        throw new SemanticException(
-            "Query state attached to Session state must be not null. Table location cannot be saved.");
-      }
+      SessionStateUtil.addResourceOrThrow(conf, META_TABLE_LOCATION, tblLocation);
       break;
     case CTT: // CREATE TRANSACTIONAL TABLE
       if (isExt && !isDefaultTableTypeChanged) {
@@ -14078,6 +14045,35 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return null;
   }
 
+  private void validateStorageFormat(
+          StorageFormat storageFormat, Map<String, String> tblProps, boolean partitionTransformSpecExists)
+          throws SemanticException {
+    HiveStorageHandler handler;
+    try {
+      handler = HiveUtils.getStorageHandler(conf, storageFormat.getStorageHandler());
+    } catch (HiveException e) {
+      throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
+    }
+
+    if (handler != null) {
+      if (partitionTransformSpecExists && !handler.supportsPartitionTransform()) {
+        throw new SemanticException("Partition transform is not supported for " + handler.getClass().getName());
+      }
+
+      String fileFormatPropertyKey = handler.getFileFormatPropertyKey();
+      if (fileFormatPropertyKey != null) {
+        if (tblProps != null && tblProps.containsKey(fileFormatPropertyKey) && storageFormat.getSerdeProps() != null &&
+                storageFormat.getSerdeProps().containsKey(fileFormatPropertyKey)) {
+          String fileFormat = tblProps.get(fileFormatPropertyKey);
+          throw new SemanticException(
+                  "Provide only one of the following: STORED BY " + fileFormat + " or WITH SERDEPROPERTIES('" +
+                          fileFormatPropertyKey + "'='" + fileFormat + "') or" + " TBLPROPERTIES('" + fileFormatPropertyKey
+                          + "'='" + fileFormat + "')");
+        }
+      }
+    }
+  }
+
   /** Adds entities for create table/create view. */
   private void addDbAndTabToOutputs(String[] qualifiedTabName, TableType type,
       boolean isTemporary, Map<String, String> tblProps, StorageFormat storageFormat) throws SemanticException {
@@ -14126,6 +14122,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String location = null;
     RowFormatParams rowFormatParams = new RowFormatParams();
     StorageFormat storageFormat = new StorageFormat(conf);
+    boolean partitionTransformSpecExists = false;
 
     LOG.info("Creating view " + dbDotTable + " position="
         + ast.getCharPositionInLine());
@@ -14190,10 +14187,17 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
               storageFormat.getSerdeProps());
         }
         break;
+      case HiveParser.TOK_TABLEPARTCOLSBYSPEC:
+        SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC,
+                PartitionTransform.getPartitionTransformSpec(child));
+        partitionTransformSpecExists = true;
+        break;
       default:
         assert false;
       }
     }
+
+    validateStorageFormat(storageFormat, tblProps, partitionTransformSpecExists);
 
     storageFormat.fillDefaultStorageFormat(false, true);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
@@ -72,6 +72,12 @@ public class SessionStateUtil {
     }
   }
 
+  public static void addResourceOrThrow(Configuration conf, String key, Object resource) {
+    getQueryState(conf)
+            .orElseThrow(() -> new IllegalStateException("Query state is missing; failed to add resource for " + key))
+            .addResource(key, resource);
+  }
+
   /**
    * @param conf Configuration object used for getting the query state, should contain the query id
    * @param tableName Name of the table for which the commit info should be retrieved

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorFactory.java
@@ -99,14 +99,18 @@ public final class CompactorFactory {
         case MINOR:
           return new MmMinorQueryCompactor();
         case MAJOR:
+        case REBALANCE:
+          // REBALANCE COMPACTION on an insert-only table is simply a MAJOR compaction. Since there is no ACID row data,
+          // there is no acid row order to keep, and the number of buckets cannot be set at all (it will be calculated
+          // and created by TEZ dynamically). Initiator won't schedule REBALANCE compactions for insert-only tables,
+          // however users can request it. In these cases we simply fall back to MAJOR compaction
           return new MmMajorQueryCompactor();
-        default:
-          throw new HiveException(
-              compactionInfo.type.name() + " compaction is not supported on insert only tables.");
       }
+    } else {
+      throw new HiveException("Only transactional tables can be compacted, " + table.getTableName() + "is not suitable " +
+          "for compaction!");
     }
-    throw new HiveException("Only transactional tables can be compacted, " + table.getTableName() + "is not suitable " +
-        "for compaction!");
+    throw new HiveException("No suitable compactor found for table: " + table.getTableName());
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -547,9 +547,8 @@ public class Initiator extends MetaStoreCompactorThread {
     // bucket size calculation can be resource intensive if there are numerous deltas, so we check for rebalance
     // compaction only if the table is in an acceptable shape: no major compaction required. This means the number of
     // files shouldn't be too high
-    if ("tez".equalsIgnoreCase(HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE)) &&
-        HiveConf.getBoolVar(conf, HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED) &&
-        AcidUtils.isFullAcidTable(tblproperties)) {
+    if (AcidUtils.isFullAcidTable(tblproperties)) {
+      // We check only full-acid tables, for insert-only tables a MAJOR compaction will also rebalance bucket data.
       long totalSize = baseSize + deltaSize;
       long minimumSize = MetastoreConf.getLongVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_REBALANCE_MINIMUM_SIZE);
       if (totalSize > minimumSize) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MinorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MinorQueryCompactor.java
@@ -76,8 +76,8 @@ final class MinorQueryCompactor extends QueryCompactor {
   @Override
   protected void commitCompaction(String dest, String tmpTableName, HiveConf conf,
       ValidWriteIdList actualWriteIds, long compactorTxnId) throws IOException, HiveException {
-    Util.cleanupEmptyDir(conf, AcidUtils.DELTA_PREFIX + tmpTableName + "_result");
-    Util.cleanupEmptyDir(conf, AcidUtils.DELETE_DELTA_PREFIX + tmpTableName + "_result");
+    Util.cleanupEmptyTableDir(conf, AcidUtils.DELTA_PREFIX + tmpTableName + "_result");
+    Util.cleanupEmptyTableDir(conf, AcidUtils.DELETE_DELTA_PREFIX + tmpTableName + "_result");
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMajorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMajorQueryCompactor.java
@@ -74,7 +74,7 @@ final class MmMajorQueryCompactor extends QueryCompactor {
   @Override
   protected void commitCompaction(String dest, String tmpTableName, HiveConf conf,
       ValidWriteIdList actualWriteIds, long compactorTxnId) throws IOException, HiveException {
-    Util.cleanupEmptyDir(conf, tmpTableName);
+    Util.cleanupEmptyTableDir(conf, tmpTableName);
   }
 
   private List<String> getCreateQueries(String tmpTableName, Table table,

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMinorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMinorQueryCompactor.java
@@ -66,11 +66,11 @@ final class MmMinorQueryCompactor extends QueryCompactor {
   }
 
   /**
-   * Move files from "result table" directory to table/partition to compact's directory.
+   * Clean up the empty table dir of 'tmpTableName'.
    */
   @Override protected void commitCompaction(String dest, String tmpTableName, HiveConf conf,
       ValidWriteIdList actualWriteIds, long compactorTxnId) throws IOException, HiveException {
-    Util.cleanupEmptyDir(conf, tmpTableName);
+    Util.cleanupEmptyTableDir(conf, tmpTableName);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/StatsUpdater.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.Warehouse;
-import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.txn.CompactionInfo;
 import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -268,6 +268,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       findNextCompactRequest.setWorkerVersion(runtimeVersion);
       findNextCompactRequest.setPoolName(this.getPoolName());
       ci = CompactionInfo.optionalCompactionInfoStructToInfo(msc.findNextCompact(findNextCompactRequest));
+      ci.errorMessage = "";
       LOG.info("Processing compaction request {}", ci);
 
       if (ci == null) {
@@ -315,10 +316,19 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         return false;
       }
 
-      if (!ci.type.equals(CompactionType.REBALANCE) && ci.numberOfBuckets > 0) {
-        if (LOG.isWarnEnabled()) {
-          LOG.warn("Only the REBALANCE compaction accepts the number of buckets clause (CLUSTERED INTO {N} BUCKETS). " +
-              "Since the compaction request is {}, it will be ignored.", ci.type);
+      if (LOG.isWarnEnabled()) {
+        boolean insertOnly = AcidUtils.isInsertOnlyTable(table.getParameters());
+        if (ci.type.equals(CompactionType.REBALANCE) && insertOnly) {
+          ci.errorMessage += "Falling back to MAJOR compaction as REBALANCE compaction is supported only on full-acid tables. ";
+          LOG.warn("REBALANCE compaction requested on an insert-only table ({}). Falling back to MAJOR compaction as " +
+              "REBALANCE compaction is supported only on full-acid tables", table.getTableName());
+        }
+        if ((!ci.type.equals(CompactionType.REBALANCE) || insertOnly) && ci.numberOfBuckets > 0) {
+          ci.errorMessage += "Only REBALANCE compaction on a full-acid table accepts the number of buckets clause. " +
+              "(CLUSTERED INTO {N} BUCKETS).";
+          LOG.warn("Only REBALANCE compaction on a full-acid table accepts the number of buckets clause " +
+                  "(CLUSTERED INTO {N} BUCKETS). Since the compaction request is {} and the table is {}, it will be ignored.",
+              ci.type, insertOnly ? "insert-only" : "full-acid");
         }
       }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -1219,6 +1219,7 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
     }
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, true);
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
 
     int numFailedCompactions = MetastoreConf.getIntVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_THRESHOLD);
     AtomicBoolean stop = new AtomicBoolean(true);
@@ -1299,6 +1300,7 @@ public class TestTxnCommands2 extends TxnCommandsBaseForTests {
       runStatementOnDriver("insert into " + tblName + " values(" + (i + 1) + ", 'foo'),(" + (i + 2) + ", 'bar'),(" + (i + 3) + ", 'baz')");
     }
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
     runInitiator(hiveConf);
     runWorker(hiveConf);
     runCleaner(hiveConf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
@@ -131,6 +131,7 @@ public abstract class TxnCommandsBaseForTests {
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVESTATSCOLAUTOGATHER, false);
     hiveConf.setBoolean("mapred.input.dir.recursive", true);
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
       
     TestTxnDbUtil.setConfValues(hiveConf);
     txnHandler = TxnUtils.getTxnStore(hiveConf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/DbTxnManagerEndToEndTestBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/DbTxnManagerEndToEndTestBase.java
@@ -60,6 +60,7 @@ public abstract class DbTxnManagerEndToEndTestBase {
 
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.WAREHOUSE, getWarehouseDir());
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
     TestTxnDbUtil.setConfValues(conf);
   }
   

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/StorageHandlerMock.java
@@ -65,12 +65,11 @@ public class StorageHandlerMock extends DefaultStorageHandler {
     };
   }
 
-  @Override public LockType getLockType(WriteEntity writeEntity
-  ) {
+  @Override public LockType getLockType(WriteEntity writeEntity) {
     if (writeEntity.getWriteType().equals(WriteEntity.WriteType.INSERT)) {
       return LockType.SHARED_READ;
     }
-    return LockType.SHARED_WRITE;
+    return super.getLockType(writeEntity);
   }
 
   @Override public Class<? extends OutputFormat> getOutputFormatClass() {

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -132,6 +132,7 @@ public abstract class CompactorTest {
     fs = FileSystem.get(conf);
     MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.TXN_OPENTXN_TIMEOUT, 2, TimeUnit.SECONDS);
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
     TestTxnDbUtil.setConfValues(conf);
     TestTxnDbUtil.cleanDb(conf);
     TestTxnDbUtil.prepDb(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -86,6 +86,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.METRICS_ENABLED, true);
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.TXN_USE_MIN_HISTORY_LEVEL, true);
     MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON, true);
+    MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON, true);
     // re-initialize metrics
     Metrics.shutdown();
     Metrics.initialize(conf);

--- a/ql/src/test/queries/clientpositive/compaction_query_based.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based.q
@@ -1,0 +1,27 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+
+drop table orc_table;
+
+create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+
+alter table orc_table compact 'MAJOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;
+

--- a/ql/src/test/queries/clientpositive/compaction_query_based_clustered.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based_clustered.q
@@ -1,0 +1,34 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+drop table orc_table;
+
+create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+insert into orc_table values('4', 'text4');
+insert into orc_table values('5', 'text5');
+insert into orc_table values('6', 'text6');
+insert into orc_table values('7', 'text7');
+insert into orc_table values('8', 'text8');
+insert into orc_table values('9', 'text9');
+insert into orc_table values('10', 'text10');
+
+describe extended orc_table;
+alter table orc_table compact 'MAJOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;
+

--- a/ql/src/test/queries/clientpositive/compaction_query_based_clustered_minor.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based_clustered_minor.q
@@ -1,0 +1,34 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+drop table orc_table;
+
+create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+insert into orc_table values('4', 'text4');
+insert into orc_table values('5', 'text5');
+insert into orc_table values('6', 'text6');
+insert into orc_table values('7', 'text7');
+insert into orc_table values('8', 'text8');
+insert into orc_table values('9', 'text9');
+insert into orc_table values('10', 'text10');
+
+describe extended orc_table;
+alter table orc_table compact 'MINOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;
+

--- a/ql/src/test/queries/clientpositive/compaction_query_based_insert_only.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based_insert_only.q
@@ -1,0 +1,25 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+drop table orc_table;
+
+create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+
+alter table orc_table compact 'MAJOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;

--- a/ql/src/test/queries/clientpositive/compaction_query_based_insert_only_minor.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based_insert_only_minor.q
@@ -1,0 +1,25 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+drop table orc_table;
+
+create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+
+alter table orc_table compact 'MINOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;

--- a/ql/src/test/queries/clientpositive/compaction_query_based_minor.q
+++ b/ql/src/test/queries/clientpositive/compaction_query_based_minor.q
@@ -1,0 +1,26 @@
+--! qt:replace:/createTime:(\d+)/#Masked#/
+--! qt:replace:/location:(\S+)/#Masked#/
+--! qt:replace:/lastAccessTime:(\d+)/#Masked#/
+--! qt:replace:/ownerType:(\S*)/#Masked#/
+--! qt:replace:/owner:(\S*)/#Masked#/
+--! qt:replace:/skewedColValueLocationMaps:(\S*)/#Masked#/
+--! qt:replace:/transient_lastDdlTime=(\d+)/#Masked#/
+--! qt:replace:/totalSize=(\d+)/#Masked#/
+--! qt:replace:/rawDataSize=(\d+)/#Masked#/
+--! qt:replace:/writeId:(\d+)/#Masked#/
+--! qt:replace:/bucketing_version=(\d+)/#Masked#/
+--! qt:replace:/id:(\d+)/#Masked#/
+
+drop table orc_table;
+
+create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true');
+
+insert into orc_table values('1', 'text1');
+insert into orc_table values('2', 'text2');
+insert into orc_table values('3', 'text3');
+
+alter table orc_table compact 'MINOR' and wait;
+analyze table orc_table compute statistics;
+
+describe extended orc_table;
+

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: alter table orc_table compact 'MAJOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MAJOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=3, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=1, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based_clustered.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based_clustered.q.out
@@ -1,0 +1,148 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('4', 'text4')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('4', 'text4')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('5', 'text5')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('5', 'text5')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('6', 'text6')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('6', 'text6')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('7', 'text7')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('7', 'text7')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('8', 'text8')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('8', 'text8')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('9', 'text9')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('9', 'text9')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('10', 'text10')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('10', 'text10')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:3, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[a], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=10, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=10, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	
+PREHOOK: query: alter table orc_table compact 'MAJOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MAJOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:3, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[a], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=10, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=3, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based_clustered_minor.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based_clustered_minor.q.out
@@ -1,0 +1,148 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) clustered by (a) into 3 buckets stored as orc TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('4', 'text4')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('4', 'text4')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('5', 'text5')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('5', 'text5')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('6', 'text6')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('6', 'text6')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('7', 'text7')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('7', 'text7')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('8', 'text8')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('8', 'text8')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('9', 'text9')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('9', 'text9')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('10', 'text10')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('10', 'text10')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:3, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[a], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=10, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=10, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	
+PREHOOK: query: alter table orc_table compact 'MINOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MINOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:3, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[a], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=10, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=3, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based_insert_only.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based_insert_only.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: alter table orc_table compact 'MAJOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MAJOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{serialization.format=1}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=3, #Masked#, transactional_properties=insert_only, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=1, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based_insert_only_minor.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based_insert_only_minor.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true', 'transactional_properties'='insert_only')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: alter table orc_table compact 'MINOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MINOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{serialization.format=1}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=3, #Masked#, transactional_properties=insert_only, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=1, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/ql/src/test/results/clientpositive/llap/compaction_query_based_minor.q.out
+++ b/ql/src/test/results/clientpositive/llap/compaction_query_based_minor.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: drop table orc_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table orc_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: create table orc_table (a int, b string) stored as orc TBLPROPERTIES('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: insert into orc_table values('1', 'text1')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('1', 'text1')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('2', 'text2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('2', 'text2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: insert into orc_table values('3', 'text3')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: insert into orc_table values('3', 'text3')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@orc_table
+POSTHOOK: Lineage: orc_table.a SCRIPT []
+POSTHOOK: Lineage: orc_table.b SCRIPT []
+PREHOOK: query: alter table orc_table compact 'MINOR' and wait
+PREHOOK: type: ALTERTABLE_COMPACT
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: alter table orc_table compact 'MINOR' and wait
+POSTHOOK: type: ALTERTABLE_COMPACT
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: analyze table orc_table compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orc_table
+PREHOOK: Output: default@orc_table
+POSTHOOK: query: analyze table orc_table compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orc_table
+POSTHOOK: Output: default@orc_table
+PREHOOK: query: describe extended orc_table
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@orc_table
+POSTHOOK: query: describe extended orc_table
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@orc_table
+a                   	int                 	                    
+b                   	string              	                    
+	 	 
+Detailed Table Information	Table(tableName:orc_table, dbName:default, #Masked# #Masked#, #Masked#, retention:0, sd:StorageDescriptor(cols:[FieldSchema(name:a, type:int, comment:null), FieldSchema(name:b, type:string, comment:null)], #Masked# inputFormat:org.apache.hadoop.hive.ql.io.orc.OrcInputFormat, outputFormat:org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat, compressed:false, numBuckets:-1, serdeInfo:SerDeInfo(name:null, serializationLib:org.apache.hadoop.hive.ql.io.orc.OrcSerde, parameters:{}), bucketCols:[], sortCols:[], parameters:{}, skewedInfo:SkewedInfo(skewedColNames:[], skewedColValues:[], #Masked# storedAsSubDirectories:false), partitionKeys:[], parameters:{#Masked#, numRows=3, #Masked#, transactional_properties=default, COLUMN_STATS_ACCURATE={\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}, numFiles=1, #Masked#, #Masked#, numFilesErasureCoded=0, transactional=true}, viewOriginalText:null, viewExpandedText:null, tableType:MANAGED_TABLE, rewriteEnabled:false, catName:hive, #Masked# #Masked#, #Masked#)	

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -319,6 +319,12 @@
       <artifactId>apacheds-server-integ</artifactId>
       <version>${apache-directory-server.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/shims/common/src/main/java/org/apache/hadoop/hive/shims/Utils.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/shims/Utils.java
@@ -56,6 +56,10 @@ public class Utils {
   public static final String DISTCP_OPTIONS_PREFIX = "distcp.options.";
 
   public static UserGroupInformation getUGI() throws LoginException, IOException {
+    if (UserGroupInformation.isSecurityEnabled()) {
+      return UserGroupInformation.getCurrentUser();
+    }
+
     String doAs = System.getenv("HADOOP_USER_NAME");
     if(doAs != null && doAs.length() > 0) {
      /*

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
@@ -64,6 +64,13 @@ public class ReplConst {
    */
   public static final String REPL_TARGET_DATABASE_PROPERTY = "repl.target.last.id";
 
+  /**
+   * Indicates initiation of RESUME action. This property can be used to avoid updation of
+   * "repl.target.last.id" when "repl.last.id" is changed(This behaviour is currently used in
+   * RESUME workflow). This property will be removed after second cycle of Optimised bootstrap.
+   */
+  public static final String REPL_RESUME_STARTED_AFTER_FAILOVER = "repl.resume.started";
+
   public static final String SOURCE_OF_REPLICATION = "repl.source.for";
 
   public static final String REPL_FIRST_INC_PENDING_FLAG = "hive.repl.first.inc.pending";

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
@@ -73,4 +73,6 @@ public class ReplConst {
   public static final String REPL_IS_CUSTOM_DB_MANAGEDLOC = "hive.repl.is.custom.db.managedloc";
 
   public static final String BOOTSTRAP_DUMP_STATE_KEY_PREFIX = "bootstrap.dump.state.";
+
+  public static final String READ_ONLY_HOOK = "org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook";
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -613,7 +613,12 @@ public class MetastoreConf {
         "Percentage (fractional) size of the delta files relative to the base directory. Deltas smaller than this threshold " +
             "count as small deltas. Default 0.01 = 1%.)"),
     COMPACTOR_INITIATOR_ON("metastore.compactor.initiator.on", "hive.compactor.initiator.on", false,
-        "Whether to run the initiator and cleaner threads on this metastore instance or not.\n" +
+        "Whether to run the initiator thread on this metastore instance or not.\n" +
+            "Set this to true on one instance of the Thrift metastore service as part of turning\n" +
+            "on Hive transactions. For a complete list of parameters required for turning on\n" +
+            "transactions, see hive.txn.manager."),
+    COMPACTOR_CLEANER_ON("metastore.compactor.cleaner.on", "hive.compactor.cleaner.on", false,
+        "Whether to run the cleaner thread on this metastore instance or not.\n" +
             "Set this to true on one instance of the Thrift metastore service as part of turning\n" +
             "on Hive transactions. For a complete list of parameters required for turning on\n" +
             "transactions, see hive.txn.manager."),
@@ -1663,7 +1668,7 @@ public class MetastoreConf {
     HIVE_TXN_MANAGER("hive.txn.manager", "hive.txn.manager",
         "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
         "Set to org.apache.hadoop.hive.ql.lockmgr.DbTxnManager as part of turning on Hive\n" +
-            "transactions, which also requires appropriate settings for hive.compactor.initiator.on,\n" +
+            "transactions, which also requires appropriate settings for hive.compactor.initiator.on,hive.compactor.cleaner.on,\n" +
             "hive.compactor.worker.threads, hive.support.concurrency (true),\n" +
             "and hive.exec.dynamic.partition.mode (nonstrict).\n" +
             "The default DummyTxnManager replicates pre-Hive-0.13 behavior and provides\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -111,6 +111,7 @@ import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE_PATT
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE;
 import static org.apache.hadoop.hive.common.AcidConstants.DELTA_DIGITS;
 
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_RESUME_STARTED_AFTER_FAILOVER;
 import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_TARGET_DATABASE_PROPERTY;
 import static org.apache.hadoop.hive.metastore.HiveMetaStoreClient.RENAME_PARTITION_MAKE_COPY;
 import static org.apache.hadoop.hive.metastore.HiveMetaStoreClient.TRUNCATE_SKIP_DATA_DELETION;
@@ -1507,7 +1508,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   private boolean isReplicationEventIdUpdate(Database oldDb, Database newDb) {
     Map<String, String> oldDbProp = oldDb.getParameters();
     Map<String, String> newDbProp = newDb.getParameters();
-    if (newDbProp == null || newDbProp.isEmpty()) {
+    if (newDbProp == null || newDbProp.isEmpty() ||
+      Boolean.parseBoolean(newDbProp.get(REPL_RESUME_STARTED_AFTER_FAILOVER))) {
       return false;
     }
     String newReplId = newDbProp.get(ReplConst.REPL_TARGET_TABLE_PROPERTY);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
@@ -66,7 +66,8 @@ public class CompactorTasks implements LeaderElection.LeadershipStateListener {
       if (MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON)) {
         MetaStoreThread initiator = instantiateThread("org.apache.hadoop.hive.ql.txn.compactor.Initiator");
         compactors.add(initiator);
-
+      }
+      if (MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON)) {
         MetaStoreThread cleaner = instantiateThread("org.apache.hadoop.hive.ql.txn.compactor.Cleaner");
         compactors.add(cleaner);
       }
@@ -92,6 +93,8 @@ public class CompactorTasks implements LeaderElection.LeadershipStateListener {
       HiveMetaStore.LOG.info("Compaction HMS parameters:");
       HiveMetaStore.LOG.info("metastore.compactor.initiator.on = {}",
           MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON));
+      HiveMetaStore.LOG.info("metastore.compactor.cleaner.on = {}",
+          MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON));
       HiveMetaStore.LOG.info("metastore.compactor.worker.threads = {}",
           MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.COMPACTOR_WORKER_THREADS));
       HiveMetaStore.LOG.info("hive.metastore.runworker.in = {}",
@@ -110,6 +113,10 @@ public class CompactorTasks implements LeaderElection.LeadershipStateListener {
       if (!MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON)) {
         HiveMetaStore.LOG.warn("Compactor Initiator is turned Off. Automatic compaction will not be triggered.");
       }
+      if (!MetastoreConf.getBoolVar(configuration, MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON)) {
+        HiveMetaStore.LOG.warn("Compactor Cleaner is turned Off. Automatic compaction cleaner will not be triggered.");
+      }
+
     } else {
       int numThreads = MetastoreConf.getIntVar(configuration, MetastoreConf.ConfVars.COMPACTOR_WORKER_THREADS);
       if (numThreads < 1) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/AcidHouseKeeperService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/AcidHouseKeeperService.java
@@ -44,7 +44,9 @@ public class AcidHouseKeeperService implements MetastoreTaskThread {
   @Override
   public void setConf(Configuration configuration) {
     conf = configuration;
-    isCompactorEnabled = MetastoreConf.getBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON);
+    isCompactorEnabled =
+        MetastoreConf.getBoolVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON) || MetastoreConf.getBoolVar(conf,
+            MetastoreConf.ConfVars.COMPACTOR_CLEANER_ON);
     txnHandler = TxnUtils.getTxnStore(conf);
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -342,15 +342,17 @@ class CompactionTxnHandler extends TxnHandler {
   public void markCompacted(CompactionInfo info) throws MetaException {
     try {
       Connection dbConn = null;
-      Statement stmt = null;
+      PreparedStatement pstmt = null;
       try {
         dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED, connPoolCompaction);
-        stmt = dbConn.createStatement();
-        String s = "UPDATE \"COMPACTION_QUEUE\" SET \"CQ_STATE\" = '" + READY_FOR_CLEANING + "', "
-            + "\"CQ_WORKER_ID\" = NULL"
-            + " WHERE \"CQ_ID\" = " + info.id;
-        LOG.debug("Going to execute update <{}>", s);
-        int updCnt = stmt.executeUpdate(s);
+        String sql = "UPDATE \"COMPACTION_QUEUE\" SET \"CQ_STATE\" = ?, "
+            + "\"CQ_WORKER_ID\" = NULL, \"CQ_ERROR_MESSAGE\" = ? WHERE \"CQ_ID\" = ?";
+        pstmt = dbConn.prepareStatement(sql);
+        pstmt.setString(1, Character.toString(READY_FOR_CLEANING));
+        pstmt.setString(2, StringUtils.isNotBlank(info.errorMessage) ? info.errorMessage : null);
+        pstmt.setLong(3, info.id);
+        LOG.debug("Going to execute update <{}>", sql);
+        int updCnt = pstmt.executeUpdate();
         if (updCnt != 1) {
           LOG.error("Unable to set cq_state={} for compaction record: {}. updCnt={}", READY_FOR_CLEANING, info, updCnt);
           LOG.debug("Going to rollback");
@@ -366,7 +368,7 @@ class CompactionTxnHandler extends TxnHandler {
         throw new MetaException("Unable to connect to transaction database " +
           e.getMessage());
       } finally {
-        closeStmt(stmt);
+        closeStmt(pstmt);
         closeDbConn(dbConn);
       }
     } catch (RetryException e) {

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -436,6 +436,12 @@
         <artifactId>apacheds-server-integ</artifactId>
         <version>${apache-directory-server.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.server</groupId>


### PR DESCRIPTION
Problem:
	- If Incremental Dump operation failes while dumping any event id  in the staging directory. Then dump directory for this event id along with file _dumpmetadata  still exists in the dump location. which is getting stored in _events_dump file
	- When user triggers dump operation for this policy again, It again resumes dumping from failed event id, and tries to dump it again but as that event id directory already created in previous cycle, it fails with the exception 
Solution:
	- fixed  cleanFailedEventDirIfExists to remove folder for failed event id for a selected database