### PR TITLE
[HIVE-27104] Upgrade Bouncy Castle to 1.68 due to high CVE's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <arrow.version>2.0.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
     <avro.version>1.11.1</avro.version>
-    <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
+    <bouncycastle.version>1.68</bouncycastle.version>
     <calcite.version>1.25.0</calcite.version>
     <datanucleus-api-jdo.version>5.2.8</datanucleus-api-jdo.version>
     <datanucleus-core.version>5.2.10</datanucleus-core.version>
@@ -877,7 +877,12 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
-        <version>${bcprov-jdk15on.version}</version>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Bouncy Castle to 1.68 due to high CVE's

CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15522


### Why are the changes needed?
Upgrade Bouncy Castle to 1.68 due to high CVE's


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
manual
