### PR TITLE
HIVE-27027: Upgrade jettison to 1.5.3 to fix CVE-2022-45693

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <javax-servlet.version>3.1.0</javax-servlet.version>
     <javax-servlet-jsp.version>2.3.1</javax-servlet-jsp.version>
     <javolution.version>5.5.1</javolution.version>
-    <jettison.version>1.5.1</jettison.version>
+    <jettison.version>1.5.3</jettison.version>
     <jetty.version>9.4.40.v20210413</jetty.version>
     <jersey.version>1.19</jersey.version>
     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jettison version to 1.5.3


### Why are the changes needed?
To fix CVE-2022-45693


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests
