### PR TITLE
HIVE-27049: Iceberg: Provide current snapshot version in show-create-table.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -928,6 +929,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     if (hmsTable != null) {
       try {
         Table tbl = IcebergTableUtil.getTable(conf, hmsTable);
+        Snapshot snapshot = tbl.currentSnapshot();
+        if (snapshot != null) {
+          hmsTable.getParameters().put("current-snapshot-id", String.valueOf(snapshot.snapshotId()));
+        }
         String formatVersion = String.valueOf(((BaseTable) tbl).operations().current().formatVersion());
         // If it is not the default format version, then set it in the table properties.
         if (!"1".equals(formatVersion)) {

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_multi_part_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_multi_part_table_to_iceberg.q
@@ -2,6 +2,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_multi_part_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_multi_part_table_to_iceberg.q
@@ -3,7 +3,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_part_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_part_table_to_iceberg.q
@@ -3,7 +3,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+/$1#Masked#/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_part_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_part_table_to_iceberg.q
@@ -2,6 +2,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+/$1#Masked#/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_table_to_iceberg.q
@@ -2,6 +2,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/alter_table_to_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/alter_table_to_iceberg.q
@@ -3,7 +3,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
@@ -1,5 +1,8 @@
 set hive.query.lifetime.hooks=org.apache.iceberg.mr.hive.HiveIcebergQueryLifeTimeHook;
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+
 set hive.explain.user=false;
 
 create table source(a int, b string, c int);

--- a/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctas_iceberg_partitioned_orc.q
@@ -1,7 +1,7 @@
 set hive.query.lifetime.hooks=org.apache.iceberg.mr.hive.HiveIcebergQueryLifeTimeHook;
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.explain.user=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_v2_deletes.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_v2_deletes.q
@@ -1,5 +1,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+'uuid'=')\S+('\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/('current-snapshot-id'=')\d+/$1#SnapshotId#/
 
 -- create an unpartitioned table with skip delete data set to false
  create table ice01 (id int) Stored by Iceberg stored as ORC

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
@@ -1,5 +1,7 @@
 -- MV data is stored by partitioned iceberg testing the existing Hive syntax (also used by native mv) to specify partition cols.
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
@@ -1,7 +1,7 @@
 -- MV data is stored by partitioned iceberg testing the existing Hive syntax (also used by native mv) to specify partition cols.
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
@@ -1,6 +1,6 @@
 -- MV data is stored by partitioned iceberg with partition spec
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
@@ -1,5 +1,6 @@
 -- MV data is stored by partitioned iceberg with partition spec
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/show_create_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/show_create_iceberg_table.q
@@ -1,5 +1,6 @@
 -- Mask random uuid
 --! qt:replace:/(\s+'uuid'=')\S+('\s*)/$1#Masked#$2/
+-- Mask random snapshot id
 --! qt:replace:/('current-snapshot-id'=')\d+/$1#SnapshotId#/
 
 DROP TABLE IF EXISTS ice_t;

--- a/iceberg/iceberg-handler/src/test/queries/positive/show_create_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/show_create_iceberg_table.q
@@ -1,5 +1,6 @@
 -- Mask random uuid
 --! qt:replace:/(\s+'uuid'=')\S+('\s*)/$1#Masked#$2/
+--! qt:replace:/('current-snapshot-id'=')\d+/$1#SnapshotId#/
 
 DROP TABLE IF EXISTS ice_t;
 CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG;
@@ -16,3 +17,8 @@ SHOW CREATE TABLE ice_t_transform_prop;
 DROP TABLE IF EXISTS ice_t_identity_part;
 CREATE EXTERNAL TABLE ice_t_identity_part (a int) PARTITIONED BY (b string) STORED BY ICEBERG;
 SHOW CREATE TABLE ice_t_identity_part;
+
+DROP TABLE IF EXISTS ice_data;
+CREATE EXTERNAL TABLE ice_data (i int, s string) STORED BY ICEBERG;
+INSERT INTO ice_data VALUES (1, 'ABC'),(2, 'CCC'),(3, 'DBD');
+SHOW CREATE TABLE ice_data;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
@@ -4,7 +4,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
@@ -3,6 +3,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
@@ -4,7 +4,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
@@ -3,6 +3,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
@@ -4,7 +4,7 @@
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
---! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
@@ -3,6 +3,8 @@
 --! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- Mask random uuid
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- Mask random snapshot id
+--! qt:replace:/(\s+current-snapshot-id\s+)\d+/$1#SnapshotId#/
 
 set hive.vectorized.execution.enabled=false;
 

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
@@ -185,6 +185,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -433,6 +434,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -681,6 +683,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
@@ -185,7 +185,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -434,7 +434,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -683,7 +683,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
@@ -143,6 +143,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -340,6 +341,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -537,6 +539,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
@@ -143,7 +143,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -341,7 +341,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -539,7 +539,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
@@ -98,7 +98,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -248,7 +248,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -398,7 +398,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
@@ -98,6 +98,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	true                
 #### A masked pattern was here ####
@@ -247,6 +248,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####
@@ -396,6 +398,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	iceberg.orc.files.only	false               
 #### A masked pattern was here ####

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -295,7 +295,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	true                

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -295,6 +295,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	true                

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_v2_deletes.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_v2_deletes.q.out
@@ -131,6 +131,7 @@ LOCATION
   'hdfs://### HDFS PATH ###'
 TBLPROPERTIES (
   'bucketing_version'='2', 
+  'current-snapshot-id'='#SnapshotId#', 
   'engine.hive.enabled'='true', 
   'format-version'='2', 
   'iceberg.delete.skiprowdata'='true', 
@@ -272,6 +273,7 @@ LOCATION
   'hdfs://### HDFS PATH ###'
 TBLPROPERTIES (
   'bucketing_version'='2', 
+  'current-snapshot-id'='#SnapshotId#', 
   'engine.hive.enabled'='true', 
   'format-version'='2', 
   'iceberg.delete.skiprowdata'='true', 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -61,7 +61,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	1                   
 	iceberg.orc.files.only	false               
@@ -140,7 +140,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId#  
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -61,6 +61,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	format-version      	1                   
 	iceberg.orc.files.only	false               
@@ -139,6 +140,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId#  
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -62,7 +62,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	1                   
 	iceberg.orc.files.only	false               
@@ -142,7 +142,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -62,6 +62,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	format-version      	1                   
 	iceberg.orc.files.only	false               
@@ -141,6 +142,7 @@ Table Type:         	MATERIALIZED_VIEW
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"b\":\"true\",\"c\":\"true\"}}
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	format-version      	2                   
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/show_create_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_create_iceberg_table.q.out
@@ -177,3 +177,50 @@ TBLPROPERTIES (
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
   'uuid'='#Masked#')
+PREHOOK: query: DROP TABLE IF EXISTS ice_data
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_data
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE EXTERNAL TABLE ice_data (i int, s string) STORED BY ICEBERG
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_data
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_data (i int, s string) STORED BY ICEBERG
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_data
+PREHOOK: query: INSERT INTO ice_data VALUES (1, 'ABC'),(2, 'CCC'),(3, 'DBD')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_data
+POSTHOOK: query: INSERT INTO ice_data VALUES (1, 'ABC'),(2, 'CCC'),(3, 'DBD')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_data
+PREHOOK: query: SHOW CREATE TABLE ice_data
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@ice_data
+POSTHOOK: query: SHOW CREATE TABLE ice_data
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@ice_data
+CREATE EXTERNAL TABLE `ice_data`(
+  `i` int, 
+  `s` string)
+ROW FORMAT SERDE 
+  'org.apache.iceberg.mr.hive.HiveIcebergSerDe' 
+STORED BY 
+  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'bucketing_version'='2', 
+  'current-snapshot-id'='#SnapshotId#', 
+  'engine.hive.enabled'='true', 
+  'iceberg.orc.files.only'='false', 
+  'metadata_location'='hdfs://### HDFS PATH ###', 
+  'previous_metadata_location'='hdfs://### HDFS PATH ###', 
+  'serialization.format'='1', 
+  'table_type'='ICEBERG', 
+#### A masked pattern was here ####
+  'uuid'='#Masked#')

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
@@ -88,7 +88,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	false               
@@ -155,7 +155,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId#  
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
@@ -88,6 +88,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	false               
@@ -154,6 +155,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId#  
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
@@ -88,7 +88,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -155,7 +155,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -220,7 +220,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -287,7 +287,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -370,7 +370,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	true                

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
@@ -88,6 +88,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -154,6 +155,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -218,6 +220,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"id\":\"true\",\"value\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -284,6 +287,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	true                
@@ -366,6 +370,7 @@ Table Parameters:
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	false               
 	iceberg.orc.files.only	true                

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
@@ -95,7 +95,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	false               
@@ -189,7 +189,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
-	current-snapshot-id 	#SnapshotId# 
+	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	false               

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
@@ -95,6 +95,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	false               
@@ -188,6 +189,7 @@ Table Parameters:
 	EXTERNAL            	TRUE                
 	MIGRATED_TO_ICEBERG 	true                
 	bucketing_version   	2                   
+	current-snapshot-id 	#SnapshotId# 
 	engine.hive.enabled 	true                
 	external.table.purge	true                
 	iceberg.orc.files.only	false               


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add current snapshot id in show create table output for iceberg tables.

### Why are the changes needed?

Better Usability 

### Does this PR introduce _any_ user-facing change?

Yes, Adds current snapshot id in show create table output for iceberg tables.

### How was this patch tested?

UT