### PR TITLE
HIVE-27056: Ensure that MR distcp goes to the same Yarn queue as other parts of the query

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4020,6 +4020,9 @@ public class HiveConf extends Configuration {
       "true", new StringSet("true", "false", "ignore"),
       "Whether Tez session pool should allow submitting queries to custom queues. The options\n" +
       "are true, false (error out), ignore (accept the query but ignore the queue setting)."),
+    HIVE_MAPRED_JOB_FOLLOW_TEZ_QUEUE("hive.mapred.job.follow.tez.queue", false,
+        "Whether the MR jobs initiated by a query should be enforced to run in the queue denoted by "
+            + "'tez.queue.name', e.g. DistCp jobs."),
 
     // Operation log configuration
     HIVE_SERVER2_LOGGING_OPERATION_ENABLED("hive.server2.logging.operation.enabled", true,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -488,7 +488,10 @@ public class TezSessionState {
       // Unset this after opening the session so that reopening of session uses the correct queue
       // names i.e, if client has not died and if the user has explicitly set a queue name
       // then reopened session will use user specified queue name else default cluster queue names.
-      conf.unset(TezConfiguration.TEZ_QUEUE_NAME);
+      if (conf.getBoolVar(ConfVars.HIVE_SERVER2_TEZ_INITIALIZE_DEFAULT_SESSIONS)) {
+        LOG.debug("Unsetting tez.queue.name (from: {})", conf.get(TezConfiguration.TEZ_QUEUE_NAME));
+        conf.unset(TezConfiguration.TEZ_QUEUE_NAME);
+      }
       return session;
     } finally {
       if (isOnThread && !isSuccessful) {

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1146,12 +1146,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
 
       // HIVE-13704 states that we should use run() instead of execute() due to a hadoop known issue
       // added by HADOOP-10459
-      int rc = runDistCpInternal(distcp, params);
-      if (rc == 0) {
-        return true;
-      } else {
-        return false;
-      }
+      return runDistCpInternal(distcp, params) ==  0;
     } catch (Exception e) {
       throw new IOException("Cannot execute DistCp process: ", e);
     } finally {
@@ -1233,8 +1228,12 @@ public class Hadoop23Shims extends HadoopShimsSecure {
    */
   protected void ensureMapReduceQueue(Configuration conf) {
     String queueName = conf.get(TezConfiguration.TEZ_QUEUE_NAME);
-    LOG.debug("Checking tez.queue.name {}", queueName);
-    if (queueName != null && queueName.length() > 0) {
+    boolean isTez = conf.get("hive.execution.engine", "tez").equalsIgnoreCase("tez");
+    boolean shouldMapredJobsFollowTezQueue = conf.getBoolean("hive.mapred.job.follow.tez.queue", false);
+
+    LOG.debug("Checking tez.queue.name {}, isTez: {}, shouldMapredJobsFollowTezQueue: {}", queueName, isTez,
+        shouldMapredJobsFollowTezQueue);
+    if (isTez && shouldMapredJobsFollowTezQueue && queueName != null && queueName.length() > 0) {
       LOG.info("Setting mapreduce.job.queuename (current: '{}') to become tez.queue.name: '{}'",
           conf.get(MRJobConfig.QUEUE_NAME), queueName);
       conf.set(MRJobConfig.QUEUE_NAME, queueName);

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1228,7 +1228,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
    */
   protected void ensureMapReduceQueue(Configuration conf) {
     String queueName = conf.get(TezConfiguration.TEZ_QUEUE_NAME);
-    boolean isTez = conf.get("hive.execution.engine", "tez").equalsIgnoreCase("tez");
+    boolean isTez = "tez".equalsIgnoreCase(conf.get("hive.execution.engine"));
     boolean shouldMapredJobsFollowTezQueue = conf.getBoolean("hive.mapred.job.follow.tez.queue", false);
 
     LOG.debug("Checking tez.queue.name {}, isTez: {}, shouldMapredJobsFollowTezQueue: {}", queueName, isTez,

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1146,7 +1146,8 @@ public class Hadoop23Shims extends HadoopShimsSecure {
 
       // HIVE-13704 states that we should use run() instead of execute() due to a hadoop known issue
       // added by HADOOP-10459
-      if (distcp.run(params.toArray(new String[0])) == 0) {
+      int rc = runDistCpInternal(distcp, params);
+      if (rc == 0) {
         return true;
       } else {
         return false;
@@ -1172,7 +1173,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     try {
       DistCp distcp = new DistCp(conf, null);
       distcp.getConf().setBoolean("mapred.mapper.new-api", true);
-      int returnCode = distcp.run(params.toArray(new String[0]));
+      int returnCode = runDistCpInternal(distcp, params);
       if (returnCode == 0) {
         return true;
       } else if (returnCode == DistCpConstants.INVALID_ARGUMENT) {
@@ -1188,13 +1189,13 @@ public class Hadoop23Shims extends HadoopShimsSecure {
               + "snapshot: {}", srcPaths, dst, oldSnapshot);
           List<String> rParams = constructDistCpWithSnapshotParams(srcPaths, dst, ".", oldSnapshot, conf, "-rdiff");
           DistCp rDistcp = new DistCp(conf, null);
-          returnCode = rDistcp.run(rParams.toArray(new String[0]));
+          returnCode = runDistCpInternal(rDistcp, rParams);
           if (returnCode == 0) {
             LOG.info("Target restored to previous state.  source: {} target: {} snapshot: {}. Reattempting to copy.",
                 srcPaths, dst, oldSnapshot);
             dst.getFileSystem(conf).deleteSnapshot(dst, oldSnapshot);
             dst.getFileSystem(conf).createSnapshot(dst, oldSnapshot);
-            returnCode = distcp.run(params.toArray(new String[0]));
+            returnCode = runDistCpInternal(distcp, params);
             if (returnCode == 0) {
               return true;
             } else {
@@ -1209,6 +1210,35 @@ public class Hadoop23Shims extends HadoopShimsSecure {
       throw new IOException("Cannot execute DistCp process: ", e);
     }
     return false;
+  }
+
+  protected int runDistCpInternal(DistCp distcp, List<String> params) {
+    ensureMapReduceQueue(distcp.getConf());
+    return distcp.run(params.toArray(new String[0]));
+  }
+
+  /**
+   * This method ensures if there is an explicit tez.queue.name set, the hadoop shim will submit jobs
+   * to the same yarn queue. This solves a security issue where e.g settings have the following values:
+   * tez.queue.name=sample
+   * hive.server2.tez.queue.access.check=true
+   * In this case, when a query submits Tez DAGs, the tez client layer checks whether the end user has access to
+   * the yarn queue 'sample' via YarnQueueHelper, but this is not respected in case of MR jobs that run
+   * even if the query execution engine is Tez. E.g. an EXPORT TABLE can submit DistCp MR jobs at some stages when
+   * certain criteria are met. We tend to restrict the setting of mapreduce.job.queuename in order to bypass this
+   * security flaw, and even the default queue is unexpected if we explicitly set tez.queue.name.
+   * Under the hood the desired behavior is to have DistCp jobs in the same yarn queue as other parts
+   * of the query. Most of the time, the user isn't aware that a query involves DistCp jobs, hence isn't aware
+   * of these details.
+   */
+  protected void ensureMapReduceQueue(Configuration conf) {
+    String queueName = conf.get(TezConfiguration.TEZ_QUEUE_NAME);
+    LOG.debug("Checking tez.queue.name {}", queueName);
+    if (queueName != null && queueName.length() > 0) {
+      LOG.info("Setting mapreduce.job.queuename (current: '{}') to become tez.queue.name: '{}'",
+          conf.get(MRJobConfig.QUEUE_NAME), queueName);
+      conf.set(MRJobConfig.QUEUE_NAME, queueName);
+    }
   }
 
   /**

--- a/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
+++ b/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
@@ -198,12 +198,14 @@ public class TestHadoop23Shims {
     Configuration conf = new Configuration();
     // there is a tez.queue.name, but hive.mapred.job.follow.tez.queue is not allowed
     conf.set(TezConfiguration.TEZ_QUEUE_NAME, "helloQ");
+    conf.set("hive.execution.engine", "tez");
     DistCp distCp = runMockDistCp(conf);
     assertEquals("default", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
 
     // there is a tez.queue.name, and hive.mapred.job.follow.tez.queue is allowed
     conf.set(TezConfiguration.TEZ_QUEUE_NAME, "helloQ");
     conf.setBoolean("hive.mapred.job.follow.tez.queue", true);
+    conf.set("hive.execution.engine", "tez");
     distCp = runMockDistCp(conf);
     assertEquals("helloQ", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
 
@@ -217,6 +219,8 @@ public class TestHadoop23Shims {
 
     // there is no tez.queue.name set at all
     conf = new Configuration();
+    conf.setBoolean("hive.mapred.job.follow.tez.queue", true);
+    conf.set("hive.execution.engine", "tez");
     distCp = runMockDistCp(conf);
     assertEquals("default", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
   }

--- a/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
+++ b/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
@@ -196,12 +196,26 @@ public class TestHadoop23Shims {
   @Test
   public void testMapReduceQueueIsSetToTezQueue() throws Exception {
     Configuration conf = new Configuration();
-    // there is a tez.queue.name
+    // there is a tez.queue.name, but hive.mapred.job.follow.tez.queue is not allowed
     conf.set(TezConfiguration.TEZ_QUEUE_NAME, "helloQ");
     DistCp distCp = runMockDistCp(conf);
+    assertEquals("default", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
+
+    // there is a tez.queue.name, and hive.mapred.job.follow.tez.queue is allowed
+    conf.set(TezConfiguration.TEZ_QUEUE_NAME, "helloQ");
+    conf.setBoolean("hive.mapred.job.follow.tez.queue", true);
+    distCp = runMockDistCp(conf);
     assertEquals("helloQ", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
 
-    // there is no tez.queue.name
+    // there is a tez.queue.name, also hive.mapred.job.follow.tez.queue is allowed,
+    // but execution engine is set to legacy 'mr': queue follow is not activated
+    conf.set(TezConfiguration.TEZ_QUEUE_NAME, "helloQ");
+    conf.setBoolean("hive.mapred.job.follow.tez.queue", true);
+    conf.set("hive.execution.engine", "mr");
+    distCp = runMockDistCp(conf);
+    assertEquals("default", distCp.getConf().get(MRJobConfig.QUEUE_NAME));
+
+    // there is no tez.queue.name set at all
     conf = new Configuration();
     distCp = runMockDistCp(conf);
     assertEquals("default", distCp.getConf().get(MRJobConfig.QUEUE_NAME));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Copy the value of tez.queue.name to mapreduce.queue.name in case of distcp jobs started as part of the query.


### Why are the changes needed?
Described on jira.

### Does this PR introduce _any_ user-facing change?
Yes, if the user was previously aware of the actual yarn queue into which the DistCp jobs went, this is a behaviour change, as from now they go to the queue set in "tez.queue.name"  if it's defined, but this is only activated if hive.mapred.job.follow.tez.queue is true.


### How was this patch tested?
Tested on cluster. MAPREDUCE jobs went to the same queue with the patch.
https://issues.apache.org/jira/secure/attachment/13055215/image%20%281%29.png
