### PR TITLE
HIVE-27029: hive query fails with Filesystem closed error, Rework done for HIVE-26352

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
@@ -94,19 +94,15 @@ public class YarnQueueHelper {
   }
 
   public void checkQueueAccess(
-      String queueName, String userName) throws IOException, InterruptedException {
+      String queueName, String userName) throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     try {
       ugi.doAs((PrivilegedExceptionAction<Void>) () -> {
         checkQueueAccessInternal(queueName, userName);
         return null;
       });
-    } finally {
-      try {
-        FileSystem.closeAllForUGI(ugi);
-      } catch (IOException exception) {
-        LOG.error("Could not clean up file-system handles for UGI: " + ugi, exception);
-      }
+    } catch (Exception exception) {
+      LOG.error("Cannot check queue access against UGI: " + ugi, exception);
     }
   }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR is raised to rework the code fixed as part of HIVE-26352.


### Why are the changes needed?
We should remove finally block as it causing the filesystem close exception when using explicit queue name the tez.queue.access is used and statistics gathering is enabled 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
