### PR TITLE
HIVE-27017: backport HIVE-26771 option to use createTable DDLTask in …

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -172,4 +172,13 @@ public interface HiveStorageHandler extends Configurable {
   default LockType getLockType(WriteEntity writeEntity){
     return LockType.EXCLUSIVE;
   }
+
+  /**
+   * Check if CTAS operations should behave in a direct-insert manner.
+   *
+   * @return whether direct insert CTAS is required.
+   */
+  default boolean directInsert() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.optimizer.GenMapRedUtils;
@@ -142,6 +143,29 @@ public abstract class TaskCompiler {
       }
 
       return;
+    }
+
+    boolean directInsert = false;
+    if (pCtx.getCreateTable() != null && pCtx.getCreateTable().getStorageHandler() != null) {
+      try {
+        directInsert =
+            HiveUtils.getStorageHandler(conf, pCtx.getCreateTable().getStorageHandler()).directInsert();
+      } catch (HiveException e) {
+        throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
+      }
+    }
+
+    if (directInsert) {
+      if (pCtx.getCreateTable() != null) {
+        CreateTableDesc crtTblDesc = pCtx.getCreateTable();
+        crtTblDesc.validate(conf);
+        Task<?> crtTask = TaskFactory.get(new DDLWork(inputs, outputs, crtTblDesc));
+        for (Task<?> rootTask : rootTasks) {
+          crtTask.addDependentTask(rootTask);
+          rootTasks.clear();
+          rootTasks.add(crtTask);
+        }
+      }
     }
 
     optimizeOperatorPlan(pCtx, inputs, outputs);
@@ -322,14 +346,14 @@ public abstract class TaskCompiler {
 
     decideExecMode(rootTasks, ctx, globalLimitCtx);
 
-    if (pCtx.getQueryProperties().isCTAS() && !pCtx.getCreateTable().isMaterialization()) {
+    if (pCtx.getQueryProperties().isCTAS() && !pCtx.getCreateTable().isMaterialization() && !directInsert) {
       // generate a DDL task and make it a dependent task of the leaf
       CreateTableDesc crtTblDesc = pCtx.getCreateTable();
       crtTblDesc.validate(conf);
       Task<? extends Serializable> crtTblTask = TaskFactory.get(new DDLWork(
           inputs, outputs, crtTblDesc));
       patchUpAfterCTASorMaterializedView(rootTasks, outputs, crtTblTask, CollectionUtils.isEmpty(crtTblDesc.getPartColNames()));
-    } else if (pCtx.getQueryProperties().isMaterializedView()) {
+    } else if (pCtx.getQueryProperties().isMaterializedView() && !directInsert) {
       // generate a DDL task and make it a dependent task of the leaf
       CreateViewDesc viewDesc = pCtx.getCreateViewDesc();
       Task<? extends Serializable> crtViewTask = TaskFactory.get(new DDLWork(


### PR DESCRIPTION
### What changes were proposed in this pull request?
HIVE-26771 is done for hive-iceberg, move createTable DDLTask ahead of TezTask can benefit other types of StorageHandler as well for CTAS. This is to partially backport HIVE-26771 (not the hive-iceberg part)


### Why are the changes needed?
To support CTAS for StorageHandler.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
no change on default behavior. tested with custom storagehandler
