### PR TITLE
HIVE-27016: Backport HIVE-24629 Invoke optional output committer in TezProcessor

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3741,6 +3741,9 @@ public class HiveConf extends Configuration {
     TEZ_LLAP_MIN_REDUCER_PER_EXECUTOR("hive.tez.llap.min.reducer.per.executor", 0.95f,
         "If above 0, the min number of reducers for auto-parallelism for LLAP scheduling will\n" +
         "be set to this fraction of the number of executors."),
+    TEZ_MAPREDUCE_OUTPUT_COMMITTER("hive.tez.mapreduce.output.committer.class",
+        "org.apache.tez.mapreduce.committer.MROutputCommitter",
+        "Output committer class which should be invoked at the setup/commit lifecycle points of vertex executions."),
     TEZ_MAX_PARTITION_FACTOR("hive.tez.max.partition.factor", 2f,
         "When auto reducer parallelism is enabled this factor will be used to over-partition data in shuffle edges."),
     TEZ_MIN_PARTITION_FACTOR("hive.tez.min.partition.factor", 0.25f,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -50,6 +50,8 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.tez.dag.api.OutputCommitterDescriptor;
 import org.apache.tez.mapreduce.common.MRInputSplitDistributor;
 import org.apache.tez.mapreduce.hadoop.InputSplitInfo;
 import org.apache.tez.mapreduce.protos.MRRuntimeProtos;
@@ -1344,7 +1346,9 @@ public class DagUtils {
 
     JobConf conf = new JobConf(new TezConfiguration(hiveConf));
 
-    conf.set("mapred.output.committer.class", NullOutputCommitter.class.getName());
+    if (conf.get("mapred.output.committer.class") == null) {
+      conf.set("mapred.output.committer.class", NullOutputCommitter.class.getName());
+    }
 
     conf.setBoolean("mapred.committer.job.setup.cleanup.needed", false);
     conf.setBoolean("mapred.committer.job.task.cleanup.needed", false);
@@ -1459,12 +1463,15 @@ public class DagUtils {
       }
     }
 
-
     // final vertices need to have at least one output
     if (!hasChildren) {
+      OutputCommitterDescriptor ocd = null;
+      if (HiveConf.getVar(conf, ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER) != null) {
+        ocd = OutputCommitterDescriptor.create("org.apache.tez.mapreduce.committer.MROutputCommitter");
+      }
       v.addDataSink("out_"+work.getName(), new DataSinkDescriptor(
           OutputDescriptor.create(MROutput.class.getName())
-          .setUserPayload(TezUtils.createUserPayloadFromConf(conf)), null, null));
+          .setUserPayload(TezUtils.createUserPayloadFromConf(conf)), ocd, null));
     }
 
     return v;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
@@ -19,10 +19,14 @@ package org.apache.hadoop.hive.ql.exec.tez;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.plan.BaseWork;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -64,6 +68,29 @@ public class TestDagUtils {
 
     Token<? extends TokenIdentifier> actualToken = dag.getCredentials().getToken(testTokenAlias);
     assertEquals(testToken, actualToken);
+  }
+
+  @Test
+  public void outputCommitterSetToDefaultIfNotPresent() throws IOException {
+    DagUtils dagUtils = DagUtils.getInstance();
+    HiveConf conf = new HiveConf();
+
+    JobConf configuration = dagUtils.createConfiguration(conf);
+
+    assertEquals(HiveFileFormatUtils.NullOutputCommitter.class.getName(),
+        configuration.get("mapred.output.committer.class"));
+  }
+
+  @Test
+  public void outputCommitterNotOverriddenIfPresent() throws IOException {
+    DagUtils dagUtils = DagUtils.getInstance();
+    HiveConf conf = new HiveConf();
+    conf.set("mapred.output.committer.class", TestTezOutputCommitter.CountingOutputCommitter.class.getName());
+
+    JobConf configuration = dagUtils.createConfiguration(conf);
+
+    assertEquals(TestTezOutputCommitter.CountingOutputCommitter.class.getName(),
+        configuration.get("mapred.output.committer.class"));
   }
   
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.DriverFactory;
+import org.apache.hadoop.hive.ql.IDriver;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hive.testutils.HiveTestEnvSetup;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestTezOutputCommitter {
+
+  @ClassRule
+  public static HiveTestEnvSetup ENVIRONMENT = new HiveTestEnvSetup();
+
+  private static final String ABORT_JOB_ERROR_MSG = "JobAbortingOutputCommitter error!!!";
+  private static final String ABORT_TASK_ERROR_MSG = "TaskAbortingOutputCommitter error!!!";
+  private static final int MAX_TASK_ATTEMPTS = 2;
+  private static final String TEST_TABLE = "output_committer_test_table";
+
+  private static int commitTaskCounter;
+  private static int abortTaskCounter;
+  private static int commitJobCounter;
+  private static int abortJobCounter;
+
+  private IDriver driver;
+
+  @Before
+  public void setUp() {
+    commitTaskCounter = 0;
+    abortTaskCounter = 0;
+    commitJobCounter = 0;
+    abortJobCounter = 0;
+  }
+
+  @Test
+  public void testSuccessfulJob() throws Exception {
+    driver = getDriverWithCommitter(CountingOutputCommitter.class.getName());
+
+    driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
+    driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
+
+    assertEquals(1, commitTaskCounter);
+    assertEquals(0, abortTaskCounter);
+    assertEquals(1, commitJobCounter);
+    assertEquals(0, abortJobCounter);
+  }
+
+  @Test
+  public void testAbortTask() throws Exception {
+    driver = getDriverWithCommitter(TaskAbortingOutputCommitter.class.getName());
+
+    try {
+      driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
+      driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains(ABORT_TASK_ERROR_MSG));
+    }
+
+    assertEquals(MAX_TASK_ATTEMPTS, commitTaskCounter);
+    assertEquals(MAX_TASK_ATTEMPTS, abortTaskCounter);
+    assertEquals(0, commitJobCounter);
+    assertEquals(1, abortJobCounter);
+  }
+
+  @Test
+  public void testAbortJob() throws Exception {
+    driver = getDriverWithCommitter(JobAbortingOutputCommitter.class.getName());
+
+    try {
+      driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
+      driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains(ABORT_JOB_ERROR_MSG));
+    }
+
+    assertEquals(1, commitTaskCounter);
+    assertEquals(0, abortTaskCounter);
+    assertEquals(1, commitJobCounter);
+    assertEquals(1, abortJobCounter);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    driver.run(String.format("DROP TABLE %s", TEST_TABLE));
+    driver.close();
+  }
+
+  private IDriver getDriverWithCommitter(String committerClass) {
+    HiveConf conf = ENVIRONMENT.getTestCtx().hiveConf;
+    conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
+        "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+    conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
+    conf.set("mapred.output.committer.class", committerClass);
+
+    SessionState.start(conf);
+    return DriverFactory.newDriver(conf);
+  }
+
+  public static class TaskAbortingOutputCommitter extends CountingOutputCommitter {
+    @Override
+    public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      super.commitTask(taskAttemptContext);
+      throw new RuntimeException(ABORT_TASK_ERROR_MSG);
+    }
+  }
+
+  public static class JobAbortingOutputCommitter extends CountingOutputCommitter {
+    @Override
+    public void commitJob(JobContext jobContext) throws IOException {
+      super.commitJob(jobContext);
+      throw new RuntimeException(ABORT_JOB_ERROR_MSG);
+    }
+  }
+
+  public static class CountingOutputCommitter extends OutputCommitter {
+
+    @Override
+    public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      commitTaskCounter++;
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+      abortTaskCounter++;
+    }
+
+    @Override
+    public void commitJob(JobContext jobContext) throws IOException {
+      super.commitJob(jobContext);
+      commitJobCounter++;
+    }
+
+    @Override
+    public void abortJob(JobContext jobContext, int status) throws IOException {
+      super.abortJob(jobContext, status);
+      abortJobCounter++;
+    }
+
+    @Override
+    public void setupJob(JobContext jobContext) throws IOException {
+
+    }
+
+    @Override
+    public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+      return true;
+    }
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -123,7 +123,7 @@ public class TestTezOutputCommitter {
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
-    conf.setInt("tez.am.app.max.app.attempts", 1);
+    conf.setInt("tez.am.max.app.attempts", 1);
     conf.set("mapred.output.committer.class", committerClass);
 
     SessionState.start(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -82,8 +82,10 @@ public class TestTezOutputCommitter {
     try {
       driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
       driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
+      System.out.println(String.format("%s|%s|%s|%s", commitTaskCounter, abortTaskCounter, commitJobCounter, abortJobCounter));
       fail();
     } catch (RuntimeException e) {
+      System.out.println(e.getMessage());
       assertTrue(e.getMessage().contains(ABORT_TASK_ERROR_MSG));
     }
 
@@ -100,8 +102,10 @@ public class TestTezOutputCommitter {
     try {
       driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
       driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
+      System.out.println(String.format("%s|%s|%s|%s", commitTaskCounter, abortTaskCounter, commitJobCounter, abortJobCounter));
       fail();
     } catch (RuntimeException e) {
+      System.out.println(e.getMessage());
       assertTrue(e.getMessage().contains(ABORT_JOB_ERROR_MSG));
     }
 
@@ -123,7 +127,7 @@ public class TestTezOutputCommitter {
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
-    conf.setInt("tez.am.max.app.attempts", 1);
+    conf.setBoolVar(HiveConf.ConfVars.HIVESTATSCOLAUTOGATHER, false);
     conf.set("mapred.output.committer.class", committerClass);
 
     SessionState.start(conf);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -83,7 +83,7 @@ public class TestTezOutputCommitter {
       driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
       driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
       fail();
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(ABORT_TASK_ERROR_MSG));
     }
 
@@ -101,7 +101,7 @@ public class TestTezOutputCommitter {
       driver.run(String.format("CREATE TABLE %s (a int)", TEST_TABLE));
       driver.run(String.format("INSERT INTO %s VALUES (4), (5)", TEST_TABLE));
       fail();
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(ABORT_JOB_ERROR_MSG));
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -123,6 +123,7 @@ public class TestTezOutputCommitter {
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
+    conf.setInt("tez.am.app.max.app.attempts", 1);
     conf.set("mapred.output.committer.class", committerClass);
 
     SessionState.start(conf);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is backport of HIVE-24629.  
1. TezProcessor should invoke output committer's commitTask after each processor execution.
2. After successful vertex completion, the DAG should invoke the Tez API output committer's commitOutput.


### Why are the changes needed?
For StorageHandler to be able to use customized OutputCommitter in Tez.


### Does this PR introduce _any_ user-facing change?
New config value, otherwise no.

### How was this patch tested?
unit tests, also local test with storagehandler.
