### PR TITLE
HIVE-24706: add the HiveHBaseTableInputFormatV2 to fix the compatible issue with spark

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3503,6 +3503,11 @@ public class HiveConf extends Configuration {
     HIVE_HBASE_GENERATE_HFILES("hive.hbase.generatehfiles", false,
         "True when HBaseStorageHandler should generate hfiles instead of operate against the online table."),
     HIVE_HBASE_SNAPSHOT_NAME("hive.hbase.snapshot.name", null, "The HBase table snapshot name to use."),
+
+    HIVE_HBASE_INPUTFORMAT_V2("hive.hbase.inputformat.v2", false, "If enabled, the new " +
+            "version (V2) of input format that inherits only mapred version of InputFormat will be used as input format " +
+            "for reading the Hbase table. By default, the old version (HiveHBaseTableInputFormat) is used that " +
+            "inherits both mapred and mapreduce version of InputFormat."),
     HIVE_HBASE_SNAPSHOT_RESTORE_DIR("hive.hbase.snapshot.restoredir", "/tmp", "The directory in which to " +
         "restore the HBase table snapshot."),
     HIVE_SECURITY_HBASE_URLENCODE_AUTHORIZATION_URI("hive.security.hbase.urlencode.authorization.uri", false,

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
@@ -143,6 +143,11 @@ public class HBaseStorageHandler extends DefaultStorageHandler
       LOG.debug("Using TableSnapshotInputFormat");
       return HiveHBaseTableSnapshotInputFormat.class;
     }
+
+    if (HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.HIVE_HBASE_INPUTFORMAT_V2)) {
+      LOG.debug("Using HiveHBaseTableInputFormatV2");
+      return HiveHBaseTableInputFormatV2.class;
+    }
     LOG.debug("Using HiveHBaseTableInputFormat");
     return HiveHBaseTableInputFormat.class;
   }

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.hbase;
 
 import org.apache.hadoop.hbase.TableName;

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
@@ -1,0 +1,17 @@
+package org.apache.hadoop.hive.hbase;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.mapreduce.TableInputFormatBase;
+
+import java.io.IOException;
+
+public class HiveHBaseTableInputFormatDelegate extends TableInputFormatBase {
+    void initializeTableDelegate(Connection connection, TableName tableName) throws IOException {
+        initializeTable(connection, tableName);
+    }
+
+    void closeTableDelegate() throws IOException {
+        closeTable();
+    }
+}

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatV2.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatV2.java
@@ -18,13 +18,6 @@
 
 package org.apache.hadoop.hive.hbase;
 
-import java.io.IOException;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
@@ -34,7 +27,6 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapred.TableMapReduceUtil;
-import org.apache.hadoop.hbase.mapreduce.TableInputFormatBase;
 import org.apache.hadoop.hbase.mapreduce.TableSplit;
 import org.apache.hadoop.hive.hbase.ColumnMappings.ColumnMapping;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
@@ -50,8 +42,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -61,25 +53,26 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
- * HiveHBaseTableInputFormat implements InputFormat for HBase storage handler
- * tables, decorating an underlying HBase TableInputFormat with extra Hive logic
- * such as column pruning and filter pushdown.
- * Update: For this inputformat,it both implements the new and old InputFormat version which will
- * cause the issue for the spark which will create the RDD depends on the version.Instead of extends
- * {@TableInputFormatBase}, its better to use delegate and make the class path clean {@HiveHBaseTableInputFormatV2}
- * TODO: For long term, need to update the {@HiveStorageHandler} which not only implements the old version Input/OutputFormat
+ * Its the pair with {@HiveHBaseTableInputFormat}, instead of directly extending TableInputFormatBase, using delegate
+ * to make the class ONLY inherit from mapred.*, which makes the hierarchy more clear and avoid downsteam application
+ * like spark issue, ex https://github.com/apache/spark/pull/31302
  */
+public class HiveHBaseTableInputFormatV2 implements InputFormat<ImmutableBytesWritable, ResultWritable> {
 
-@Deprecated
-public class HiveHBaseTableInputFormat extends TableInputFormatBase
-    implements InputFormat<ImmutableBytesWritable, ResultWritable> {
-
-  static final Logger LOG = LoggerFactory.getLogger(HiveHBaseTableInputFormat.class);
+  static final Logger LOG = LoggerFactory.getLogger(HiveHBaseTableInputFormatV2.class);
   private static final Object HBASE_TABLE_MONITOR = new Object();
 
+  private HiveHBaseTableInputFormatDelegate delegate = new HiveHBaseTableInputFormatDelegate();
+
   @Override public RecordReader<ImmutableBytesWritable, ResultWritable> getRecordReader(InputSplit split,
-      JobConf jobConf, final Reporter reporter) throws IOException {
+                                                                                        JobConf jobConf, final Reporter reporter) throws IOException {
 
     HBaseSplit hbaseSplit = (HBaseSplit) split;
     TableSplit tableSplit = hbaseSplit.getTableSplit();
@@ -89,23 +82,17 @@ public class HiveHBaseTableInputFormat extends TableInputFormatBase
     Job job = new Job(jobConf);
     TaskAttemptContext tac = ShimLoader.getHadoopShims().newTaskAttemptContext(job.getConfiguration(), reporter);
 
-    final Configuration hbaseConf = HBaseConfiguration.create(jobConf);
-    final Scan scan = HiveHBaseInputFormatUtil.getScan(jobConf);
-
-    LOG.debug("HBase configurations: {}", hbaseConf);
-    LOG.info("Using global scan configuration (ignore per-split scan configs): {}", scan);
-
     final Connection conn;
 
     synchronized (HBASE_TABLE_MONITOR) {
-      conn = ConnectionFactory.createConnection(hbaseConf);
-      initializeTable(conn, tableSplit.getTable());
-      setScan(scan);
-      recordReader = createRecordReader(tableSplit, tac);
+      conn = ConnectionFactory.createConnection(HBaseConfiguration.create(jobConf));
+      delegate.initializeTableDelegate(conn, tableSplit.getTable());
+      delegate.setScan(HiveHBaseInputFormatUtil.getScan(jobConf));
+      recordReader = delegate.createRecordReader(tableSplit, tac);
       try {
         recordReader.initialize(tableSplit, tac);
       } catch (InterruptedException e) {
-        closeTable(); // Free up the HTable connections
+        delegate.closeTableDelegate(); // Free up the HTable connections
         conn.close();
         throw new IOException("Failed to initialize RecordReader", e);
       }
@@ -116,7 +103,7 @@ public class HiveHBaseTableInputFormat extends TableInputFormatBase
       @Override public void close() throws IOException {
         synchronized (HBASE_TABLE_MONITOR) {
           recordReader.close();
-          closeTable();
+          delegate.closeTableDelegate();
           conn.close();
         }
       }
@@ -302,7 +289,7 @@ public class HiveHBaseTableInputFormat extends TableInputFormatBase
     Connection conn = ConnectionFactory.createConnection(HBaseConfiguration.create(jobConf));
 
     TableName tableName = TableName.valueOf(hbaseTableName);
-    initializeTable(conn, tableName);
+    delegate.initializeTableDelegate(conn, tableName);
 
     String hbaseColumnsMapping = jobConf.get(HBaseSerDe.HBASE_COLUMNS_MAPPING);
     boolean doColumnRegexMatching = jobConf.getBoolean(HBaseSerDe.HBASE_COLUMNS_REGEX_MATCHING, true);
@@ -353,13 +340,13 @@ public class HiveHBaseTableInputFormat extends TableInputFormatBase
           }
         }
       }
-      setScan(scan);
+      delegate.setScan(scan);
 
       Job job = new Job(jobConf);
       JobContext jobContext = ShimLoader.getHadoopShims().newJobContext(job);
       Path[] tablePaths = FileInputFormat.getInputPaths(jobContext);
 
-      List<org.apache.hadoop.mapreduce.InputSplit> splits = super.getSplits(jobContext);
+      List<org.apache.hadoop.mapreduce.InputSplit> splits = delegate.getSplits(jobContext);
       InputSplit[] results = new InputSplit[splits.size()];
 
       for (int i = 0; i < splits.size(); i++) {
@@ -368,14 +355,14 @@ public class HiveHBaseTableInputFormat extends TableInputFormatBase
 
       return results;
     } finally {
-      closeTable();
+      delegate.closeTableDelegate();
       conn.close();
     }
   }
 
   @Override protected void finalize() throws Throwable {
     try {
-      closeTable();
+      delegate.closeTableDelegate();
     } finally {
       super.finalize();
     }

--- a/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHiveHBaseTableInputFormatV2.java
+++ b/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHiveHBaseTableInputFormatV2.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.hbase;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ *  Test tot make sure the HiveHBaseTableInputFormatV2 can ONLY assignable to old version
+ */
+public class TestHiveHBaseTableInputFormatV2 {
+
+  @Test
+  public void testInstanceOfTestHiveHBaseTableInputFormatV2() {
+    assertTrue(org.apache.hadoop.mapred.InputFormat.class.isAssignableFrom(HiveHBaseTableInputFormatV2.class));
+    assertFalse(org.apache.hadoop.mapreduce.InputFormat.class.isAssignableFrom(HiveHBaseTableInputFormatV2.class));
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?

For HIVE-24706, the main issue here is the HiveHbaseTableInput format implements two version of InputFormat, which make the spark cannot get the correct version correctly, and this is indeed not very clear implementation.

So in this request, instead of directly extending TableInputFormatBase, I put it as a delegate which do the exactly the same as before, but avoid the confusing because the HbaseStorageHandler just need the old version InputFormat.

In the long term, I think hive should update the storage handler instead of keep mixing these two different API versions


### Why are the changes needed?

Its impacting the spark and hive compatible and reported by different uses in hive and spark


### Does this PR introduce _any_ user-facing change?
There is configuration parameter added hive.hbase.inputformat.v2, so maybe need update doc to keep the end user informed


### How was this patch tested?

create hbase table

```
echo "create 'students','account','address'" | sudo -u hbase hbase shell -n
echo "put 'students','student1','account:name','Alice'" |sudo -u hbase hbase shell -n
```

create hive table
```
hive -e "create external table test1 (key string, value string)
> stored by 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
> with serdeproperties ('hbase.columns.mapping' = ':key,account:name')
> tblproperties ('hbase.table.name' = 'students')"


SLF4J: Class path contains multiple SLF4J bindings.
Logging initialized using configuration in file:/etc/hive/conf.dist/hive-log4j2.properties Async: true
Hive Session ID = 05b4ec22-d15f-4614-9bc3-6c183e868728
OK
Time taken: 2.913 seconds
```

Spark test:

spark-sql --jars /usr/lib/hive/lib/hive-hbase-handler.jar,/usr/lib/hbase/hbase-common-2.4.4.jar,/usr/lib/hbase/hbase-client-2.4.4.jar,/usr/lib/hbase/lib/hbase-mapreduce-2.4.4.jar,/usr/lib/hbase/lib/shaded-clients/hbase-shaded-client-2.4.4.jar --conf spark.hive.hbase.inputformat.v2=true

```
spark-sql> select * from test1;

student1    Alice
```

Unit Test

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.hbase.TestHiveHBaseTableInputFormatV2
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.069 s - in org.apache.hadoop.hive.hbase.TestHiveHBaseTableInputFormatV2
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
