### PR TITLE
HIVE-27060: Exception in add partitions with SQL Server db when number of parameters in insert query exceed 2100

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -195,16 +195,12 @@ class MetaStoreDirectSql {
 
     this.dbType = dbType;
     int batchSize = MetastoreConf.getIntVar(conf, ConfVars.DIRECT_SQL_PARTITION_BATCH_SIZE);
+    this.directSqlInsertPart = new DirectSqlInsertPart(pm, dbType, batchSize);
     if (batchSize == DETECT_BATCHING) {
       batchSize = dbType.needsInBatching() ? 1000 : NO_BATCHING;
     }
     this.batchSize = batchSize;
     this.updateStat = new DirectSqlUpdateStat(pm, conf, dbType, batchSize);
-
-    // TODO: Oracle supports to insert more than 1000 rows with a single insert query. Can use NO_BATCHING for oracle db
-    //  too during batch detection(DETECT_BATCHING) for insert queries as future improvement. Currently, used the same
-    //  limit as IN clause/operator limit(i.e., 1000) during batch detection.
-    this.directSqlInsertPart = new DirectSqlInsertPart(pm, dbType, batchSize);
     ImmutableMap.Builder<String, String> fieldNameToTableNameBuilder =
         new ImmutableMap.Builder<>();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In add partitions via direct sql, limiting the number of rows in a single insert query such that total parameters in a query do not exceed 2100 for SQL Server db.

### Why are the changes needed?
Add partitions with SQL Server db  throws SQLServerException when the number of parameters in the direct sql insert query exceeds 2100.
Exception Stack:
`Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: The incoming request has too many parameters. The server supports a maximum of 2100 parameters. Reduce the number of parameters and resend the request.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:258) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getNextResult(SQLServerStatement.java:1535) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.doExecutePreparedStatement(SQLServerPreparedStatement.java:467) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement$PrepStmtExecCmd.doExecute(SQLServerPreparedStatement.java:409) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.TDSCommand.execute(IOBuffer.java:7151) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.executeCommand(SQLServerConnection.java:2478) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeCommand(SQLServerStatement.java:219) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeStatement(SQLServerStatement.java:199) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.executeUpdate(SQLServerPreparedStatement.java:356) ~[mssql-jdbc-6.2.1.jre8.jar:?]
	at org.apache.hive.com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.apache.hive.com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.datanucleus.store.rdbms.ParamLoggingPreparedStatement.executeUpdate(ParamLoggingPreparedStatement.java:393) ~[datanucleus-rdbms-5.2.10.jar:?]
	at org.datanucleus.store.rdbms.SQLController.executeStatementUpdate(SQLController.java:435) ~[datanucleus-rdbms-5.2.10.jar:?]
	at org.datanucleus.store.rdbms.query.SQLQuery.performExecute(SQLQuery.java:622) ~[datanucleus-rdbms-5.2.10.jar:?]
	at org.datanucleus.store.query.Query.executeQuery(Query.java:1975) ~[datanucleus-core-5.2.10.jar:?]
	at org.datanucleus.store.rdbms.query.SQLQuery.executeWithArray(SQLQuery.java:818) ~[datanucleus-rdbms-5.2.10.jar:?]
	at org.datanucleus.api.jdo.JDOQuery.executeInternal(JDOQuery.java:433) ~[datanucleus-api-jdo-5.2.8.jar:?]
	... 66 more`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested with SQL Server
