### PR TITLE
HIVE-27010: Reduce compilation time

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ExprNodeGenericFuncEvaluator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ExprNodeGenericFuncEvaluator.java
@@ -170,7 +170,7 @@ public class ExprNodeGenericFuncEvaluator extends ExprNodeEvaluator<ExprNodeGene
     // when "hive.fetch.task.conversion" occurs.
     if (context != null) {
       context.setup(genericUDF);
-    } else {
+    } else if (MapredContext.needConfigure(genericUDF)) {
       // It is a bit unfortunate that currently the UDF configuration signature expects a
       // MapredContext (even if execution is tez or another engine) - this causes an
       // impedence mismatch. For example: MapredContext has Reporter objects that may or

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MapredContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MapredContext.java
@@ -153,7 +153,7 @@ public class MapredContext {
     // close is called by UDTFOperator
   }
 
-  private boolean needConfigure(Object func) {
+  static boolean needConfigure(Object func) {
     try {
       Method initMethod = func.getClass().getMethod("configure", MapredContext.class);
       return initMethod.getDeclaringClass() != GenericUDF.class &&


### PR DESCRIPTION
Post https://issues.apache.org/jira/browse/HIVE-24645, query compilation time increased for lot of queries. This is due to the fact that "MapredContext.createDummy" gets called from ExprNodeGenericFuncEvaluator.initialize() early in the compilation cycle. The fix for HIVE-24645 was supposed to be mainly for fetch.task.conversion, but got impacted for other cases.

Intent of this ticket is to go through that fix only on need basis. i.e for the cases where UDF configure needs to be called. For queries that do not have UDF, it will not go through this path and will reduce compilation times.


### Does this PR introduce _any_ user-facing change?
No

