### PR TITLE
HIVE-27103: Fix thrift compilation warnings on drop_dataconnector()

### DIFF
--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
@@ -4034,7 +4034,7 @@ uint32_t ThriftHiveMetastore_drop_dataconnector_args::read(::apache::thrift::pro
           xfer += iprot->skip(ftype);
         }
         break;
-      case -1:
+      case 2:
         if (ftype == ::apache::thrift::protocol::T_BOOL) {
           xfer += iprot->readBool(this->ifNotExists);
           this->__isset.ifNotExists = true;
@@ -4042,7 +4042,7 @@ uint32_t ThriftHiveMetastore_drop_dataconnector_args::read(::apache::thrift::pro
           xfer += iprot->skip(ftype);
         }
         break;
-      case -2:
+      case 3:
         if (ftype == ::apache::thrift::protocol::T_BOOL) {
           xfer += iprot->readBool(this->checkReferences);
           this->__isset.checkReferences = true;
@@ -4067,16 +4067,16 @@ uint32_t ThriftHiveMetastore_drop_dataconnector_args::write(::apache::thrift::pr
   ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
   xfer += oprot->writeStructBegin("ThriftHiveMetastore_drop_dataconnector_args");
 
-  xfer += oprot->writeFieldBegin("checkReferences", ::apache::thrift::protocol::T_BOOL, -2);
-  xfer += oprot->writeBool(this->checkReferences);
+  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeString(this->name);
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("ifNotExists", ::apache::thrift::protocol::T_BOOL, -1);
+  xfer += oprot->writeFieldBegin("ifNotExists", ::apache::thrift::protocol::T_BOOL, 2);
   xfer += oprot->writeBool(this->ifNotExists);
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
-  xfer += oprot->writeString(this->name);
+  xfer += oprot->writeFieldBegin("checkReferences", ::apache::thrift::protocol::T_BOOL, 3);
+  xfer += oprot->writeBool(this->checkReferences);
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldStop();
@@ -4094,16 +4094,16 @@ uint32_t ThriftHiveMetastore_drop_dataconnector_pargs::write(::apache::thrift::p
   ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
   xfer += oprot->writeStructBegin("ThriftHiveMetastore_drop_dataconnector_pargs");
 
-  xfer += oprot->writeFieldBegin("checkReferences", ::apache::thrift::protocol::T_BOOL, -2);
-  xfer += oprot->writeBool((*(this->checkReferences)));
+  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeString((*(this->name)));
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("ifNotExists", ::apache::thrift::protocol::T_BOOL, -1);
+  xfer += oprot->writeFieldBegin("ifNotExists", ::apache::thrift::protocol::T_BOOL, 2);
   xfer += oprot->writeBool((*(this->ifNotExists)));
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
-  xfer += oprot->writeString((*(this->name)));
+  xfer += oprot->writeFieldBegin("checkReferences", ::apache::thrift::protocol::T_BOOL, 3);
+  xfer += oprot->writeBool((*(this->checkReferences)));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_dataconnector_args.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_drop_dataconnector_args.php
@@ -26,12 +26,12 @@ class ThriftHiveMetastore_drop_dataconnector_args
             'isRequired' => false,
             'type' => TType::STRING,
         ),
-        -1 => array(
+        2 => array(
             'var' => 'ifNotExists',
             'isRequired' => false,
             'type' => TType::BOOL,
         ),
-        -2 => array(
+        3 => array(
             'var' => 'checkReferences',
             'isRequired' => false,
             'type' => TType::BOOL,
@@ -92,14 +92,14 @@ class ThriftHiveMetastore_drop_dataconnector_args
                         $xfer += $input->skip($ftype);
                     }
                     break;
-                case -1:
+                case 2:
                     if ($ftype == TType::BOOL) {
                         $xfer += $input->readBool($this->ifNotExists);
                     } else {
                         $xfer += $input->skip($ftype);
                     }
                     break;
-                case -2:
+                case 3:
                     if ($ftype == TType::BOOL) {
                         $xfer += $input->readBool($this->checkReferences);
                     } else {
@@ -120,19 +120,19 @@ class ThriftHiveMetastore_drop_dataconnector_args
     {
         $xfer = 0;
         $xfer += $output->writeStructBegin('ThriftHiveMetastore_drop_dataconnector_args');
-        if ($this->checkReferences !== null) {
-            $xfer += $output->writeFieldBegin('checkReferences', TType::BOOL, -2);
-            $xfer += $output->writeBool($this->checkReferences);
-            $xfer += $output->writeFieldEnd();
-        }
-        if ($this->ifNotExists !== null) {
-            $xfer += $output->writeFieldBegin('ifNotExists', TType::BOOL, -1);
-            $xfer += $output->writeBool($this->ifNotExists);
-            $xfer += $output->writeFieldEnd();
-        }
         if ($this->name !== null) {
             $xfer += $output->writeFieldBegin('name', TType::STRING, 1);
             $xfer += $output->writeString($this->name);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->ifNotExists !== null) {
+            $xfer += $output->writeFieldBegin('ifNotExists', TType::BOOL, 2);
+            $xfer += $output->writeBool($this->ifNotExists);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->checkReferences !== null) {
+            $xfer += $output->writeFieldBegin('checkReferences', TType::BOOL, 3);
+            $xfer += $output->writeBool($this->checkReferences);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
@@ -22813,12 +22813,12 @@ class drop_dataconnector_args(object):
                     self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
-            elif fid == -1:
+            elif fid == 2:
                 if ftype == TType.BOOL:
                     self.ifNotExists = iprot.readBool()
                 else:
                     iprot.skip(ftype)
-            elif fid == -2:
+            elif fid == 3:
                 if ftype == TType.BOOL:
                     self.checkReferences = iprot.readBool()
                 else:
@@ -22833,17 +22833,17 @@ class drop_dataconnector_args(object):
             oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
             return
         oprot.writeStructBegin('drop_dataconnector_args')
-        if self.checkReferences is not None:
-            oprot.writeFieldBegin('checkReferences', TType.BOOL, -2)
-            oprot.writeBool(self.checkReferences)
-            oprot.writeFieldEnd()
-        if self.ifNotExists is not None:
-            oprot.writeFieldBegin('ifNotExists', TType.BOOL, -1)
-            oprot.writeBool(self.ifNotExists)
-            oprot.writeFieldEnd()
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
             oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeFieldEnd()
+        if self.ifNotExists is not None:
+            oprot.writeFieldBegin('ifNotExists', TType.BOOL, 2)
+            oprot.writeBool(self.ifNotExists)
+            oprot.writeFieldEnd()
+        if self.checkReferences is not None:
+            oprot.writeFieldBegin('checkReferences', TType.BOOL, 3)
+            oprot.writeBool(self.checkReferences)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -22862,7 +22862,12 @@ class drop_dataconnector_args(object):
     def __ne__(self, other):
         return not (self == other)
 all_structs.append(drop_dataconnector_args)
-drop_dataconnector_args.thrift_spec = ()
+drop_dataconnector_args.thrift_spec = (
+    None,  # 0
+    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (2, TType.BOOL, 'ifNotExists', None, None, ),  # 2
+    (3, TType.BOOL, 'checkReferences', None, None, ),  # 3
+)
 
 
 class drop_dataconnector_result(object):

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
@@ -8520,8 +8520,8 @@ module ThriftHiveMetastore
   class Drop_dataconnector_args
     include ::Thrift::Struct, ::Thrift::Struct_Union
     NAME = 1
-    IFNOTEXISTS = -1
-    CHECKREFERENCES = -2
+    IFNOTEXISTS = 2
+    CHECKREFERENCES = 3
 
     FIELDS = {
       NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -2485,7 +2485,7 @@ service ThriftHiveMetastore extends fb303.FacebookService
 
   void create_dataconnector(1:DataConnector connector) throws(1:AlreadyExistsException o1, 2:InvalidObjectException o2, 3:MetaException o3)
   DataConnector get_dataconnector_req(1:GetDataConnectorRequest request) throws(1:NoSuchObjectException o1, 2:MetaException o2)
-  void drop_dataconnector(1:string name, bool ifNotExists, bool checkReferences) throws(1:NoSuchObjectException o1, 2:InvalidOperationException o2, 3:MetaException o3)
+  void drop_dataconnector(1:string name, 2:bool ifNotExists, 3:bool checkReferences) throws(1:NoSuchObjectException o1, 2:InvalidOperationException o2, 3:MetaException o3)
   list<string> get_dataconnectors() throws(1:MetaException o1)
   void alter_dataconnector(1:string name, 2:DataConnector connector) throws(1:MetaException o1, 2:NoSuchObjectException o2)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix thrift compilation warnings due to missing argument indexes in drop_dataconnector()

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Lots of compilation warnings show up when compiling hive_metastore.thrift.
```
[WARNING:/home/quanlong/workspace/Impala/toolchain/cdp_components-36109364/hive-3.1.3000.7.2.17.0-75/standalone-metastore/src/main/thrift/hive_metastore.thrift:2397] No field key specified for ifNotExists, resulting protocol may have conflicts or not be backwards compatible!
[WARNING:/home/quanlong/workspace/Impala/toolchain/cdp_components-36109364/hive-3.1.3000.7.2.17.0-75/standalone-metastore/src/main/thrift/hive_metastore.thrift:2397] No field key specified for checkReferences, resulting protocol may have conflicts or not be backwards compatible!
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Compiled locally and verified the warnings disappeared.