### PR TITLE
HIVE-26933: Cleanup dump directory for eventId which was failed in previous dump cycle

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -874,11 +874,17 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
         LOG.info("Event id {} to {} are already dumped, skipping {} events", work.eventFrom, resumeFrom, dumpedCount);
       }
       cleanFailedEventDirIfExists(dumpRoot, resumeFrom);
+      boolean isStagingDirCheckedForFailedEvents = false;
       while (evIter.hasNext()) {
         NotificationEvent ev = evIter.next();
         lastReplId = ev.getEventId();
         if (ev.getEventId() <= resumeFrom) {
           continue;
+        }
+        // Checking and removing remnant file from staging directory if previous incremental repl dump is failed
+        if (!isStagingDirCheckedForFailedEvents) {
+          cleanFailedEventDirIfExists(dumpRoot, ev.getEventId());
+          isStagingDirCheckedForFailedEvents = true;
         }
 
         //disable materialized-view replication if not configured
@@ -1069,16 +1075,18 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
     return currentEventMaxLimit;
   }
 
-  private void cleanFailedEventDirIfExists(Path dumpDir, long resumeFrom) throws SemanticException {
-    Path nextEventRoot = new Path(dumpDir, String.valueOf(resumeFrom + 1));
+  private void cleanFailedEventDirIfExists(Path dumpDir, long eventId) throws SemanticException {
+    Path eventRoot = new Path(dumpDir, String.valueOf(eventId));
     Retryable retryable = Retryable.builder()
       .withHiveConf(conf)
       .withRetryOnException(IOException.class).build();
     try {
       retryable.executeCallable((Callable<Void>) () -> {
-        FileSystem fs = FileSystem.get(nextEventRoot.toUri(), conf);
         try {
-          fs.delete(nextEventRoot, true);
+          FileSystem fs = FileSystem.get(eventRoot.toUri(), conf);
+          if (fs.exists(eventRoot))  {
+            fs.delete(eventRoot, true);
+          }
         } catch (FileNotFoundException e) {
           // no worries
         }


### PR DESCRIPTION

Problem:
- If Incremental Dump operation fails while dumping any event id in the staging directory. Then dump directory for this event id along with file _dumpmetadata still exists in the dump location. which is getting stored in _events_dump file
- When user triggers dump operation for this policy again, It again resumes dumping from failed event id, and tries to dump it again but as that event id directory already created in previous cycle, it fails with the exception 
Solution:
- fixed cleanFailedEventDirIfExists to remove folder for failed event id for a selected database