### PR TITLE
HIVE-27071: Select query with LIMIT clause can fail if there are marker files like _SUCCESS and _MANIFEST.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -260,7 +261,7 @@ public class SamplePruner extends Transform {
       Collection<Path> retPathList)
       throws IOException {
     LOG.info("Path pattern = " + pathPattern);
-    FileStatus srcs[] = fs.globStatus(new Path(pathPattern));
+    FileStatus srcs[] = fs.globStatus(new Path(pathPattern), FileUtils.HIDDEN_FILES_PATH_FILTER);
     Arrays.sort(srcs);
 
     boolean hasFile = false, allFile = true;

--- a/ql/src/test/queries/clientpositive/global_limit.q
+++ b/ql/src/test/queries/clientpositive/global_limit.q
@@ -15,6 +15,7 @@ load data local inpath '../../data/files/srcbucket20.txt' INTO TABLE gl_src1;
 load data local inpath '../../data/files/srcbucket20.txt' INTO TABLE gl_src1;
 load data local inpath '../../data/files/srcbucket20.txt' INTO TABLE gl_src1;
 
+dfs -touchz ${hiveconf:hive.metastore.warehouse.dir}/gl_src1/_SUCCESS;
 
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Filter Hidden files to avoid failures due to marker files preset in the table directory

### Why are the changes needed?

To avoid failures during read with Limit clause, when hidden files like _SUCCESS are present

### Does this PR introduce _any_ user-facing change?

Yes, the query passes when we have hidden files in the table directory

### How was this patch tested?

UT