### PR TITLE
HIVE-23935. Fetching primaryKey through beeline fails with NPE.

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
@@ -91,7 +91,7 @@ public class StringUtils {
    * @return normalized version, with white space removed and all lower case.
    */
   public static String normalizeIdentifier(String identifier) {
-    return identifier == null ? null : identifier.trim().toLowerCase();
+    return identifier.trim().toLowerCase();
   }
 
   /**

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
@@ -91,7 +91,7 @@ public class StringUtils {
    * @return normalized version, with white space removed and all lower case.
    */
   public static String normalizeIdentifier(String identifier) {
-    return identifier.trim().toLowerCase();
+    return identifier == null ? null : identifier.trim().toLowerCase();
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -12022,24 +12022,22 @@ public class ObjectStore implements RawStore, Configurable {
   }
 
   private List<SQLPrimaryKey> getPrimaryKeysInternal(final String catName,
-                                                     final String db_name_input,
-                                                     final String tbl_name_input)
+                                                     final String dbNameInput,
+                                                     final String tblNameInput)
   throws MetaException, NoSuchObjectException {
-    final String db_name = StringUtils.isNotBlank(db_name_input) ?
-        normalizeIdentifier(db_name_input) :
-        null;
-    final String tbl_name = normalizeIdentifier(tbl_name_input);
-    return new GetListHelper<SQLPrimaryKey>(catName, db_name, tbl_name, true, true) {
+    final String dbName = normalizeIdentifier(dbNameInput);
+    final String tblName = normalizeIdentifier(tblNameInput);
+    return new GetListHelper<SQLPrimaryKey>(catName, dbName, tblName, true, true) {
 
       @Override
       protected List<SQLPrimaryKey> getSqlResult(GetHelper<List<SQLPrimaryKey>> ctx) throws MetaException {
-        return directSql.getPrimaryKeys(catName, db_name, tbl_name);
+        return directSql.getPrimaryKeys(catName, dbName, tblName);
       }
 
       @Override
       protected List<SQLPrimaryKey> getJdoResult(
         GetHelper<List<SQLPrimaryKey>> ctx) throws MetaException, NoSuchObjectException {
-        return getPrimaryKeysViaJdo(catName, db_name, tbl_name);
+        return getPrimaryKeysViaJdo(catName, dbName, tblName);
       }
     }.run(false);
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -12025,7 +12025,7 @@ public class ObjectStore implements RawStore, Configurable {
                                                      final String dbNameInput,
                                                      final String tblNameInput)
   throws MetaException, NoSuchObjectException {
-    final String dbName = normalizeIdentifier(dbNameInput);
+    final String dbName = dbNameInput != null ? normalizeIdentifier(dbNameInput) : null;
     final String tblName = normalizeIdentifier(tblNameInput);
     return new GetListHelper<SQLPrimaryKey>(catName, dbName, tblName, true, true) {
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -12025,7 +12025,9 @@ public class ObjectStore implements RawStore, Configurable {
                                                      final String db_name_input,
                                                      final String tbl_name_input)
   throws MetaException, NoSuchObjectException {
-    final String db_name = normalizeIdentifier(db_name_input);
+    final String db_name = StringUtils.isNotBlank(db_name_input) ?
+        normalizeIdentifier(db_name_input) :
+        null;
     final String tbl_name = normalizeIdentifier(tbl_name_input);
     return new GetListHelper<SQLPrimaryKey>(catName, db_name, tbl_name, true, true) {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-23935

Entire Trace -
```
0: jdbc:hive2://localhost:10000> !primarykeys Persons
Error: MetaException(message:java.lang.NullPointerException) (state=,code=0)
org.apache.hive.service.cli.HiveSQLException: MetaException(message:java.lang.NullPointerException)
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:360)
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:351)
	at org.apache.hive.jdbc.HiveDatabaseMetaData.getPrimaryKeys(HiveDatabaseMetaData.java:573)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hive.beeline.Reflector.invoke(Reflector.java:89)
	at org.apache.hive.beeline.Commands.metadata(Commands.java:125)
	at org.apache.hive.beeline.Commands.primarykeys(Commands.java:231)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hive.beeline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:57)
	at org.apache.hive.beeline.BeeLine.execCommandWithPrefix(BeeLine.java:1465)
	at org.apache.hive.beeline.BeeLine.dispatch(BeeLine.java:1504)
	at org.apache.hive.beeline.BeeLine.execute(BeeLine.java:1364)
	at org.apache.hive.beeline.BeeLine.begin(BeeLine.java:1134)
	at org.apache.hive.beeline.BeeLine.begin(BeeLine.java:1082)
	at org.apache.hive.beeline.BeeLine.mainWithInputRedirection(BeeLine.java:546)
	at org.apache.hive.beeline.BeeLine.main(BeeLine.java:528)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:323)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:236)
Caused by: org.apache.hive.service.cli.HiveSQLException: MetaException(message:java.lang.NullPointerException)
	at org.apache.hive.service.cli.operation.GetPrimaryKeysOperation.runInternal(GetPrimaryKeysOperation.java:120)
	at org.apache.hive.service.cli.operation.Operation.run(Operation.java:277)
	at org.apache.hive.service.cli.session.HiveSessionImpl.getPrimaryKeys(HiveSessionImpl.java:997)
	at org.apache.hive.service.cli.CLIService.getPrimaryKeys(CLIService.java:416)
	at org.apache.hive.service.cli.thrift.ThriftCLIService.GetPrimaryKeys(ThriftCLIService.java:838)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$GetPrimaryKeys.getResult(TCLIService.java:1717)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$GetPrimaryKeys.getResult(TCLIService.java:1702)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: MetaException(message:java.lang.NullPointerException)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.newMetaException(HiveMetaStore.java:7921)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.throwMetaException(HiveMetaStore.java:9105)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.get_primary_keys(HiveMetaStore.java:9067)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:147)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:108)
	at com.sun.proxy.$Proxy44.get_primary_keys(Unknown Source)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getPrimaryKeys(HiveMetaStoreClient.java:2617)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:215)
	at com.sun.proxy.$Proxy45.getPrimaryKeys(Unknown Source)
	at org.apache.hive.service.cli.operation.GetPrimaryKeysOperation.runInternal(GetPrimaryKeysOperation.java:94)
	... 13 more
Caused by: java.lang.NullPointerException: null
	at org.apache.hadoop.hive.metastore.utils.StringUtils.normalizeIdentifier(StringUtils.java:94)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPrimaryKeysInternal(ObjectStore.java:10723)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPrimaryKeys(ObjectStore.java:10713)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RawStoreProxy.invoke(RawStoreProxy.java:97)
	at com.sun.proxy.$Proxy42.getPrimaryKeys(Unknown Source)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.get_primary_keys(HiveMetaStore.java:9064)
	... 28 more
```
Post Fix

```
: jdbc:hive2://localhost:10000> !primarykeys persons
+------------+--------------+-------------+--------------+----------+-------------------------------+
| TABLE_CAT  | TABLE_SCHEM  | TABLE_NAME  | COLUMN_NAME  | KEY_SEQ  |            PK_NAME            |
+------------+--------------+-------------+--------------+----------+-------------------------------+
|            | default      | persons     | id           | 1        | pk_250096773_1595006111286_0  |
+------------+--------------+-------------+--------------+----------+-------------------------------+
```