### PR TITLE
HIVE-27067: Backport HIVE-26300: Upgraded Jackson bom version to 2.12.6.1+ to avoid CVE-2020-36518 in branch-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <httpcomponents.client.version>4.5.2</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.4</httpcomponents.core.version>
     <ivy.version>2.4.0</ivy.version>
-    <jackson.version>2.12.0</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.3.1</jamon-runtime.version>
     <javaewah.version>0.3.2</javaewah.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -73,7 +73,7 @@
     <guava.version>19.0</guava.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
-    <jackson.version>2.12.0</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.11</junit.version>
     <libfb303.version>0.9.3</libfb303.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jackson version to 2.12.7


### Why are the changes needed?
To fix the CVE and be in-sync with master branch


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests