### PR TITLE
HIVE-27023: Add setting to prevent tez session from being opened duri…

### DIFF
--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -809,6 +809,7 @@ public class CliDriver {
     } catch (CommandProcessorException e) {
       return e.getResponseCode();
     } finally {
+      SessionState.endStart(ss);
       ss.resetThreadName();
       ss.close();
     }

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3693,8 +3693,12 @@ public class HiveConf extends Configuration {
     HIVE_CLI_PRINT_ESCAPE_CRLF("hive.cli.print.escape.crlf", false,
         "Whether to print carriage returns and line feeds in row output as escaped \\r and \\n"),
 
+    HIVE_CLI_TEZ_INITIALIZE_SESSION("hive.cli.tez.initialize.session", true,
+        "When enabled, CLI running with Tez will preemptively open a tez session during start up."),
+
     HIVE_CLI_TEZ_SESSION_ASYNC("hive.cli.tez.session.async", true, "Whether to start Tez\n" +
-        "session in background when running CLI with Tez, allowing CLI to be available earlier."),
+        "session in background when running CLI with Tez, allowing CLI to be available earlier. " +
+        "If hive.cli.tez.initialize.session is set to false, this value is ignored."),
 
     HIVE_DISABLE_UNSAFE_EXTERNALTABLE_OPERATIONS("hive.disable.unsafe.external.table.operations", true,
         "Whether to disable certain optimizations and operations on external tables," +

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -733,7 +733,9 @@ public class SessionState implements ISessionAuthState{
     }
 
     String engine = HiveConf.getVar(startSs.getConf(), HiveConf.ConfVars.HIVE_EXECUTION_ENGINE);
-    if (!engine.equals("tez") || startSs.isHiveServerQuery) {
+
+    if (!engine.equals("tez") || startSs.isHiveServerQuery
+            || !HiveConf.getBoolVar(startSs.getConf(), ConfVars.HIVE_CLI_TEZ_INITIALIZE_SESSION)) {
       return;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
A setting to disable tez session being preemptively opened during startup of hive cli.


### Why are the changes needed?
DML only operations won't need a tez session to be opened. Oozie action that launches hive cli for DML only operations  need this setting. Sometimes before the tez session thread could complete, the oozie hive action completes its DML operations and clears the scratch folders causing the tez session to fail with following exception:

```
Application application_1667416881396_24229473 failed 3 times due to AM Container for appattempt_1667416881396_24229473_000003 exited with exitCode: -1000
Failing this attempt.Diagnostics: [2023-02-02 19:02:12.139]File does not exist: hdfs://<name_node>/tmp/<db>/_tez_session_dir/4050c4b0-b7af-4eda-832b-399c954eb576/.tez/application_1667416881396_24229473/tez.session.local-resources.pbjava.io.FileNotFoundException: File does not exist: hdfs://<name_node>/tmp/<db>/_tez_session_dir/4050c4b0-b7af-4eda-832b-399c954eb576/.tez/application_1667416881396_24229473/tez.session.local-resources.pbat org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1529)at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1522)at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1537)at
```


### Does this PR introduce _any_ user-facing change?
New config value, otherwise no.


### How was this patch tested?
Manually tested
