### PR TITLE
HIVE-26950: Iceberg: (CTLT) Create external table like V2 table is not preserving table properties.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -1115,7 +1115,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       Map<String, String> origParams) {
     // Preserve the format-version of the iceberg table and filter out rest.
     String formatVersion = origParams.get(TableProperties.FORMAT_VERSION);
-    if (formatVersion.equals("2")) {
+    if ("2".equals(formatVersion)) {
       tbl.getParameters().put(TableProperties.FORMAT_VERSION, formatVersion);
       tbl.getParameters().put(TableProperties.DELETE_MODE, "merge-on-read");
       tbl.getParameters().put(TableProperties.UPDATE_MODE, "merge-on-read");
@@ -1126,9 +1126,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     if (!desc.isExternal()) {
       tbl.getParameters().put("TRANSLATED_TO_EXTERNAL", "TRUE");
       desc.setIsExternal(true);
-    }
-    if (desc.getTblProps() != null) {
-      tbl.getParameters().putAll(desc.getTblProps());
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.Context.Operation;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
+import org.apache.hadoop.hive.ql.ddl.table.create.like.CreateTableLikeDesc;
 import org.apache.hadoop.hive.ql.ddl.table.misc.properties.AlterTableSetPropertiesDesc;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -1106,6 +1107,28 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         alterTableDesc.getProps().containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)) {
       // signal manual iceberg metadata location updated by user
       environmentContext.putToProperties(HiveIcebergMetaHook.MANUAL_ICEBERG_METADATA_LOCATION_CHANGE, "true");
+    }
+  }
+
+  @Override
+  public void setTableParametersForCTLT(org.apache.hadoop.hive.ql.metadata.Table tbl, CreateTableLikeDesc desc,
+      Map<String, String> origParams) {
+    // Preserve the format-version of the iceberg table and filter out rest.
+    String formatVersion = origParams.get(TableProperties.FORMAT_VERSION);
+    if (formatVersion.equals("2")) {
+      tbl.getParameters().put(TableProperties.FORMAT_VERSION, formatVersion);
+      tbl.getParameters().put(TableProperties.DELETE_MODE, "merge-on-read");
+      tbl.getParameters().put(TableProperties.UPDATE_MODE, "merge-on-read");
+      tbl.getParameters().put(TableProperties.MERGE_MODE, "merge-on-read");
+    }
+
+    // check if the table is being created as managed table, in that case we translate it to external
+    if (!desc.isExternal()) {
+      tbl.getParameters().put("TRANSLATED_TO_EXTERNAL", "TRUE");
+      desc.setIsExternal(true);
+    }
+    if (desc.getTblProps() != null) {
+      tbl.getParameters().putAll(desc.getTblProps());
     }
   }
 }

--- a/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
@@ -1,0 +1,24 @@
+-- Mask the totalSize value as it can have slight variability, causing test flakiness
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
+-- Mask random uuid
+--! qt:replace:/(\s+'uuid'=')\S+('\s*)/$1#Masked#$2/
+
+set hive.explain.user=false;
+
+create table source(a int) stored by iceberg tblproperties ('format-version'='2') ;
+
+insert into source values (1), (2);
+
+create table target like source stored by iceberg;
+
+show create table target;
+
+select count(*) from target;
+
+insert into target values (1), (2);
+
+select a from target order by a;
+
+delete from target where a=2;
+
+select a from target order by a;

--- a/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
@@ -1,0 +1,97 @@
+PREHOOK: query: create table source(a int) stored by iceberg tblproperties ('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source
+POSTHOOK: query: create table source(a int) stored by iceberg tblproperties ('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source
+PREHOOK: query: insert into source values (1), (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source
+POSTHOOK: query: insert into source values (1), (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source
+PREHOOK: query: create table target like source stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@target
+POSTHOOK: query: create table target like source stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@target
+PREHOOK: query: show create table target
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@target
+POSTHOOK: query: show create table target
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@target
+CREATE EXTERNAL TABLE `target`(
+  `a` int)
+ROW FORMAT SERDE 
+  'org.apache.iceberg.mr.hive.HiveIcebergSerDe' 
+STORED BY 
+  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'TRANSLATED_TO_EXTERNAL'='TRUE', 
+  'bucketing_version'='2', 
+  'created_with_ctlt'='true', 
+  'engine.hive.enabled'='true', 
+  'format-version'='2', 
+  'iceberg.orc.files.only'='false', 
+  'metadata_location'='hdfs://### HDFS PATH ###', 
+  'table_type'='ICEBERG', 
+#### A masked pattern was here ####
+  'uuid'='#Masked#', 
+  'write.delete.mode'='merge-on-read', 
+  'write.merge.mode'='merge-on-read', 
+  'write.update.mode'='merge-on-read')
+PREHOOK: query: select count(*) from target
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from target
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: insert into target values (1), (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@target
+POSTHOOK: query: insert into target values (1), (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@target
+PREHOOK: query: select a from target order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select a from target order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1
+2
+PREHOOK: query: delete from target where a=2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target
+PREHOOK: Output: default@target
+POSTHOOK: query: delete from target where a=2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target
+POSTHOOK: Output: default@target
+PREHOOK: query: select a from target order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@target
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select a from target order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@target
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeDesc.java
@@ -37,7 +37,7 @@ public class CreateTableLikeDesc implements DDLDesc, Serializable {
   private static final long serialVersionUID = 1L;
 
   private final String tableName;
-  private final boolean isExternal;
+  private boolean isExternal;
   private final boolean isTemporary;
   private final String defaultInputFormat;
   private final String defaultOutputFormat;
@@ -94,6 +94,10 @@ public class CreateTableLikeDesc implements DDLDesc, Serializable {
   @Explain(displayName = "isExternal", displayOnlyOnTrue = true)
   public boolean isExternal() {
     return isExternal;
+  }
+
+  public void setIsExternal(boolean isExternal) {
+    this.isExternal = isExternal;
   }
 
   @Explain(displayName = "default serde name")

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
@@ -18,18 +18,12 @@
 
 package org.apache.hadoop.hive.ql.ddl.table.create.like;
 
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
-
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.PartitionManagementTask;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -39,13 +33,11 @@ import org.apache.hadoop.hive.ql.ddl.DDLUtils;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableOperation;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.hive.serde2.Deserializer;
-import org.apache.hadoop.hive.serde2.SerDeSpec;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
-import org.apache.hive.common.util.AnnotationUtils;
 
 /**
  * Operation process of creating a table like an existing one.
@@ -151,10 +143,14 @@ public class CreateTableLikeOperation extends DDLOperation<CreateTableLikeDesc> 
     // With Hive-25813, we'll not copy over table properties from the source.
     // CTLT should should copy column schema but not table properties. It is also consistent
     // with other query engines like mysql, redshift.
+    Map<String, String> origParams = new HashMap<>(tbl.getParameters());
     tbl.getParameters().clear();
-
     if (desc.getTblProps() != null) {
       tbl.setParameters(desc.getTblProps());
+    }
+    HiveStorageHandler storageHandler = tbl.getStorageHandler();
+    if (storageHandler != null) {
+      storageHandler.setTableParametersForCTLT(tbl, desc, origParams);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.Context.Operation;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
+import org.apache.hadoop.hive.ql.ddl.table.create.like.CreateTableLikeDesc;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec;
 import org.apache.hadoop.hive.ql.parse.TransformSpec;
@@ -268,6 +269,16 @@ public interface HiveStorageHandler extends Configurable {
    */
   default boolean alwaysUnpartitioned() {
     return false;
+  }
+
+  /**
+   * Retains storage handler specific properties during CTLT.
+   * @param tbl        the table
+   * @param desc       the table descriptor
+   * @param origParams the original table properties
+   */
+  default void setTableParametersForCTLT(org.apache.hadoop.hive.ql.metadata.Table tbl, CreateTableLikeDesc desc,
+      Map<String, String> origParams) {
   }
 
   enum AcidSupportType {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two changes:

- Preserve the format version for the iceberg table
- Add auto translation logic for iceberg CTLT tables as well(if table created without external keyword, allow that by auto translating to external with purge true)

### Why are the changes needed?

Better usability of iceberg tables with CTLT

### Does this PR introduce _any_ user-facing change?

Yes, format version preserved for Iceberg CTLT tables & auto translation to external with purge true like other commands for iceberg tables.

### How was this patch tested?

UT