### PR TITLE
HIVE-27063: Allow JWT auth to be set independent of other auth mechanisms

### DIFF
--- a/service/src/java/org/apache/hive/service/auth/AuthType.java
+++ b/service/src/java/org/apache/hive/service/auth/AuthType.java
@@ -58,7 +58,7 @@ public class AuthType {
       // single authentication type has no conflicts
       return;
     }
-    if (typeBits.get(HiveAuthConstants.AuthTypes.SAML.ordinal()) &&
+    if ((typeBits.get(HiveAuthConstants.AuthTypes.SAML.ordinal()) || typeBits.get(HiveAuthConstants.AuthTypes.JWT.ordinal())) &&
         !typeBits.get(HiveAuthConstants.AuthTypes.NOSASL.ordinal()) &&
         !typeBits.get(HiveAuthConstants.AuthTypes.KERBEROS.ordinal()) &&
         !typeBits.get(HiveAuthConstants.AuthTypes.NONE.ordinal()) &&

--- a/service/src/test/org/apache/hive/service/auth/TestAuthType.java
+++ b/service/src/test/org/apache/hive/service/auth/TestAuthType.java
@@ -55,6 +55,13 @@ public class TestAuthType {
     testOnePasswordAuthWithSAML(HiveAuthConstants.AuthTypes.CUSTOM);
   }
 
+  @Test
+  public void testOnePasswordAuthWithJWT() throws Exception {
+    testOnePasswordAuthWithJWT(HiveAuthConstants.AuthTypes.LDAP);
+    testOnePasswordAuthWithJWT(HiveAuthConstants.AuthTypes.PAM);
+    testOnePasswordAuthWithJWT(HiveAuthConstants.AuthTypes.CUSTOM);
+  }
+
   private void testOnePasswordAuthWithSAML(HiveAuthConstants.AuthTypes type) throws Exception {
     AuthType authType = new AuthType("SAML," + type.getAuthName());
     Assert.assertTrue(authType.isEnabled(HiveAuthConstants.AuthTypes.SAML));
@@ -63,6 +70,21 @@ public class TestAuthType {
     Set<HiveAuthConstants.AuthTypes> disabledAuthTypes = Arrays.stream(HiveAuthConstants.AuthTypes.values())
         .collect(Collectors.toSet());
     disabledAuthTypes.remove(HiveAuthConstants.AuthTypes.SAML);
+    disabledAuthTypes.remove(type);
+    for (HiveAuthConstants.AuthTypes disabledType : disabledAuthTypes) {
+      Assert.assertFalse(authType.isEnabled(disabledType));
+    }
+    Assert.assertEquals(type.getAuthName(), authType.getPasswordBasedAuthStr());
+  }
+
+  private void testOnePasswordAuthWithJWT(HiveAuthConstants.AuthTypes type) throws Exception {
+    AuthType authType = new AuthType("JWT," + type.getAuthName());
+    Assert.assertTrue(authType.isEnabled(HiveAuthConstants.AuthTypes.JWT));
+    Assert.assertTrue(authType.isEnabled(type));
+
+    Set<HiveAuthConstants.AuthTypes> disabledAuthTypes = Arrays.stream(HiveAuthConstants.AuthTypes.values())
+        .collect(Collectors.toSet());
+    disabledAuthTypes.remove(HiveAuthConstants.AuthTypes.JWT);
     disabledAuthTypes.remove(type);
     for (HiveAuthConstants.AuthTypes disabledType : disabledAuthTypes) {
       Assert.assertFalse(authType.isEnabled(disabledType));
@@ -108,5 +130,41 @@ public class TestAuthType {
   @Test(expected = Exception.class)
   public void testNotExistAuth() throws Exception {
     AuthType authType = new AuthType("SAML,OTHER");
+    authType = new AuthType("JWT,OTHER");
+  }
+
+  @Test(expected = Exception.class)
+  public void testKerberosWithJWT() throws Exception {
+    AuthType authType = new AuthType("KERBEROS,JWT");
+  }
+
+  @Test(expected = Exception.class)
+  public void testKerberosWithJWTAndLdap() throws Exception {
+    AuthType authType = new AuthType("KERBEROS,JWT,LDAP");
+  }
+
+  @Test(expected = Exception.class)
+  public void testNoneWithJWT() throws Exception {
+    AuthType authType = new AuthType("NONE,JWT");
+  }
+
+  @Test(expected = Exception.class)
+  public void testNoSaslWithJWT() throws Exception {
+    AuthType authType = new AuthType("NOSASL,JWT");
+  }
+
+  @Test(expected = Exception.class)
+  public void testMultiPasswordAuthWithJWT() throws Exception {
+    AuthType authType = new AuthType("JWT,LDAP,PAM,CUSTOM");
+  }
+
+  @Test
+  public void testLDAPWithSAMLAndJWT() throws Exception {
+    AuthType authType = new AuthType("JWT,SAML,LDAP");
+  }
+
+  @Test
+  public void testSAMLWithJWT() throws Exception {
+    AuthType authType = new AuthType("JWT,SAML");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
If hive.server2.authentication is just set to "LDAP,JWT", HS2 fails to start with the exception shown in the HIVE-27063

### Why are the changes needed?
There is some validation code that check to ensure that certain auth mechanisms cannot co-exist with others. This validation code does not do anything with JWT authentication. Added code to account for JWT auth as well.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually
Unit Tests
