### PR TITLE
[HIVE-27062] Disable flaky test TestRpc

### DIFF
--- a/spark-client/src/test/java/org/apache/hive/spark/client/rpc/TestRpc.java
+++ b/spark-client/src/test/java/org/apache/hive/spark/client/rpc/TestRpc.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+@Ignore("HIVE-27092: Flaky test")
 public class TestRpc {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestRpc.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR disables TestRpc because it is flaky. I ran the flaky test runner and it failed.
ref: http://ci.hive.apache.org/job/hive-flaky-check/613/console

### Why are the changes needed?
branch-3 stability


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Confirmed that the test skips locally.
