### PR TITLE
HIVE-27016 (addendum): Invoke optional output committer in TezProcessor for FileSink

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1463,8 +1463,10 @@ public class DagUtils {
       }
     }
 
+    // If there is a fileSink add a DataSink to the vertex
+    boolean hasFileSink = work.getAllOperators().stream().anyMatch(o -> o instanceof FileSinkOperator);
     // final vertices need to have at least one output
-    if (!hasChildren) {
+    if (!hasChildren || hasFileSink) {
       OutputCommitterDescriptor ocd = null;
       if (HiveConf.getVar(conf, ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER) != null) {
         ocd = OutputCommitterDescriptor.create("org.apache.tez.mapreduce.committer.MROutputCommitter");

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -113,6 +113,7 @@ public class TestTezOutputCommitter {
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
+    conf.setBoolVar(HiveConf.ConfVars.HIVESTATSCOLAUTOGATHER, false);
     conf.set("mapred.output.committer.class", committerClass);
     SessionState.start(conf);
     return DriverFactory.newDriver(conf);


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case of multi-insert and statistics auto-gathering, the leaf vertex may not include the filesinkoperator. This is to add datasink for vertex that has FileSinkOperator. It is done in HIVE-4.0 by HIVE-25276 for hive-iceberge. This is to add this condition into HIVE-3.2.0 as well.


### Why are the changes needed?
To fix issues with multi-insert and auto-stats for StorageHandler to use customized OutputCommitter in Tez.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local test with storagehandler.
