### PR TITLE
HIVE-27065: Exception in partition column statistics update with SQL Server db when histogram statistics is not enabled

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
@@ -260,7 +260,7 @@ class DirectSqlUpdateStat {
         preparedStatement.setObject(15, mPartitionColumnStatistics.getNumNulls());
         preparedStatement.setObject(16, mPartitionColumnStatistics.getNumDVs());
         preparedStatement.setObject(17, mPartitionColumnStatistics.getBitVector());
-        preparedStatement.setObject(18, mPartitionColumnStatistics.getHistogram());
+        preparedStatement.setBytes(18, mPartitionColumnStatistics.getHistogram());
         preparedStatement.setObject(19, mPartitionColumnStatistics.getAvgColLen());
         preparedStatement.setObject(20, mPartitionColumnStatistics.getMaxColLen());
         preparedStatement.setObject(21, mPartitionColumnStatistics.getNumTrues());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Used `preparedStatement.setBytes()` to set the histogram.

### Why are the changes needed?
`java.sql.BatchUpdateException` thrown from `DirectSqlUpdateStat.insertIntoPartColStatTable()` with SQL Server db when histogram statistics is not enabled.

**Exception Stack:**
`2023-02-10T05:16:42,921 ERROR [HiveServer2-Background-Pool: Thread-112] metastore.DirectSqlUpdateStat: Unable to update Column stats for  dynpart
java.sql.BatchUpdateException: Implicit conversion from data type varchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.
    at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.executeBatch(SQLServerPreparedStatement.java:2303) ~[mssql-jdbc-6.2.1.jre8.jar:?]
    at org.apache.hive.com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:127) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    at org.apache.hive.com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeBatch(HikariProxyPreparedStatement.java) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    at org.apache.hadoop.hive.metastore.DirectSqlUpdateStat.insertIntoPartColStatTable(DirectSqlUpdateStat.java:281) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    at org.apache.hadoop.hive.metastore.DirectSqlUpdateStat.updatePartitionColumnStatistics(DirectSqlUpdateStat.java:612) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    at org.apache.hadoop.hive.metastore.MetaStoreDirectSql.updatePartitionColumnStatisticsBatch(MetaStoreDirectSql.java:3063) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    at org.apache.hadoop.hive.metastore.ObjectStore.updatePartitionColumnStatisticsInBatch(ObjectStore.java:9943) ~[hive-exec-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested manually with SQL Server
