### PR TITLE
HIVE-27012:Remove JavaEWAH dependency from HIVE to fix CVEs.

### DIFF
--- a/lib/README
+++ b/lib/README
@@ -1,4 +1,3 @@
 Folowing is the list of external jars contained in this directory and the sources from where they were obtained:
 ---------------------------------------------------------------------------------------------------------------
 
-*  javaewah-0.3.jar - http://code.google.com/p/javaewah/downloads/

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
     <jackson.version>2.12.7</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
-    <javaewah.version>1.1.7</javaewah.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>
     <javax-servlet-jsp.version>2.3.1</javax-servlet-jsp.version>
     <javolution.version>5.5.1</javolution.version>
@@ -314,11 +313,6 @@
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.googlecode.javaewah</groupId>
-        <artifactId>JavaEWAH</artifactId>
-        <version>${javaewah.version}</version>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <jackson.version>2.12.7</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
-    <javaewah.version>0.3.2</javaewah.version>
+    <javaewah.version>1.1.7</javaewah.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>
     <javax-servlet-jsp.version>2.3.1</javax-servlet-jsp.version>
     <javolution.version>5.5.1</javolution.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -517,10 +517,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.javaewah</groupId>
-      <artifactId>JavaEWAH</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
@@ -1073,7 +1069,6 @@
                   <include>org.apache.hive.shims:hive-shims-0.23</include>
                   <include>org.apache.hive.shims:hive-shims-0.23</include>
                   <include>org.apache.hive.shims:hive-shims-common</include>
-                  <include>com.googlecode.javaewah:JavaEWAH</include>
                   <include>javolution:javolution</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>io.airlift:aircompressor</include>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade JavaEWAH to 1.1.7


### Why are the changes needed?
Fix CVEs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Hive was build locally , then javaewah was removed and was successfully built again. 
