### PR TITLE
HIVE-27004 : DateTimeFormatterBuilder#appendZoneText  cannot parse 'U…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
@@ -79,7 +79,7 @@ public class TimestampTZUtil {
         optionalEnd().optionalEnd();
     // Zone part
     builder.optionalStart().appendLiteral(" ").optionalEnd();
-    builder.optionalStart().appendZoneText(TextStyle.NARROW).optionalEnd();
+    builder.optionalStart().appendZoneOrOffsetId().optionalEnd();
 
     FORMATTER = builder.toFormatter();
   }


### PR DESCRIPTION
…TC+' in Java versions higher than 8.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Make changes in _common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java_ to prevent 


### Why are the changes needed?
Required to prevent parsing related error in Java ver greater than 8


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested at my setup with related unit tests that were failing on Java ver greater than 8
