### PR TITLE
HIVE-26931: REPL LOAD command does not throw any error for incorrect syntax

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -2098,7 +2098,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
       replica.loadWithoutExplain("", "`*`");
       fail();
     } catch (HiveException e) {
-      assertEquals("MetaException(message:Database name cannot be null.)", e.getMessage());
+      assertEquals("REPL LOAD Target database name shouldn't be null", e.getMessage());
     }
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -701,7 +701,7 @@ public class TestReplicationScenariosAcrossInstances extends BaseReplicationAcro
       replica.load("", "`*`");
       Assert.fail();
     } catch (HiveException e) {
-      assertEquals("MetaException(message:Database name cannot be null.)", e.getMessage());
+      assertEquals("REPL LOAD Target database name shouldn't be null", e.getMessage());
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSemanticAnalyzer.java
@@ -320,7 +320,8 @@ public class ReplicationSemanticAnalyzer extends BaseSemanticAnalyzer {
     // looking at each db, and then each table, and then setting up the appropriate
     // import job in its place.
     try {
-      assert (sourceDbNameOrPattern != null);
+      Objects.requireNonNull(sourceDbNameOrPattern, "REPL LOAD Source database name shouldn't be null");
+      Objects.requireNonNull(replScope.getDbName(), "REPL LOAD Target database name shouldn't be null");
       Path loadPath = getCurrentLoadPath();
 
       // Now, the dumped path can be one of three things:
@@ -370,7 +371,7 @@ public class ReplicationSemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       } else {
         ReplUtils.reportStatusInReplicationMetrics("REPL_LOAD", Status.SKIPPED, null, conf,  sourceDbNameOrPattern, null);
-        LOG.warn("Previous Dump Already Loaded");
+        LOG.warn("No dump to load or the previous dump already loaded");
       }
     } catch (Exception e) {
       // TODO : simple wrap & rethrow for now, clean up with error codes


### PR DESCRIPTION
### What changes were proposed in this pull request?
While performing a REPL LOAD, the source and target database names are made mandatory.

### Why are the changes needed?
The standard REPL LOAD syntax is,
`repl load src into tgt with ( <config properties (if any) >);`

But in some cases, users are using the REPL LOAD command incorrectly. It does not really throw any meaningful error/warning message, and as expected it does not replicate the database as well.

For example,
`repl load target_db with ('hive.repl.rootdir'='hdfs://c3649-node2.coelab.cloudera.com:8020/user/hive/repl', 'hive.repl.include.external.tables'= 'true', 'hive.repl.replica.external.table.base.dir'='hdfs://c3649node2.coelab.cloudera.com:8020/warehouse/tablespace/external/hive/target_db.db')
`
The above command does not follow the REPL LOAD syntax. This does not produce any error message, nor it replicates the database. So, it causes confusion.


### Does this PR introduce _any_ user-facing change?
No, it's more of a validation for the correct REPL LOAD usage.


### How was this patch tested?
Tested manually, and also updated the automated tests to reflect this.
