### PR TITLE
HIVE-26986: Fix OperatorGraph when a query plan contains UnionOperator

### DIFF
--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_copy_on_write_unpartitioned.q.out
@@ -41,7 +41,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -73,13 +73,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: FILE__PATH (type: string)
                       Statistics: Num rows: 4 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: tbl_ice
-                  filterExpr: ((a = 22) or (b) IN ('one', 'four')) (type: boolean)
-                  Statistics: Num rows: 7 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((a = 22) or (b) IN ('one', 'four')) (type: boolean)
                     Statistics: Num rows: 4 Data size: 384 Basic stats: COMPLETE Column stats: COMPLETE
@@ -159,7 +152,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator

--- a/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_mixed.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/delete_iceberg_mixed.q.out
@@ -70,7 +70,7 @@ POSTHOOK: Output: default@ice01
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
 Reducer 4 <- Map 1 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 
 Stage-4
   Stats Work{}
@@ -87,36 +87,36 @@ Stage-4
                   Select Operator [SEL_44] (rows=3 width=479)
                     Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
                     Merge Join Operator [MERGEJOIN_43] (rows=3 width=479)
-                      Conds:RS_57._col4=RS_63._col0(Left Semi),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
+                      Conds:RS_59._col4=RS_65._col0(Left Semi),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
                     <-Map 1 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_57]
+                      SHUFFLE [RS_59]
                         PartitionCols:_col4
-                        Select Operator [SEL_55] (rows=5 width=479)
+                        Select Operator [SEL_56] (rows=5 width=479)
                           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
                           Filter Operator [FIL_53] (rows=5 width=91)
                             predicate:((((id <= 4) and (id <> 2)) or ((id > 4) or (id = 2)) is null) and ((id <= 4) or (id <> 2) or ((id > 4) or (id = 2)) is null) and FILE__PATH is not null)
                             TableScan [TS_0] (rows=7 width=78)
                               default@ice01,ice01,Tbl:COMPLETE,Col:COMPLETE,Output:["id","name"]
                     <-Reducer 4 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_63]
+                      SHUFFLE [RS_65]
                         PartitionCols:_col0
-                        Group By Operator [GBY_62] (rows=3 width=184)
+                        Group By Operator [GBY_64] (rows=3 width=184)
                           Output:["_col0"],keys:_col0
-                          Select Operator [SEL_61] (rows=3 width=184)
+                          Select Operator [SEL_63] (rows=3 width=184)
                             Output:["_col0"]
-                            Filter Operator [FIL_60] (rows=3 width=184)
+                            Filter Operator [FIL_62] (rows=3 width=184)
                               predicate:(row_number_window_0 = 1)
-                              PTF Operator [PTF_59] (rows=6 width=184)
+                              PTF Operator [PTF_61] (rows=6 width=184)
                                 Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col4 ASC NULLS FIRST","partition by:":"_col4"}]
-                                Select Operator [SEL_58] (rows=6 width=184)
+                                Select Operator [SEL_60] (rows=6 width=184)
                                   Output:["_col4"]
                                 <-Map 1 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_56]
+                                  SHUFFLE [RS_57]
                                     PartitionCols:FILE__PATH
                                     Filter Operator [FIL_54] (rows=6 width=4)
                                       predicate:(((id > 4) or (id = 2)) and FILE__PATH is not null)
                                        Please refer to the previous TableScan [TS_0]
-              <-Reducer 6 [CONTAINS] vectorized
+              <-Reducer 5 [CONTAINS] vectorized
                 File Output Operator [FS_70]
                   table:{"name:":"default.ice01"}
                   Select Operator [SEL_69] (rows=3 width=450)
@@ -127,13 +127,12 @@ Stage-4
                         Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col4 ASC NULLS FIRST","partition by:":"_col4"}]
                         Select Operator [SEL_66] (rows=6 width=456)
                           Output:["_col0","_col1","_col2","_col3","_col4","_col6"]
-                        <-Map 5 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_65]
+                        <-Map 1 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_58]
                             PartitionCols:FILE__PATH
-                            Filter Operator [FIL_64] (rows=6 width=76)
+                            Filter Operator [FIL_55] (rows=6 width=76)
                               predicate:((id > 4) or (id = 2))
-                              TableScan [TS_18] (rows=7 width=78)
-                                default@ice01,ice01,Tbl:COMPLETE,Col:COMPLETE,Output:["id","name"]
+                               Please refer to the previous TableScan [TS_0]
 
 PREHOOK: query: delete from ice01 where id>4 OR id=2
 PREHOOK: type: QUERY

--- a/iceberg/iceberg-handler/src/test/results/positive/dynamic_partition_pruning.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/dynamic_partition_pruning.q.out
@@ -2209,7 +2209,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2239,7 +2239,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -2249,18 +2249,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart_iceberg
-                  Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -2310,7 +2300,7 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2345,11 +2335,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2422,7 +2412,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2452,7 +2442,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -2462,18 +2452,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart_iceberg
-                  Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -2525,7 +2505,7 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2560,11 +2540,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2635,11 +2615,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 9 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+        Reducer 9 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2664,44 +2644,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart_iceberg
-                  Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: min(ds)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart_iceberg
-                  filterExpr: ds is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: ds (type: string)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -2709,7 +2651,7 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 2 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: srcpart_iceberg
@@ -2729,62 +2671,18 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Reducer 11 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: min(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col0 is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: _col0 (type: string)
-                    minReductionHashAggr: 0.5
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
+                    Group By Operator
+                      aggregations: min(ds)
+                      minReductionHashAggr: 0.99
+                      mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart_iceberg
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 1
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart_iceberg
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
+                        value expressions: _col0 (type: string)
+            Execution mode: vectorized
         Reducer 2 
             Execution mode: vectorized
             Reduce Operator Tree:
@@ -2816,7 +2714,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -2830,7 +2728,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 4 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -2869,6 +2767,29 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col0 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: string)
+                    minReductionHashAggr: 0.5
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: string)
                       outputColumnNames: _col0
@@ -2884,11 +2805,11 @@ STAGE PLANS:
                           Target Input: srcpart_iceberg
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
+                          Target Vertex: Map 1
         Union 3 
             Vertex: Union 3
-        Union 9 
-            Vertex: Union 9
+        Union 8 
+            Vertex: Union 8
 
   Stage: Stage-0
     Fetch Operator
@@ -4021,7 +3942,7 @@ STAGE PLANS:
         Map 1 <- Union 5 (BROADCAST_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
         Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4067,7 +3988,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4077,18 +3998,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart_iceberg
-                  Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 188000 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4118,7 +4029,7 @@ STAGE PLANS:
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4153,11 +4064,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_atomic_merge_update.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_atomic_merge_update.q.out
@@ -63,7 +63,6 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@display
 Warning: Shuffle Join MERGEJOIN[65][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[66][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 7' is a cross product
 PREHOOK: query: MERGE INTO display USING (
   SELECT distinct display_skey, display, display as orig_display
   FROM (

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
@@ -63,7 +63,6 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@display
 Warning: Shuffle Join MERGEJOIN[65][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[66][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 7' is a cross product
 PREHOOK: query: explain vectorization only detail MERGE INTO display USING (
   SELECT distinct display_skey, display, display as orig_display 
   FROM (
@@ -184,10 +183,6 @@ STAGE PLANS:
                             className: VectorReduceSinkEmptyKeyOperator
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                        Reduce Sink Vectorization:
-                            className: VectorReduceSinkEmptyKeyOperator
-                            native: true
-                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
             Execution mode: vectorized
             Map Vectorization:
                 enabled: true
@@ -232,11 +227,6 @@ STAGE PLANS:
                           className: VectorSelectOperator
                           native: true
                           projectedOutputColumnNums: [4]
-                        Reduce Sink Vectorization:
-                            className: VectorReduceSinkEmptyKeyOperator
-                            native: true
-                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            valueColumns: 4:string
                         Reduce Sink Vectorization:
                             className: VectorReduceSinkEmptyKeyOperator
                             native: true
@@ -387,7 +377,6 @@ STAGE PLANS:
   Stage: Stage-7
 
 Warning: Shuffle Join MERGEJOIN[65][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[66][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 7' is a cross product
 PREHOOK: query: MERGE INTO display USING (
   SELECT distinct display_skey, display, display as orig_display 
   FROM (

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_merge_schema.q.out
@@ -159,12 +159,11 @@ STAGE PLANS:
   Stage: Stage-4
     Tez
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Map 9 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Map 8 (XPROD_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 9 (SIMPLE_EDGE), Union 4 (SIMPLE_EDGE)
+        Reducer 5 <- Map 8 (SIMPLE_EDGE), Union 4 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 1 (XPROD_EDGE), Map 9 (XPROD_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 7 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
       Vertices:
         Map 1 
             Map Operator Tree:
@@ -199,7 +198,7 @@ STAGE PLANS:
                     dataColumns: s_key:bigint, year:int
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 9 
+        Map 8 
             Map Operator Tree:
                   TableScan Vectorization:
                       native: true
@@ -327,10 +326,6 @@ STAGE PLANS:
                           className: VectorFileSinkOperator
                           native: false
         Reducer 7 
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 8 
             Execution mode: vectorized
             Reduce Vectorization:
                 enabled: true

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read_orc.q.out
@@ -99,7 +99,6 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@display
 Warning: Shuffle Join MERGEJOIN[65][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[66][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 7' is a cross product
 PREHOOK: query: MERGE INTO display USING (
   SELECT distinct display_skey, display, display as orig_display
   FROM (

--- a/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/merge_iceberg_copy_on_write_unpartitioned.q.out
@@ -74,22 +74,32 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((a <= 100) or a is not null) (type: boolean)
-                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: string), c (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: int)
                   Filter Operator
                     predicate: (a <= 100) (type: boolean)
                     Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
@@ -129,41 +139,7 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: target_ice
-                  Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                    Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col5 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col5 (type: int)
-                      Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
-            Execution mode: vectorized
-        Map 12 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: a (type: int), b (type: string), c (type: int)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 576 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized
-        Map 13 
+        Map 11 
             Map Operator Tree:
                 TableScan
                   alias: target_ice
@@ -196,6 +172,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string), _col6 (type: int)
+                  Select Operator
+                    expressions: PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string), a (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                    Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col5 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col5 (type: int)
+                      Statistics: Num rows: 4 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: bigint), _col4 (type: string)
                   Filter Operator
                     predicate: (a is not null and FILE__PATH is not null) (type: boolean)
                     Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
@@ -225,7 +212,48 @@ STAGE PLANS:
                         Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: string), _col3 (type: string), _col5 (type: string), _col6 (type: int)
             Execution mode: vectorized
-        Reducer 11 
+        Reducer 10 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
+                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                            name: default.target_ice
+        Reducer 2 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -250,7 +278,7 @@ STAGE PLANS:
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                           serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                           name: default.target_ice
-        Reducer 2 
+        Reducer 4 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -272,7 +300,7 @@ STAGE PLANS:
                         output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                         serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                         name: default.target_ice
-        Reducer 4 
+        Reducer 5 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -296,7 +324,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col2 (type: string)
                       Statistics: Num rows: 8 Data size: 3864 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: bigint), _col3 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 5 
+        Reducer 6 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -314,7 +342,7 @@ STAGE PLANS:
                       output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                       serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                       name: default.target_ice
-        Reducer 6 
+        Reducer 7 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -330,7 +358,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col1 (type: string)
                   Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 8 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -376,7 +404,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 9 
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
@@ -393,47 +421,6 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: string)
                   Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: int), _col2 (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-        Reducer 9 
-            Execution mode: vectorized
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: int), VALUE._col2 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: int), VALUE._col5 (type: string), VALUE._col6 (type: int)
-                outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col3 ASC NULLS FIRST
-                        partition by: _col3
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 4 Data size: 1900 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: string), -1L (type: bigint), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: int)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 2 Data size: 966 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 17 Data size: 6808 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                            output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                            serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                            name: default.target_ice
         Union 3 
             Vertex: Union 3
 

--- a/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_copy_on_write_unpartitioned.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/update_iceberg_copy_on_write_unpartitioned.q.out
@@ -40,9 +40,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Union 2 (CONTAINS)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 2 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (SIMPLE_EDGE), Union 2 (CONTAINS)
+        Reducer 5 <- Map 3 (SIMPLE_EDGE)
+        Reducer 6 <- Map 3 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -71,28 +71,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: tbl_ice
-                  filterExpr: (((b <> 'one') and (b <> 'four') and (a <> 22)) or ((a = 22) or (b) IN ('one', 'four')) is null) (type: boolean)
-                  Statistics: Num rows: 7 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((((b <> 'one') and (b <> 'four') and (a <> 22)) or ((a = 22) or (b) IN ('one', 'four')) is null) and FILE__PATH is not null) (type: boolean)
-                    Statistics: Num rows: 7 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), b (type: string), c (type: int), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                      Statistics: Num rows: 7 Data size: 3388 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col5 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col5 (type: string)
-                        Statistics: Num rows: 7 Data size: 3388 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: bigint), _col6 (type: bigint), _col7 (type: string)
-            Execution mode: vectorized
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: tbl_ice
-                  filterExpr: ((a = 22) or (b) IN ('one', 'four')) (type: boolean)
+                  filterExpr: ((a = 22) or (b) IN ('one', 'four') or ((b <> 'one') and (b <> 'four') and (a <> 22)) or ((a = 22) or (b) IN ('one', 'four')) is null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((a = 22) or (b) IN ('one', 'four')) (type: boolean)
@@ -113,30 +92,22 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: FILE__PATH (type: string)
                       Statistics: Num rows: 4 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((((b <> 'one') and (b <> 'four') and (a <> 22)) or ((a = 22) or (b) IN ('one', 'four')) is null) and FILE__PATH is not null) (type: boolean)
+                    Statistics: Num rows: 7 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: string), c (type: int), PARTITION__SPEC__ID (type: int), PARTITION__HASH (type: bigint), FILE__PATH (type: string), ROW__POSITION (type: bigint), PARTITION__PROJECTION (type: string)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                      Statistics: Num rows: 7 Data size: 3388 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col5 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col5 (type: string)
+                        Statistics: Num rows: 7 Data size: 3388 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: bigint), _col6 (type: bigint), _col7 (type: string)
             Execution mode: vectorized
         Reducer 4 
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 _col5 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                Statistics: Num rows: 2 Data size: 968 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), _col1 (type: string), _col2 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
-                  Statistics: Num rows: 2 Data size: 968 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
-                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
-                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
-                        name: default.tbl_ice
-        Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -177,7 +148,7 @@ STAGE PLANS:
                             output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                             serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
                             name: default.tbl_ice
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized
             Reduce Operator Tree:
               Select Operator
@@ -223,6 +194,28 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col5 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                Statistics: Num rows: 2 Data size: 968 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col3 (type: int), _col4 (type: bigint), _col5 (type: string), _col6 (type: bigint), _col7 (type: string), _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                  Statistics: Num rows: 2 Data size: 968 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 8 Data size: 3884 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.iceberg.mr.hive.HiveIcebergInputFormat
+                        output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
+                        serde: org.apache.iceberg.mr.hive.HiveIcebergSerDe
+                        name: default.tbl_ice
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
@@ -217,6 +217,7 @@ public class ParallelEdgeFixer extends Transform {
       }
     }
 
+    HashSet<Pair<Operator<?>, Operator<?>>> processedEdge = new HashSet<>();
     // process all edges and fix parallel edges if there are any
     for (Pair<Cluster, Cluster> key : edgeOperators.keySet()) {
       List<Pair<Operator<?>, Operator<?>>> values = edgeOperators.get(key);
@@ -232,7 +233,10 @@ public class ParallelEdgeFixer extends Transform {
       Iterator<Pair<Operator<?>, Operator<?>>> it = values.iterator();
       while (it.hasNext()) {
         Pair<Operator<?>, Operator<?>> pair = it.next();
-        fixParallelEdge(pair.left, pair.right);
+        if (!processedEdge.contains(pair)) {
+          fixParallelEdge(pair.left, pair.right);
+          processedEdge.add(pair);
+        }
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
@@ -207,7 +207,6 @@ public class ParallelEdgeFixer extends Transform {
     for (Cluster cluster: og.getClusters()) {
       for (Cluster parentCluster: cluster.parentClusters(actualEdgePredicate)) {
         Set<Operator<?>> parentOperators = parentCluster.getMembers();
-        List<Pair<Operator<?>, Operator<?>>> operatorPairs = new LinkedList<>();
         for (Operator<?> operator: cluster.getMembers()) {
           for (Operator<?> parentOperator: operator.getParentOperators()) {
             if (parentOperators.contains(parentOperator)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
@@ -188,7 +188,8 @@ public class ParallelEdgeFixer extends Transform {
   }
 
   private static class ActualEdgePredicate implements OperatorGraph.OperatorEdgePredicate {
-    EnumSet<EdgeType> acceptableEdgeTypes = EnumSet.of(EdgeType.FLOW, EdgeType.SEMIJOIN, EdgeType.BROADCAST);
+    private static final EnumSet<EdgeType> acceptableEdgeTypes =
+        EnumSet.of(EdgeType.FLOW, EdgeType.SEMIJOIN, EdgeType.BROADCAST);
 
     @Override
     public boolean accept(Operator<?> s, Operator<?> t, OperatorGraph.OpEdge opEdge) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
@@ -188,12 +188,12 @@ public class ParallelEdgeFixer extends Transform {
   }
 
   private static class ActualEdgePredicate implements OperatorGraph.OperatorEdgePredicate {
-    private static final EnumSet<EdgeType> acceptableEdgeTypes =
+    private static final EnumSet<EdgeType> ACCEPTABLE_EDGE_TYPES =
         EnumSet.of(EdgeType.FLOW, EdgeType.SEMIJOIN, EdgeType.BROADCAST);
 
     @Override
     public boolean accept(Operator<?> s, Operator<?> t, OperatorGraph.OpEdge opEdge) {
-      return acceptableEdgeTypes.contains(opEdge.getEdgeType());
+      return ACCEPTABLE_EDGE_TYPES.contains(opEdge.getEdgeType());
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ParallelEdgeFixer.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SharedWorkOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SharedWorkOptimizer.java
@@ -1892,7 +1892,7 @@ public class SharedWorkOptimizer extends Transform {
         Set<Cluster> cc2 = cluster2.childClusters(edgePredicate);
 
         if (!Collections.disjoint(cc1, cc2)) {
-          LOG.debug("merge would create an unsupported parallel edge(CHILDS)", op1, op2);
+          LOG.debug("merging {} and {} would create an unsupported parallel edge(CHILDS)", op1, op2);
           return false;
         }
       }
@@ -1929,7 +1929,7 @@ public class SharedWorkOptimizer extends Transform {
         }
 
         if (pc.size() > 0) {
-          LOG.debug("merge would create an unsupported parallel edge(PARENTS)", op1, op2);
+          LOG.debug("merging {} and {} would create an unsupported parallel edge(PARENTS)", op1, op2);
           return false;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/graph/DotExporter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/graph/DotExporter.java
@@ -53,25 +53,25 @@ public class DotExporter {
     DagGraph<Operator<?>, OpEdge> g = operatorGraph.getDagGraph();
     PrintWriter writer = new PrintWriter(outFile);
     writer.println("digraph G");
-    writer.println("{\n");
+    writer.println("{%n");
     Set<Cluster> clusters = operatorGraph.getClusters();
     Map<Cluster, Integer> clusterIndicesMap = new HashMap<>();
     int idx = 0;
     for (Cluster cluster : clusters) {
       idx++;
       clusterIndicesMap.put(cluster, idx);
-      writer.printf("subgraph cluster_%d {\n", idx);
+      writer.printf("subgraph cluster_%d {%n", idx);
       for (Operator<?> member : cluster.getMembers()) {
-        writer.printf("%s;\n", nodeName(member, idx));
+        writer.printf("%s;%n", nodeName(member, idx));
       }
-      writer.printf("label = \"cluster %d\";\n", idx);
-      writer.printf("}\n");
+      writer.printf("label = \"cluster %d\";%n", idx);
+      writer.printf("}%n");
     }
     Set<Operator<?>> nodes = g.nodes();
     for (Operator<?> n : nodes) {
       for (Cluster curCluster: operatorGraph.clusterOf(n)) {
         int curClusterIdx = clusterIndicesMap.get(curCluster);
-        writer.printf("%s[shape=record,label=\"%s\",%s];\n",
+        writer.printf("%s[shape=record,label=\"%s\",%s];%n",
             nodeName(n, curClusterIdx), nodeLabel(n), style(n));
         Set<Operator<?>> succ = g.successors(n);
         for (Operator<?> s : succ) {
@@ -91,18 +91,18 @@ public class DotExporter {
 
           Set<Cluster> childClusters = operatorGraph.clusterOf(s);
           if (childClusters.contains(curCluster)) {
-            writer.printf("%s->%s%s;\n", nodeName(n, curClusterIdx), nodeName(s, curClusterIdx), style);
+            writer.printf("%s->%s%s;%n", nodeName(n, curClusterIdx), nodeName(s, curClusterIdx), style);
           } else {
             for (Cluster childCluster: childClusters) {
               int childClusterIdx = clusterIndicesMap.get(childCluster);
-              writer.printf("%s->%s%s;\n", nodeName(n, curClusterIdx), nodeName(s, childClusterIdx), style);
+              writer.printf("%s->%s%s;%n", nodeName(n, curClusterIdx), nodeName(s, childClusterIdx), style);
             }
           }
         }
       }
     }
 
-    writer.println("}\n");
+    writer.println("}%n");
     writer.close();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/graph/DotExporter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/graph/DotExporter.java
@@ -177,5 +177,4 @@ public class DotExporter {
     return member.toString();
   }
 
-
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.CompilationOpContext;

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
@@ -80,7 +80,7 @@ public class TestOperatorGraph {
       List<Task<?>> rootTasks = new ArrayList<>();
       generateTaskTree(rootTasks, pCtx, new ArrayList<>(), new HashSet<>(), new HashSet<>());
 
-      assertEquals(rootTasks.size(), 1);
+      assertEquals(1, rootTasks.size());
       assertTrue(rootTasks.get(0) instanceof TezTask);
       TezTask tezTask = (TezTask) rootTasks.get(0);
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.optimizer.graph;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.exec.GroupByOperator;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
+import org.apache.hadoop.hive.ql.exec.SelectOperator;
+import org.apache.hadoop.hive.ql.exec.TableScanOperator;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.UnionOperator;
+import org.apache.hadoop.hive.ql.exec.tez.TezTask;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.optimizer.graph.OperatorGraph.Cluster;
+import org.apache.hadoop.hive.ql.parse.ParseContext;
+import org.apache.hadoop.hive.ql.parse.SemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.parse.TezCompiler;
+import org.apache.hadoop.hive.ql.plan.BaseWork;
+import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
+import org.apache.hadoop.hive.ql.plan.GroupByDesc;
+import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
+import org.apache.hadoop.hive.ql.plan.SelectDesc;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
+import org.apache.hadoop.hive.ql.plan.UnionDesc;
+import org.apache.hadoop.hive.ql.plan.UnionWork;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestOperatorGraph {
+
+  TezCompilerMimic tezCompiler;
+  ParseContext pctx;
+
+  TableScanOperator ts1, ts2;
+  UnionOperator union;
+  SelectOperator sel;
+  ReduceSinkOperator rs;
+  GroupByOperator gby;
+  FileSinkOperator fs;
+
+  private class TezCompilerMimic extends TezCompiler {
+    public List<BaseWork> runGenerateTaskTree(ParseContext pCtx) throws SemanticException {
+      List<Task<?>> rootTasks = new ArrayList<>();
+      generateTaskTree(rootTasks, pCtx, new ArrayList<>(), new HashSet<>(), new HashSet<>());
+
+      assertEquals(rootTasks.size(), 1);
+      assertTrue(rootTasks.get(0) instanceof TezTask);
+      TezTask tezTask = (TezTask) rootTasks.get(0);
+
+      return tezTask.getWork().getAllWork();
+    }
+  }
+
+  private boolean isMatchingOperatorSet(Set<Operator<?>> opSet1, Set<Operator<?>> opSet2) {
+    List<String> opSetTypes1 = opSet1.stream()
+        .filter(op -> !(op instanceof UnionOperator))
+        .map(Operator::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    List<String> opSetTypes2 = opSet2.stream()
+        .filter(op -> !(op instanceof UnionOperator))
+        .map(Operator::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    
+    if (opSetTypes1.size() == opSetTypes2.size()) {
+      boolean result = true;
+      for (int i = 0; i < opSet1.size(); i++) {
+        result = result && opSetTypes1.get(i) == opSetTypes2.get(i);
+      }
+      return result;
+    } else {
+      return false;
+    }
+  }
+
+  private void connectOperators(Operator<?> parent, Operator<?> child) {
+    parent.getChildOperators().add(child);
+    child.getParentOperators().add(parent);
+  }
+
+  @Before
+  public void setUp() throws SemanticException {
+    CompilationOpContext cCtx = new CompilationOpContext();
+
+    ts1 = new TableScanOperator(cCtx);
+    ts2 = new TableScanOperator(cCtx);
+    union = new UnionOperator(cCtx);
+    sel = new SelectOperator(cCtx);
+    rs = new ReduceSinkOperator(cCtx);
+    gby = new GroupByOperator(cCtx);
+    fs = new FileSinkOperator(cCtx);
+
+    TableScanDesc tsConf1 = new TableScanDesc(new Table("db", "table1"));
+    tsConf1.setAlias("table1");
+    tsConf1.getTableMetadata().getSd().setLocation("file:///table1");
+
+    TableScanDesc tsConf2 = new TableScanDesc(new Table("db", "table2"));
+    tsConf2.setAlias("table2");
+    tsConf2.getTableMetadata().getSd().setLocation("file:///table2");
+
+    TableDesc rsTableDesc = new TableDesc();
+    rsTableDesc.setProperties(new Properties());
+    ReduceSinkDesc rsConf = new ReduceSinkDesc();
+    rsConf.setKeySerializeInfo(rsTableDesc);
+
+    GroupByDesc gbyConf = new GroupByDesc();
+    gbyConf.setKeys(new ArrayList<>());
+
+    TableDesc fsTableDesc = new TableDesc();
+    fsTableDesc.setProperties(new Properties());
+    FileSinkDesc fsConf = new FileSinkDesc();
+    fsConf.setTableInfo(fsTableDesc);
+
+    ts1.setConf(tsConf1);
+    ts2.setConf(tsConf2);
+    union.setConf(new UnionDesc());
+    sel.setConf(new SelectDesc());
+    rs.setConf(rsConf);
+    gby.setConf(gbyConf);
+    fs.setConf(fsConf);
+
+    connectOperators(ts1, union);
+    connectOperators(ts2, union);
+    connectOperators(union, sel);
+    connectOperators(sel, rs);
+    connectOperators(rs, gby);
+    connectOperators(gby, fs);
+
+    HiveConf conf = new HiveConf();
+    SessionState.start(conf);
+    QueryState queryState = QueryState.getNewQueryState(conf, null);
+    SemanticAnalyzer sem = new SemanticAnalyzer(queryState);
+
+    tezCompiler = new TezCompilerMimic();
+    tezCompiler.init(queryState, null, null);
+
+    pctx = sem.getParseContext();
+    pctx.setContext(new Context(conf));
+
+    pctx.setTopOps(new HashMap<>());
+    pctx.getTopOps().put("table1", ts1);
+    pctx.getTopOps().put("table2", ts2);
+  }
+
+  @After
+  public void tearDown() {
+    tezCompiler = null;
+    pctx = null;
+    ts1 = null;
+    ts2 = null;
+    union = null;
+    sel = null;
+    rs = null;
+    gby = null;
+    fs = null;
+  }
+
+  @Test
+  public void testCompareDAGIncludingUnion() throws SemanticException {
+    OperatorGraph og = new OperatorGraph(pctx);
+    HashSet<Cluster> operatorGraphClusters = new HashSet<>(og.getClusters());
+
+    List<BaseWork> nonUnionBaseWorks = tezCompiler.runGenerateTaskTree(pctx)
+        .stream().filter(work -> !(work instanceof UnionWork))
+        .collect(Collectors.toList());
+
+    assertEquals(nonUnionBaseWorks.size(), operatorGraphClusters.size());
+    for (BaseWork work: nonUnionBaseWorks) {
+      Optional<Cluster> matchingCluster = operatorGraphClusters.stream()
+          .filter(cluster -> isMatchingOperatorSet(work.getAllOperators(), cluster.getMembers()))
+          .findFirst();
+
+      assertTrue(matchingCluster.isPresent());
+
+      operatorGraphClusters.remove(matchingCluster.get());
+    }
+  }
+}
+

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/graph/TestOperatorGraph.java
@@ -15,10 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.hive.ql.optimizer.graph;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -166,6 +166,7 @@ public class TestOperatorGraph {
     connectOperators(gby, fs);
 
     HiveConf conf = new HiveConf();
+    conf.setBoolean(HiveConf.ConfVars.HIVE_CLI_TEZ_INITIALIZE_SESSION.varname, false);
     SessionState.start(conf);
     QueryState queryState = QueryState.getNewQueryState(conf, null);
     SemanticAnalyzer sem = new SemanticAnalyzer(queryState);

--- a/ql/src/test/queries/clientpositive/script_env_var1.q
+++ b/ql/src/test/queries/clientpositive/script_env_var1.q
@@ -1,6 +1,8 @@
 --! qt:dataset:src
 -- Verifies that script operator ID environment variables have unique values
 -- in each instance of the script operator.
+-- Disable SharedWorkOptimization in order to create 2 Script operators.
+set hive.optimize.shared.work=false;
 SELECT count(1) FROM
 ( SELECT * FROM (SELECT TRANSFORM('echo $HIVE_SCRIPT_OPERATOR_ID') USING 'sh' AS key FROM src order by key LIMIT 1)x UNION ALL
   SELECT * FROM (SELECT TRANSFORM('echo $HIVE_SCRIPT_OPERATOR_ID') USING 'sh' AS key FROM src order by key LIMIT 1)y ) a GROUP BY key;

--- a/ql/src/test/queries/clientpositive/script_env_var2.q
+++ b/ql/src/test/queries/clientpositive/script_env_var2.q
@@ -1,6 +1,8 @@
 --! qt:dataset:src
 set hive.script.operator.id.env.var = MY_ID;
 -- Same test as script_env_var1, but test setting the variable name
+-- Disable SharedWorkOptimization in order to create 2 Script operators.
+set hive.optimize.shared.work=false;
 SELECT count(1) FROM
 ( SELECT * FROM (SELECT TRANSFORM('echo $MY_ID') USING 'sh' AS key FROM src LIMIT 1)a UNION ALL
   SELECT * FROM (SELECT TRANSFORM('echo $MY_ID') USING 'sh' AS key FROM src LIMIT 1)b ) a GROUP BY key;

--- a/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
@@ -344,10 +344,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -370,16 +369,9 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: src1
@@ -388,12 +380,6 @@ STAGE PLANS:
                     expressions: key (type: string)
                     outputColumnNames: _col0
                     Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
                       null sort order: z
@@ -426,6 +412,12 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                       TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string)
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
+                      TopN Hash Memory Usage: 0.1
+                      value expressions: _col0 (type: string), _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -447,30 +439,6 @@ STAGE PLANS:
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 5 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Right Outer Join 0 to 1
-                keys:
-                  0 _col0 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                Limit
-                  Number of rows: 10
-                  Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: string), _col1 (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
-                      value expressions: _col0 (type: string), _col1 (type: string)
-        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -636,7 +604,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -657,20 +625,6 @@ STAGE PLANS:
                         Statistics: Num rows: 5 Data size: 435 Basic stats: COMPLETE Column stats: COMPLETE
                         TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 5
-                    Statistics: Num rows: 5 Data size: 435 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 5 Data size: 435 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -699,7 +653,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -757,7 +711,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -780,23 +734,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                  Top N Key Operator
-                    sort order: +
-                    keys: key (type: string)
-                    null sort order: z
-                    Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                    top n: 5
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -842,7 +779,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -916,8 +853,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
         Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -952,13 +888,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -971,12 +900,6 @@ STAGE PLANS:
                   expressions: VALUE._col0 (type: string)
                   outputColumnNames: _col0
                   Statistics: Num rows: 5 Data size: 435 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: string)
-                    Statistics: Num rows: 5 Data size: 435 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: string)
                     null sort order: z
@@ -1007,6 +930,12 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 799 Basic stats: COMPLETE Column stats: COMPLETE
                       TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string)
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 5 Data size: 799 Basic stats: COMPLETE Column stats: COMPLETE
+                      TopN Hash Memory Usage: 0.1
+                      value expressions: _col0 (type: string), _col1 (type: string)
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1028,30 +957,6 @@ STAGE PLANS:
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 6 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Right Outer Join 0 to 1
-                keys:
-                  0 _col0 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 12 Data size: 1772 Basic stats: COMPLETE Column stats: COMPLETE
-                Limit
-                  Number of rows: 5
-                  Statistics: Num rows: 5 Data size: 799 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col2 (type: string), _col1 (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 799 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 5 Data size: 799 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
-                      value expressions: _col0 (type: string), _col1 (type: string)
-        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
@@ -32,15 +32,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 6 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
+                  filterExpr: ((UDFToDouble(key) < 20.0D) or (UDFToDouble(key) > 100.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
@@ -59,14 +59,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x1
-                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -86,7 +78,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -146,7 +138,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -240,15 +232,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 6 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
+                  filterExpr: ((UDFToDouble(key) < 20.0D) or (UDFToDouble(key) > 100.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
@@ -267,14 +259,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x1
-                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -294,7 +278,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -354,7 +338,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -888,40 +872,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 6 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: x
-                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
                   alias: x1
-                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
+                  filterExpr: ((UDFToDouble(key) > 100.0D) or (UDFToDouble(key) < 20.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
@@ -940,9 +899,26 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 166 Data size: 30876 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                  Filter Operator
+                    predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -965,44 +941,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: bigint)
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col1, _col2, _col3
-                Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col2 (type: string), _col3 (type: string), _col1 (type: bigint)
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1022,6 +960,44 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col1, _col2, _col3
+                Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col2 (type: string), _col3 (type: string), _col1 (type: bigint)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 332 Data size: 31540 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: bigint)
         Union 3 
             Vertex: Union 3
 
@@ -1067,16 +1043,33 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 6 (SIMPLE_EDGE), Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: x
-                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
+                  alias: x1
+                  filterExpr: ((UDFToDouble(key) > 100.0D) or (UDFToDouble(key) < 20.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
                   Filter Operator
                     predicate: (UDFToDouble(key) < 20.0D) (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1096,32 +1089,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x1
-                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -1149,7 +1117,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: UDFToLong(UDFToInteger(_col0)) (type: bigint), _col1 (type: bigint)
+                  expressions: _col1 (type: bigint), UDFToLong(UDFToInteger(_col0)) (type: bigint)
                   outputColumnNames: _col0, _col1
                   Statistics: Num rows: 166 Data size: 2656 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -1185,7 +1153,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1195,7 +1163,7 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col1 (type: bigint), UDFToLong(UDFToInteger(_col0)) (type: bigint)
+                  expressions: UDFToLong(UDFToInteger(_col0)) (type: bigint), _col1 (type: bigint)
                   outputColumnNames: _col0, _col1
                   Statistics: Num rows: 166 Data size: 2656 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator

--- a/ql/src/test/results/clientpositive/llap/cte_cbo_rewrite_0.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_cbo_rewrite_0.q.out
@@ -134,11 +134,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 6 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -161,16 +160,9 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 8 Data size: 928 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: decimal(8,2))
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 8 Data size: 928 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: decimal(8,2))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: d
@@ -183,13 +175,6 @@ STAGE PLANS:
                       expressions: deptno (type: int), name (type: varchar(20))
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: varchar(20))
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
@@ -217,6 +202,13 @@ STAGE PLANS:
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: varchar(20))
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: varchar(20))
+                    Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: decimal(18,2)), _col2 (type: bigint)
                   Reduce Output Operator
                     key expressions: _col0 (type: varchar(20))
                     null sort order: z
@@ -268,31 +260,6 @@ STAGE PLANS:
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 6 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col1, _col3
-                Statistics: Num rows: 8 Data size: 1632 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: sum(_col1), count(_col1)
-                  keys: _col3 (type: varchar(20))
-                  minReductionHashAggr: 0.625
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: varchar(20))
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: varchar(20))
-                    Statistics: Num rows: 3 Data size: 636 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: decimal(18,2)), _col2 (type: bigint)
-        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning.q.out
@@ -3798,7 +3798,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3829,7 +3829,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -3839,19 +3839,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -3903,7 +3892,7 @@ STAGE PLANS:
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3938,11 +3927,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4031,7 +4020,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4062,7 +4051,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4072,19 +4061,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4138,7 +4116,7 @@ STAGE PLANS:
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4173,11 +4151,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4264,11 +4242,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 9 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+        Reducer 9 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4289,42 +4267,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: min(ds)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  filterExpr: ds is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: ds (type: string)
-                    minReductionHashAggr: 0.99
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
                       null sort order: z
@@ -4333,7 +4275,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: srcpart
@@ -4353,63 +4295,19 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
+                    Group By Operator
+                      aggregations: min(ds)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
-        Reducer 11 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: min(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col0 is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: _col0 (type: string)
-                    minReductionHashAggr: 0.5
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 1
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -4442,7 +4340,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -4456,7 +4354,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -4495,6 +4393,29 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
+        Reducer 9 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col0 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: string)
+                    minReductionHashAggr: 0.5
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: string)
                       outputColumnNames: _col0
@@ -4510,11 +4431,11 @@ STAGE PLANS:
                           Target Input: srcpart
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
+                          Target Vertex: Map 1
         Union 3 
             Vertex: Union 3
-        Union 9 
-            Vertex: Union 9
+        Union 8 
+            Vertex: Union 8
 
   Stage: Stage-0
     Fetch Operator
@@ -6493,7 +6414,7 @@ STAGE PLANS:
         Map 1 <- Union 5 (BROADCAST_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
         Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6540,7 +6461,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -6550,19 +6471,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -6593,7 +6503,7 @@ STAGE PLANS:
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6628,11 +6538,11 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_partition_pruning_2.q.out
@@ -946,8 +946,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 3 <- Reducer 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Map 3 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -997,7 +996,7 @@ STAGE PLANS:
                         1 _col0 (type: int)
                       outputColumnNames: _col0
                       input vertices:
-                        1 Reducer 5
+                        1 Map 4
                       Statistics: Num rows: 9 Data size: 1148 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
@@ -1074,18 +1073,6 @@ STAGE PLANS:
                             Target Vertex: Map 1
             Execution mode: llap
             LLAP IO: all inputs
-        Reducer 5 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: NONE
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/test/results/clientpositive/llap/except_all.q.out
+++ b/ql/src/test/results/clientpositive/llap/except_all.q.out
@@ -233,7 +233,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -259,24 +259,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -344,7 +326,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -411,7 +393,7 @@ STAGE PLANS:
       Edges:
         Reducer 10 <- Map 1 (SIMPLE_EDGE), Union 8 (CONTAINS)
         Reducer 11 <- Map 1 (SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 13 <- Map 12 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 12 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
@@ -456,24 +438,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 12 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -545,7 +509,7 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 61304 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 13 
+        Reducer 12 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/except_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/except_distinct.q.out
@@ -224,7 +224,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -250,24 +250,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -331,7 +313,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -397,7 +379,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 10 <- Map 1 (SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 11 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
         Reducer 6 <- Union 5 (SIMPLE_EDGE), Union 7 (CONTAINS)
@@ -442,24 +424,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -500,7 +464,7 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 61304 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 12 
+        Reducer 11 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/explainanalyze_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainanalyze_2.q.out
@@ -48,16 +48,15 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 11 <- Union 9 (CONTAINS)
-Map 13 <- Union 14 (CONTAINS)
-Map 16 <- Union 14 (CONTAINS)
+Map 12 <- Union 13 (CONTAINS)
+Map 15 <- Union 13 (CONTAINS)
 Map 8 <- Union 9 (CONTAINS)
 Reducer 10 <- Union 9 (SIMPLE_EDGE)
-Reducer 15 <- Union 14 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
+Reducer 14 <- Union 13 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 Reducer 5 <- Union 4 (SIMPLE_EDGE)
-Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
-Reducer 7 <- Reducer 15 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Reducer 6 <- Reducer 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 
 Stage-0
   Fetch Operator
@@ -75,6 +74,29 @@ Stage-0
                 Output:["_col0","_col1","_col2"]
                 Merge Join Operator [MERGEJOIN_123] (rows=66/61 width=268)
                   Conds:RS_21._col3=RS_22._col0(Inner),Output:["_col1","_col2","_col4"]
+                <-Reducer 2 [SIMPLE_EDGE] llap
+                  SHUFFLE [RS_21]
+                    PartitionCols:_col3
+                    Merge Join Operator [MERGEJOIN_119] (rows=39/37 width=266)
+                      Conds:RS_18._col0=RS_19._col0(Inner),Output:["_col1","_col2","_col3"]
+                    <-Map 1 [SIMPLE_EDGE] llap
+                      SHUFFLE [RS_18]
+                        PartitionCols:_col0
+                        Select Operator [SEL_2] (rows=500/500 width=178)
+                          Output:["_col0","_col1"]
+                          Filter Operator [FIL_69] (rows=500/500 width=178)
+                            predicate:key is not null
+                            TableScan [TS_0] (rows=500/500 width=178)
+                              default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                    <-Map 7 [SIMPLE_EDGE] llap
+                      SHUFFLE [RS_19]
+                        PartitionCols:_col0
+                        Select Operator [SEL_5] (rows=25/25 width=175)
+                          Output:["_col0","_col1"]
+                          Filter Operator [FIL_70] (rows=25/25 width=175)
+                            predicate:(key is not null and value is not null)
+                            TableScan [TS_3] (rows=25/25 width=175)
+                              default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                 <-Reducer 10 [SIMPLE_EDGE] llap
                   SHUFFLE [RS_22]
                     PartitionCols:_col0
@@ -101,45 +123,26 @@ Stage-0
                                 predicate:value is not null
                                 TableScan [TS_131] (rows=25/25 width=175)
                                   default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                <-Reducer 2 [SIMPLE_EDGE] llap
-                  SHUFFLE [RS_21]
-                    PartitionCols:_col3
-                    Merge Join Operator [MERGEJOIN_119] (rows=39/37 width=266)
-                      Conds:RS_18._col0=RS_19._col0(Inner),Output:["_col1","_col2","_col3"]
-                    <-Map 1 [SIMPLE_EDGE] llap
-                      SHUFFLE [RS_18]
-                        PartitionCols:_col0
-                        Select Operator [SEL_2] (rows=500/500 width=178)
-                          Output:["_col0","_col1"]
-                          Filter Operator [FIL_69] (rows=500/500 width=178)
-                            predicate:key is not null
-                            TableScan [TS_0] (rows=500/500 width=178)
-                              default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                    <-Map 12 [SIMPLE_EDGE] llap
-                      SHUFFLE [RS_19]
-                        PartitionCols:_col0
-                        Select Operator [SEL_30] (rows=25/25 width=175)
-                          Output:["_col0","_col1"]
-                          Filter Operator [FIL_74] (rows=25/25 width=175)
-                            predicate:(key is not null and value is not null)
-                            TableScan [TS_28] (rows=25/25 width=175)
-                              default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-          <-Reducer 7 [CONTAINS] llap
+          <-Reducer 6 [CONTAINS] llap
             Reduce Output Operator [RS_130]
               PartitionCols:_col0, _col1, _col2
               Select Operator [SEL_128] (rows=66/61 width=268)
                 Output:["_col0","_col1","_col2"]
                 Merge Join Operator [MERGEJOIN_127] (rows=66/61 width=268)
                   Conds:RS_46._col3=RS_47._col0(Inner),Output:["_col1","_col2","_col4"]
-                <-Reducer 15 [SIMPLE_EDGE] llap
+                <-Reducer 2 [SIMPLE_EDGE] llap
+                  SHUFFLE [RS_46]
+                    PartitionCols:_col3
+                     Please refer to the previous Merge Join Operator [MERGEJOIN_119]
+                <-Reducer 14 [SIMPLE_EDGE] llap
                   SHUFFLE [RS_47]
                     PartitionCols:_col0
                     Select Operator [SEL_42] (rows=525/319 width=91)
                       Output:["_col0"]
                       Group By Operator [GBY_41] (rows=525/319 width=178)
                         Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                      <-Union 14 [SIMPLE_EDGE]
-                        <-Map 13 [CONTAINS] llap
+                      <-Union 13 [SIMPLE_EDGE]
+                        <-Map 12 [CONTAINS] llap
                           Reduce Output Operator [RS_145]
                             PartitionCols:_col1, _col0
                             Select Operator [SEL_143] (rows=25/25 width=175)
@@ -148,7 +151,7 @@ Stage-0
                                 predicate:value is not null
                                 TableScan [TS_141] (rows=25/25 width=175)
                                   default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                        <-Map 16 [CONTAINS] llap
+                        <-Map 15 [CONTAINS] llap
                           Reduce Output Operator [RS_150]
                             PartitionCols:_col1, _col0
                             Select Operator [SEL_148] (rows=500/500 width=178)
@@ -157,19 +160,6 @@ Stage-0
                                 predicate:value is not null
                                 TableScan [TS_146] (rows=500/500 width=178)
                                   default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                <-Reducer 6 [SIMPLE_EDGE] llap
-                  SHUFFLE [RS_46]
-                    PartitionCols:_col3
-                    Merge Join Operator [MERGEJOIN_120] (rows=39/37 width=266)
-                      Conds:RS_43._col0=RS_44._col0(Inner),Output:["_col1","_col2","_col3"]
-                    <-Map 1 [SIMPLE_EDGE] llap
-                      SHUFFLE [RS_43]
-                        PartitionCols:_col0
-                         Please refer to the previous Select Operator [SEL_2]
-                    <-Map 12 [SIMPLE_EDGE] llap
-                      SHUFFLE [RS_44]
-                        PartitionCols:_col0
-                         Please refer to the previous Select Operator [SEL_30]
 
 PREHOOK: query: SELECT x.key, y.value
 FROM src1 x JOIN src y ON (x.key = y.key) 
@@ -238,26 +228,25 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Map 11 <- Union 12 (CONTAINS)
 Map 14 <- Union 12 (CONTAINS)
-Map 16 <- Union 17 (CONTAINS)
-Map 21 <- Union 17 (CONTAINS)
-Map 22 <- Union 19 (CONTAINS)
-Map 23 <- Union 24 (CONTAINS)
-Map 30 <- Union 24 (CONTAINS)
-Map 31 <- Union 26 (CONTAINS)
-Map 32 <- Union 28 (CONTAINS)
-Reducer 10 <- Reducer 20 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Map 15 <- Union 16 (CONTAINS)
+Map 20 <- Union 16 (CONTAINS)
+Map 21 <- Union 18 (CONTAINS)
+Map 22 <- Union 23 (CONTAINS)
+Map 29 <- Union 23 (CONTAINS)
+Map 30 <- Union 25 (CONTAINS)
+Map 31 <- Union 27 (CONTAINS)
 Reducer 13 <- Union 12 (SIMPLE_EDGE)
-Reducer 18 <- Union 17 (SIMPLE_EDGE), Union 19 (CONTAINS)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
-Reducer 20 <- Union 19 (SIMPLE_EDGE)
-Reducer 25 <- Union 24 (SIMPLE_EDGE), Union 26 (CONTAINS)
-Reducer 27 <- Union 26 (SIMPLE_EDGE), Union 28 (CONTAINS)
-Reducer 29 <- Union 28 (SIMPLE_EDGE)
+Reducer 17 <- Union 16 (SIMPLE_EDGE), Union 18 (CONTAINS)
+Reducer 19 <- Union 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+Reducer 24 <- Union 23 (SIMPLE_EDGE), Union 25 (CONTAINS)
+Reducer 26 <- Union 25 (SIMPLE_EDGE), Union 27 (CONTAINS)
+Reducer 28 <- Union 27 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 Reducer 5 <- Union 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
 Reducer 7 <- Union 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE), Union 6 (CONTAINS)
-Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Reducer 9 <- Reducer 2 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE), Union 6 (CONTAINS)
 
 Stage-0
   Fetch Operator
@@ -274,79 +263,6 @@ Stage-0
               Group By Operator [GBY_227] (rows=196/15 width=177)
                 Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
               <-Union 4 [SIMPLE_EDGE]
-                <-Reducer 10 [CONTAINS] llap
-                  Reduce Output Operator [RS_237]
-                    PartitionCols:_col0, _col1
-                    Select Operator [SEL_235] (rows=130/61 width=177)
-                      Output:["_col0","_col1"]
-                      Merge Join Operator [MERGEJOIN_234] (rows=130/61 width=177)
-                        Conds:RS_55._col3=RS_56._col0(Inner),Output:["_col1","_col2"]
-                      <-Reducer 20 [SIMPLE_EDGE] llap
-                        SHUFFLE [RS_56]
-                          PartitionCols:_col0
-                          Select Operator [SEL_51] (rows=1025/319 width=91)
-                            Output:["_col0"]
-                            Group By Operator [GBY_50] (rows=1025/319 width=178)
-                              Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                            <-Union 19 [SIMPLE_EDGE]
-                              <-Map 22 [CONTAINS] llap
-                                Reduce Output Operator [RS_266]
-                                  PartitionCols:_col1, _col0
-                                  Select Operator [SEL_264] (rows=500/500 width=178)
-                                    Output:["_col0","_col1"]
-                                    Filter Operator [FIL_263] (rows=500/500 width=178)
-                                      predicate:value is not null
-                                      TableScan [TS_262] (rows=500/500 width=178)
-                                        default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                              <-Reducer 18 [CONTAINS] llap
-                                Reduce Output Operator [RS_256]
-                                  PartitionCols:_col1, _col0
-                                  Select Operator [SEL_254] (rows=525/319 width=178)
-                                    Output:["_col0","_col1"]
-                                    Group By Operator [GBY_253] (rows=525/319 width=178)
-                                      Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                    <-Union 17 [SIMPLE_EDGE]
-                                      <-Map 16 [CONTAINS] llap
-                                        Reduce Output Operator [RS_252]
-                                          PartitionCols:_col1, _col0
-                                          Select Operator [SEL_250] (rows=25/25 width=175)
-                                            Output:["_col0","_col1"]
-                                            Filter Operator [FIL_249] (rows=25/25 width=175)
-                                              predicate:value is not null
-                                              TableScan [TS_248] (rows=25/25 width=175)
-                                                default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                      <-Map 21 [CONTAINS] llap
-                                        Reduce Output Operator [RS_261]
-                                          PartitionCols:_col1, _col0
-                                          Select Operator [SEL_259] (rows=500/500 width=178)
-                                            Output:["_col0","_col1"]
-                                            Filter Operator [FIL_258] (rows=500/500 width=178)
-                                              predicate:value is not null
-                                              TableScan [TS_257] (rows=500/500 width=178)
-                                                default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                      <-Reducer 9 [SIMPLE_EDGE] llap
-                        SHUFFLE [RS_55]
-                          PartitionCols:_col3
-                          Merge Join Operator [MERGEJOIN_218] (rows=39/37 width=266)
-                            Conds:RS_52._col0=RS_53._col0(Inner),Output:["_col1","_col2","_col3"]
-                          <-Map 1 [SIMPLE_EDGE] llap
-                            SHUFFLE [RS_52]
-                              PartitionCols:_col0
-                              Select Operator [SEL_2] (rows=500/500 width=178)
-                                Output:["_col0","_col1"]
-                                Filter Operator [FIL_136] (rows=500/500 width=178)
-                                  predicate:key is not null
-                                  TableScan [TS_0] (rows=500/500 width=178)
-                                    default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                          <-Map 15 [SIMPLE_EDGE] llap
-                            SHUFFLE [RS_53]
-                              PartitionCols:_col0
-                              Select Operator [SEL_30] (rows=25/25 width=175)
-                                Output:["_col0","_col1"]
-                                Filter Operator [FIL_141] (rows=25/25 width=175)
-                                  predicate:(key is not null and value is not null)
-                                  TableScan [TS_28] (rows=25/25 width=175)
-                                    default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                 <-Reducer 3 [CONTAINS] llap
                   Reduce Output Operator [RS_226]
                     PartitionCols:_col0, _col1
@@ -362,11 +278,21 @@ Stage-0
                           <-Map 1 [SIMPLE_EDGE] llap
                             SHUFFLE [RS_18]
                               PartitionCols:_col0
-                               Please refer to the previous Select Operator [SEL_2]
-                          <-Map 15 [SIMPLE_EDGE] llap
+                              Select Operator [SEL_2] (rows=500/500 width=178)
+                                Output:["_col0","_col1"]
+                                Filter Operator [FIL_136] (rows=500/500 width=178)
+                                  predicate:key is not null
+                                  TableScan [TS_0] (rows=500/500 width=178)
+                                    default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                          <-Map 10 [SIMPLE_EDGE] llap
                             SHUFFLE [RS_19]
                               PartitionCols:_col0
-                               Please refer to the previous Select Operator [SEL_30]
+                              Select Operator [SEL_5] (rows=25/25 width=175)
+                                Output:["_col0","_col1"]
+                                Filter Operator [FIL_137] (rows=25/25 width=175)
+                                  predicate:(key is not null and value is not null)
+                                  TableScan [TS_3] (rows=25/25 width=175)
+                                    default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                       <-Reducer 13 [SIMPLE_EDGE] llap
                         SHUFFLE [RS_22]
                           PartitionCols:_col0
@@ -393,26 +319,80 @@ Stage-0
                                       predicate:value is not null
                                       TableScan [TS_243] (rows=500/500 width=178)
                                         default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-          <-Reducer 8 [CONTAINS] llap
-            Reduce Output Operator [RS_233]
+                <-Reducer 8 [CONTAINS] llap
+                  Reduce Output Operator [RS_233]
+                    PartitionCols:_col0, _col1
+                    Select Operator [SEL_231] (rows=130/61 width=177)
+                      Output:["_col0","_col1"]
+                      Merge Join Operator [MERGEJOIN_230] (rows=130/61 width=177)
+                        Conds:RS_55._col3=RS_56._col0(Inner),Output:["_col1","_col2"]
+                      <-Reducer 2 [SIMPLE_EDGE] llap
+                        SHUFFLE [RS_55]
+                          PartitionCols:_col3
+                           Please refer to the previous Merge Join Operator [MERGEJOIN_217]
+                      <-Reducer 19 [SIMPLE_EDGE] llap
+                        SHUFFLE [RS_56]
+                          PartitionCols:_col0
+                          Select Operator [SEL_51] (rows=1025/319 width=91)
+                            Output:["_col0"]
+                            Group By Operator [GBY_50] (rows=1025/319 width=178)
+                              Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                            <-Union 18 [SIMPLE_EDGE]
+                              <-Map 21 [CONTAINS] llap
+                                Reduce Output Operator [RS_266]
+                                  PartitionCols:_col1, _col0
+                                  Select Operator [SEL_264] (rows=500/500 width=178)
+                                    Output:["_col0","_col1"]
+                                    Filter Operator [FIL_263] (rows=500/500 width=178)
+                                      predicate:value is not null
+                                      TableScan [TS_262] (rows=500/500 width=178)
+                                        default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                              <-Reducer 17 [CONTAINS] llap
+                                Reduce Output Operator [RS_256]
+                                  PartitionCols:_col1, _col0
+                                  Select Operator [SEL_254] (rows=525/319 width=178)
+                                    Output:["_col0","_col1"]
+                                    Group By Operator [GBY_253] (rows=525/319 width=178)
+                                      Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                                    <-Union 16 [SIMPLE_EDGE]
+                                      <-Map 15 [CONTAINS] llap
+                                        Reduce Output Operator [RS_252]
+                                          PartitionCols:_col1, _col0
+                                          Select Operator [SEL_250] (rows=25/25 width=175)
+                                            Output:["_col0","_col1"]
+                                            Filter Operator [FIL_249] (rows=25/25 width=175)
+                                              predicate:value is not null
+                                              TableScan [TS_248] (rows=25/25 width=175)
+                                                default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                      <-Map 20 [CONTAINS] llap
+                                        Reduce Output Operator [RS_261]
+                                          PartitionCols:_col1, _col0
+                                          Select Operator [SEL_259] (rows=500/500 width=178)
+                                            Output:["_col0","_col1"]
+                                            Filter Operator [FIL_258] (rows=500/500 width=178)
+                                              predicate:value is not null
+                                              TableScan [TS_257] (rows=500/500 width=178)
+                                                default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+          <-Reducer 9 [CONTAINS] llap
+            Reduce Output Operator [RS_237]
               PartitionCols:_col0, _col1
-              Select Operator [SEL_231] (rows=193/61 width=177)
+              Select Operator [SEL_235] (rows=193/61 width=177)
                 Output:["_col0","_col1"]
-                Merge Join Operator [MERGEJOIN_230] (rows=193/61 width=177)
+                Merge Join Operator [MERGEJOIN_234] (rows=193/61 width=177)
                   Conds:RS_104._col3=RS_105._col0(Inner),Output:["_col1","_col2"]
                 <-Reducer 2 [SIMPLE_EDGE] llap
                   SHUFFLE [RS_104]
                     PartitionCols:_col3
                      Please refer to the previous Merge Join Operator [MERGEJOIN_217]
-                <-Reducer 29 [SIMPLE_EDGE] llap
+                <-Reducer 28 [SIMPLE_EDGE] llap
                   SHUFFLE [RS_105]
                     PartitionCols:_col0
                     Select Operator [SEL_100] (rows=1525/319 width=91)
                       Output:["_col0"]
                       Group By Operator [GBY_99] (rows=1525/319 width=178)
                         Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                      <-Union 28 [SIMPLE_EDGE]
-                        <-Map 32 [CONTAINS] llap
+                      <-Union 27 [SIMPLE_EDGE]
+                        <-Map 31 [CONTAINS] llap
                           Reduce Output Operator [RS_294]
                             PartitionCols:_col1, _col0
                             Select Operator [SEL_292] (rows=500/500 width=178)
@@ -421,15 +401,15 @@ Stage-0
                                 predicate:value is not null
                                 TableScan [TS_290] (rows=500/500 width=178)
                                   default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                        <-Reducer 27 [CONTAINS] llap
+                        <-Reducer 26 [CONTAINS] llap
                           Reduce Output Operator [RS_279]
                             PartitionCols:_col1, _col0
                             Select Operator [SEL_277] (rows=1025/319 width=178)
                               Output:["_col0","_col1"]
                               Group By Operator [GBY_276] (rows=1025/319 width=178)
                                 Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                              <-Union 26 [SIMPLE_EDGE]
-                                <-Map 31 [CONTAINS] llap
+                              <-Union 25 [SIMPLE_EDGE]
+                                <-Map 30 [CONTAINS] llap
                                   Reduce Output Operator [RS_289]
                                     PartitionCols:_col1, _col0
                                     Select Operator [SEL_287] (rows=500/500 width=178)
@@ -438,15 +418,15 @@ Stage-0
                                         predicate:value is not null
                                         TableScan [TS_285] (rows=500/500 width=178)
                                           default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                <-Reducer 25 [CONTAINS] llap
+                                <-Reducer 24 [CONTAINS] llap
                                   Reduce Output Operator [RS_275]
                                     PartitionCols:_col1, _col0
                                     Select Operator [SEL_273] (rows=525/319 width=178)
                                       Output:["_col0","_col1"]
                                       Group By Operator [GBY_272] (rows=525/319 width=178)
                                         Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                      <-Union 24 [SIMPLE_EDGE]
-                                        <-Map 23 [CONTAINS] llap
+                                      <-Union 23 [SIMPLE_EDGE]
+                                        <-Map 22 [CONTAINS] llap
                                           Reduce Output Operator [RS_271]
                                             PartitionCols:_col1, _col0
                                             Select Operator [SEL_269] (rows=25/25 width=175)
@@ -455,7 +435,7 @@ Stage-0
                                                 predicate:value is not null
                                                 TableScan [TS_267] (rows=25/25 width=175)
                                                   default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                        <-Map 30 [CONTAINS] llap
+                                        <-Map 29 [CONTAINS] llap
                                           Reduce Output Operator [RS_284]
                                             PartitionCols:_col1, _col0
                                             Select Operator [SEL_282] (rows=500/500 width=178)

--- a/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
@@ -914,8 +914,8 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 Reducer 4 <- Union 3 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 
 Stage-0
   Fetch Operator
@@ -940,34 +940,24 @@ Stage-0
                         Output:["key"]
                         TableScan [TS_0] (rows=20 width=80)
                           default@cbo_t3,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-          <-Reducer 6 [CONTAINS] llap
+          <-Reducer 5 [CONTAINS] llap
             Reduce Output Operator [RS_33]
               Select Operator [SEL_31] (rows=1 width=87)
                 Output:["_col0"]
                 Group By Operator [GBY_30] (rows=1 width=8)
                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                <-Map 5 [CUSTOM_SIMPLE_EDGE] llap
+                <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                   PARTITION_ONLY_SHUFFLE [RS_10]
-                    Group By Operator [GBY_9] (rows=1 width=8)
-                      Output:["_col0"],aggregations:["count(key)"]
-                      Select Operator [SEL_8] (rows=20 width=80)
-                        Output:["key"]
-                        TableScan [TS_7] (rows=20 width=80)
-                          default@cbo_t3,s2,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-          <-Reducer 8 [CONTAINS] llap
+                     Please refer to the previous Group By Operator [GBY_2]
+          <-Reducer 6 [CONTAINS] llap
             Reduce Output Operator [RS_37]
               Select Operator [SEL_35] (rows=1 width=87)
                 Output:["_col0"]
                 Group By Operator [GBY_34] (rows=1 width=8)
                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                <-Map 7 [CUSTOM_SIMPLE_EDGE] llap
+                <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                   PARTITION_ONLY_SHUFFLE [RS_18]
-                    Group By Operator [GBY_17] (rows=1 width=8)
-                      Output:["_col0"],aggregations:["count(key)"]
-                      Select Operator [SEL_16] (rows=20 width=80)
-                        Output:["key"]
-                        TableScan [TS_15] (rows=20 width=80)
-                          default@cbo_t3,s3,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                     Please refer to the previous Group By Operator [GBY_2]
 
 PREHOOK: query: explain select unionsrc.key, count(1) FROM (select 'max' as key, max(c_int) as value from cbo_t3 s1
     UNION  ALL
@@ -991,8 +981,8 @@ Vertex dependency in root stage
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 Reducer 4 <- Union 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 
 Stage-0
   Fetch Operator
@@ -1024,7 +1014,7 @@ Stage-0
                               Output:["key"]
                               TableScan [TS_0] (rows=20 width=80)
                                 default@cbo_t3,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-              <-Reducer 7 [CONTAINS] llap
+              <-Reducer 6 [CONTAINS] llap
                 Reduce Output Operator [RS_40]
                   PartitionCols:_col0
                   Group By Operator [GBY_39] (rows=1 width=95)
@@ -1033,15 +1023,10 @@ Stage-0
                       Output:["_col0"]
                       Group By Operator [GBY_36] (rows=1 width=8)
                         Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                      <-Map 6 [CUSTOM_SIMPLE_EDGE] llap
+                      <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                         PARTITION_ONLY_SHUFFLE [RS_10]
-                          Group By Operator [GBY_9] (rows=1 width=8)
-                            Output:["_col0"],aggregations:["count(key)"]
-                            Select Operator [SEL_8] (rows=20 width=80)
-                              Output:["key"]
-                              TableScan [TS_7] (rows=20 width=80)
-                                default@cbo_t3,s2,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-              <-Reducer 9 [CONTAINS] llap
+                           Please refer to the previous Group By Operator [GBY_2]
+              <-Reducer 7 [CONTAINS] llap
                 Reduce Output Operator [RS_45]
                   PartitionCols:_col0
                   Group By Operator [GBY_44] (rows=1 width=95)
@@ -1050,14 +1035,9 @@ Stage-0
                       Output:["_col0"]
                       Group By Operator [GBY_41] (rows=1 width=8)
                         Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                      <-Map 8 [CUSTOM_SIMPLE_EDGE] llap
+                      <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                         PARTITION_ONLY_SHUFFLE [RS_18]
-                          Group By Operator [GBY_17] (rows=1 width=8)
-                            Output:["_col0"],aggregations:["count(key)"]
-                            Select Operator [SEL_16] (rows=20 width=80)
-                              Output:["key"]
-                              TableScan [TS_15] (rows=20 width=80)
-                                default@cbo_t3,s3,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                           Please refer to the previous Group By Operator [GBY_2]
 
 PREHOOK: query: explain select cbo_t1.key from cbo_t1 join cbo_t3 where cbo_t1.key=cbo_t3.key and cbo_t1.key >= 1
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/explainuser_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainuser_2.q.out
@@ -480,24 +480,23 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 11 <- Union 9 (CONTAINS)
-Map 13 <- Union 14 (CONTAINS)
-Map 16 <- Union 14 (CONTAINS)
+Map 12 <- Union 13 (CONTAINS)
+Map 15 <- Union 13 (CONTAINS)
 Map 8 <- Union 9 (CONTAINS)
 Reducer 10 <- Union 9 (SIMPLE_EDGE)
-Reducer 15 <- Union 14 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
+Reducer 14 <- Union 13 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 Reducer 5 <- Union 4 (SIMPLE_EDGE)
-Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
-Reducer 7 <- Reducer 15 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Reducer 6 <- Reducer 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
       Reducer 5 vectorized, llap
-      File Output Operator [FS_172]
-        Group By Operator [GBY_171] (rows=40 width=268)
+      File Output Operator [FS_170]
+        Group By Operator [GBY_169] (rows=40 width=268)
           Output:["_col0","_col1","_col2"],keys:KEY._col0, KEY._col1, KEY._col2
         <-Union 4 [SIMPLE_EDGE]
           <-Reducer 3 [CONTAINS] llap
@@ -508,42 +507,12 @@ Stage-0
                 Select Operator [SEL_127] (rows=40 width=268)
                   Output:["_col0","_col1","_col2"]
                   Merge Join Operator [MERGEJOIN_126] (rows=40 width=268)
-                    Conds:RS_22._col3=RS_170._col0(Inner),Output:["_col1","_col2","_col4"]
-                  <-Reducer 10 [SIMPLE_EDGE] vectorized, llap
-                    SHUFFLE [RS_170]
-                      PartitionCols:_col0
-                      Select Operator [SEL_169] (rows=316 width=91)
-                        Output:["_col0"]
-                        Group By Operator [GBY_168] (rows=316 width=178)
-                          Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                        <-Union 9 [SIMPLE_EDGE]
-                          <-Map 11 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_183]
-                              PartitionCols:_col0, _col1
-                              Group By Operator [GBY_182] (rows=316 width=178)
-                                Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_181] (rows=500 width=178)
-                                  Output:["_col0","_col1"]
-                                  Filter Operator [FIL_180] (rows=500 width=178)
-                                    predicate:value is not null
-                                    TableScan [TS_142] (rows=500 width=178)
-                                      default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                          <-Map 8 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_179]
-                              PartitionCols:_col0, _col1
-                              Group By Operator [GBY_178] (rows=316 width=178)
-                                Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_177] (rows=25 width=175)
-                                  Output:["_col0","_col1"]
-                                  Filter Operator [FIL_176] (rows=25 width=175)
-                                    predicate:value is not null
-                                    TableScan [TS_136] (rows=25 width=175)
-                                      default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                    Conds:RS_22._col3=RS_168._col0(Inner),Output:["_col1","_col2","_col4"]
                   <-Reducer 2 [SIMPLE_EDGE] llap
                     SHUFFLE [RS_22]
                       PartitionCols:_col3
                       Merge Join Operator [MERGEJOIN_122] (rows=39 width=266)
-                        Conds:RS_162._col0=RS_167._col0(Inner),Output:["_col1","_col2","_col3"]
+                        Conds:RS_162._col0=RS_165._col0(Inner),Output:["_col1","_col2","_col3"]
                       <-Map 1 [SIMPLE_EDGE] vectorized, llap
                         SHUFFLE [RS_162]
                           PartitionCols:_col0
@@ -553,16 +522,46 @@ Stage-0
                               predicate:key is not null
                               TableScan [TS_0] (rows=500 width=178)
                                 default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                      <-Map 12 [SIMPLE_EDGE] vectorized, llap
-                        SHUFFLE [RS_167]
+                      <-Map 7 [SIMPLE_EDGE] vectorized, llap
+                        SHUFFLE [RS_165]
                           PartitionCols:_col0
-                          Select Operator [SEL_165] (rows=25 width=175)
+                          Select Operator [SEL_164] (rows=25 width=175)
                             Output:["_col0","_col1"]
-                            Filter Operator [FIL_164] (rows=25 width=175)
+                            Filter Operator [FIL_163] (rows=25 width=175)
                               predicate:(key is not null and value is not null)
-                              TableScan [TS_29] (rows=25 width=175)
+                              TableScan [TS_3] (rows=25 width=175)
                                 default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-          <-Reducer 7 [CONTAINS] llap
+                  <-Reducer 10 [SIMPLE_EDGE] vectorized, llap
+                    SHUFFLE [RS_168]
+                      PartitionCols:_col0
+                      Select Operator [SEL_167] (rows=316 width=91)
+                        Output:["_col0"]
+                        Group By Operator [GBY_166] (rows=316 width=178)
+                          Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                        <-Union 9 [SIMPLE_EDGE]
+                          <-Map 11 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_181]
+                              PartitionCols:_col0, _col1
+                              Group By Operator [GBY_180] (rows=316 width=178)
+                                Output:["_col0","_col1"],keys:_col1, _col0
+                                Select Operator [SEL_179] (rows=500 width=178)
+                                  Output:["_col0","_col1"]
+                                  Filter Operator [FIL_178] (rows=500 width=178)
+                                    predicate:value is not null
+                                    TableScan [TS_142] (rows=500 width=178)
+                                      default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                          <-Map 8 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_177]
+                              PartitionCols:_col0, _col1
+                              Group By Operator [GBY_176] (rows=316 width=178)
+                                Output:["_col0","_col1"],keys:_col1, _col0
+                                Select Operator [SEL_175] (rows=25 width=175)
+                                  Output:["_col0","_col1"]
+                                  Filter Operator [FIL_174] (rows=25 width=175)
+                                    predicate:value is not null
+                                    TableScan [TS_136] (rows=25 width=175)
+                                      default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+          <-Reducer 6 [CONTAINS] llap
             Reduce Output Operator [RS_135]
               PartitionCols:_col0, _col1, _col2
               Group By Operator [GBY_134] (rows=40 width=268)
@@ -570,50 +569,41 @@ Stage-0
                 Select Operator [SEL_132] (rows=40 width=268)
                   Output:["_col0","_col1","_col2"]
                   Merge Join Operator [MERGEJOIN_131] (rows=40 width=268)
-                    Conds:RS_48._col3=RS_175._col0(Inner),Output:["_col1","_col2","_col4"]
-                  <-Reducer 15 [SIMPLE_EDGE] vectorized, llap
-                    SHUFFLE [RS_175]
+                    Conds:RS_48._col3=RS_173._col0(Inner),Output:["_col1","_col2","_col4"]
+                  <-Reducer 2 [SIMPLE_EDGE] llap
+                    SHUFFLE [RS_48]
+                      PartitionCols:_col3
+                       Please refer to the previous Merge Join Operator [MERGEJOIN_122]
+                  <-Reducer 14 [SIMPLE_EDGE] vectorized, llap
+                    SHUFFLE [RS_173]
                       PartitionCols:_col0
-                      Select Operator [SEL_174] (rows=316 width=91)
+                      Select Operator [SEL_172] (rows=316 width=91)
                         Output:["_col0"]
-                        Group By Operator [GBY_173] (rows=316 width=178)
+                        Group By Operator [GBY_171] (rows=316 width=178)
                           Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                        <-Union 14 [SIMPLE_EDGE]
-                          <-Map 13 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_187]
+                        <-Union 13 [SIMPLE_EDGE]
+                          <-Map 12 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_185]
                               PartitionCols:_col0, _col1
-                              Group By Operator [GBY_186] (rows=316 width=178)
+                              Group By Operator [GBY_184] (rows=316 width=178)
                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_185] (rows=25 width=175)
+                                Select Operator [SEL_183] (rows=25 width=175)
                                   Output:["_col0","_col1"]
-                                  Filter Operator [FIL_184] (rows=25 width=175)
+                                  Filter Operator [FIL_182] (rows=25 width=175)
                                     predicate:value is not null
                                     TableScan [TS_148] (rows=25 width=175)
                                       default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                          <-Map 16 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_191]
+                          <-Map 15 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_189]
                               PartitionCols:_col0, _col1
-                              Group By Operator [GBY_190] (rows=316 width=178)
+                              Group By Operator [GBY_188] (rows=316 width=178)
                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_189] (rows=500 width=178)
+                                Select Operator [SEL_187] (rows=500 width=178)
                                   Output:["_col0","_col1"]
-                                  Filter Operator [FIL_188] (rows=500 width=178)
+                                  Filter Operator [FIL_186] (rows=500 width=178)
                                     predicate:value is not null
                                     TableScan [TS_154] (rows=500 width=178)
                                       default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                  <-Reducer 6 [SIMPLE_EDGE] llap
-                    SHUFFLE [RS_48]
-                      PartitionCols:_col3
-                      Merge Join Operator [MERGEJOIN_123] (rows=39 width=266)
-                        Conds:RS_163._col0=RS_166._col0(Inner),Output:["_col1","_col2","_col3"]
-                      <-Map 1 [SIMPLE_EDGE] vectorized, llap
-                        SHUFFLE [RS_163]
-                          PartitionCols:_col0
-                           Please refer to the previous Select Operator [SEL_161]
-                      <-Map 12 [SIMPLE_EDGE] vectorized, llap
-                        SHUFFLE [RS_166]
-                          PartitionCols:_col0
-                           Please refer to the previous Select Operator [SEL_165]
 
 PREHOOK: query: explain
 SELECT x.key, y.value
@@ -652,127 +642,43 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Map 11 <- Union 12 (CONTAINS)
 Map 14 <- Union 12 (CONTAINS)
-Map 16 <- Union 17 (CONTAINS)
-Map 21 <- Union 17 (CONTAINS)
-Map 22 <- Union 19 (CONTAINS)
-Map 23 <- Union 24 (CONTAINS)
-Map 30 <- Union 24 (CONTAINS)
-Map 31 <- Union 26 (CONTAINS)
-Map 32 <- Union 28 (CONTAINS)
-Reducer 10 <- Reducer 20 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Map 15 <- Union 16 (CONTAINS)
+Map 20 <- Union 16 (CONTAINS)
+Map 21 <- Union 18 (CONTAINS)
+Map 22 <- Union 23 (CONTAINS)
+Map 29 <- Union 23 (CONTAINS)
+Map 30 <- Union 25 (CONTAINS)
+Map 31 <- Union 27 (CONTAINS)
 Reducer 13 <- Union 12 (SIMPLE_EDGE)
-Reducer 18 <- Union 17 (SIMPLE_EDGE), Union 19 (CONTAINS)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
-Reducer 20 <- Union 19 (SIMPLE_EDGE)
-Reducer 25 <- Union 24 (SIMPLE_EDGE), Union 26 (CONTAINS)
-Reducer 27 <- Union 26 (SIMPLE_EDGE), Union 28 (CONTAINS)
-Reducer 29 <- Union 28 (SIMPLE_EDGE)
+Reducer 17 <- Union 16 (SIMPLE_EDGE), Union 18 (CONTAINS)
+Reducer 19 <- Union 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
+Reducer 24 <- Union 23 (SIMPLE_EDGE), Union 25 (CONTAINS)
+Reducer 26 <- Union 25 (SIMPLE_EDGE), Union 27 (CONTAINS)
+Reducer 28 <- Union 27 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 Reducer 5 <- Union 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
 Reducer 7 <- Union 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE), Union 6 (CONTAINS)
-Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Reducer 9 <- Reducer 2 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE), Union 6 (CONTAINS)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
       Reducer 7 vectorized, llap
-      File Output Operator [FS_334]
-        Group By Operator [GBY_333] (rows=51 width=177)
+      File Output Operator [FS_332]
+        Group By Operator [GBY_331] (rows=51 width=177)
           Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
         <-Union 6 [SIMPLE_EDGE]
           <-Reducer 5 [CONTAINS] vectorized, llap
-            Reduce Output Operator [RS_332]
+            Reduce Output Operator [RS_330]
               PartitionCols:_col0, _col1
-              Group By Operator [GBY_331] (rows=51 width=177)
+              Group By Operator [GBY_329] (rows=51 width=177)
                 Output:["_col0","_col1"],keys:_col0, _col1
-                Group By Operator [GBY_330] (rows=45 width=177)
+                Group By Operator [GBY_328] (rows=45 width=177)
                   Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
                 <-Union 4 [SIMPLE_EDGE]
-                  <-Reducer 10 [CONTAINS] llap
-                    Reduce Output Operator [RS_249]
-                      PartitionCols:_col0, _col1
-                      Group By Operator [GBY_248] (rows=45 width=177)
-                        Output:["_col0","_col1"],keys:_col0, _col1
-                        Select Operator [SEL_246] (rows=51 width=177)
-                          Output:["_col0","_col1"]
-                          Merge Join Operator [MERGEJOIN_245] (rows=51 width=177)
-                            Conds:RS_58._col3=RS_340._col0(Inner),Output:["_col1","_col2"]
-                          <-Reducer 20 [SIMPLE_EDGE] vectorized, llap
-                            SHUFFLE [RS_340]
-                              PartitionCols:_col0
-                              Select Operator [SEL_339] (rows=408 width=91)
-                                Output:["_col0"]
-                                Group By Operator [GBY_338] (rows=408 width=178)
-                                  Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                <-Union 19 [SIMPLE_EDGE]
-                                  <-Map 22 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_364]
-                                      PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_363] (rows=408 width=178)
-                                        Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_362] (rows=500 width=178)
-                                          Output:["_col0","_col1"]
-                                          Filter Operator [FIL_361] (rows=500 width=178)
-                                            predicate:value is not null
-                                            TableScan [TS_279] (rows=500 width=178)
-                                              default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                  <-Reducer 18 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_356]
-                                      PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_355] (rows=408 width=178)
-                                        Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_354] (rows=316 width=178)
-                                          Output:["_col0","_col1"]
-                                          Group By Operator [GBY_353] (rows=316 width=178)
-                                            Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                          <-Union 17 [SIMPLE_EDGE]
-                                            <-Map 16 [CONTAINS] vectorized, llap
-                                              Reduce Output Operator [RS_352]
-                                                PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_351] (rows=316 width=178)
-                                                  Output:["_col0","_col1"],keys:_col1, _col0
-                                                  Select Operator [SEL_350] (rows=25 width=175)
-                                                    Output:["_col0","_col1"]
-                                                    Filter Operator [FIL_349] (rows=25 width=175)
-                                                      predicate:value is not null
-                                                      TableScan [TS_262] (rows=25 width=175)
-                                                        default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                            <-Map 21 [CONTAINS] vectorized, llap
-                                              Reduce Output Operator [RS_360]
-                                                PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_359] (rows=316 width=178)
-                                                  Output:["_col0","_col1"],keys:_col1, _col0
-                                                  Select Operator [SEL_358] (rows=500 width=178)
-                                                    Output:["_col0","_col1"]
-                                                    Filter Operator [FIL_357] (rows=500 width=178)
-                                                      predicate:value is not null
-                                                      TableScan [TS_273] (rows=500 width=178)
-                                                        default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                          <-Reducer 9 [SIMPLE_EDGE] llap
-                            SHUFFLE [RS_58]
-                              PartitionCols:_col3
-                              Merge Join Operator [MERGEJOIN_226] (rows=39 width=266)
-                                Conds:RS_322._col0=RS_325._col0(Inner),Output:["_col1","_col2","_col3"]
-                              <-Map 1 [SIMPLE_EDGE] vectorized, llap
-                                SHUFFLE [RS_322]
-                                  PartitionCols:_col0
-                                  Select Operator [SEL_320] (rows=500 width=178)
-                                    Output:["_col0","_col1"]
-                                    Filter Operator [FIL_319] (rows=500 width=178)
-                                      predicate:key is not null
-                                      TableScan [TS_0] (rows=500 width=178)
-                                        default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                              <-Map 15 [SIMPLE_EDGE] vectorized, llap
-                                SHUFFLE [RS_325]
-                                  PartitionCols:_col0
-                                  Select Operator [SEL_324] (rows=25 width=175)
-                                    Output:["_col0","_col1"]
-                                    Filter Operator [FIL_323] (rows=25 width=175)
-                                      predicate:(key is not null and value is not null)
-                                      TableScan [TS_29] (rows=25 width=175)
-                                        default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                   <-Reducer 3 [CONTAINS] llap
                     Reduce Output Operator [RS_235]
                       PartitionCols:_col0, _col1
@@ -781,132 +687,206 @@ Stage-0
                         Select Operator [SEL_232] (rows=40 width=177)
                           Output:["_col0","_col1"]
                           Merge Join Operator [MERGEJOIN_231] (rows=40 width=177)
-                            Conds:RS_22._col3=RS_329._col0(Inner),Output:["_col1","_col2"]
+                            Conds:RS_22._col3=RS_327._col0(Inner),Output:["_col1","_col2"]
                           <-Reducer 2 [SIMPLE_EDGE] llap
                             SHUFFLE [RS_22]
                               PartitionCols:_col3
                               Merge Join Operator [MERGEJOIN_225] (rows=39 width=266)
-                                Conds:RS_321._col0=RS_326._col0(Inner),Output:["_col1","_col2","_col3"]
+                                Conds:RS_321._col0=RS_324._col0(Inner),Output:["_col1","_col2","_col3"]
                               <-Map 1 [SIMPLE_EDGE] vectorized, llap
                                 SHUFFLE [RS_321]
                                   PartitionCols:_col0
-                                   Please refer to the previous Select Operator [SEL_320]
-                              <-Map 15 [SIMPLE_EDGE] vectorized, llap
-                                SHUFFLE [RS_326]
+                                  Select Operator [SEL_320] (rows=500 width=178)
+                                    Output:["_col0","_col1"]
+                                    Filter Operator [FIL_319] (rows=500 width=178)
+                                      predicate:key is not null
+                                      TableScan [TS_0] (rows=500 width=178)
+                                        default@src,y,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                              <-Map 10 [SIMPLE_EDGE] vectorized, llap
+                                SHUFFLE [RS_324]
                                   PartitionCols:_col0
-                                   Please refer to the previous Select Operator [SEL_324]
+                                  Select Operator [SEL_323] (rows=25 width=175)
+                                    Output:["_col0","_col1"]
+                                    Filter Operator [FIL_322] (rows=25 width=175)
+                                      predicate:(key is not null and value is not null)
+                                      TableScan [TS_3] (rows=25 width=175)
+                                        default@src1,x,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                           <-Reducer 13 [SIMPLE_EDGE] vectorized, llap
-                            SHUFFLE [RS_329]
+                            SHUFFLE [RS_327]
                               PartitionCols:_col0
-                              Select Operator [SEL_328] (rows=316 width=91)
+                              Select Operator [SEL_326] (rows=316 width=91)
                                 Output:["_col0"]
-                                Group By Operator [GBY_327] (rows=316 width=178)
+                                Group By Operator [GBY_325] (rows=316 width=178)
                                   Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
                                 <-Union 12 [SIMPLE_EDGE]
                                   <-Map 11 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_344]
+                                    Reduce Output Operator [RS_342]
                                       PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_343] (rows=316 width=178)
+                                      Group By Operator [GBY_341] (rows=316 width=178)
                                         Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_342] (rows=25 width=175)
+                                        Select Operator [SEL_340] (rows=25 width=175)
                                           Output:["_col0","_col1"]
-                                          Filter Operator [FIL_341] (rows=25 width=175)
+                                          Filter Operator [FIL_339] (rows=25 width=175)
                                             predicate:value is not null
                                             TableScan [TS_250] (rows=25 width=175)
                                               default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                                   <-Map 14 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_348]
+                                    Reduce Output Operator [RS_346]
                                       PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_347] (rows=316 width=178)
+                                      Group By Operator [GBY_345] (rows=316 width=178)
                                         Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_346] (rows=500 width=178)
+                                        Select Operator [SEL_344] (rows=500 width=178)
                                           Output:["_col0","_col1"]
-                                          Filter Operator [FIL_345] (rows=500 width=178)
+                                          Filter Operator [FIL_343] (rows=500 width=178)
                                             predicate:value is not null
                                             TableScan [TS_256] (rows=500 width=178)
                                               default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-          <-Reducer 8 [CONTAINS] llap
-            Reduce Output Operator [RS_244]
+                  <-Reducer 8 [CONTAINS] llap
+                    Reduce Output Operator [RS_244]
+                      PartitionCols:_col0, _col1
+                      Group By Operator [GBY_243] (rows=45 width=177)
+                        Output:["_col0","_col1"],keys:_col0, _col1
+                        Select Operator [SEL_241] (rows=51 width=177)
+                          Output:["_col0","_col1"]
+                          Merge Join Operator [MERGEJOIN_240] (rows=51 width=177)
+                            Conds:RS_58._col3=RS_335._col0(Inner),Output:["_col1","_col2"]
+                          <-Reducer 2 [SIMPLE_EDGE] llap
+                            SHUFFLE [RS_58]
+                              PartitionCols:_col3
+                               Please refer to the previous Merge Join Operator [MERGEJOIN_225]
+                          <-Reducer 19 [SIMPLE_EDGE] vectorized, llap
+                            SHUFFLE [RS_335]
+                              PartitionCols:_col0
+                              Select Operator [SEL_334] (rows=408 width=91)
+                                Output:["_col0"]
+                                Group By Operator [GBY_333] (rows=408 width=178)
+                                  Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                                <-Union 18 [SIMPLE_EDGE]
+                                  <-Map 21 [CONTAINS] vectorized, llap
+                                    Reduce Output Operator [RS_362]
+                                      PartitionCols:_col0, _col1
+                                      Group By Operator [GBY_361] (rows=408 width=178)
+                                        Output:["_col0","_col1"],keys:_col1, _col0
+                                        Select Operator [SEL_360] (rows=500 width=178)
+                                          Output:["_col0","_col1"]
+                                          Filter Operator [FIL_359] (rows=500 width=178)
+                                            predicate:value is not null
+                                            TableScan [TS_279] (rows=500 width=178)
+                                              default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                  <-Reducer 17 [CONTAINS] vectorized, llap
+                                    Reduce Output Operator [RS_354]
+                                      PartitionCols:_col0, _col1
+                                      Group By Operator [GBY_353] (rows=408 width=178)
+                                        Output:["_col0","_col1"],keys:_col1, _col0
+                                        Select Operator [SEL_352] (rows=316 width=178)
+                                          Output:["_col0","_col1"]
+                                          Group By Operator [GBY_351] (rows=316 width=178)
+                                            Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                                          <-Union 16 [SIMPLE_EDGE]
+                                            <-Map 15 [CONTAINS] vectorized, llap
+                                              Reduce Output Operator [RS_350]
+                                                PartitionCols:_col0, _col1
+                                                Group By Operator [GBY_349] (rows=316 width=178)
+                                                  Output:["_col0","_col1"],keys:_col1, _col0
+                                                  Select Operator [SEL_348] (rows=25 width=175)
+                                                    Output:["_col0","_col1"]
+                                                    Filter Operator [FIL_347] (rows=25 width=175)
+                                                      predicate:value is not null
+                                                      TableScan [TS_262] (rows=25 width=175)
+                                                        default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                                            <-Map 20 [CONTAINS] vectorized, llap
+                                              Reduce Output Operator [RS_358]
+                                                PartitionCols:_col0, _col1
+                                                Group By Operator [GBY_357] (rows=316 width=178)
+                                                  Output:["_col0","_col1"],keys:_col1, _col0
+                                                  Select Operator [SEL_356] (rows=500 width=178)
+                                                    Output:["_col0","_col1"]
+                                                    Filter Operator [FIL_355] (rows=500 width=178)
+                                                      predicate:value is not null
+                                                      TableScan [TS_273] (rows=500 width=178)
+                                                        default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+          <-Reducer 9 [CONTAINS] llap
+            Reduce Output Operator [RS_249]
               PartitionCols:_col0, _col1
-              Group By Operator [GBY_243] (rows=51 width=177)
+              Group By Operator [GBY_248] (rows=51 width=177)
                 Output:["_col0","_col1"],keys:_col0, _col1
-                Select Operator [SEL_241] (rows=57 width=177)
+                Select Operator [SEL_246] (rows=57 width=177)
                   Output:["_col0","_col1"]
-                  Merge Join Operator [MERGEJOIN_240] (rows=57 width=177)
-                    Conds:RS_111._col3=RS_337._col0(Inner),Output:["_col1","_col2"]
+                  Merge Join Operator [MERGEJOIN_245] (rows=57 width=177)
+                    Conds:RS_111._col3=RS_338._col0(Inner),Output:["_col1","_col2"]
                   <-Reducer 2 [SIMPLE_EDGE] llap
                     SHUFFLE [RS_111]
                       PartitionCols:_col3
                        Please refer to the previous Merge Join Operator [MERGEJOIN_225]
-                  <-Reducer 29 [SIMPLE_EDGE] vectorized, llap
-                    SHUFFLE [RS_337]
+                  <-Reducer 28 [SIMPLE_EDGE] vectorized, llap
+                    SHUFFLE [RS_338]
                       PartitionCols:_col0
-                      Select Operator [SEL_336] (rows=454 width=91)
+                      Select Operator [SEL_337] (rows=454 width=91)
                         Output:["_col0"]
-                        Group By Operator [GBY_335] (rows=454 width=178)
+                        Group By Operator [GBY_336] (rows=454 width=178)
                           Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                        <-Union 28 [SIMPLE_EDGE]
-                          <-Map 32 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_388]
+                        <-Union 27 [SIMPLE_EDGE]
+                          <-Map 31 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_386]
                               PartitionCols:_col0, _col1
-                              Group By Operator [GBY_387] (rows=454 width=178)
+                              Group By Operator [GBY_385] (rows=454 width=178)
                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_386] (rows=500 width=178)
+                                Select Operator [SEL_384] (rows=500 width=178)
                                   Output:["_col0","_col1"]
-                                  Filter Operator [FIL_385] (rows=500 width=178)
+                                  Filter Operator [FIL_383] (rows=500 width=178)
                                     predicate:value is not null
                                     TableScan [TS_313] (rows=500 width=178)
                                       default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                          <-Reducer 27 [CONTAINS] vectorized, llap
-                            Reduce Output Operator [RS_376]
+                          <-Reducer 26 [CONTAINS] vectorized, llap
+                            Reduce Output Operator [RS_374]
                               PartitionCols:_col0, _col1
-                              Group By Operator [GBY_375] (rows=454 width=178)
+                              Group By Operator [GBY_373] (rows=454 width=178)
                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                Select Operator [SEL_374] (rows=408 width=178)
+                                Select Operator [SEL_372] (rows=408 width=178)
                                   Output:["_col0","_col1"]
-                                  Group By Operator [GBY_373] (rows=408 width=178)
+                                  Group By Operator [GBY_371] (rows=408 width=178)
                                     Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                  <-Union 26 [SIMPLE_EDGE]
-                                    <-Map 31 [CONTAINS] vectorized, llap
-                                      Reduce Output Operator [RS_384]
+                                  <-Union 25 [SIMPLE_EDGE]
+                                    <-Map 30 [CONTAINS] vectorized, llap
+                                      Reduce Output Operator [RS_382]
                                         PartitionCols:_col0, _col1
-                                        Group By Operator [GBY_383] (rows=408 width=178)
+                                        Group By Operator [GBY_381] (rows=408 width=178)
                                           Output:["_col0","_col1"],keys:_col1, _col0
-                                          Select Operator [SEL_382] (rows=500 width=178)
+                                          Select Operator [SEL_380] (rows=500 width=178)
                                             Output:["_col0","_col1"]
-                                            Filter Operator [FIL_381] (rows=500 width=178)
+                                            Filter Operator [FIL_379] (rows=500 width=178)
                                               predicate:value is not null
                                               TableScan [TS_307] (rows=500 width=178)
                                                 default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                    <-Reducer 25 [CONTAINS] vectorized, llap
-                                      Reduce Output Operator [RS_372]
+                                    <-Reducer 24 [CONTAINS] vectorized, llap
+                                      Reduce Output Operator [RS_370]
                                         PartitionCols:_col0, _col1
-                                        Group By Operator [GBY_371] (rows=408 width=178)
+                                        Group By Operator [GBY_369] (rows=408 width=178)
                                           Output:["_col0","_col1"],keys:_col1, _col0
-                                          Select Operator [SEL_370] (rows=316 width=178)
+                                          Select Operator [SEL_368] (rows=316 width=178)
                                             Output:["_col0","_col1"]
-                                            Group By Operator [GBY_369] (rows=316 width=178)
+                                            Group By Operator [GBY_367] (rows=316 width=178)
                                               Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                            <-Union 24 [SIMPLE_EDGE]
-                                              <-Map 23 [CONTAINS] vectorized, llap
-                                                Reduce Output Operator [RS_368]
+                                            <-Union 23 [SIMPLE_EDGE]
+                                              <-Map 22 [CONTAINS] vectorized, llap
+                                                Reduce Output Operator [RS_366]
                                                   PartitionCols:_col0, _col1
-                                                  Group By Operator [GBY_367] (rows=316 width=178)
+                                                  Group By Operator [GBY_365] (rows=316 width=178)
                                                     Output:["_col0","_col1"],keys:_col1, _col0
-                                                    Select Operator [SEL_366] (rows=25 width=175)
+                                                    Select Operator [SEL_364] (rows=25 width=175)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_365] (rows=25 width=175)
+                                                      Filter Operator [FIL_363] (rows=25 width=175)
                                                         predicate:value is not null
                                                         TableScan [TS_285] (rows=25 width=175)
                                                           default@src1,src1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                                              <-Map 30 [CONTAINS] vectorized, llap
-                                                Reduce Output Operator [RS_380]
+                                              <-Map 29 [CONTAINS] vectorized, llap
+                                                Reduce Output Operator [RS_378]
                                                   PartitionCols:_col0, _col1
-                                                  Group By Operator [GBY_379] (rows=316 width=178)
+                                                  Group By Operator [GBY_377] (rows=316 width=178)
                                                     Output:["_col0","_col1"],keys:_col1, _col0
-                                                    Select Operator [SEL_378] (rows=500 width=178)
+                                                    Select Operator [SEL_376] (rows=500 width=178)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_377] (rows=500 width=178)
+                                                      Filter Operator [FIL_375] (rows=500 width=178)
                                                         predicate:value is not null
                                                         TableScan [TS_301] (rows=500 width=178)
                                                           default@src,src,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
@@ -1185,121 +1165,119 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
-Map 10 <- Union 11 (CONTAINS)
-Map 13 <- Union 11 (CONTAINS)
-Map 4 <- Union 5 (CONTAINS)
-Map 9 <- Union 5 (CONTAINS)
-Reducer 12 <- Map 1 (BROADCAST_EDGE), Union 11 (SIMPLE_EDGE), Union 7 (CONTAINS)
-Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 6 <- Reducer 2 (BROADCAST_EDGE), Union 5 (SIMPLE_EDGE), Union 7 (CONTAINS)
-Reducer 8 <- Union 7 (SIMPLE_EDGE)
+Map 1 <- Map 2 (BROADCAST_EDGE)
+Map 12 <- Union 10 (CONTAINS)
+Map 3 <- Union 4 (CONTAINS)
+Map 8 <- Union 4 (CONTAINS)
+Map 9 <- Union 10 (CONTAINS)
+Reducer 11 <- Map 1 (BROADCAST_EDGE), Union 10 (SIMPLE_EDGE), Union 6 (CONTAINS)
+Reducer 5 <- Map 1 (BROADCAST_EDGE), Union 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
+Reducer 7 <- Union 6 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
-      Reducer 8 vectorized, llap
-      File Output Operator [FS_192]
-        Group By Operator [GBY_191] (rows=605 width=10)
+      Reducer 7 vectorized, llap
+      File Output Operator [FS_188]
+        Group By Operator [GBY_187] (rows=605 width=10)
           Output:["_col0","_col1","_col2"],keys:KEY._col0, KEY._col1, KEY._col2
-        <-Union 7 [SIMPLE_EDGE]
-          <-Reducer 12 [CONTAINS] vectorized, llap
-            Reduce Output Operator [RS_206]
+        <-Union 6 [SIMPLE_EDGE]
+          <-Reducer 11 [CONTAINS] vectorized, llap
+            Reduce Output Operator [RS_202]
               PartitionCols:_col0, _col1, _col2
-              Group By Operator [GBY_205] (rows=1210 width=10)
+              Group By Operator [GBY_201] (rows=1210 width=10)
                 Output:["_col0","_col1","_col2"],keys:_col0, _col1, _col2
-                Select Operator [SEL_204] (rows=605 width=10)
+                Select Operator [SEL_200] (rows=605 width=10)
                   Output:["_col0","_col1","_col2"]
-                  Map Join Operator [MAPJOIN_203] (rows=605 width=10)
-                    Conds:RS_182._col3=SEL_202._col0(Inner),Output:["_col1","_col2","_col4"]
+                  Map Join Operator [MAPJOIN_199] (rows=605 width=10)
+                    Conds:RS_180._col3=SEL_198._col0(Inner),Output:["_col1","_col2","_col4"]
                   <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                    SHUFFLE [RS_182]
+                    BROADCAST [RS_180]
                       PartitionCols:_col3
-                      Map Join Operator [MAPJOIN_180] (rows=550 width=10)
-                        Conds:SEL_179._col0=RS_177._col0(Inner),Output:["_col1","_col2","_col3"]
-                      <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                        BROADCAST [RS_177]
+                      Map Join Operator [MAPJOIN_178] (rows=550 width=10)
+                        Conds:SEL_177._col0=RS_175._col0(Inner),Output:["_col1","_col2","_col3"]
+                      <-Map 2 [BROADCAST_EDGE] vectorized, llap
+                        BROADCAST [RS_175]
                           PartitionCols:_col0
-                          Select Operator [SEL_176] (rows=25 width=7)
+                          Select Operator [SEL_174] (rows=25 width=7)
                             Output:["_col0","_col1"]
-                            Filter Operator [FIL_175] (rows=25 width=7)
+                            Filter Operator [FIL_173] (rows=25 width=7)
                               predicate:(key is not null and value is not null)
                               TableScan [TS_3] (rows=25 width=7)
                                 default@src1,x,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                      <-Select Operator [SEL_179] (rows=500 width=10)
+                      <-Select Operator [SEL_177] (rows=500 width=10)
                           Output:["_col0","_col1"]
-                          Filter Operator [FIL_178] (rows=500 width=10)
+                          Filter Operator [FIL_176] (rows=500 width=10)
                             predicate:key is not null
                             TableScan [TS_0] (rows=500 width=10)
                               default@src,y,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                  <-Select Operator [SEL_202] (rows=262 width=10)
+                  <-Select Operator [SEL_198] (rows=262 width=10)
                       Output:["_col0"]
-                      Group By Operator [GBY_201] (rows=262 width=10)
+                      Group By Operator [GBY_197] (rows=262 width=10)
                         Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                      <-Union 11 [SIMPLE_EDGE]
-                        <-Map 10 [CONTAINS] vectorized, llap
-                          Reduce Output Operator [RS_200]
+                      <-Union 10 [SIMPLE_EDGE]
+                        <-Map 12 [CONTAINS] vectorized, llap
+                          Reduce Output Operator [RS_206]
                             PartitionCols:_col0, _col1
-                            Group By Operator [GBY_199] (rows=525 width=10)
+                            Group By Operator [GBY_205] (rows=525 width=10)
                               Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_198] (rows=25 width=7)
+                              Select Operator [SEL_204] (rows=500 width=10)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_197] (rows=25 width=7)
+                                Filter Operator [FIL_203] (rows=500 width=10)
                                   predicate:value is not null
-                                  TableScan [TS_151] (rows=25 width=7)
-                                    default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                        <-Map 13 [CONTAINS] vectorized, llap
-                          Reduce Output Operator [RS_210]
-                            PartitionCols:_col0, _col1
-                            Group By Operator [GBY_209] (rows=525 width=10)
-                              Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_208] (rows=500 width=10)
-                                Output:["_col0","_col1"]
-                                Filter Operator [FIL_207] (rows=500 width=10)
-                                  predicate:value is not null
-                                  TableScan [TS_165] (rows=500 width=10)
+                                  TableScan [TS_163] (rows=500 width=10)
                                     default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-          <-Reducer 6 [CONTAINS] vectorized, llap
-            Reduce Output Operator [RS_190]
-              PartitionCols:_col0, _col1, _col2
-              Group By Operator [GBY_189] (rows=1210 width=10)
-                Output:["_col0","_col1","_col2"],keys:_col0, _col1, _col2
-                Select Operator [SEL_188] (rows=605 width=10)
-                  Output:["_col0","_col1","_col2"]
-                  Map Join Operator [MAPJOIN_187] (rows=605 width=10)
-                    Conds:RS_184._col3=SEL_186._col0(Inner),Output:["_col1","_col2","_col4"]
-                  <-Reducer 2 [BROADCAST_EDGE] vectorized, llap
-                    BROADCAST [RS_184]
-                      PartitionCols:_col3
-                      Select Operator [SEL_183]
-                        Output:["_col3","_col1","_col2"]
-                  <-Select Operator [SEL_186] (rows=262 width=10)
-                      Output:["_col0"]
-                      Group By Operator [GBY_185] (rows=262 width=10)
-                        Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                      <-Union 5 [SIMPLE_EDGE]
-                        <-Map 4 [CONTAINS] vectorized, llap
-                          Reduce Output Operator [RS_174]
-                            PartitionCols:_col0, _col1
-                            Group By Operator [GBY_173] (rows=525 width=10)
-                              Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_172] (rows=25 width=7)
-                                Output:["_col0","_col1"]
-                                Filter Operator [FIL_171] (rows=25 width=7)
-                                  predicate:value is not null
-                                  TableScan [TS_131] (rows=25 width=7)
-                                    default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
                         <-Map 9 [CONTAINS] vectorized, llap
                           Reduce Output Operator [RS_196]
                             PartitionCols:_col0, _col1
                             Group By Operator [GBY_195] (rows=525 width=10)
                               Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_194] (rows=500 width=10)
+                              Select Operator [SEL_194] (rows=25 width=7)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_193] (rows=500 width=10)
+                                Filter Operator [FIL_193] (rows=25 width=7)
                                   predicate:value is not null
-                                  TableScan [TS_145] (rows=500 width=10)
+                                  TableScan [TS_149] (rows=25 width=7)
+                                    default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
+          <-Reducer 5 [CONTAINS] vectorized, llap
+            Reduce Output Operator [RS_186]
+              PartitionCols:_col0, _col1, _col2
+              Group By Operator [GBY_185] (rows=1210 width=10)
+                Output:["_col0","_col1","_col2"],keys:_col0, _col1, _col2
+                Select Operator [SEL_184] (rows=605 width=10)
+                  Output:["_col0","_col1","_col2"]
+                  Map Join Operator [MAPJOIN_183] (rows=605 width=10)
+                    Conds:RS_179._col3=SEL_182._col0(Inner),Output:["_col1","_col2","_col4"]
+                  <-Map 1 [BROADCAST_EDGE] vectorized, llap
+                    BROADCAST [RS_179]
+                      PartitionCols:_col3
+                       Please refer to the previous Map Join Operator [MAPJOIN_178]
+                  <-Select Operator [SEL_182] (rows=262 width=10)
+                      Output:["_col0"]
+                      Group By Operator [GBY_181] (rows=262 width=10)
+                        Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
+                      <-Union 4 [SIMPLE_EDGE]
+                        <-Map 3 [CONTAINS] vectorized, llap
+                          Reduce Output Operator [RS_172]
+                            PartitionCols:_col0, _col1
+                            Group By Operator [GBY_171] (rows=525 width=10)
+                              Output:["_col0","_col1"],keys:_col1, _col0
+                              Select Operator [SEL_170] (rows=25 width=7)
+                                Output:["_col0","_col1"]
+                                Filter Operator [FIL_169] (rows=25 width=7)
+                                  predicate:value is not null
+                                  TableScan [TS_129] (rows=25 width=7)
+                                    default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
+                        <-Map 8 [CONTAINS] vectorized, llap
+                          Reduce Output Operator [RS_192]
+                            PartitionCols:_col0, _col1
+                            Group By Operator [GBY_191] (rows=525 width=10)
+                              Output:["_col0","_col1"],keys:_col1, _col0
+                              Select Operator [SEL_190] (rows=500 width=10)
+                                Output:["_col0","_col1"]
+                                Filter Operator [FIL_189] (rows=500 width=10)
+                                  predicate:value is not null
+                                  TableScan [TS_143] (rows=500 width=10)
                                     default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
 
 PREHOOK: query: explain
@@ -1337,242 +1315,240 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Map 3 (BROADCAST_EDGE)
-Map 11 <- Union 5 (CONTAINS)
-Map 12 <- Union 13 (CONTAINS)
-Map 17 <- Union 13 (CONTAINS)
-Map 18 <- Union 15 (CONTAINS)
-Map 19 <- Union 20 (CONTAINS)
-Map 26 <- Union 20 (CONTAINS)
-Map 27 <- Union 22 (CONTAINS)
-Map 28 <- Union 24 (CONTAINS)
-Map 4 <- Union 5 (CONTAINS)
-Reducer 10 <- Union 9 (SIMPLE_EDGE)
-Reducer 14 <- Union 13 (SIMPLE_EDGE), Union 15 (CONTAINS)
-Reducer 16 <- Map 1 (BROADCAST_EDGE), Union 15 (SIMPLE_EDGE), Union 7 (CONTAINS)
-Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 21 <- Union 20 (SIMPLE_EDGE), Union 22 (CONTAINS)
-Reducer 23 <- Union 22 (SIMPLE_EDGE), Union 24 (CONTAINS)
-Reducer 25 <- Map 1 (BROADCAST_EDGE), Union 24 (SIMPLE_EDGE), Union 9 (CONTAINS)
-Reducer 6 <- Reducer 2 (BROADCAST_EDGE), Union 5 (SIMPLE_EDGE), Union 7 (CONTAINS)
-Reducer 8 <- Union 7 (SIMPLE_EDGE), Union 9 (CONTAINS)
+Map 1 <- Map 2 (BROADCAST_EDGE)
+Map 10 <- Union 4 (CONTAINS)
+Map 11 <- Union 12 (CONTAINS)
+Map 16 <- Union 12 (CONTAINS)
+Map 17 <- Union 14 (CONTAINS)
+Map 18 <- Union 19 (CONTAINS)
+Map 25 <- Union 19 (CONTAINS)
+Map 26 <- Union 21 (CONTAINS)
+Map 27 <- Union 23 (CONTAINS)
+Map 3 <- Union 4 (CONTAINS)
+Reducer 13 <- Union 12 (SIMPLE_EDGE), Union 14 (CONTAINS)
+Reducer 15 <- Map 1 (BROADCAST_EDGE), Union 14 (SIMPLE_EDGE), Union 6 (CONTAINS)
+Reducer 20 <- Union 19 (SIMPLE_EDGE), Union 21 (CONTAINS)
+Reducer 22 <- Union 21 (SIMPLE_EDGE), Union 23 (CONTAINS)
+Reducer 24 <- Map 1 (BROADCAST_EDGE), Union 23 (SIMPLE_EDGE), Union 8 (CONTAINS)
+Reducer 5 <- Map 1 (BROADCAST_EDGE), Union 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
+Reducer 7 <- Union 6 (SIMPLE_EDGE), Union 8 (CONTAINS)
+Reducer 9 <- Union 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
-      Reducer 10 vectorized, llap
-      File Output Operator [FS_359]
-        Group By Operator [GBY_358] (rows=605 width=10)
+      Reducer 9 vectorized, llap
+      File Output Operator [FS_355]
+        Group By Operator [GBY_354] (rows=605 width=10)
           Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-        <-Union 9 [SIMPLE_EDGE]
-          <-Reducer 25 [CONTAINS] vectorized, llap
-            Reduce Output Operator [RS_403]
+        <-Union 8 [SIMPLE_EDGE]
+          <-Reducer 24 [CONTAINS] vectorized, llap
+            Reduce Output Operator [RS_399]
               PartitionCols:_col0, _col1
-              Group By Operator [GBY_402] (rows=1210 width=10)
+              Group By Operator [GBY_398] (rows=1210 width=10)
                 Output:["_col0","_col1"],keys:_col0, _col1
-                Select Operator [SEL_401] (rows=605 width=10)
+                Select Operator [SEL_397] (rows=605 width=10)
                   Output:["_col0","_col1"]
-                  Map Join Operator [MAPJOIN_400] (rows=605 width=10)
-                    Conds:RS_346._col3=SEL_399._col0(Inner),Output:["_col1","_col2"]
+                  Map Join Operator [MAPJOIN_396] (rows=605 width=10)
+                    Conds:RS_344._col3=SEL_395._col0(Inner),Output:["_col1","_col2"]
                   <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                    BROADCAST [RS_346]
+                    BROADCAST [RS_344]
                       PartitionCols:_col3
-                      Map Join Operator [MAPJOIN_343] (rows=550 width=10)
-                        Conds:SEL_342._col0=RS_340._col0(Inner),Output:["_col1","_col2","_col3"]
-                      <-Map 3 [BROADCAST_EDGE] vectorized, llap
-                        BROADCAST [RS_340]
+                      Map Join Operator [MAPJOIN_341] (rows=550 width=10)
+                        Conds:SEL_340._col0=RS_338._col0(Inner),Output:["_col1","_col2","_col3"]
+                      <-Map 2 [BROADCAST_EDGE] vectorized, llap
+                        BROADCAST [RS_338]
                           PartitionCols:_col0
-                          Select Operator [SEL_339] (rows=25 width=7)
+                          Select Operator [SEL_337] (rows=25 width=7)
                             Output:["_col0","_col1"]
-                            Filter Operator [FIL_338] (rows=25 width=7)
+                            Filter Operator [FIL_336] (rows=25 width=7)
                               predicate:(key is not null and value is not null)
                               TableScan [TS_3] (rows=25 width=7)
                                 default@src1,x,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                      <-Select Operator [SEL_342] (rows=500 width=10)
+                      <-Select Operator [SEL_340] (rows=500 width=10)
                           Output:["_col0","_col1"]
-                          Filter Operator [FIL_341] (rows=500 width=10)
+                          Filter Operator [FIL_339] (rows=500 width=10)
                             predicate:key is not null
                             TableScan [TS_0] (rows=500 width=10)
                               default@src,y,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                  <-Select Operator [SEL_399] (rows=440 width=10)
+                  <-Select Operator [SEL_395] (rows=440 width=10)
                       Output:["_col0"]
-                      Group By Operator [GBY_398] (rows=440 width=10)
+                      Group By Operator [GBY_394] (rows=440 width=10)
                         Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                      <-Union 24 [SIMPLE_EDGE]
-                        <-Map 28 [CONTAINS] vectorized, llap
-                          Reduce Output Operator [RS_415]
+                      <-Union 23 [SIMPLE_EDGE]
+                        <-Map 27 [CONTAINS] vectorized, llap
+                          Reduce Output Operator [RS_411]
                             PartitionCols:_col0, _col1
-                            Group By Operator [GBY_414] (rows=881 width=10)
+                            Group By Operator [GBY_410] (rows=881 width=10)
                               Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_413] (rows=500 width=10)
+                              Select Operator [SEL_409] (rows=500 width=10)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_412] (rows=500 width=10)
+                                Filter Operator [FIL_408] (rows=500 width=10)
                                   predicate:value is not null
-                                  TableScan [TS_328] (rows=500 width=10)
+                                  TableScan [TS_326] (rows=500 width=10)
                                     default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                        <-Reducer 23 [CONTAINS] vectorized, llap
-                          Reduce Output Operator [RS_397]
+                        <-Reducer 22 [CONTAINS] vectorized, llap
+                          Reduce Output Operator [RS_393]
                             PartitionCols:_col0, _col1
-                            Group By Operator [GBY_396] (rows=881 width=10)
+                            Group By Operator [GBY_392] (rows=881 width=10)
                               Output:["_col0","_col1"],keys:_col1, _col0
-                              Select Operator [SEL_395] (rows=381 width=10)
+                              Select Operator [SEL_391] (rows=381 width=10)
                                 Output:["_col0","_col1"]
-                                Group By Operator [GBY_394] (rows=381 width=10)
+                                Group By Operator [GBY_390] (rows=381 width=10)
                                   Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                <-Union 22 [SIMPLE_EDGE]
-                                  <-Map 27 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_411]
+                                <-Union 21 [SIMPLE_EDGE]
+                                  <-Map 26 [CONTAINS] vectorized, llap
+                                    Reduce Output Operator [RS_407]
                                       PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_410] (rows=762 width=10)
+                                      Group By Operator [GBY_406] (rows=762 width=10)
                                         Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_409] (rows=500 width=10)
+                                        Select Operator [SEL_405] (rows=500 width=10)
                                           Output:["_col0","_col1"]
-                                          Filter Operator [FIL_408] (rows=500 width=10)
+                                          Filter Operator [FIL_404] (rows=500 width=10)
                                             predicate:value is not null
-                                            TableScan [TS_322] (rows=500 width=10)
+                                            TableScan [TS_320] (rows=500 width=10)
                                               default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                                  <-Reducer 21 [CONTAINS] vectorized, llap
-                                    Reduce Output Operator [RS_393]
+                                  <-Reducer 20 [CONTAINS] vectorized, llap
+                                    Reduce Output Operator [RS_389]
                                       PartitionCols:_col0, _col1
-                                      Group By Operator [GBY_392] (rows=762 width=10)
+                                      Group By Operator [GBY_388] (rows=762 width=10)
                                         Output:["_col0","_col1"],keys:_col1, _col0
-                                        Select Operator [SEL_391] (rows=262 width=10)
+                                        Select Operator [SEL_387] (rows=262 width=10)
                                           Output:["_col0","_col1"]
-                                          Group By Operator [GBY_390] (rows=262 width=10)
+                                          Group By Operator [GBY_386] (rows=262 width=10)
                                             Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                          <-Union 20 [SIMPLE_EDGE]
-                                            <-Map 19 [CONTAINS] vectorized, llap
-                                              Reduce Output Operator [RS_389]
+                                          <-Union 19 [SIMPLE_EDGE]
+                                            <-Map 18 [CONTAINS] vectorized, llap
+                                              Reduce Output Operator [RS_385]
                                                 PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_388] (rows=525 width=10)
+                                                Group By Operator [GBY_384] (rows=525 width=10)
                                                   Output:["_col0","_col1"],keys:_col1, _col0
-                                                  Select Operator [SEL_387] (rows=25 width=7)
+                                                  Select Operator [SEL_383] (rows=25 width=7)
                                                     Output:["_col0","_col1"]
-                                                    Filter Operator [FIL_386] (rows=25 width=7)
+                                                    Filter Operator [FIL_382] (rows=25 width=7)
                                                       predicate:value is not null
-                                                      TableScan [TS_292] (rows=25 width=7)
+                                                      TableScan [TS_290] (rows=25 width=7)
                                                         default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                                            <-Map 26 [CONTAINS] vectorized, llap
-                                              Reduce Output Operator [RS_407]
+                                            <-Map 25 [CONTAINS] vectorized, llap
+                                              Reduce Output Operator [RS_403]
                                                 PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_406] (rows=525 width=10)
+                                                Group By Operator [GBY_402] (rows=525 width=10)
                                                   Output:["_col0","_col1"],keys:_col1, _col0
-                                                  Select Operator [SEL_405] (rows=500 width=10)
+                                                  Select Operator [SEL_401] (rows=500 width=10)
                                                     Output:["_col0","_col1"]
-                                                    Filter Operator [FIL_404] (rows=500 width=10)
+                                                    Filter Operator [FIL_400] (rows=500 width=10)
                                                       predicate:value is not null
-                                                      TableScan [TS_316] (rows=500 width=10)
+                                                      TableScan [TS_314] (rows=500 width=10)
                                                         default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-          <-Reducer 8 [CONTAINS] vectorized, llap
-            Reduce Output Operator [RS_357]
+          <-Reducer 7 [CONTAINS] vectorized, llap
+            Reduce Output Operator [RS_353]
               PartitionCols:_col0, _col1
-              Group By Operator [GBY_356] (rows=1210 width=10)
+              Group By Operator [GBY_352] (rows=1210 width=10)
                 Output:["_col0","_col1"],keys:_col0, _col1
-                Group By Operator [GBY_355] (rows=605 width=10)
+                Group By Operator [GBY_351] (rows=605 width=10)
                   Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                <-Union 7 [SIMPLE_EDGE]
-                  <-Reducer 16 [CONTAINS] vectorized, llap
-                    Reduce Output Operator [RS_377]
+                <-Union 6 [SIMPLE_EDGE]
+                  <-Reducer 15 [CONTAINS] vectorized, llap
+                    Reduce Output Operator [RS_373]
                       PartitionCols:_col0, _col1
-                      Group By Operator [GBY_376] (rows=1210 width=10)
+                      Group By Operator [GBY_372] (rows=1210 width=10)
                         Output:["_col0","_col1"],keys:_col0, _col1
-                        Select Operator [SEL_375] (rows=605 width=10)
+                        Select Operator [SEL_371] (rows=605 width=10)
                           Output:["_col0","_col1"]
-                          Map Join Operator [MAPJOIN_374] (rows=605 width=10)
-                            Conds:RS_345._col3=SEL_373._col0(Inner),Output:["_col1","_col2"]
+                          Map Join Operator [MAPJOIN_370] (rows=605 width=10)
+                            Conds:RS_343._col3=SEL_369._col0(Inner),Output:["_col1","_col2"]
                           <-Map 1 [BROADCAST_EDGE] vectorized, llap
-                            BROADCAST [RS_345]
+                            BROADCAST [RS_343]
                               PartitionCols:_col3
-                               Please refer to the previous Map Join Operator [MAPJOIN_343]
-                          <-Select Operator [SEL_373] (rows=381 width=10)
+                               Please refer to the previous Map Join Operator [MAPJOIN_341]
+                          <-Select Operator [SEL_369] (rows=381 width=10)
                               Output:["_col0"]
-                              Group By Operator [GBY_372] (rows=381 width=10)
+                              Group By Operator [GBY_368] (rows=381 width=10)
                                 Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                              <-Union 15 [SIMPLE_EDGE]
-                                <-Map 18 [CONTAINS] vectorized, llap
-                                  Reduce Output Operator [RS_385]
+                              <-Union 14 [SIMPLE_EDGE]
+                                <-Map 17 [CONTAINS] vectorized, llap
+                                  Reduce Output Operator [RS_381]
                                     PartitionCols:_col0, _col1
-                                    Group By Operator [GBY_384] (rows=762 width=10)
+                                    Group By Operator [GBY_380] (rows=762 width=10)
                                       Output:["_col0","_col1"],keys:_col1, _col0
-                                      Select Operator [SEL_383] (rows=500 width=10)
+                                      Select Operator [SEL_379] (rows=500 width=10)
                                         Output:["_col0","_col1"]
-                                        Filter Operator [FIL_382] (rows=500 width=10)
+                                        Filter Operator [FIL_378] (rows=500 width=10)
                                           predicate:value is not null
-                                          TableScan [TS_286] (rows=500 width=10)
+                                          TableScan [TS_284] (rows=500 width=10)
                                             default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                                <-Reducer 14 [CONTAINS] vectorized, llap
-                                  Reduce Output Operator [RS_371]
+                                <-Reducer 13 [CONTAINS] vectorized, llap
+                                  Reduce Output Operator [RS_367]
                                     PartitionCols:_col0, _col1
-                                    Group By Operator [GBY_370] (rows=762 width=10)
+                                    Group By Operator [GBY_366] (rows=762 width=10)
                                       Output:["_col0","_col1"],keys:_col1, _col0
-                                      Select Operator [SEL_369] (rows=262 width=10)
+                                      Select Operator [SEL_365] (rows=262 width=10)
                                         Output:["_col0","_col1"]
-                                        Group By Operator [GBY_368] (rows=262 width=10)
+                                        Group By Operator [GBY_364] (rows=262 width=10)
                                           Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                        <-Union 13 [SIMPLE_EDGE]
-                                          <-Map 12 [CONTAINS] vectorized, llap
-                                            Reduce Output Operator [RS_367]
+                                        <-Union 12 [SIMPLE_EDGE]
+                                          <-Map 11 [CONTAINS] vectorized, llap
+                                            Reduce Output Operator [RS_363]
                                               PartitionCols:_col0, _col1
-                                              Group By Operator [GBY_366] (rows=525 width=10)
+                                              Group By Operator [GBY_362] (rows=525 width=10)
                                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                                Select Operator [SEL_365] (rows=25 width=7)
+                                                Select Operator [SEL_361] (rows=25 width=7)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_364] (rows=25 width=7)
+                                                  Filter Operator [FIL_360] (rows=25 width=7)
                                                     predicate:value is not null
-                                                    TableScan [TS_261] (rows=25 width=7)
+                                                    TableScan [TS_259] (rows=25 width=7)
                                                       default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                                          <-Map 17 [CONTAINS] vectorized, llap
-                                            Reduce Output Operator [RS_381]
+                                          <-Map 16 [CONTAINS] vectorized, llap
+                                            Reduce Output Operator [RS_377]
                                               PartitionCols:_col0, _col1
-                                              Group By Operator [GBY_380] (rows=525 width=10)
+                                              Group By Operator [GBY_376] (rows=525 width=10)
                                                 Output:["_col0","_col1"],keys:_col1, _col0
-                                                Select Operator [SEL_379] (rows=500 width=10)
+                                                Select Operator [SEL_375] (rows=500 width=10)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_378] (rows=500 width=10)
+                                                  Filter Operator [FIL_374] (rows=500 width=10)
                                                     predicate:value is not null
-                                                    TableScan [TS_280] (rows=500 width=10)
+                                                    TableScan [TS_278] (rows=500 width=10)
                                                       default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                  <-Reducer 6 [CONTAINS] vectorized, llap
-                    Reduce Output Operator [RS_354]
+                  <-Reducer 5 [CONTAINS] vectorized, llap
+                    Reduce Output Operator [RS_350]
                       PartitionCols:_col0, _col1
-                      Group By Operator [GBY_353] (rows=1210 width=10)
+                      Group By Operator [GBY_349] (rows=1210 width=10)
                         Output:["_col0","_col1"],keys:_col0, _col1
-                        Select Operator [SEL_352] (rows=605 width=10)
+                        Select Operator [SEL_348] (rows=605 width=10)
                           Output:["_col0","_col1"]
-                          Map Join Operator [MAPJOIN_351] (rows=605 width=10)
-                            Conds:RS_348._col3=SEL_350._col0(Inner),Output:["_col1","_col2"]
-                          <-Reducer 2 [BROADCAST_EDGE] vectorized, llap
-                            BROADCAST [RS_348]
+                          Map Join Operator [MAPJOIN_347] (rows=605 width=10)
+                            Conds:RS_342._col3=SEL_346._col0(Inner),Output:["_col1","_col2"]
+                          <-Map 1 [BROADCAST_EDGE] vectorized, llap
+                            BROADCAST [RS_342]
                               PartitionCols:_col3
-                              Select Operator [SEL_347]
-                                Output:["_col3","_col1","_col2"]
-                          <-Select Operator [SEL_350] (rows=262 width=10)
+                               Please refer to the previous Map Join Operator [MAPJOIN_341]
+                          <-Select Operator [SEL_346] (rows=262 width=10)
                               Output:["_col0"]
-                              Group By Operator [GBY_349] (rows=262 width=10)
+                              Group By Operator [GBY_345] (rows=262 width=10)
                                 Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                              <-Union 5 [SIMPLE_EDGE]
-                                <-Map 11 [CONTAINS] vectorized, llap
-                                  Reduce Output Operator [RS_363]
+                              <-Union 4 [SIMPLE_EDGE]
+                                <-Map 10 [CONTAINS] vectorized, llap
+                                  Reduce Output Operator [RS_359]
                                     PartitionCols:_col0, _col1
-                                    Group By Operator [GBY_362] (rows=525 width=10)
+                                    Group By Operator [GBY_358] (rows=525 width=10)
                                       Output:["_col0","_col1"],keys:_col1, _col0
-                                      Select Operator [SEL_361] (rows=500 width=10)
+                                      Select Operator [SEL_357] (rows=500 width=10)
                                         Output:["_col0","_col1"]
-                                        Filter Operator [FIL_360] (rows=500 width=10)
+                                        Filter Operator [FIL_356] (rows=500 width=10)
                                           predicate:value is not null
-                                          TableScan [TS_255] (rows=500 width=10)
+                                          TableScan [TS_253] (rows=500 width=10)
                                             default@src,src,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
-                                <-Map 4 [CONTAINS] vectorized, llap
-                                  Reduce Output Operator [RS_337]
+                                <-Map 3 [CONTAINS] vectorized, llap
+                                  Reduce Output Operator [RS_335]
                                     PartitionCols:_col0, _col1
-                                    Group By Operator [GBY_336] (rows=525 width=10)
+                                    Group By Operator [GBY_334] (rows=525 width=10)
                                       Output:["_col0","_col1"],keys:_col1, _col0
-                                      Select Operator [SEL_335] (rows=25 width=7)
+                                      Select Operator [SEL_333] (rows=25 width=7)
                                         Output:["_col0","_col1"]
-                                        Filter Operator [FIL_334] (rows=25 width=7)
+                                        Filter Operator [FIL_332] (rows=25 width=7)
                                           predicate:value is not null
-                                          TableScan [TS_237] (rows=25 width=7)
+                                          TableScan [TS_235] (rows=25 width=7)
                                             default@src1,src1,Tbl:COMPLETE,Col:NONE,Output:["key","value"]
 
 PREHOOK: query: CREATE TABLE srcbucket_mapjoin_n22(key int, value string) partitioned by (ds string) CLUSTERED BY (key) INTO 2 BUCKETS STORED AS TEXTFILE

--- a/ql/src/test/results/clientpositive/llap/filter_union.q.out
+++ b/ql/src/test/results/clientpositive/llap/filter_union.q.out
@@ -45,7 +45,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -76,62 +76,6 @@ STAGE PLANS:
                         tag: -1
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: src
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    bucket_count -1
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types string:string
-#### A masked pattern was here ####
-                    name default.src
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 'default','default'
-                      columns.types string:string
-#### A masked pattern was here ####
-                      name default.src
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.src
-                  name: default.src
-            Truncated Path -> Alias:
-              /src [src]
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count(key)
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         bucketingVersion: 2
                         key expressions: _col0 (type: string)
@@ -220,7 +164,7 @@ STAGE PLANS:
                     TotalFiles: 1
                     GatherStats: false
                     MultiFileSpray: false
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
@@ -983,11 +983,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Map 6 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Map 3 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 9 <- Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1016,13 +1017,45 @@ STAGE PLANS:
                       Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 2 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: z
-                  filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_106_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
-                  Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: (value is not null or key is not null) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: value is not null (type: boolean)
+                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 value (type: string)
+                        1 value (type: string)
+                      outputColumnNames: _col1
+                      input vertices:
+                        0 Reducer 2
+                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col1 (type: string)
+                          1 value (type: string)
+                        input vertices:
+                          1 Map 8
+                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          aggregations: count()
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1043,50 +1076,8 @@ STAGE PLANS:
                           0 _col0 (type: string)
                           1 key (type: string)
                         input vertices:
-                          1 Map 8
+                          1 Reducer 9
                         Statistics: Num rows: 250 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                        Group By Operator
-                          aggregations: count()
-                          minReductionHashAggr: 0.99
-                          mode: hash
-                          outputColumnNames: _col0
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            null sort order: 
-                            sort order: 
-                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: value is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_108_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.5276872964169381
-                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Map Join Operator
-                      condition map:
-                           Inner Join 0 to 1
-                      keys:
-                        0 value (type: string)
-                        1 value (type: string)
-                      outputColumnNames: _col1
-                      input vertices:
-                        0 Map 1
-                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col1 (type: string)
-                          1 value (type: string)
-                        input vertices:
-                          1 Map 8
-                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
                           minReductionHashAggr: 0.99
@@ -1126,7 +1117,19 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 3 
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: value
+                Reduce Output Operator
+                  key expressions: value (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: value (type: string)
+                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1146,7 +1149,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1181,8 +1184,20 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: key
+                Reduce Output Operator
+                  key expressions: key (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: key (type: string)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator
@@ -1267,11 +1282,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Map 6 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Map 3 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 9 <- Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1300,13 +1316,45 @@ STAGE PLANS:
                       Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 2 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: z
-                  filterExpr: key is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_106_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
-                  Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: (value is not null or key is not null) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: value is not null (type: boolean)
+                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 value (type: string)
+                        1 value (type: string)
+                      outputColumnNames: _col1
+                      input vertices:
+                        0 Reducer 2
+                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col1 (type: string)
+                          1 value (type: string)
+                        input vertices:
+                          1 Map 8
+                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          aggregations: count()
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1327,50 +1375,8 @@ STAGE PLANS:
                           0 _col0 (type: string)
                           1 key (type: string)
                         input vertices:
-                          1 Map 8
+                          1 Reducer 9
                         Statistics: Num rows: 250 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                        Group By Operator
-                          aggregations: count()
-                          minReductionHashAggr: 0.99
-                          mode: hash
-                          outputColumnNames: _col0
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            null sort order: 
-                            sort order: 
-                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: value is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_108_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.5276872964169381
-                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Map Join Operator
-                      condition map:
-                           Inner Join 0 to 1
-                      keys:
-                        0 value (type: string)
-                        1 value (type: string)
-                      outputColumnNames: _col1
-                      input vertices:
-                        0 Map 1
-                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col1 (type: string)
-                          1 value (type: string)
-                        input vertices:
-                          1 Map 8
-                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
                           minReductionHashAggr: 0.99
@@ -1410,7 +1416,19 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 3 
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: value
+                Reduce Output Operator
+                  key expressions: value (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: value (type: string)
+                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1430,7 +1448,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1465,8 +1483,20 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: key
+                Reduce Output Operator
+                  key expressions: key (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: key (type: string)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/intersect_all.q.out
+++ b/ql/src/test/results/clientpositive/llap/intersect_all.q.out
@@ -156,7 +156,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -182,24 +182,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -262,7 +244,7 @@ STAGE PLANS:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -819,11 +801,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -849,24 +831,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -876,79 +854,6 @@ STAGE PLANS:
                         value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string), _col1 (type: string)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string), _col1 (type: string)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: string), KEY._col1 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: min(_col2), count(_col2)
-                  keys: _col0 (type: string), _col1 (type: string)
-                  minReductionHashAggr: 0.4
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 632 Data size: 122608 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string), _col1 (type: string)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                    Statistics: Num rows: 632 Data size: 122608 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint), _col3 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1002,6 +907,29 @@ STAGE PLANS:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: min(_col2), count(_col2)
+                  keys: _col0 (type: string), _col1 (type: string)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 632 Data size: 122608 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col1 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                    Statistics: Num rows: 632 Data size: 122608 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint), _col3 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1025,7 +953,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 632 Data size: 122608 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/intersect_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/intersect_distinct.q.out
@@ -154,7 +154,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -180,24 +180,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -253,7 +235,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -619,11 +601,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -649,24 +631,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -676,79 +654,6 @@ STAGE PLANS:
                         value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string), _col1 (type: string)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string), _col1 (type: string)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                        Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: string), KEY._col1 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: string), _col1 (type: string)
-                  minReductionHashAggr: 0.4
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 632 Data size: 117552 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string), _col1 (type: string)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                    Statistics: Num rows: 632 Data size: 117552 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -795,6 +700,29 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: string), _col1 (type: string)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 632 Data size: 117552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col1 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                    Statistics: Num rows: 632 Data size: 117552 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -818,7 +746,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 632 Data size: 117552 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/intersect_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/intersect_merge.q.out
@@ -53,12 +53,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -84,24 +84,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -109,24 +91,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n7
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -139,31 +103,6 @@ STAGE PLANS:
         Map 7 
             Map Operator Tree:
                 TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
                   alias: a_n7
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -184,54 +123,15 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -278,6 +178,29 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -302,6 +225,29 @@ STAGE PLANS:
                     Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
         Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -352,11 +298,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -382,9 +328,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: a_n7
@@ -407,24 +360,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -434,54 +369,6 @@ STAGE PLANS:
                         value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n7
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.75
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -528,7 +415,30 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.75
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -602,12 +512,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -633,24 +543,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -658,24 +550,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n7
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -688,31 +562,6 @@ STAGE PLANS:
         Map 7 
             Map Operator Tree:
                 TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
                   alias: a_n7
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -733,54 +582,15 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -827,6 +637,29 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -851,6 +684,29 @@ STAGE PLANS:
                     Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
         Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -901,12 +757,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -932,24 +788,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -957,24 +795,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n7
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -987,31 +807,6 @@ STAGE PLANS:
         Map 7 
             Map Operator Tree:
                 TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
                   alias: a_n7
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -1032,54 +827,15 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1126,6 +882,29 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1150,6 +929,29 @@ STAGE PLANS:
                     Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
         Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1200,12 +1002,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 9 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1231,24 +1033,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -1256,24 +1040,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: a_n7
-                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: int)
                         null sort order: zz
@@ -1286,31 +1052,6 @@ STAGE PLANS:
         Map 7 
             Map Operator Tree:
                 TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
                   alias: a_n7
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -1331,54 +1072,15 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int), KEY._col1 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col2)
-                  keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.8
-                  mode: hash
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int), _col1 (type: int)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col2 (type: bigint)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1425,6 +1127,29 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1449,6 +1174,29 @@ STAGE PLANS:
                     Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
         Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1501,8 +1249,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1528,9 +1276,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: a_n7
@@ -1543,31 +1298,6 @@ STAGE PLANS:
                       aggregations: count()
                       keys: key (type: int), value (type: int)
                       minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1626,7 +1356,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1649,7 +1379,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                     Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1702,8 +1432,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1729,9 +1459,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: a_n7
@@ -1744,31 +1481,6 @@ STAGE PLANS:
                       aggregations: count()
                       keys: key (type: int), value (type: int)
                       minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b_n5
-                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: int), value (type: int)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2
                       Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1834,7 +1546,7 @@ STAGE PLANS:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1857,7 +1569,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                     Statistics: Num rows: 3 Data size: 72 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/join35.q.out
+++ b/ql/src/test/results/clientpositive/llap/join35.q.out
@@ -57,16 +57,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (BROADCAST_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 6 (BROADCAST_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: (UDFToDouble(key) < 20.0D) (type: boolean)
+                  filterExpr: ((UDFToDouble(key) < 20.0D) or (UDFToDouble(key) > 100.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -91,52 +91,6 @@ STAGE PLANS:
                         tag: -1
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: src
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    bucket_count -1
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types string:string
-#### A masked pattern was here ####
-                    name default.src
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 'default','default'
-                      columns.types string:string
-#### A masked pattern was here ####
-                      name default.src
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.src
-                  name: default.src
-            Truncated Path -> Alias:
-              /src [x]
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x1
-                  filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
                   Filter Operator
                     isSamplingPred: false
                     predicate: (UDFToDouble(key) > 100.0D) (type: boolean)
@@ -197,8 +151,8 @@ STAGE PLANS:
                     name: default.src
                   name: default.src
             Truncated Path -> Alias:
-              /src [x1]
-        Map 7 
+              /src [x]
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: x
@@ -287,13 +241,13 @@ STAGE PLANS:
                 Map Join Operator
                   condition map:
                        Inner Join 0 to 1
-                  Estimated key counts: Map 7 => 25
+                  Estimated key counts: Map 6 => 25
                   keys:
                     0 _col0 (type: string)
                     1 _col0 (type: string)
                   outputColumnNames: _col1, _col2, _col3
                   input vertices:
-                    1 Map 7
+                    1 Map 6
                   Position of Big Table: 0
                   Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
@@ -382,7 +336,7 @@ STAGE PLANS:
                     TotalFiles: 1
                     GatherStats: false
                     MultiFileSpray: false
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:
@@ -395,13 +349,13 @@ STAGE PLANS:
                 Map Join Operator
                   condition map:
                        Inner Join 0 to 1
-                  Estimated key counts: Map 7 => 25
+                  Estimated key counts: Map 6 => 25
                   keys:
                     0 _col0 (type: string)
                     1 _col0 (type: string)
                   outputColumnNames: _col1, _col2, _col3
                   input vertices:
-                    1 Map 7
+                    1 Map 6
                   Position of Big Table: 0
                   Statistics: Num rows: 50 Data size: 9150 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator

--- a/ql/src/test/results/clientpositive/llap/lineage1.q.out
+++ b/ql/src/test/results/clientpositive/llap/lineage1.q.out
@@ -49,51 +49,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: t1
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: p2
@@ -113,9 +74,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
-        Map 8 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: t2
@@ -124,6 +92,12 @@ STAGE PLANS:
                     expressions: key (type: string)
                     outputColumnNames: _col0
                     Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
                       null sort order: z
@@ -193,7 +167,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator

--- a/ql/src/test/results/clientpositive/llap/llap_nullscan.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_nullscan.q.out
@@ -253,7 +253,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -275,13 +275,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src_orc_n1
-                  Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: string)
                     outputColumnNames: key
@@ -314,7 +307,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/load_dyn_part14.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_dyn_part14.q.out
@@ -59,8 +59,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -78,35 +78,11 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         TopN Hash Memory Usage: 0.1
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 2
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         TopN Hash Memory Usage: 0.1
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 2
-                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -170,7 +146,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -206,7 +182,7 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 2 Data size: 650 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int), _col2 (type: struct<count:bigint,sum:double,input:int>), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: binary)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit

--- a/ql/src/test/results/clientpositive/llap/multiMapJoin2.q.out
+++ b/ql/src/test/results/clientpositive/llap/multiMapJoin2.q.out
@@ -28,9 +28,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 4 <- Reducer 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 4 <- Map 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
         Reducer 3 <- Union 2 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -86,7 +85,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col0
                         input vertices:
-                          1 Reducer 6
+                          1 Map 5
                         Statistics: Num rows: 39 Data size: 3393 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
@@ -136,18 +135,6 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
         Union 2 
             Vertex: Union 2
 
@@ -279,9 +266,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -303,12 +290,18 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
-                  alias: y1
+                  alias: y2
                   filterExpr: key is not null (type: boolean)
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
@@ -324,42 +317,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: x2
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: y2
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -398,7 +355,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -545,10 +502,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 6 <- Reducer 5 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Map 5 <- Map 1 (BROADCAST_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -587,7 +543,7 @@ STAGE PLANS:
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: x2
@@ -609,7 +565,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col0
                         input vertices:
-                          1 Reducer 5
+                          1 Map 1
                         Statistics: Num rows: 39 Data size: 3393 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
@@ -645,18 +601,6 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
         Union 3 
             Vertex: Union 3
 

--- a/ql/src/test/results/clientpositive/llap/reduce_deduplicate_extended2.q.out
+++ b/ql/src/test/results/clientpositive/llap/reduce_deduplicate_extended2.q.out
@@ -732,7 +732,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 7 <- Map 1 (SIMPLE_EDGE)
@@ -787,17 +787,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: (key is not null and value is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (key is not null and value is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: value (type: string), key (type: string)
                       outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/setop_subq.q.out
+++ b/ql/src/test/results/clientpositive/llap/setop_subq.q.out
@@ -109,7 +109,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -135,24 +135,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -208,7 +190,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -259,7 +241,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -285,24 +267,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -358,7 +322,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -409,7 +373,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -435,24 +399,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -508,7 +454,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/sharedwork_semi_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/sharedwork_semi_2.q.out
@@ -104,10 +104,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 3 <- Map 5 (BROADCAST_EDGE), Reducer 7 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 3 <- Map 5 (BROADCAST_EDGE), Reducer 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
         Map 4 <- Map 5 (BROADCAST_EDGE), Reducer 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
         Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -268,17 +267,6 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: binary)
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: binary)
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: binary)
-                outputColumnNames: _col0, _col1, _col2
                 Reduce Output Operator
                   null sort order: 
                   sort order: 

--- a/ql/src/test/results/clientpositive/llap/sharedwork_virtualcol_schema_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/sharedwork_virtualcol_schema_merge.q.out
@@ -43,16 +43,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  filterExpr: ((a <> 1) and INPUT__FILE__NAME is not null) (type: boolean)
+                  filterExpr: (((a <> 1) and INPUT__FILE__NAME is not null) or (a = 1)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: ((a <> 1) and INPUT__FILE__NAME is not null) (type: boolean)
@@ -68,9 +68,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col2 (type: string)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: bigint)
+                  Filter Operator
+                    predicate: (a = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: INPUT__FILE__NAME (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: INPUT__FILE__NAME (type: string)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: BLOCK__OFFSET__INSIDE__FILE (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs
-        Map 4 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: t1
@@ -85,24 +95,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: INPUT__FILE__NAME (type: string)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: t1
-                  filterExpr: (a = 1) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (a = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: INPUT__FILE__NAME (type: string)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: INPUT__FILE__NAME (type: string)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: BLOCK__OFFSET__INSIDE__FILE (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
@@ -127,7 +119,47 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col1 (type: bigint), _col2 (type: string), 1 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -173,46 +205,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col2 ASC NULLS FIRST
-                        partition by: _col2
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: _col1 (type: bigint), _col2 (type: string), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        table:
-                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Union 3 
             Vertex: Union 3
 
@@ -259,16 +251,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  filterExpr: (((a <> 1) and INPUT__FILE__NAME is not null) or ((a = 1) and INPUT__FILE__NAME is not null)) (type: boolean)
+                  filterExpr: (((a <> 1) and INPUT__FILE__NAME is not null) or (a = 1) or ((a = 1) and INPUT__FILE__NAME is not null)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: ((a <> 1) and INPUT__FILE__NAME is not null) (type: boolean)
@@ -285,23 +277,6 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: bigint)
                   Filter Operator
-                    predicate: ((a = 1) and INPUT__FILE__NAME is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: INPUT__FILE__NAME (type: string)
-                      null sort order: a
-                      sort order: +
-                      Map-reduce partition columns: INPUT__FILE__NAME (type: string)
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: t1
-                  filterExpr: (a = 1) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
                     predicate: (a = 1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
@@ -311,6 +286,15 @@ STAGE PLANS:
                       Map-reduce partition columns: INPUT__FILE__NAME (type: string)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                       value expressions: BLOCK__OFFSET__INSIDE__FILE (type: bigint)
+                  Filter Operator
+                    predicate: ((a = 1) and INPUT__FILE__NAME is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: INPUT__FILE__NAME (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: INPUT__FILE__NAME (type: string)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
@@ -336,6 +320,46 @@ STAGE PLANS:
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col1 (type: bigint), _col2 (type: string), 1 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -381,46 +405,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: bigint), KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: ptf_0
-                        type: WINDOWING
-                      Windowing table definition
-                        input alias: ptf_1
-                        name: windowingtablefunction
-                        order by: _col2 ASC NULLS FIRST
-                        partition by: _col2
-                        raw input shape:
-                        window functions:
-                            window function definition
-                              alias: row_number_window_0
-                              name: row_number
-                              window function: GenericUDAFRowNumberEvaluator
-                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
-                              isPivotResult: true
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (row_number_window_0 = 1) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: _col1 (type: bigint), _col2 (type: string), 1 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        table:
-                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Union 3 
             Vertex: Union 3
 

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin7.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin7.q.out
@@ -64,8 +64,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 3 <- Reducer 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Map 3 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -127,7 +126,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col0, _col1, _col3
                         input vertices:
-                          1 Reducer 5
+                          1 Map 4
                         Statistics: Num rows: 1 Data size: 404 Basic stats: COMPLETE Column stats: NONE
                         Select Operator
                           expressions: _col0 (type: string), _col1 (type: string), _col3 (type: string)
@@ -171,19 +170,6 @@ STAGE PLANS:
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string)
-                outputColumnNames: _col0, _col1
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                  value expressions: _col1 (type: string)
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
@@ -276,8 +276,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -300,17 +300,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: c_int (type: int)
-                    outputColumnNames: c_int
-                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: min(c_int)
                       minReductionHashAggr: 0.95
@@ -322,17 +311,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: s3
-                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: c_int (type: int)
-                    outputColumnNames: c_int
-                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: avg(c_int)
                       minReductionHashAggr: 0.95
@@ -385,7 +363,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -410,7 +388,7 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/swo_vertex_merge.q.out
+++ b/ql/src/test/results/clientpositive/llap/swo_vertex_merge.q.out
@@ -32,8 +32,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tv
 POSTHOOK: Lineage: tv.b SCRIPT []
-Warning: Map Join MAPJOIN[86][bigTable=?] in task 'Map 1' is a cross product
-Warning: Map Join MAPJOIN[96][bigTable=?] in task 'Map 7' is a cross product
+Warning: Map Join MAPJOIN[82][bigTable=?] in task 'Map 1' is a cross product
+Warning: Map Join MAPJOIN[92][bigTable=?] in task 'Map 5' is a cross product
 PREHOOK: query: explain
 with t as (
 	select a+b as s from tu,tv where a>1 and b>2 and a*a=b
@@ -65,11 +65,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Reducer 4 (BROADCAST_EDGE), Reducer 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 3 <- Map 5 (BROADCAST_EDGE)
-        Map 7 <- Map 3 (BROADCAST_EDGE), Map 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Map 1 <- Map 3 (BROADCAST_EDGE), Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 3 <- Map 4 (BROADCAST_EDGE)
+        Map 5 <- Map 3 (BROADCAST_EDGE), Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -93,7 +91,7 @@ STAGE PLANS:
                           1 
                         outputColumnNames: _col0, _col1, _col3
                         input vertices:
-                          0 Reducer 4
+                          0 Map 3
                         Statistics: Num rows: 4 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -103,7 +101,7 @@ STAGE PLANS:
                             1 _col1 (type: int)
                           outputColumnNames: _col0, _col1, _col3, _col4
                           input vertices:
-                            1 Reducer 6
+                            1 Map 4
                           residual filter predicates: {((_col1 + _col0) = ((_col4 + _col3) + 1))}
                           Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
@@ -140,7 +138,7 @@ STAGE PLANS:
                           1 _col1 (type: int)
                         outputColumnNames: _col0, _col1
                         input vertices:
-                          1 Map 5
+                          1 Map 4
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           null sort order: 
@@ -154,7 +152,7 @@ STAGE PLANS:
                           value expressions: _col0 (type: int), _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: tu
@@ -190,7 +188,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: tv
@@ -221,7 +219,7 @@ STAGE PLANS:
                             1 _col1 (type: int)
                           outputColumnNames: _col0, _col1, _col3, _col4
                           input vertices:
-                            1 Map 5
+                            1 Map 4
                           residual filter predicates: {(((_col1 + _col0) + 1) = (_col4 + _col3))}
                           Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
@@ -237,30 +235,6 @@ STAGE PLANS:
                                   serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: llap
             LLAP IO: all inputs
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int)
-                outputColumnNames: _col0, _col1
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: int)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
-                outputColumnNames: _col1, _col0
-                Reduce Output Operator
-                  key expressions: _col1 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: int)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
         Union 2 
             Vertex: Union 2
 
@@ -270,8 +244,8 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Map Join MAPJOIN[86][bigTable=?] in task 'Map 1' is a cross product
-Warning: Map Join MAPJOIN[96][bigTable=?] in task 'Map 7' is a cross product
+Warning: Map Join MAPJOIN[82][bigTable=?] in task 'Map 1' is a cross product
+Warning: Map Join MAPJOIN[92][bigTable=?] in task 'Map 5' is a cross product
 PREHOOK: query: with t as (
 	select a+b as s from tu,tv where a>1 and b>2 and a*a=b
 )

--- a/ql/src/test/results/clientpositive/llap/swo_vertex_merge0.q.out
+++ b/ql/src/test/results/clientpositive/llap/swo_vertex_merge0.q.out
@@ -32,8 +32,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tv
 POSTHOOK: Lineage: tv.b SCRIPT []
-Warning: Map Join MAPJOIN[78][bigTable=?] in task 'Map 1' is a cross product
-Warning: Map Join MAPJOIN[81][bigTable=?] in task 'Map 6' is a cross product
+Warning: Map Join MAPJOIN[81][bigTable=?] in task 'Map 4' is a cross product
 PREHOOK: query: explain
 with t as (
 	select a+b as s from tu,tv where a>1 and b>2 and a*a=b
@@ -65,65 +64,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 4 (BROADCAST_EDGE), Map 5 (BROADCAST_EDGE)
-        Map 4 <- Map 5 (BROADCAST_EDGE)
-        Map 6 <- Map 4 (BROADCAST_EDGE), Map 5 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+        Map 4 <- Map 1 (BROADCAST_EDGE), Map 2 (BROADCAST_EDGE), Reducer 3 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: tv
-                  filterExpr: (b > 2) (type: boolean)
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (b > 2) (type: boolean)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: b (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 
-                          1 
-                        outputColumnNames: _col0, _col1, _col3
-                        input vertices:
-                          0 Map 4
-                        Statistics: Num rows: 4 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                        Map Join Operator
-                          condition map:
-                               Inner Join 0 to 1
-                          keys:
-                            0 _col3 (type: int)
-                            1 _col1 (type: int)
-                          outputColumnNames: _col0, _col1, _col3, _col4
-                          input vertices:
-                            1 Map 5
-                          residual filter predicates: {((_col1 + _col0) = ((_col4 + _col3) + 1))}
-                          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                          Select Operator
-                            expressions: (_col1 + _col0) (type: int)
-                            outputColumnNames: _col0
-                            Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                            Group By Operator
-                              aggregations: sum(_col0)
-                              minReductionHashAggr: 0.4
-                              mode: hash
-                              outputColumnNames: _col0
-                              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                              Reduce Output Operator
-                                null sort order: 
-                                sort order: 
-                                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                                value expressions: _col0 (type: bigint)
-            Execution mode: llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: tv
@@ -144,13 +92,8 @@ STAGE PLANS:
                           1 _col1 (type: int)
                         outputColumnNames: _col0, _col1
                         input vertices:
-                          1 Map 5
+                          1 Map 2
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          null sort order: 
-                          sort order: 
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: int), _col1 (type: int)
                         Reduce Output Operator
                           null sort order: 
                           sort order: 
@@ -158,7 +101,7 @@ STAGE PLANS:
                           value expressions: _col0 (type: int), _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: tu
@@ -194,7 +137,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 6 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: tv
@@ -215,7 +158,7 @@ STAGE PLANS:
                           1 
                         outputColumnNames: _col0, _col1, _col3
                         input vertices:
-                          0 Map 4
+                          0 Map 1
                         Statistics: Num rows: 4 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -225,8 +168,34 @@ STAGE PLANS:
                             1 _col1 (type: int)
                           outputColumnNames: _col0, _col1, _col3, _col4
                           input vertices:
-                            1 Map 5
+                            1 Map 2
                           residual filter predicates: {(((_col1 + _col0) + 1) = (_col4 + _col3))}
+                          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: (_col1 + _col0) (type: int)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                            Group By Operator
+                              aggregations: sum(_col0)
+                              minReductionHashAggr: 0.4
+                              mode: hash
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                              Reduce Output Operator
+                                null sort order: 
+                                sort order: 
+                                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                                value expressions: _col0 (type: bigint)
+                        Map Join Operator
+                          condition map:
+                               Inner Join 0 to 1
+                          keys:
+                            0 _col3 (type: int)
+                            1 _col1 (type: int)
+                          outputColumnNames: _col0, _col1, _col3, _col4
+                          input vertices:
+                            1 Reducer 3
+                          residual filter predicates: {((_col1 + _col0) = ((_col4 + _col3) + 1))}
                           Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: (_col1 + _col0) (type: int)
@@ -245,7 +214,20 @@ STAGE PLANS:
                                 value expressions: _col0 (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs
-        Reducer 2 
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                outputColumnNames: _col1, _col0
+                Reduce Output Operator
+                  key expressions: _col1 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: int)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int)
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -275,8 +257,8 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Union 3 
-            Vertex: Union 3
+        Union 6 
+            Vertex: Union 6
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/tez_union.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_union.q.out
@@ -1056,8 +1056,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 3 <- Reducer 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Map 3 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1115,7 +1114,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col0
                         input vertices:
-                          1 Reducer 5
+                          1 Map 4
                         Statistics: Num rows: 791 Data size: 68817 Basic stats: COMPLETE Column stats: COMPLETE
                         File Output Operator
                           compressed: false
@@ -1153,18 +1152,6 @@ STAGE PLANS:
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/test/results/clientpositive/llap/union10.q.out
+++ b/ql/src/test/results/clientpositive/llap/union10.q.out
@@ -39,8 +39,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -61,41 +61,11 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: s3
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -161,7 +131,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -200,7 +170,7 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: int), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union11.q.out
+++ b/ql/src/test/results/clientpositive/llap/union11.q.out
@@ -27,8 +27,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -51,45 +51,11 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count(key)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: s3
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count(key)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -139,7 +105,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -165,7 +131,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union28.q.out
+++ b/ql/src/test/results/clientpositive/llap/union28.q.out
@@ -50,7 +50,7 @@ STAGE PLANS:
         Map 1 <- Union 2 (CONTAINS)
         Reducer 3 <- Union 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE), Union 2 (CONTAINS)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Union 2 (CONTAINS)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -112,23 +112,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -191,7 +174,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union3.q.out
+++ b/ql/src/test/results/clientpositive/llap/union3.q.out
@@ -45,11 +45,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -67,18 +67,16 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         TopN Hash Memory Usage: 0.1
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 1
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        TopN Hash Memory Usage: 0.1
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        TopN Hash Memory Usage: 0.1
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -86,56 +84,6 @@ STAGE PLANS:
                         TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 1
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Limit
-                    Number of rows: 1
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Limit
-                Number of rows: 1
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: 4 (type: int)
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: int)
-                    null sort order: a
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: int)
-                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -166,14 +114,14 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: 2 (type: int)
+                  expressions: 4 (type: int)
                   outputColumnNames: _col0
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
@@ -182,7 +130,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -190,6 +138,22 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: 3 (type: int)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Limit
+                Number of rows: 1
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 2 (type: int)
                   outputColumnNames: _col0
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator

--- a/ql/src/test/results/clientpositive/llap/union30.q.out
+++ b/ql/src/test/results/clientpositive/llap/union30.q.out
@@ -65,7 +65,7 @@ STAGE PLANS:
         Map 4 <- Union 2 (CONTAINS)
         Reducer 3 <- Union 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Union 2 (CONTAINS)
+        Reducer 7 <- Map 5 (SIMPLE_EDGE), Union 2 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -165,23 +165,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -244,7 +227,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union4.q.out
+++ b/ql/src/test/results/clientpositive/llap/union4.q.out
@@ -35,7 +35,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -56,21 +56,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -136,7 +121,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union5.q.out
+++ b/ql/src/test/results/clientpositive/llap/union5.q.out
@@ -23,7 +23,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -46,23 +46,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count(key)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -112,7 +95,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/unionDistinct_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/unionDistinct_3.q.out
@@ -872,8 +872,8 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
         Reducer 6 <- Union 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -899,21 +899,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -999,30 +984,6 @@ STAGE PLANS:
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: 'tst3' (type: string), _col0 (type: bigint)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: _col0 (type: string), _col1 (type: bigint)
-                    minReductionHashAggr: 0.5
-                    mode: hash
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string), _col1 (type: bigint)
-                      null sort order: zz
-                      sort order: ++
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
                   expressions: 'tst2' (type: string), _col0 (type: bigint)
                   outputColumnNames: _col0, _col1
                   Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1037,6 +998,30 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: bigint)
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'tst3' (type: string), _col0 (type: bigint)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: string), _col1 (type: bigint)
+                    minReductionHashAggr: 0.5
+                    mode: hash
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string), _col1 (type: bigint)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
         Union 3 
             Vertex: Union 3

--- a/ql/src/test/results/clientpositive/llap/union_offcbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_offcbo.q.out
@@ -253,33 +253,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest1
-                  filterExpr: (ts1 = '2015-11-20') (type: boolean)
-                  Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (ts1 = '2015-11-20') (type: boolean)
-                    Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
-                      outputColumnNames: _col8, _col9
-                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col8 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: ttest2
@@ -299,6 +277,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 936 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col2 (type: string), _col3 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
+                    Select Operator
+                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
+                      outputColumnNames: _col1, _col8, _col9
+                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col8 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col8 (type: string)
+                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: string), _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 5 
@@ -321,28 +310,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 294 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest2
-                  filterExpr: '2015-11-20' BETWEEN dt1 AND dt2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: '2015-11-20' BETWEEN dt1 AND dt2 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
-                      outputColumnNames: _col1, _col8, _col9
-                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
+                      outputColumnNames: _col8, _col9
+                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col8 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: string), _col9 (type: string)
+                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -374,7 +352,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -603,36 +581,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest1
-                  filterExpr: (ts1 = '2015-11-20') (type: boolean)
-                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (ts1 = '2015-11-20') (type: boolean)
-                    Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                      Filter Operator
-                        predicate: _col0 is not null (type: boolean)
-                        Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: ttest2
@@ -652,6 +605,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: string)
                         Statistics: Num rows: 1 Data size: 936 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: bigint), _col6 (type: string)
+                    Select Operator
+                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: string)
+                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 5 
@@ -677,28 +641,20 @@ STAGE PLANS:
                           Map-reduce partition columns: _col3 (type: string)
                           Statistics: Num rows: 1 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: bigint), _col1 (type: string), _col2 (type: bigint), _col4 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest2
-                  filterExpr: ('2015-11-20' BETWEEN dt1 AND dt2 and khash is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: ('2015-11-20' BETWEEN dt1 AND dt2 and khash is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: string)
-                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: string), _col2 (type: string)
+                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                      Filter Operator
+                        predicate: _col0 is not null (type: boolean)
+                        Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                          value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -730,7 +686,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -959,33 +915,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest1
-                  filterExpr: (ts1 = '2015-11-20') (type: boolean)
-                  Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (ts1 = '2015-11-20') (type: boolean)
-                    Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
-                      outputColumnNames: _col8, _col9
-                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col8 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: ttest2
@@ -1005,6 +939,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 936 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col2 (type: string), _col3 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
+                    Select Operator
+                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
+                      outputColumnNames: _col1, _col8, _col9
+                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col8 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col8 (type: string)
+                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: string), _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 5 
@@ -1027,28 +972,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 294 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest2
-                  filterExpr: '2015-11-20' BETWEEN dt1 AND dt2 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: '2015-11-20' BETWEEN dt1 AND dt2 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
-                      outputColumnNames: _col1, _col8, _col9
-                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
+                      outputColumnNames: _col8, _col9
+                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col8 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: string), _col9 (type: string)
+                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -1087,7 +1021,7 @@ STAGE PLANS:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1323,32 +1257,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest1
-                  Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (ts1 = '2015-11-20') (type: boolean)
-                    Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
-                      outputColumnNames: _col8, _col9
-                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col8 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: ttest2
@@ -1367,6 +1280,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 936 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col2 (type: string), _col3 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
+                    Select Operator
+                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
+                      outputColumnNames: _col1, _col8, _col9
+                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col8 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col8 (type: string)
+                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: string), _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 5 
@@ -1388,27 +1312,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col8 (type: string)
                         Statistics: Num rows: 1 Data size: 294 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: string), _col6 (type: string), _col7 (type: bigint), _col9 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest2
-                  Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: '2015-11-20' BETWEEN dt1 AND dt2 (type: boolean)
-                    Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
-                      outputColumnNames: _col1, _col8, _col9
-                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
+                      outputColumnNames: _col8, _col9
+                      Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col8 (type: string)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col8 (type: string)
-                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: string), _col9 (type: string)
+                        Statistics: Num rows: 1 Data size: 110 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col9 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -1447,7 +1361,7 @@ STAGE PLANS:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1683,35 +1597,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest1
-                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (ts1 = '2015-11-20') (type: boolean)
-                    Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                      Filter Operator
-                        predicate: _col0 is not null (type: boolean)
-                        Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: ttest2
@@ -1730,6 +1620,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: string)
                         Statistics: Num rows: 1 Data size: 936 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: bigint), _col6 (type: string)
+                    Select Operator
+                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: string)
+                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Map 5 
@@ -1754,27 +1655,20 @@ STAGE PLANS:
                           Map-reduce partition columns: _col3 (type: string)
                           Statistics: Num rows: 1 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: bigint), _col1 (type: string), _col2 (type: bigint), _col4 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: ttest2
-                  Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: ('2015-11-20' BETWEEN dt1 AND dt2 and khash is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
-                      expressions: ts1 (type: string), khash (type: string), rhash (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: string)
-                        Statistics: Num rows: 1 Data size: 920 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col0 (type: string), _col2 (type: string)
+                      expressions: reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( id1 AS STRING))) (type: string), reflect('org.apache.commons.codec.digest.DigestUtils','sha256Hex',concat(CAST( at1 AS STRING))) (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                      Filter Operator
+                        predicate: _col0 is not null (type: boolean)
+                        Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
+                          value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -1806,7 +1700,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator

--- a/ql/src/test/results/clientpositive/llap/union_pos_alias.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_pos_alias.q.out
@@ -25,8 +25,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -47,41 +47,11 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: s3
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -121,7 +91,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -139,7 +109,7 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1484,7 +1454,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1510,24 +1480,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
                         Statistics: Num rows: 307 Data size: 31621 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_n9
-                  filterExpr: (key > 0) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (key > 0) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: int), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 307 Data size: 31621 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int), _col1 (type: string)
                         null sort order: zz
@@ -1590,7 +1542,7 @@ STAGE PLANS:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union_remove_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_remove_6.q.out
@@ -66,7 +66,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -92,24 +92,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: inputtbl1_n10
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -144,7 +126,7 @@ STAGE PLANS:
                       output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                       name: default.outputtbl2_n4
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union_remove_6_subq.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_remove_6_subq.q.out
@@ -70,7 +70,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -96,24 +96,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: inputtbl1_n0
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -148,7 +130,7 @@ STAGE PLANS:
                       output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                       name: default.outputtbl2
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -294,7 +276,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -315,21 +297,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         null sort order: 
                         sort order: 
@@ -379,7 +346,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -455,7 +422,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -481,24 +448,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string)
-                    outputColumnNames: key
-                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -575,7 +524,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/union_top_level.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_top_level.q.out
@@ -26,15 +26,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
+                  filterExpr: (((UDFToDouble(key) % 3.0D) = 0.0D) or ((UDFToDouble(key) % 3.0D) = 1.0D) or ((UDFToDouble(key) % 3.0D) = 2.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
@@ -52,14 +52,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -76,14 +68,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -119,7 +103,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -136,7 +120,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -210,10 +194,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 5 <- Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -236,16 +219,9 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 7 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: s1
@@ -258,12 +234,6 @@ STAGE PLANS:
                       expressions: key (type: string)
                       outputColumnNames: _col0
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string)
                         null sort order: z
@@ -299,6 +269,12 @@ STAGE PLANS:
                       sort order: +
                       Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -317,33 +293,6 @@ STAGE PLANS:
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 5 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: string)
-                  1 _col0 (type: string)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                Top N Key Operator
-                  sort order: +
-                  keys: _col2 (type: string)
-                  null sort order: z
-                  Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                  top n: 10
-                  Select Operator
-                    expressions: _col2 (type: string), _col1 (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string)
-        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -437,15 +386,15 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
+                  filterExpr: (((UDFToDouble(key) % 3.0D) = 0.0D) or ((UDFToDouble(key) % 3.0D) = 1.0D) or ((UDFToDouble(key) % 3.0D) = 2.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
@@ -463,14 +412,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -487,14 +428,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -565,7 +498,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -598,7 +531,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: int), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -737,15 +670,15 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
+                  filterExpr: (((UDFToDouble(key) % 3.0D) = 0.0D) or ((UDFToDouble(key) % 3.0D) = 1.0D) or ((UDFToDouble(key) % 3.0D) = 2.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
@@ -763,14 +696,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -787,14 +712,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -865,7 +782,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -898,7 +815,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: int), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -1025,15 +942,15 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
+                  filterExpr: (((UDFToDouble(key) % 3.0D) = 0.0D) or ((UDFToDouble(key) % 3.0D) = 1.0D) or ((UDFToDouble(key) % 3.0D) = 2.0D)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 0.0D) (type: boolean)
@@ -1051,14 +968,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 1.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1075,14 +984,6 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
                           TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((UDFToDouble(key) % 3.0D) = 2.0D) (type: boolean)
                     Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1153,7 +1054,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
@@ -1186,7 +1087,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: struct<count:bigint,sum:double,input:int>), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: int), _col7 (type: bigint), _col8 (type: binary)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit

--- a/ql/src/test/results/clientpositive/llap/vectorized_dynamic_partition_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_dynamic_partition_pruning.q.out
@@ -4235,7 +4235,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4275,7 +4275,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4285,28 +4285,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4382,7 +4362,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4417,7 +4397,7 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -4427,7 +4407,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4520,7 +4500,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
+        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Union 6 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4560,7 +4540,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4570,28 +4550,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -4669,7 +4629,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4704,7 +4664,7 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -4714,7 +4674,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4805,11 +4765,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 9 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 9 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE), Union 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+        Reducer 9 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4830,6 +4790,12 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -4841,7 +4807,7 @@ STAGE PLANS:
                 allNative: false
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Map 10 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: srcpart
@@ -4850,6 +4816,17 @@ STAGE PLANS:
                     expressions: ds (type: string)
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: max(ds)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
                     Group By Operator
                       aggregations: min(ds)
                       minReductionHashAggr: 0.99
@@ -4872,127 +4849,6 @@ STAGE PLANS:
                 allNative: false
                 usesVectorUDFAdaptor: false
                 vectorized: true
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  filterExpr: ds is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: ds (type: string)
-                    minReductionHashAggr: 0.99
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 2 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: max(ds)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-        Reducer 11 
-            Execution mode: vectorized, llap
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: min(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col0 is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    keys: _col0 (type: string)
-                    minReductionHashAggr: 0.5
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: string)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: string)
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 1
-                    Select Operator
-                      expressions: _col0 (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.4
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Dynamic Partitioning Event Operator
-                          Target column: ds (string)
-                          Target Input: srcpart
-                          Partition key expr: ds
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -5034,7 +4890,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -5054,7 +4910,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 4 Data size: 736 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -5099,6 +4955,35 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez] IS true
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col0 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: string)
+                    minReductionHashAggr: 0.5
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: string)
                       outputColumnNames: _col0
@@ -5114,11 +4999,11 @@ STAGE PLANS:
                           Target Input: srcpart
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 5
+                          Target Vertex: Map 1
         Union 3 
             Vertex: Union 3
-        Union 9 
-            Vertex: Union 9
+        Union 8 
+            Vertex: Union 8
 
   Stage: Stage-0
     Fetch Operator
@@ -7318,7 +7203,7 @@ STAGE PLANS:
         Map 1 <- Union 5 (BROADCAST_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
         Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7374,7 +7259,7 @@ STAGE PLANS:
                     outputColumnNames: ds
                     Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: max(ds)
+                      aggregations: min(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -7384,28 +7269,8 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
-                usesVectorUDFAdaptor: false
-                vectorized: true
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: srcpart
-                  Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: ds (type: string)
-                    outputColumnNames: ds
-                    Statistics: Num rows: 2000 Data size: 389248 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
-                      aggregations: min(ds)
+                      aggregations: max(ds)
                       minReductionHashAggr: 0.99
                       mode: hash
                       outputColumnNames: _col0
@@ -7457,7 +7322,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: max(VALUE._col0)
+                aggregations: min(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -7492,7 +7357,7 @@ STAGE PLANS:
                           Partition key expr: ds
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                           Target Vertex: Map 1
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -7502,7 +7367,7 @@ STAGE PLANS:
                 vectorized: true
             Reduce Operator Tree:
               Group By Operator
-                aggregations: min(VALUE._col0)
+                aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
                 Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/view_cbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/view_cbo.q.out
@@ -682,7 +682,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
         Reducer 4 <- Union 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -710,26 +710,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  properties:
-                    insideView TRUE
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: key (type: string), value (type: string)
-                    outputColumnNames: key, value
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string), value (type: string)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 316 Data size: 58776 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: string), _col1 (type: string)
                         null sort order: zz
@@ -793,7 +773,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/cbo_query14.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/cbo_query14.q.out
@@ -64,10 +64,10 @@ HiveProject(ss_item_sk=[$0])
                   HiveFilter(condition=[AND(IS NOT NULL($7), IS NOT NULL($9), IS NOT NULL($11))])
                     HiveTableScan(table=[[default, item]], table:alias=[iws])
 
-Warning: Map Join MAPJOIN[1098][bigTable=?] in task 'Reducer 10' is a cross product
-Warning: Map Join MAPJOIN[1147][bigTable=?] in task 'Reducer 15' is a cross product
-Warning: Map Join MAPJOIN[1163][bigTable=?] in task 'Reducer 21' is a cross product
-Warning: Map Join MAPJOIN[1199][bigTable=?] in task 'Reducer 30' is a cross product
+Warning: Map Join MAPJOIN[1090][bigTable=?] in task 'Reducer 8' is a cross product
+Warning: Map Join MAPJOIN[1135][bigTable=?] in task 'Reducer 11' is a cross product
+Warning: Map Join MAPJOIN[1151][bigTable=?] in task 'Reducer 17' is a cross product
+Warning: Map Join MAPJOIN[1187][bigTable=?] in task 'Reducer 26' is a cross product
 CBO PLAN:
 HiveSortLimit(sort0=[$0], sort1=[$1], sort2=[$2], sort3=[$3], dir0=[ASC], dir1=[ASC], dir2=[ASC], dir3=[ASC], fetch=[100])
   HiveProject(channel=[$0], i_brand_id=[$1], i_class_id=[$2], i_category_id=[$3], $f4=[$4], $f5=[$5])

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query14.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query14.q.out
@@ -1,7 +1,7 @@
-Warning: Map Join MAPJOIN[1098][bigTable=?] in task 'Reducer 10' is a cross product
-Warning: Map Join MAPJOIN[1147][bigTable=?] in task 'Reducer 15' is a cross product
-Warning: Map Join MAPJOIN[1163][bigTable=?] in task 'Reducer 21' is a cross product
-Warning: Map Join MAPJOIN[1199][bigTable=?] in task 'Reducer 30' is a cross product
+Warning: Map Join MAPJOIN[1090][bigTable=?] in task 'Reducer 8' is a cross product
+Warning: Map Join MAPJOIN[1135][bigTable=?] in task 'Reducer 11' is a cross product
+Warning: Map Join MAPJOIN[1151][bigTable=?] in task 'Reducer 17' is a cross product
+Warning: Map Join MAPJOIN[1187][bigTable=?] in task 'Reducer 26' is a cross product
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-2 depends on stages: Stage-1
@@ -15,11 +15,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 7 <- Reducer 5 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 8 <- Reducer 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 5 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 6 <- Map 4 (BROADCAST_EDGE), Union 2 (CONTAINS)
         Reducer 3 <- Union 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -122,13 +120,13 @@ STAGE PLANS:
                             Target Input: catalog_sales
                             Partition key expr: cs_sold_date_sk
                             Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 7
+                            Target Vertex: Map 5
                           Dynamic Partitioning Event Operator
                             Target column: ws_sold_date_sk (bigint)
                             Target Input: web_sales
                             Partition key expr: ws_sold_date_sk
                             Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 8
+                            Target Vertex: Map 6
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -137,7 +135,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 7 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
@@ -155,7 +153,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col1
                       input vertices:
-                        1 Reducer 5
+                        1 Map 4
                       Statistics: Num rows: 25746588712 Data size: 2974162204528 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: (CAST( _col0 AS decimal(10,0)) * _col1) (type: decimal(18,2))
@@ -174,7 +172,7 @@ STAGE PLANS:
                             value expressions: _col0 (type: decimal(28,2)), _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 8 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: web_sales
@@ -192,7 +190,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col1
                       input vertices:
-                        1 Reducer 6
+                        1 Map 4
                       Statistics: Num rows: 13020465516 Data size: 1510060361116 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: (CAST( _col0 AS decimal(10,0)) * _col1) (type: decimal(18,2))
@@ -231,30 +229,6 @@ STAGE PLANS:
                         output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
                         serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
                         name: default.avg_sales
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
         Union 2 
             Vertex: Union 2
 
@@ -265,28 +239,26 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 14 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE), Reducer 25 (BROADCAST_EDGE)
-        Map 20 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE), Reducer 25 (BROADCAST_EDGE)
-        Map 22 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE)
-        Map 27 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE)
-        Map 29 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE), Reducer 25 (BROADCAST_EDGE)
-        Map 31 <- Map 19 (BROADCAST_EDGE), Map 26 (BROADCAST_EDGE)
-        Reducer 10 <- Map 9 (CUSTOM_SIMPLE_EDGE), Reducer 13 (BROADCAST_EDGE)
-        Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE)
-        Reducer 12 <- Reducer 10 (CUSTOM_SIMPLE_EDGE)
-        Reducer 13 <- Map 9 (CUSTOM_SIMPLE_EDGE)
-        Reducer 15 <- Map 14 (SIMPLE_EDGE), Reducer 11 (BROADCAST_EDGE), Union 16 (CONTAINS)
-        Reducer 17 <- Union 16 (SIMPLE_EDGE)
-        Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
-        Reducer 21 <- Map 20 (SIMPLE_EDGE), Reducer 12 (BROADCAST_EDGE), Union 16 (CONTAINS)
-        Reducer 23 <- Map 22 (SIMPLE_EDGE), Union 24 (CONTAINS)
-        Reducer 25 <- Map 26 (BROADCAST_EDGE), Union 24 (SIMPLE_EDGE)
-        Reducer 28 <- Map 27 (SIMPLE_EDGE), Union 24 (CONTAINS)
-        Reducer 30 <- Map 29 (SIMPLE_EDGE), Reducer 10 (BROADCAST_EDGE), Union 16 (CONTAINS)
-        Reducer 32 <- Map 31 (SIMPLE_EDGE), Union 24 (CONTAINS)
+        Map 10 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE), Reducer 21 (BROADCAST_EDGE)
+        Map 16 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE), Reducer 21 (BROADCAST_EDGE)
+        Map 18 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE)
+        Map 23 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE)
+        Map 25 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE), Reducer 21 (BROADCAST_EDGE)
+        Map 27 <- Map 15 (BROADCAST_EDGE), Map 22 (BROADCAST_EDGE)
+        Reducer 11 <- Map 10 (SIMPLE_EDGE), Reducer 8 (BROADCAST_EDGE), Union 12 (CONTAINS)
+        Reducer 13 <- Union 12 (SIMPLE_EDGE)
+        Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+        Reducer 17 <- Map 16 (SIMPLE_EDGE), Reducer 8 (BROADCAST_EDGE), Union 12 (CONTAINS)
+        Reducer 19 <- Map 18 (SIMPLE_EDGE), Union 20 (CONTAINS)
+        Reducer 21 <- Map 22 (BROADCAST_EDGE), Union 20 (SIMPLE_EDGE)
+        Reducer 24 <- Map 23 (SIMPLE_EDGE), Union 20 (CONTAINS)
+        Reducer 26 <- Map 25 (SIMPLE_EDGE), Reducer 8 (BROADCAST_EDGE), Union 12 (CONTAINS)
+        Reducer 28 <- Map 27 (SIMPLE_EDGE), Union 20 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Reducer 9 (BROADCAST_EDGE)
+        Reducer 9 <- Map 7 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
-        Map 14 
+        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -303,7 +275,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col1, _col2
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 1400767848 Data size: 11206142900 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -313,7 +285,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
-                          1 Reducer 25
+                          1 Reducer 21
                         Statistics: Num rows: 1400767848 Data size: 11206142900 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -323,7 +295,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col1, _col2, _col8, _col9, _col10
                           input vertices:
-                            1 Map 26
+                            1 Map 22
                           Statistics: Num rows: 1400767848 Data size: 16809200716 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col8 (type: int), _col9 (type: int), _col10 (type: int), (CAST( _col1 AS decimal(10,0)) * _col2) (type: decimal(18,2))
@@ -345,7 +317,7 @@ STAGE PLANS:
                                 value expressions: _col3 (type: decimal(28,2)), _col4 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 19 
+        Map 15 
             Map Operator Tree:
                 TableScan
                   alias: date_dim
@@ -379,7 +351,7 @@ STAGE PLANS:
                             Target Input: store_sales
                             Partition key expr: ss_sold_date_sk
                             Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 14
+                            Target Vertex: Map 10
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -401,7 +373,7 @@ STAGE PLANS:
                             Target Input: web_sales
                             Partition key expr: ws_sold_date_sk
                             Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 29
+                            Target Vertex: Map 25
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -423,7 +395,7 @@ STAGE PLANS:
                             Target Input: catalog_sales
                             Partition key expr: cs_sold_date_sk
                             Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 20
+                            Target Vertex: Map 16
                   Filter Operator
                     predicate: d_year BETWEEN 1999 AND 2001 (type: boolean)
                     Statistics: Num rows: 1101 Data size: 13212 Basic stats: COMPLETE Column stats: COMPLETE
@@ -452,7 +424,7 @@ STAGE PLANS:
                             Target Input: catalog_sales
                             Partition key expr: cs_sold_date_sk
                             Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 27
+                            Target Vertex: Map 23
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -474,7 +446,7 @@ STAGE PLANS:
                             Target Input: web_sales
                             Partition key expr: ws_sold_date_sk
                             Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 31
+                            Target Vertex: Map 27
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -496,10 +468,10 @@ STAGE PLANS:
                             Target Input: store_sales
                             Partition key expr: ss_sold_date_sk
                             Statistics: Num rows: 1101 Data size: 8808 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 22
+                            Target Vertex: Map 18
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 20 
+        Map 16 
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
@@ -516,7 +488,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col1, _col2
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 724926652 Data size: 77448818784 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -526,7 +498,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
-                          1 Reducer 25
+                          1 Reducer 21
                         Statistics: Num rows: 724926652 Data size: 77448818784 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -536,7 +508,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col1, _col2, _col8, _col9, _col10
                           input vertices:
-                            1 Map 26
+                            1 Map 22
                           Statistics: Num rows: 724926652 Data size: 80348511816 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col8 (type: int), _col9 (type: int), _col10 (type: int), (CAST( _col1 AS decimal(10,0)) * _col2) (type: decimal(18,2))
@@ -558,7 +530,7 @@ STAGE PLANS:
                                 value expressions: _col3 (type: decimal(28,2)), _col4 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 22 
+        Map 18 
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -575,7 +547,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 49749852010 Data size: 397998816080 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -585,7 +557,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col4, _col5, _col6
                         input vertices:
-                          1 Map 26
+                          1 Map 22
                         Statistics: Num rows: 49385019517 Data size: 592620220724 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -603,7 +575,7 @@ STAGE PLANS:
                             value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 26 
+        Map 22 
             Map Operator Tree:
                 TableScan
                   alias: iss
@@ -670,7 +642,7 @@ STAGE PLANS:
                       value expressions: _col1 (type: int), _col2 (type: int), _col3 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 27 
+        Map 23 
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
@@ -687,7 +659,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 25746588712 Data size: 205972709696 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -697,7 +669,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col4, _col5, _col6
                         input vertices:
-                          1 Map 26
+                          1 Map 22
                         Statistics: Num rows: 25557780268 Data size: 306693349736 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -715,7 +687,7 @@ STAGE PLANS:
                             value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 29 
+        Map 25 
             Map Operator Tree:
                 TableScan
                   alias: web_sales
@@ -732,7 +704,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col1, _col2
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 366607110 Data size: 45145642900 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -742,7 +714,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
-                          1 Reducer 25
+                          1 Reducer 21
                         Statistics: Num rows: 366607110 Data size: 45145642900 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -752,7 +724,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col1, _col2, _col8, _col9, _col10
                           input vertices:
-                            1 Map 26
+                            1 Map 22
                           Statistics: Num rows: 366607110 Data size: 46612057764 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col8 (type: int), _col9 (type: int), _col10 (type: int), (CAST( _col1 AS decimal(10,0)) * _col2) (type: decimal(18,2))
@@ -774,7 +746,7 @@ STAGE PLANS:
                                 value expressions: _col3 (type: decimal(28,2)), _col4 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 31 
+        Map 27 
             Map Operator Tree:
                 TableScan
                   alias: web_sales
@@ -791,7 +763,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0
                       input vertices:
-                        1 Map 19
+                        1 Map 15
                       Statistics: Num rows: 13020465516 Data size: 104163724128 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -801,7 +773,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col4, _col5, _col6
                         input vertices:
-                          1 Map 26
+                          1 Map 22
                         Statistics: Num rows: 12924982039 Data size: 155099770988 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -819,7 +791,7 @@ STAGE PLANS:
                             value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 9 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: avg_sales
@@ -851,78 +823,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: decimal(22,6))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: sq_count_check(_col0) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Map Join Operator
-                      condition map:
-                           Inner Join 0 to 1
-                      keys:
-                        0 
-                        1 
-                      outputColumnNames: _col1
-                      input vertices:
-                        1 Reducer 13
-                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: decimal(22,6))
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: decimal(22,6))
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: decimal(22,6))
         Reducer 11 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: decimal(22,6))
-                outputColumnNames: _col1
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: decimal(22,6))
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col1 (type: decimal(22,6))
-                outputColumnNames: _col1
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: decimal(22,6))
-        Reducer 13 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: decimal(22,6))
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: decimal(22,6))
-        Reducer 15 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -942,7 +843,7 @@ STAGE PLANS:
                       1 
                     outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6
                     input vertices:
-                      0 Reducer 11
+                      0 Reducer 8
                     Statistics: Num rows: 180081 Data size: 43939764 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: (_col5 > _col1) (type: boolean)
@@ -972,7 +873,7 @@ STAGE PLANS:
                               Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: bigint)
                               Statistics: Num rows: 450202 Data size: 103996662 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col5 (type: decimal(38,2)), _col6 (type: bigint)
-        Reducer 17 
+        Reducer 13 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -992,7 +893,7 @@ STAGE PLANS:
                     sort order: ++++
                     Statistics: Num rows: 450202 Data size: 100395046 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col4 (type: decimal(38,2)), _col5 (type: bigint)
-        Reducer 18 
+        Reducer 14 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -1009,7 +910,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 21 
+        Reducer 17 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1029,7 +930,7 @@ STAGE PLANS:
                       1 
                     outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6
                     input vertices:
-                      0 Reducer 12
+                      0 Reducer 8
                     Statistics: Num rows: 180081 Data size: 43939764 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: (_col5 > _col1) (type: boolean)
@@ -1059,7 +960,7 @@ STAGE PLANS:
                               Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: bigint)
                               Statistics: Num rows: 450202 Data size: 103996662 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col5 (type: decimal(38,2)), _col6 (type: bigint)
-        Reducer 23 
+        Reducer 19 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1082,7 +983,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: int)
                     Statistics: Num rows: 153920 Data size: 3078400 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col3 (type: bigint)
-        Reducer 25 
+        Reducer 21 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1106,7 +1007,7 @@ STAGE PLANS:
                         1 _col0 (type: int), _col1 (type: int), _col2 (type: int)
                       outputColumnNames: _col0
                       input vertices:
-                        0 Map 26
+                        0 Map 22
                       Statistics: Num rows: 476 Data size: 3808 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: _col0 (type: bigint)
@@ -1132,7 +1033,7 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: bigint)
                           Statistics: Num rows: 477 Data size: 3816 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 28 
+        Reducer 24 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1155,7 +1056,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: int)
                     Statistics: Num rows: 153920 Data size: 3078400 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col3 (type: bigint)
-        Reducer 30 
+        Reducer 26 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1175,7 +1076,7 @@ STAGE PLANS:
                       1 
                     outputColumnNames: _col1, _col2, _col3, _col4, _col5, _col6
                     input vertices:
-                      0 Reducer 10
+                      0 Reducer 8
                     Statistics: Num rows: 180081 Data size: 43939764 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: (_col5 > _col1) (type: boolean)
@@ -1205,7 +1106,7 @@ STAGE PLANS:
                               Map-reduce partition columns: _col0 (type: string), _col1 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: bigint)
                               Statistics: Num rows: 450202 Data size: 103996662 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col5 (type: decimal(38,2)), _col6 (type: bigint)
-        Reducer 32 
+        Reducer 28 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1228,10 +1129,59 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: int)
                     Statistics: Num rows: 153920 Data size: 3078400 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col3 (type: bigint)
-        Union 16 
-            Vertex: Union 16
-        Union 24 
-            Vertex: Union 24
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: sq_count_check(_col0) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 
+                        1 
+                      outputColumnNames: _col1
+                      input vertices:
+                        1 Reducer 9
+                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: decimal(22,6))
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: decimal(22,6))
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: decimal(22,6))
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: decimal(22,6))
+                outputColumnNames: _col0
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: decimal(22,6))
+        Union 12 
+            Vertex: Union 12
+        Union 20 
+            Vertex: Union 20
 
   Stage: Stage-0
     Move Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query23.q.out
@@ -8,18 +8,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 14 (BROADCAST_EDGE), Reducer 12 (BROADCAST_EDGE), Reducer 7 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 4 <- Reducer 13 (BROADCAST_EDGE), Reducer 16 (BROADCAST_EDGE), Reducer 8 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 9 <- Map 14 (BROADCAST_EDGE), Reducer 15 (BROADCAST_EDGE)
-        Reducer 10 <- Map 9 (SIMPLE_EDGE)
-        Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE)
-        Reducer 12 <- Map 5 (BROADCAST_EDGE), Map 9 (SIMPLE_EDGE)
-        Reducer 13 <- Reducer 12 (SIMPLE_EDGE)
-        Reducer 15 <- Map 14 (SIMPLE_EDGE)
-        Reducer 16 <- Map 14 (SIMPLE_EDGE)
+        Map 1 <- Map 12 (BROADCAST_EDGE), Reducer 11 (BROADCAST_EDGE), Reducer 7 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 4 <- Map 12 (BROADCAST_EDGE), Reducer 11 (BROADCAST_EDGE), Reducer 7 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 8 <- Map 12 (BROADCAST_EDGE), Reducer 13 (BROADCAST_EDGE)
+        Reducer 10 <- Reducer 9 (CUSTOM_SIMPLE_EDGE)
+        Reducer 11 <- Map 5 (BROADCAST_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 13 <- Map 12 (SIMPLE_EDGE)
         Reducer 3 <- Union 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Reducer 11 (BROADCAST_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE), Reducer 10 (BROADCAST_EDGE)
+        Reducer 9 <- Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -44,7 +41,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
-                          1 Map 14
+                          1 Map 12
                         Statistics: Num rows: 723144625 Data size: 82199941740 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -54,7 +51,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col0, _col2, _col3
                           input vertices:
-                            1 Reducer 12
+                            1 Reducer 11
                           Statistics: Num rows: 723144625 Data size: 76414784740 Basic stats: COMPLETE Column stats: COMPLETE
                           Map Join Operator
                             condition map:
@@ -83,7 +80,7 @@ STAGE PLANS:
                                   value expressions: _col0 (type: decimal(28,2))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 14 
+        Map 12 
             Map Operator Tree:
                 TableScan
                   alias: date_dim
@@ -117,7 +114,7 @@ STAGE PLANS:
                             Target Input: store_sales
                             Partition key expr: ss_sold_date_sk
                             Statistics: Num rows: 1468 Data size: 11744 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 9
+                            Target Vertex: Map 8
                     Select Operator
                       expressions: d_date_sk (type: bigint), d_date (type: date)
                       outputColumnNames: _col0, _col1
@@ -144,7 +141,7 @@ STAGE PLANS:
                             Target Input: store_sales
                             Partition key expr: ss_sold_date_sk
                             Statistics: Num rows: 1468 Data size: 11744 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 9
+                            Target Vertex: Map 8
                   Filter Operator
                     predicate: ((d_year = 1999) and (d_moy = 1)) (type: boolean)
                     Statistics: Num rows: 31 Data size: 496 Basic stats: COMPLETE Column stats: COMPLETE
@@ -220,7 +217,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
-                          1 Reducer 16
+                          1 Map 12
                         Statistics: Num rows: 366561381 Data size: 48050956264 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -230,7 +227,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col1, _col2, _col3
                           input vertices:
-                            1 Reducer 13
+                            1 Reducer 11
                           Statistics: Num rows: 366561381 Data size: 45118465216 Basic stats: COMPLETE Column stats: COMPLETE
                           Map Join Operator
                             condition map:
@@ -240,7 +237,7 @@ STAGE PLANS:
                               1 _col0 (type: bigint)
                             outputColumnNames: _col2, _col3
                             input vertices:
-                              1 Reducer 8
+                              1 Reducer 7
                             Statistics: Num rows: 366561381 Data size: 42207520544 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: (CAST( _col2 AS decimal(10,0)) * _col3) (type: decimal(18,2))
@@ -305,7 +302,7 @@ STAGE PLANS:
                           value expressions: _col1 (type: decimal(28,2))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 9 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -325,7 +322,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col1, _col2
                         input vertices:
-                          1 Reducer 15
+                          1 Reducer 13
                         Statistics: Num rows: 64769599664 Data size: 7757159825120 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(_col2)
@@ -353,7 +350,7 @@ STAGE PLANS:
                         1 _col0 (type: bigint)
                       outputColumnNames: _col0, _col3
                       input vertices:
-                        1 Map 14
+                        1 Map 12
                       Statistics: Num rows: 66333133964 Data size: 4245320573696 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
@@ -375,30 +372,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
-                aggregations: sum(VALUE._col0)
-                keys: KEY._col0 (type: bigint)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 63129535 Data size: 7560736760 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: decimal(28,2))
-                  outputColumnNames: _col1
-                  Statistics: Num rows: 63129535 Data size: 7560736760 Basic stats: COMPLETE Column stats: COMPLETE
-                  Group By Operator
-                    aggregations: max(_col1)
-                    minReductionHashAggr: 0.99
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: decimal(28,2))
-        Reducer 11 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
                 aggregations: max(VALUE._col0)
                 mode: mergepartial
                 outputColumnNames: _col0
@@ -415,7 +388,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: decimal(37,8))
-        Reducer 12 
+        Reducer 11 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -478,31 +451,7 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 64646121 Data size: 517168968 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 15 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
                   Statistics: Num rows: 1468 Data size: 11744 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 16 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -538,7 +487,7 @@ STAGE PLANS:
                       1 
                     outputColumnNames: _col0, _col1, _col2
                     input vertices:
-                      1 Reducer 11
+                      1 Reducer 10
                     Statistics: Num rows: 78525966 Data size: 18189742160 Basic stats: COMPLETE Column stats: COMPLETE
                     Filter Operator
                       predicate: (_col1 > _col2) (type: boolean)
@@ -565,18 +514,30 @@ STAGE PLANS:
                             sort order: +
                             Map-reduce partition columns: _col0 (type: bigint)
                             Statistics: Num rows: 26175322 Data size: 199975264 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 26175322 Data size: 199975264 Basic stats: COMPLETE Column stats: COMPLETE
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: bigint)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 63129535 Data size: 7560736760 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: decimal(28,2))
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 63129535 Data size: 7560736760 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: max(_col1)
+                    minReductionHashAggr: 0.99
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: decimal(28,2))
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query71.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query71.q.out
@@ -7,15 +7,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 10 (BROADCAST_EDGE), Map 13 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 5 <- Map 10 (BROADCAST_EDGE), Map 13 (BROADCAST_EDGE), Reducer 11 (BROADCAST_EDGE), Reducer 7 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Map 9 <- Map 10 (BROADCAST_EDGE), Map 13 (BROADCAST_EDGE), Reducer 12 (BROADCAST_EDGE), Reducer 8 (BROADCAST_EDGE), Union 2 (CONTAINS)
-        Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-        Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE)
+        Map 1 <- Map 10 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 5 <- Map 10 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE), Union 2 (CONTAINS)
+        Map 7 <- Map 10 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE), Union 2 (CONTAINS)
         Reducer 3 <- Union 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (SIMPLE_EDGE)
+        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -54,7 +51,7 @@ STAGE PLANS:
                               1 _col0 (type: bigint)
                             outputColumnNames: _col0, _col2, _col4, _col5
                             input vertices:
-                              1 Map 10
+                              1 Map 8
                             Statistics: Num rows: 23627911 Data size: 2457302824 Basic stats: COMPLETE Column stats: COMPLETE
                             Map Join Operator
                               condition map:
@@ -64,7 +61,7 @@ STAGE PLANS:
                                 1 _col0 (type: bigint)
                               outputColumnNames: _col0, _col4, _col5, _col7, _col8
                               input vertices:
-                                1 Map 13
+                                1 Map 10
                               Statistics: Num rows: 11813956 Data size: 1323163144 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: sum(_col0)
@@ -83,57 +80,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: item
-                  filterExpr: (i_manager_id = 1) (type: boolean)
-                  Statistics: Num rows: 462000 Data size: 53582956 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (i_manager_id = 1) (type: boolean)
-                    Statistics: Num rows: 4442 Data size: 515192 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: i_item_sk (type: bigint), i_brand_id (type: int), i_brand (type: char(50))
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: bigint)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: char(50))
-                      Select Operator
-                        expressions: _col0 (type: bigint)
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 4442 Data size: 35536 Basic stats: COMPLETE Column stats: COMPLETE
-                        Group By Operator
-                          aggregations: min(_col0), max(_col0), bloom_filter(_col0, expectedEntries=1000000)
-                          minReductionHashAggr: 0.99
-                          mode: hash
-                          outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            null sort order: 
-                            sort order: 
-                            Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
-                      Reduce Output Operator
-                        key expressions: _col0 (type: bigint)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: char(50))
-                      Reduce Output Operator
-                        key expressions: _col0 (type: bigint)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col2 (type: char(50))
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 13 
             Map Operator Tree:
                 TableScan
                   alias: time_dim
@@ -190,7 +136,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
-                          1 Reducer 7
+                          1 Map 6
                         Statistics: Num rows: 723126157 Data size: 79690952072 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col2 (type: decimal(7,2)), _col1 (type: bigint), _col0 (type: bigint)
@@ -204,7 +150,7 @@ STAGE PLANS:
                               1 _col0 (type: bigint)
                             outputColumnNames: _col0, _col2, _col4, _col5
                             input vertices:
-                              1 Map 10
+                              1 Map 8
                             Statistics: Num rows: 23627911 Data size: 2457302824 Basic stats: COMPLETE Column stats: COMPLETE
                             Map Join Operator
                               condition map:
@@ -214,7 +160,7 @@ STAGE PLANS:
                                 1 _col0 (type: bigint)
                               outputColumnNames: _col0, _col4, _col5, _col7, _col8
                               input vertices:
-                                1 Map 13
+                                1 Map 10
                               Statistics: Num rows: 11813956 Data size: 1323163144 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: sum(_col0)
@@ -288,7 +234,7 @@ STAGE PLANS:
                             Target Input: store_sales
                             Partition key expr: ss_sold_date_sk
                             Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                            Target Vertex: Map 9
+                            Target Vertex: Map 7
                       Reduce Output Operator
                         key expressions: _col0 (type: bigint)
                         null sort order: z
@@ -313,7 +259,7 @@ STAGE PLANS:
                             Target Vertex: Map 1
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 9 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -334,7 +280,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col1, _col2
                         input vertices:
-                          1 Reducer 8
+                          1 Map 6
                         Statistics: Num rows: 1367785359 Data size: 10942282992 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col2 (type: decimal(7,2)), _col1 (type: bigint), _col0 (type: bigint)
@@ -348,7 +294,7 @@ STAGE PLANS:
                               1 _col0 (type: bigint)
                             outputColumnNames: _col0, _col2, _col4, _col5
                             input vertices:
-                              1 Map 10
+                              1 Map 8
                             Statistics: Num rows: 23627911 Data size: 2457302824 Basic stats: COMPLETE Column stats: COMPLETE
                             Map Join Operator
                               condition map:
@@ -358,7 +304,7 @@ STAGE PLANS:
                                 1 _col0 (type: bigint)
                               outputColumnNames: _col0, _col4, _col5, _col7, _col8
                               input vertices:
-                                1 Map 13
+                                1 Map 10
                               Statistics: Num rows: 11813956 Data size: 1323163144 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: sum(_col0)
@@ -376,35 +322,57 @@ STAGE PLANS:
                                   value expressions: _col4 (type: decimal(17,2))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Reducer 11 
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: item
+                  filterExpr: (i_manager_id = 1) (type: boolean)
+                  Statistics: Num rows: 462000 Data size: 53582956 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (i_manager_id = 1) (type: boolean)
+                    Statistics: Num rows: 4442 Data size: 515192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: i_item_sk (type: bigint), i_brand_id (type: int), i_brand (type: char(50))
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: bigint)
+                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), _col2 (type: char(50))
+                      Select Operator
+                        expressions: _col0 (type: bigint)
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 4442 Data size: 35536 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          aggregations: min(_col0), max(_col0), bloom_filter(_col0, expectedEntries=1000000)
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: bigint)
+                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), _col2 (type: char(50))
+                      Reduce Output Operator
+                        key expressions: _col0 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: bigint)
+                        Statistics: Num rows: 4442 Data size: 497464 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), _col2 (type: char(50))
             Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: min(VALUE._col0), max(VALUE._col1), bloom_filter(VALUE._col2, 1, expectedEntries=1000000)
-                mode: final
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: binary)
-                outputColumnNames: _col0, _col1, _col2
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+            LLAP IO: may be used (ACID table)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -438,30 +406,24 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 9 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), bloom_filter(VALUE._col2, 1, expectedEntries=1000000)
+                mode: final
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
                 Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 31 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
         Union 2 
             Vertex: Union 2
 

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query76.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query76.q.out
@@ -7,15 +7,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 11 <- Reducer 10 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE), Union 5 (CONTAINS)
-        Map 12 <- Map 8 (BROADCAST_EDGE), Reducer 3 (BROADCAST_EDGE), Union 5 (CONTAINS)
-        Map 4 <- Map 1 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE), Union 5 (CONTAINS)
-        Reducer 10 <- Map 8 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Union 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Map 7 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Map 8 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -49,7 +45,7 @@ STAGE PLANS:
                           Target Input: store_sales
                           Partition key expr: ss_sold_date_sk
                           Statistics: Num rows: 67850 Data size: 542800 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 4
+                          Target Vertex: Map 2
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
@@ -72,7 +68,7 @@ STAGE PLANS:
                           Target Input: web_sales
                           Partition key expr: ws_sold_date_sk
                           Statistics: Num rows: 67850 Data size: 542800 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 11
+                          Target Vertex: Map 7
                     Reduce Output Operator
                       key expressions: _col0 (type: bigint)
                       null sort order: z
@@ -95,130 +91,10 @@ STAGE PLANS:
                           Target Input: catalog_sales
                           Partition key expr: cs_sold_date_sk
                           Statistics: Num rows: 67850 Data size: 542800 Basic stats: COMPLETE Column stats: COMPLETE
-                          Target Vertex: Map 12
+                          Target Vertex: Map 8
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: web_sales
-                  filterExpr: ws_web_page_sk is null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_126_container, bigKeyColName:ws_item_sk, smallTablePos:1, keyRatio:1.2496236076135138E-4
-                  Statistics: Num rows: 21594638446 Data size: 2936546632992 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ws_web_page_sk is null (type: boolean)
-                    Statistics: Num rows: 2698517 Data size: 366957880 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: ws_item_sk (type: bigint), ws_ext_sales_price (type: decimal(7,2)), ws_sold_date_sk (type: bigint)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 2698517 Data size: 345372432 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col2 (type: bigint)
-                          1 _col0 (type: bigint)
-                        outputColumnNames: _col0, _col1, _col4, _col5
-                        input vertices:
-                          1 Reducer 2
-                        Statistics: Num rows: 2698517 Data size: 345372432 Basic stats: COMPLETE Column stats: COMPLETE
-                        Map Join Operator
-                          condition map:
-                               Inner Join 0 to 1
-                          keys:
-                            0 _col0 (type: bigint)
-                            1 _col0 (type: bigint)
-                          outputColumnNames: _col1, _col4, _col5, _col7
-                          input vertices:
-                            1 Reducer 10
-                          Statistics: Num rows: 2698517 Data size: 566650826 Basic stats: COMPLETE Column stats: COMPLETE
-                          Select Operator
-                            expressions: 'web' (type: string), 'ws_web_page_sk' (type: string), _col4 (type: int), _col5 (type: int), _col7 (type: char(50)), _col1 (type: decimal(7,2))
-                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                            Statistics: Num rows: 2698517 Data size: 1065876471 Basic stats: COMPLETE Column stats: COMPLETE
-                            Top N Key Operator
-                              sort order: +++++
-                              keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                              null sort order: zzzzz
-                              Statistics: Num rows: 2057228617 Data size: 804076268851 Basic stats: COMPLETE Column stats: COMPLETE
-                              top n: 100
-                              Group By Operator
-                                aggregations: count(), sum(_col5)
-                                keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                minReductionHashAggr: 0.99
-                                mode: hash
-                                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                                Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
-                                Reduce Output Operator
-                                  key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                  null sort order: zzzzz
-                                  sort order: +++++
-                                  Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                  Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
-                                  value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 12 
-            Map Operator Tree:
-                TableScan
-                  alias: catalog_sales
-                  filterExpr: cs_warehouse_sk is null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_127_container, bigKeyColName:cs_item_sk, smallTablePos:1, keyRatio:0.0025041257292801387
-                  Statistics: Num rows: 43005109025 Data size: 5835786558816 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: cs_warehouse_sk is null (type: boolean)
-                    Statistics: Num rows: 107690200 Data size: 14613543432 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: cs_item_sk (type: bigint), cs_ext_sales_price (type: decimal(7,2)), cs_sold_date_sk (type: bigint)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 107690200 Data size: 13754179184 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col2 (type: bigint)
-                          1 _col0 (type: bigint)
-                        outputColumnNames: _col0, _col1, _col4, _col5
-                        input vertices:
-                          1 Reducer 3
-                        Statistics: Num rows: 107690200 Data size: 13754179184 Basic stats: COMPLETE Column stats: COMPLETE
-                        Map Join Operator
-                          condition map:
-                               Inner Join 0 to 1
-                          keys:
-                            0 _col0 (type: bigint)
-                            1 _col0 (type: bigint)
-                          outputColumnNames: _col1, _col4, _col5, _col7
-                          input vertices:
-                            1 Map 8
-                          Statistics: Num rows: 107690200 Data size: 22584775584 Basic stats: COMPLETE Column stats: COMPLETE
-                          Select Operator
-                            expressions: 'catalog' (type: string), 'cs_warehouse_sk' (type: string), _col4 (type: int), _col5 (type: int), _col7 (type: char(50)), _col1 (type: decimal(7,2))
-                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                            Statistics: Num rows: 107690200 Data size: 43045913584 Basic stats: COMPLETE Column stats: COMPLETE
-                            Top N Key Operator
-                              sort order: +++++
-                              keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                              null sort order: zzzzz
-                              Statistics: Num rows: 2057228617 Data size: 804076268851 Basic stats: COMPLETE Column stats: COMPLETE
-                              top n: 100
-                              Group By Operator
-                                aggregations: count(), sum(_col5)
-                                keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                minReductionHashAggr: 0.99
-                                mode: hash
-                                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                                Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
-                                Reduce Output Operator
-                                  key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                  null sort order: zzzzz
-                                  sort order: +++++
-                                  Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
-                                  Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
-                                  value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 4 
+        Map 2 
             Map Operator Tree:
                 TableScan
                   alias: store_sales
@@ -250,7 +126,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col1, _col2, _col4, _col7
                           input vertices:
-                            1 Reducer 9
+                            1 Map 6
                           Statistics: Num rows: 1946839900 Data size: 403692777096 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: 'store' (type: string), 'ss_addr_sk' (type: string), _col1 (type: int), _col2 (type: int), _col7 (type: char(50)), _col4 (type: decimal(7,2))
@@ -278,7 +154,7 @@ STAGE PLANS:
                                   value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 8 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: item
@@ -310,46 +186,127 @@ STAGE PLANS:
                       value expressions: _col1 (type: char(50))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Reducer 10 
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: web_sales
+                  filterExpr: ws_web_page_sk is null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_126_container, bigKeyColName:ws_item_sk, smallTablePos:1, keyRatio:1.2496236076135138E-4
+                  Statistics: Num rows: 21594638446 Data size: 2936546632992 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ws_web_page_sk is null (type: boolean)
+                    Statistics: Num rows: 2698517 Data size: 366957880 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: ws_item_sk (type: bigint), ws_ext_sales_price (type: decimal(7,2)), ws_sold_date_sk (type: bigint)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 2698517 Data size: 345372432 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col2 (type: bigint)
+                          1 _col0 (type: bigint)
+                        outputColumnNames: _col0, _col1, _col4, _col5
+                        input vertices:
+                          1 Map 1
+                        Statistics: Num rows: 2698517 Data size: 345372432 Basic stats: COMPLETE Column stats: COMPLETE
+                        Map Join Operator
+                          condition map:
+                               Inner Join 0 to 1
+                          keys:
+                            0 _col0 (type: bigint)
+                            1 _col0 (type: bigint)
+                          outputColumnNames: _col1, _col4, _col5, _col7
+                          input vertices:
+                            1 Map 6
+                          Statistics: Num rows: 2698517 Data size: 566650826 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: 'web' (type: string), 'ws_web_page_sk' (type: string), _col4 (type: int), _col5 (type: int), _col7 (type: char(50)), _col1 (type: decimal(7,2))
+                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                            Statistics: Num rows: 2698517 Data size: 1065876471 Basic stats: COMPLETE Column stats: COMPLETE
+                            Top N Key Operator
+                              sort order: +++++
+                              keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                              null sort order: zzzzz
+                              Statistics: Num rows: 2057228617 Data size: 804076268851 Basic stats: COMPLETE Column stats: COMPLETE
+                              top n: 100
+                              Group By Operator
+                                aggregations: count(), sum(_col5)
+                                keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                minReductionHashAggr: 0.99
+                                mode: hash
+                                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                                Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
+                                Reduce Output Operator
+                                  key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                  null sort order: zzzzz
+                                  sort order: +++++
+                                  Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                  Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
+                                  value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
             Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint), VALUE._col0 (type: char(50))
-                outputColumnNames: _col0, _col1
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 462000 Data size: 45276000 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: char(50))
-        Reducer 2 
+            LLAP IO: may be used (ACID table)
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: catalog_sales
+                  filterExpr: cs_warehouse_sk is null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_127_container, bigKeyColName:cs_item_sk, smallTablePos:1, keyRatio:0.0025041257292801387
+                  Statistics: Num rows: 43005109025 Data size: 5835786558816 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: cs_warehouse_sk is null (type: boolean)
+                    Statistics: Num rows: 107690200 Data size: 14613543432 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: cs_item_sk (type: bigint), cs_ext_sales_price (type: decimal(7,2)), cs_sold_date_sk (type: bigint)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 107690200 Data size: 13754179184 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col2 (type: bigint)
+                          1 _col0 (type: bigint)
+                        outputColumnNames: _col0, _col1, _col4, _col5
+                        input vertices:
+                          1 Map 1
+                        Statistics: Num rows: 107690200 Data size: 13754179184 Basic stats: COMPLETE Column stats: COMPLETE
+                        Map Join Operator
+                          condition map:
+                               Inner Join 0 to 1
+                          keys:
+                            0 _col0 (type: bigint)
+                            1 _col0 (type: bigint)
+                          outputColumnNames: _col1, _col4, _col5, _col7
+                          input vertices:
+                            1 Map 6
+                          Statistics: Num rows: 107690200 Data size: 22584775584 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: 'catalog' (type: string), 'cs_warehouse_sk' (type: string), _col4 (type: int), _col5 (type: int), _col7 (type: char(50)), _col1 (type: decimal(7,2))
+                            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                            Statistics: Num rows: 107690200 Data size: 43045913584 Basic stats: COMPLETE Column stats: COMPLETE
+                            Top N Key Operator
+                              sort order: +++++
+                              keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                              null sort order: zzzzz
+                              Statistics: Num rows: 2057228617 Data size: 804076268851 Basic stats: COMPLETE Column stats: COMPLETE
+                              top n: 100
+                              Group By Operator
+                                aggregations: count(), sum(_col5)
+                                keys: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                minReductionHashAggr: 0.99
+                                mode: hash
+                                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                                Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
+                                Reduce Output Operator
+                                  key expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                  null sort order: zzzzz
+                                  sort order: +++++
+                                  Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: int), _col3 (type: int), _col4 (type: char(50))
+                                  Statistics: Num rows: 27502596 Data size: 11221059168 Basic stats: COMPLETE Column stats: COMPLETE
+                                  value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
             Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 73049 Data size: 1168784 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: int)
-        Reducer 3 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint), VALUE._col0 (type: int), VALUE._col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 73049 Data size: 1168784 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: int), _col2 (type: int)
-        Reducer 6 
+            LLAP IO: may be used (ACID table)
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -364,7 +321,7 @@ STAGE PLANS:
                   sort order: +++++
                   Statistics: Num rows: 8756 Data size: 3572448 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col5 (type: bigint), _col6 (type: decimal(17,2))
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -381,21 +338,8 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: bigint), VALUE._col0 (type: char(50))
-                outputColumnNames: _col0, _col1
-                Reduce Output Operator
-                  key expressions: _col0 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: bigint)
-                  Statistics: Num rows: 462000 Data size: 45276000 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: char(50))
-        Union 5 
-            Vertex: Union 5
+        Union 3 
+            Vertex: Union 3
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
@@ -965,11 +965,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Map 6 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Map 3 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 9 <- Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -997,12 +998,45 @@ STAGE PLANS:
                       Map-reduce partition columns: value (type: string)
                       Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 2 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: z
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: (value is not null or key is not null) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: value is not null (type: boolean)
+                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 value (type: string)
+                        1 value (type: string)
+                      outputColumnNames: _col1
+                      input vertices:
+                        0 Reducer 2
+                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col1 (type: string)
+                          1 value (type: string)
+                        input vertices:
+                          1 Map 8
+                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
+                        Group By Operator
+                          aggregations: count()
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1023,48 +1057,8 @@ STAGE PLANS:
                           0 _col0 (type: string)
                           1 key (type: string)
                         input vertices:
-                          1 Map 8
+                          1 Reducer 9
                         Statistics: Num rows: 250 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                        Group By Operator
-                          aggregations: count()
-                          minReductionHashAggr: 0.99
-                          mode: hash
-                          outputColumnNames: _col0
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            null sort order: 
-                            sort order: 
-                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: bigint)
-            Execution mode: vectorized
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Map Join Operator
-                      condition map:
-                           Inner Join 0 to 1
-                      keys:
-                        0 value (type: string)
-                        1 value (type: string)
-                      outputColumnNames: _col1
-                      input vertices:
-                        0 Map 1
-                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col1 (type: string)
-                          1 value (type: string)
-                        input vertices:
-                          1 Map 8
-                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
                           minReductionHashAggr: 0.99
@@ -1102,7 +1096,19 @@ STAGE PLANS:
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Reducer 3 
+        Reducer 2 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: value
+                Reduce Output Operator
+                  key expressions: value (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: value (type: string)
+                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -1122,7 +1128,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -1157,8 +1163,20 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: key
+                Reduce Output Operator
+                  key expressions: key (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: key (type: string)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator
@@ -1243,11 +1261,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Map 6 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE)
-        Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Map 3 <- Map 1 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE), Reducer 9 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 3 (CUSTOM_SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 9 <- Map 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1275,12 +1294,47 @@ STAGE PLANS:
                       Map-reduce partition columns: value (type: string)
                       Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 2 
+        Map 3 
             Map Operator Tree:
                 TableScan
                   alias: z
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
+                  filterExpr: (value is not null or key is not null) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: value is not null (type: boolean)
+                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Map Join Operator
+                      condition map:
+                           Inner Join 0 to 1
+                      keys:
+                        0 value (type: string)
+                        1 value (type: string)
+                      outputColumnNames: _col1
+                      input vertices:
+                        0 Reducer 2
+                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
+                      HybridGraceHashJoin: true
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col1 (type: string)
+                          1 value (type: string)
+                        input vertices:
+                          1 Map 8
+                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
+                        HybridGraceHashJoin: true
+                        Group By Operator
+                          aggregations: count()
+                          minReductionHashAggr: 0.99
+                          mode: hash
+                          outputColumnNames: _col0
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            null sort order: 
+                            sort order: 
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            value expressions: _col0 (type: bigint)
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1302,50 +1356,8 @@ STAGE PLANS:
                           0 _col0 (type: string)
                           1 key (type: string)
                         input vertices:
-                          1 Map 8
+                          1 Reducer 9
                         Statistics: Num rows: 250 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                        HybridGraceHashJoin: true
-                        Group By Operator
-                          aggregations: count()
-                          minReductionHashAggr: 0.99
-                          mode: hash
-                          outputColumnNames: _col0
-                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                          Reduce Output Operator
-                            null sort order: 
-                            sort order: 
-                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                            value expressions: _col0 (type: bigint)
-            Execution mode: vectorized
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Map Join Operator
-                      condition map:
-                           Inner Join 0 to 1
-                      keys:
-                        0 value (type: string)
-                        1 value (type: string)
-                      outputColumnNames: _col1
-                      input vertices:
-                        0 Map 1
-                      Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
-                      HybridGraceHashJoin: true
-                      Map Join Operator
-                        condition map:
-                             Inner Join 0 to 1
-                        keys:
-                          0 _col1 (type: string)
-                          1 value (type: string)
-                        input vertices:
-                          1 Map 8
-                        Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         HybridGraceHashJoin: true
                         Group By Operator
                           aggregations: count()
@@ -1384,7 +1396,19 @@ STAGE PLANS:
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Reducer 3 
+        Reducer 2 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: value
+                Reduce Output Operator
+                  key expressions: value (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: value (type: string)
+                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -1404,7 +1428,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -1439,8 +1463,20 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Union 4 
-            Vertex: Union 4
+        Reducer 9 
+            Execution mode: vectorized
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: key
+                Reduce Output Operator
+                  key expressions: key (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: key (type: string)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I rewrite OperatorGraph to make sure that OperatorGraph represents actual Tez DAG.
In new OperatorGraph, each cluster has a unique root operator and one Operator can belong to more than one cluster.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Tez DAG and current OperatorGraph group operators differently when a query plan contains union operators. More precisely, OperatorGraph groups all root operators of a union operator into the same cluster, but Tez DAG creates a BaseWork for each of the root operators and clones descendants of the union operator if needed. This difference makes false-positive errors when detecting parallel edges, which leads to insertion of unnecessary concentrator RS by ParallelEdgeFixer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I run the below maven tests and add a unit test for OperatorGraph.
```
mvn test -Dtest=TestSharedWorkOptimizer
cd itests; mvn test -Dtest=TestCliDriver
```
