### PR TITLE
Hive 27011 - Default value of PartitionManagementTask frequency should be set to higher value

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1149,7 +1149,7 @@ public class MetastoreConf {
     // Partition management task params
     PARTITION_MANAGEMENT_TASK_FREQUENCY("metastore.partition.management.task.frequency",
       "metastore.partition.management.task.frequency",
-      300, TimeUnit.SECONDS, "Frequency at which timer task runs to do automatic partition management for tables\n" +
+      6, TimeUnit.HOURS, "Frequency at which timer task runs to do automatic partition management for tables\n" +
       "with table property 'discover.partitions'='true'. Partition management include 2 pieces. One is partition\n" +
       "discovery and other is partition retention period. When 'discover.partitions'='true' is set, partition\n" +
       "management will look for partitions in table location and add partitions objects for it in metastore.\n" +


### PR DESCRIPTION
**What changes were proposed in this pull request?**

Set metastore.partition.management.task.frequency defaults to a higher value (6 hours) instead of 5 minutes.

**Why are the changes needed?**
Proposed to increase the default frequency as it scans all the tables and partitions under Databases and in PROD scenarios it is not feasible to complete this scan in minutes.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Existing test cases should not be failing with the config value changes.