### PR TITLE
HIVE-26974: Iceberg: CTL from iceberg table should copy partition fields correctly.

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
@@ -22,3 +22,26 @@ select a from target order by a;
 delete from target where a=2;
 
 select a from target order by a;
+
+--create a partitioned iceberg table
+create table emp_iceberg (id int) partitioned by (company string) stored by iceberg;
+
+show create table emp_iceberg;
+
+-- CTLT with the source as the partitioned iceberg table
+create table emp_like1 like emp_iceberg stored by iceberg;
+
+-- Partition column should be there
+show create table emp_like1;
+
+--create a partitioned non iceberg table
+create table emp (id int) partitioned by (company string);
+
+show create table emp;
+
+-- CTLT with the source as the partitioned iceberg table
+create table emp_like2 like emp stored by iceberg;
+
+-- Partition column should be there
+show create table emp_like2;
+

--- a/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
@@ -95,3 +95,139 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@target
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1
+PREHOOK: query: create table emp_iceberg (id int) partitioned by (company string) stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@emp_iceberg
+POSTHOOK: query: create table emp_iceberg (id int) partitioned by (company string) stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@emp_iceberg
+PREHOOK: query: show create table emp_iceberg
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@emp_iceberg
+POSTHOOK: query: show create table emp_iceberg
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@emp_iceberg
+CREATE TABLE `emp_iceberg`(
+  `id` int, 
+  `company` string)
+PARTITIONED BY SPEC ( 
+company)
+ROW FORMAT SERDE 
+  'org.apache.iceberg.mr.hive.HiveIcebergSerDe' 
+STORED BY 
+  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'bucketing_version'='2', 
+  'engine.hive.enabled'='true', 
+  'iceberg.orc.files.only'='false', 
+  'metadata_location'='hdfs://### HDFS PATH ###', 
+  'serialization.format'='1', 
+  'table_type'='ICEBERG', 
+#### A masked pattern was here ####
+  'uuid'='#Masked#')
+PREHOOK: query: create table emp_like1 like emp_iceberg stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@emp_like1
+POSTHOOK: query: create table emp_like1 like emp_iceberg stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@emp_like1
+PREHOOK: query: show create table emp_like1
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@emp_like1
+POSTHOOK: query: show create table emp_like1
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@emp_like1
+CREATE EXTERNAL TABLE `emp_like1`(
+  `id` int, 
+  `company` string)
+PARTITIONED BY SPEC ( 
+company)
+ROW FORMAT SERDE 
+  'org.apache.iceberg.mr.hive.HiveIcebergSerDe' 
+STORED BY 
+  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'TRANSLATED_TO_EXTERNAL'='TRUE', 
+  'bucketing_version'='2', 
+  'created_with_ctlt'='true', 
+  'engine.hive.enabled'='true', 
+  'iceberg.orc.files.only'='false', 
+  'metadata_location'='hdfs://### HDFS PATH ###', 
+  'table_type'='ICEBERG', 
+#### A masked pattern was here ####
+  'uuid'='#Masked#')
+PREHOOK: query: create table emp (id int) partitioned by (company string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@emp
+POSTHOOK: query: create table emp (id int) partitioned by (company string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@emp
+PREHOOK: query: show create table emp
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@emp
+POSTHOOK: query: show create table emp
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@emp
+CREATE TABLE `emp`(
+  `id` int)
+PARTITIONED BY ( 
+  `company` string)
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.mapred.TextInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'bucketing_version'='2', 
+#### A masked pattern was here ####
+PREHOOK: query: create table emp_like2 like emp stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@emp_like2
+POSTHOOK: query: create table emp_like2 like emp stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@emp_like2
+PREHOOK: query: show create table emp_like2
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@emp_like2
+POSTHOOK: query: show create table emp_like2
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@emp_like2
+CREATE EXTERNAL TABLE `emp_like2`(
+  `id` int, 
+  `company` string)
+PARTITIONED BY SPEC ( 
+company)
+ROW FORMAT SERDE 
+  'org.apache.iceberg.mr.hive.HiveIcebergSerDe' 
+STORED BY 
+  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'TRANSLATED_TO_EXTERNAL'='TRUE', 
+  'bucketing_version'='2', 
+  'created_with_ctlt'='true', 
+  'engine.hive.enabled'='true', 
+  'iceberg.orc.files.only'='false', 
+  'metadata_location'='hdfs://### HDFS PATH ###', 
+  'table_type'='ICEBERG', 
+#### A masked pattern was here ####
+  'uuid'='#Masked#')

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
@@ -56,8 +56,9 @@ public class CreateTableLikeOperation extends DDLOperation<CreateTableLikeDesc> 
       tbl = createViewLikeTable(oldTable);
     } else {
       Map<String, String> originalProperties = new HashMap<>();
-      if (oldTable.getStorageHandler() != null) {
-        originalProperties = new HashMap<>(oldTable.getStorageHandler().getNativeProperties(oldTable));
+      Table sourceTable = oldTable.makeCopy();
+      if (sourceTable.getStorageHandler() != null) {
+        originalProperties = new HashMap<>(sourceTable.getStorageHandler().getNativeProperties(sourceTable));
       }
       tbl = createTableLikeTable(oldTable, originalProperties);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
@@ -56,9 +56,10 @@ public class CreateTableLikeOperation extends DDLOperation<CreateTableLikeDesc> 
       tbl = createViewLikeTable(oldTable);
     } else {
       Map<String, String> originalProperties = new HashMap<>();
-      Table sourceTable = oldTable.makeCopy();
-      if (sourceTable.getStorageHandler() != null) {
-        originalProperties = new HashMap<>(sourceTable.getStorageHandler().getNativeProperties(sourceTable));
+      // Get the storage handler without caching, since the storage handler can get changed when copying the
+      // properties of the target table and
+      if (oldTable.getStorageHandlerWithoutCaching() != null) {
+        originalProperties = new HashMap<>(oldTable.getStorageHandlerWithoutCaching().getNativeProperties(oldTable));
       }
       tbl = createTableLikeTable(oldTable, originalProperties);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -279,6 +280,15 @@ public interface HiveStorageHandler extends Configurable {
    */
   default void setTableParametersForCTLT(org.apache.hadoop.hive.ql.metadata.Table tbl, CreateTableLikeDesc desc,
       Map<String, String> origParams) {
+  }
+
+  /**
+   * Extract the native properties of the table which aren't stored in the HMS
+   * @param table the table
+   * @return map with native table level properties
+   */
+  default Map<String, String> getNativeProperties(org.apache.hadoop.hive.ql.metadata.Table table) {
+    return new HashMap<>();
   }
 
   enum AcidSupportType {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
@@ -368,6 +368,18 @@ public class Table implements Serializable {
     return storageHandler;
   }
 
+  public HiveStorageHandler getStorageHandlerWithoutCaching() {
+    if (storageHandler != null || !isNonNative()) {
+      return storageHandler;
+    }
+    try {
+      return HiveUtils.getStorageHandler(SessionState.getSessionConf(),
+          getProperty(org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public void setStorageHandler(HiveStorageHandler sh){
     storageHandler = sh;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Preserve Partition Column in case of creating an iceberg table via CTLT

### Why are the changes needed?

Partition Column isn't preserved if the source table is partitioned and target is Iceberg, when creating table via CTLT

### Does this PR introduce _any_ user-facing change?

Yes, partition columns preserved in CTLT when source table is partitioned

### How was this patch tested?

UT