### PR TITLE
HIVE-27036: Upgrade gson to 2.9.0 in branch-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <curator.version>2.12.0</curator.version>
     <jsr305.version>3.0.0</jsr305.version>
     <tephra.version>0.6.0</tephra.version>
-    <gson.version>2.2.4</gson.version>
+    <gson.version>2.9.0</gson.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Backported HIVE-26078, HIVE-26322

### What changes were proposed in this pull request?
Upgrading gson version from 2.2.4 -> 2.9.0

### Why are the changes needed?
To fix the CVE's and be in-sync with master branch


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing Tests
