### PR TITLE
HIVE-27068: Use Accumulator V2 instead of the deprecated Accumulator V1

### DIFF
--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -125,6 +125,12 @@
       <artifactId>hive-service-rpc</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>org.jetbrains</groupId>
+          <artifactId>annotations</artifactId>
+          <version>17.0.0</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use Accumulator V2 instead of the deprecated Accumulator V1 from spark 2.0.0


### Why are the changes needed?
1.Accumulator V2 can do the same thing with the deprecated Accumulator V1.
2.If we use the new version such as 3.1.3 of spark,the Accumulator V1 will have compatibility problem.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
local test
