### PR TITLE
HIVE-27073: Apply SerDe properties when creating materialized view

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
@@ -2,6 +2,8 @@
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
 --! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
+-- Mask the totalSize value as it can change at file format library update
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
@@ -1,6 +1,8 @@
 -- MV data is stored by partitioned iceberg with partition spec
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 --! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
+-- Mask the totalSize value as it can change at file format library update
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 -- SORT_QUERY_RESULTS
 
 drop materialized view if exists mat1;

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -71,7 +71,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	700                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.format.default	orc                 
@@ -151,7 +151,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	700                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.delete.mode   	merge-on-read       

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -64,16 +64,17 @@ Table Parameters:
 	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	1                   
-	iceberg.orc.files.only	false               
+	iceberg.orc.files.only	true                
 	metadata_location   	hdfs://### HDFS PATH ###
 	numFiles            	2                   
 	numRows             	2                   
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1282                
+	totalSize           	700                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
+	write.format.default	orc                 
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -143,17 +144,18 @@ Table Parameters:
 	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	2                   
-	iceberg.orc.files.only	false               
+	iceberg.orc.files.only	true                
 	metadata_location   	hdfs://### HDFS PATH ###
 	numFiles            	2                   
 	numRows             	2                   
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1282                
+	totalSize           	700                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.delete.mode   	merge-on-read       
+	write.format.default	orc                 
 	write.merge.mode    	merge-on-read       
 	write.update.mode   	merge-on-read       
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -65,16 +65,17 @@ Table Parameters:
 	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	1                   
-	iceberg.orc.files.only	false               
+	iceberg.orc.files.only	true                
 	metadata_location   	hdfs://### HDFS PATH ###
 	numFiles            	2                   
 	numRows             	2                   
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1282                
+	totalSize           	698                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
+	write.format.default	orc                 
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
@@ -145,17 +146,18 @@ Table Parameters:
 	current-snapshot-id 	#SnapshotId#
 	engine.hive.enabled 	true                
 	format-version      	2                   
-	iceberg.orc.files.only	false               
+	iceberg.orc.files.only	true                
 	metadata_location   	hdfs://### HDFS PATH ###
 	numFiles            	2                   
 	numRows             	2                   
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1282                
+	totalSize           	698                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.delete.mode   	merge-on-read       
+	write.format.default	orc                 
 	write.merge.mode    	merge-on-read       
 	write.update.mode   	merge-on-read       
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -72,7 +72,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	698                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.format.default	orc                 
@@ -153,7 +153,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	698                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	uuid                	#Masked#
 	write.delete.mode   	merge-on-read       

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateMaterializedViewDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateMaterializedViewDesc.java
@@ -349,6 +349,12 @@ public class CreateMaterializedViewDesc implements DDLDesc, Serializable {
           org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE,
           getStorageHandler());
     }
+    if (getSerdeProps() != null) {
+      for (Map.Entry<String, String> entry : getSerdeProps().entrySet()) {
+        tbl.setSerdeParam(entry.getKey(), entry.getValue());
+      }
+    }
+
     HiveStorageHandler storageHandler = tbl.getStorageHandler();
 
     setColumnsAndStorePartitionTransformSpecOfTable(getSchema(), getPartCols(), conf, tbl);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Set serde parameters when converting `CreateMaterializedViewDesc` to `Table`

### Why are the changes needed?
Some serde parameters are affects the behavior of storage handler specified at create materialized view statements.

### Does this PR introduce _any_ user-facing change?
No. But the file format specified in cmv statements are show by `describe formatted` output.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestIcebergCliDriver -Dqfile=mv_iceberg_partitioned_orc.q,mv_iceberg_partitioned_orc2.q -pl itests/qtest-iceberg -Piceberg -Pitests
```