### PR TITLE
HIVE-27064: Change default new conf TEZ_MAPREDUCE_OUTPUT_COMMITTER va…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3743,7 +3743,8 @@ public class HiveConf extends Configuration {
         "be set to this fraction of the number of executors."),
     TEZ_MAPREDUCE_OUTPUT_COMMITTER("hive.tez.mapreduce.output.committer.class",
         "",
-        "Output committer class which should be invoked at the setup/commit lifecycle points of vertex executions."),
+        "Output committer class which should be invoked at the setup/commit lifecycle points of vertex executions.\n" +
+            "Set to org.apache.tez.mapreduce.committer.MROutputCommitter if want to enable it"),
     TEZ_MAX_PARTITION_FACTOR("hive.tez.max.partition.factor", 2f,
         "When auto reducer parallelism is enabled this factor will be used to over-partition data in shuffle edges."),
     TEZ_MIN_PARTITION_FACTOR("hive.tez.min.partition.factor", 0.25f,

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3742,7 +3742,7 @@ public class HiveConf extends Configuration {
         "If above 0, the min number of reducers for auto-parallelism for LLAP scheduling will\n" +
         "be set to this fraction of the number of executors."),
     TEZ_MAPREDUCE_OUTPUT_COMMITTER("hive.tez.mapreduce.output.committer.class",
-        "org.apache.tez.mapreduce.committer.MROutputCommitter",
+        "",
         "Output committer class which should be invoked at the setup/commit lifecycle points of vertex executions."),
     TEZ_MAX_PARTITION_FACTOR("hive.tez.max.partition.factor", 2f,
         "When auto reducer parallelism is enabled this factor will be used to over-partition data in shuffle edges."),

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1468,8 +1468,9 @@ public class DagUtils {
     // final vertices need to have at least one output
     if (!hasChildren || hasFileSink) {
       OutputCommitterDescriptor ocd = null;
-      if (HiveConf.getVar(conf, ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER) != null) {
-        ocd = OutputCommitterDescriptor.create("org.apache.tez.mapreduce.committer.MROutputCommitter");
+      String committer = HiveConf.getVar(conf, ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER);
+      if (committer != null && !committer.isEmpty()) {
+        ocd = OutputCommitterDescriptor.create(committer);
       }
       v.addDataSink("out_"+work.getName(), new DataSinkDescriptor(
           OutputDescriptor.create(MROutput.class.getName())

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -111,6 +111,7 @@ public class TestTezOutputCommitter {
     HiveConf conf = ENVIRONMENT.getTestCtx().hiveConf;
     conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+    conf.setVar(HiveConf.ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER, "org.apache.tez.mapreduce.committer.MROutputCommitter");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
     conf.setBoolVar(HiveConf.ConfVars.HIVESTATSCOLAUTOGATHER, false);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezOutputCommitter.java
@@ -111,8 +111,8 @@ public class TestTezOutputCommitter {
     HiveConf conf = ENVIRONMENT.getTestCtx().hiveConf;
     conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
-    conf.setVar(HiveConf.ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER, "org.apache.tez.mapreduce.committer.MROutputCommitter");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+    conf.setVar(HiveConf.ConfVars.TEZ_MAPREDUCE_OUTPUT_COMMITTER, "org.apache.tez.mapreduce.committer.MROutputCommitter");
     conf.setInt("tez.am.task.max.failed.attempts", MAX_TASK_ATTEMPTS);
     conf.setBoolVar(HiveConf.ConfVars.HIVESTATSCOLAUTOGATHER, false);
     conf.set("mapred.output.committer.class", committerClass);


### PR DESCRIPTION
### What changes were proposed in this pull request?
change a new configuration TEZ_MAPREDUCE_OUTPUT_COMMITTER default value to be empty, so that it is backward compatible. 

### Why are the changes needed?
the new configuration TEZ_MAPREDUCE_OUTPUT_COMMITTER("hive.tez.mapreduce.output.committer.class") default value is not empty, this by default enables customized output committer to run in tez mode. This is to change default value so that it is backward compatible.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
tested locally with customized outputcommitter
