### PR TITLE
HIVE-27093: Fix NPE in initialize() of Partition class

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Partition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Partition.java
@@ -166,7 +166,7 @@ public class Partition implements Serializable {
       return;
     }
 
-    if (table.isPartitioned()) {
+    if (table.isPartitioned() && tPartition.isSetSd()) {
       try {
         if (tPartition.getSd().getLocation() == null) {
           // set default if location is not set and this is a physical


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check if the SD of a Partition exists to avoid NPE. 


### Why are the changes needed?
The Partition SD may lost in backend metadata database for some reasons. For these partitions with corrupted metadata, we can  not even drop them if the NPE exists.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No new tests.
