### PR TITLE
HIVE-27043: Upgrade ant to 1.10.12 in branch-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <!-- Library Dependency Versions -->
     <accumulo.version>1.7.3</accumulo.version>
     <activemq.version>5.5.0</activemq.version>
-    <ant.version>1.9.1</ant.version>
+    <ant.version>1.10.12</ant.version>
     <antlr.version>3.5.2</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->


### PR DESCRIPTION
Backported HIVE-26081, HIVE-26172

### What changes were proposed in this pull request?
Upgrade ant version to 1.10.12


### Why are the changes needed?
To fix CVE-2021-36373 and be in-sync with master branch

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing Tests
