### PR TITLE
[HIVE-27004](https://issues.apache.org/jira/browse/HIVE-27004) : DateTimeFormatterBuilder#appendZoneText  cannot parse 'UTC+' in Java …

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
@@ -79,7 +79,7 @@ public class TimestampTZUtil {
         optionalEnd().optionalEnd();
     // Zone part
     builder.optionalStart().appendLiteral(" ").optionalEnd();
-    builder.optionalStart().appendZoneText(TextStyle.NARROW).optionalEnd();
+    builder.optionalStart().appendZoneOrOffsetId().optionalEnd();
 
     FORMATTER = builder.toFormatter();
   }


### PR DESCRIPTION
[…versions](https://issues.apache.org/jira/browse/HIVE-27004) higher than 8.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Changes in _common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java_ 


### Why are the changes needed?
DateTimeFormatterBuilder cannot parse 'UTC+' in Java versions higher than 8 and throws an error.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
The unit tests at my setup which were failing for Java ver. greater than 8 worked.
