### PR TITLE
HIVE-26967: Deadlock when enabling/disabling Materialized view stored by Iceberg

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_orc2.q
@@ -20,6 +20,15 @@ select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
 
 select * from mat1;
 
+alter materialized view mat1 disable rewrite;
+
+-- no rewrite
+explain cbo
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
+
+alter materialized view mat1 enable rewrite;
+
+-- rewrite
 explain cbo
 select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52;
 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_orc2.q.out
@@ -170,6 +170,37 @@ POSTHOOK: Input: default@mat1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 five	54
 four	53
+PREHOOK: query: alter materialized view mat1 disable rewrite
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 disable rewrite
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: explain cbo
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_ice
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain cbo
+select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_ice
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+CBO PLAN:
+HiveProject(b=[$1], c=[$2])
+  HiveFilter(condition=[>($2, 52)])
+    HiveTableScan(table=[[default, tbl_ice]], table:alias=[tbl_ice])
+
+PREHOOK: query: alter materialized view mat1 enable rewrite
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: alter materialized view mat1 enable rewrite
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REWRITE
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
 PREHOOK: query: explain cbo
 select tbl_ice.b, tbl_ice.c from tbl_ice where tbl_ice.c > 52
 PREHOOK: type: QUERY

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.ddl.view.materialized.alter.rewrite;
 
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.api.SourceTable;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc.DDLDescWithWriteId;
@@ -87,8 +88,15 @@ public class AlterMaterializedViewRewriteAnalyzer extends BaseSemanticAnalyzer {
     }
 
     inputs.add(new ReadEntity(materializedViewTable));
-    outputs.add(new WriteEntity(materializedViewTable, AcidUtils.isLocklessReadsEnabled(materializedViewTable, conf) ?
-      WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE));
+    WriteEntity.WriteType type;
+    if (MetaStoreUtils.isNonNativeTable(materializedViewTable.getTTable())
+            && materializedViewTable.getStorageHandler().areSnapshotsSupported()) {
+      type = WriteEntity.WriteType.DDL_SHARED;
+    } else {
+       type = AcidUtils.isLocklessReadsEnabled(materializedViewTable, conf) ?
+              WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE;
+    }
+    outputs.add(new WriteEntity(materializedViewTable, type));
 
     // Create task for alterMVRewriteDesc
     DDLWork work = new DDLWork(getInputs(), getOutputs(), desc);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rewrite/AlterMaterializedViewRewriteAnalyzer.java
@@ -90,11 +90,11 @@ public class AlterMaterializedViewRewriteAnalyzer extends BaseSemanticAnalyzer {
     inputs.add(new ReadEntity(materializedViewTable));
     WriteEntity.WriteType type;
     if (MetaStoreUtils.isNonNativeTable(materializedViewTable.getTTable())
-            && materializedViewTable.getStorageHandler().areSnapshotsSupported()) {
+        && materializedViewTable.getStorageHandler().areSnapshotsSupported()) {
       type = WriteEntity.WriteType.DDL_SHARED;
     } else {
-       type = AcidUtils.isLocklessReadsEnabled(materializedViewTable, conf) ?
-              WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE;
+      type = AcidUtils.isLocklessReadsEnabled(materializedViewTable, conf) ?
+          WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE;
     }
     outputs.add(new WriteEntity(materializedViewTable, type));
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Use DDL_SHARED write type when Materialized view stored by iceberg is altered for enabling/disabling automatic query rewrite.

### Why are the changes needed?
Later Iceberg commit request an exclusive write lock on the MV while updating data in metastore.

### Does this PR introduce _any_ user-facing change?
Yes, `alter materialized view <mv> [enable|disable] rewrite` not hangs and times out.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=mv_iceberg_orc2.q -pl itests/qtest-iceberg -Piceberg -Pitests
```