### PR TITLE
HIVE-27105: Parquet and kafka-client both use zstd-jni. Upgrading kaf…

### DIFF
--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaStorageHandler.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaStorageHandler.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -310,7 +311,7 @@ import java.util.function.Predicate;
 
     RetryUtils.CleanupAfterFailure cleanUpTheMap = new RetryUtils.CleanupAfterFailure() {
       @Override public void cleanup() {
-        producersMap.forEach((s, producer) -> producer.close(0, TimeUnit.MILLISECONDS));
+        producersMap.forEach((s, producer) -> producer.close(Duration.ofMillis(0)));
         producersMap.clear();
       }
     };
@@ -346,7 +347,7 @@ import java.util.function.Predicate;
       RetryUtils.retry(commitTask, isRetrayable, maxTries);
     } catch (Exception e) {
       // at this point we are in a funky state if one commit happend!! close and log it
-      producersMap.forEach((key, producer) -> producer.close(0, TimeUnit.MILLISECONDS));
+      producersMap.forEach((key, producer) -> producer.close(Duration.ofMillis(0)));
       LOG.error("Commit transaction failed", e);
       if (committedTx.size() > 0) {
         LOG.error("Partial Data Got Commited Some actions need to be Done");

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/SimpleKafkaWriter.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/SimpleKafkaWriter.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -120,7 +121,7 @@ class SimpleKafkaWriter implements FileSinkOperator.RecordWriter, RecordWriter<B
   @Override public void close(boolean abort) throws IOException {
     if (abort) {
       LOG.info("Aborting is set to TRUE, Closing writerId [{}] without flush.", writerId);
-      producer.close(0, TimeUnit.MICROSECONDS);
+      producer.close(Duration.ofMillis(0));
       return;
     } else {
       LOG.info("Flushing Kafka Producer with writerId [{}]", writerId);
@@ -159,7 +160,7 @@ class SimpleKafkaWriter implements FileSinkOperator.RecordWriter, RecordWriter<B
   private void checkExceptions() throws IOException {
     if (sendExceptionRef.get() != null) {
       LOG.error("Send Exception Aborting write from writerId [{}]", writerId);
-      producer.close(0, TimeUnit.MICROSECONDS);
+      producer.close(Duration.ofMillis(0));
       throw new IOException(sendExceptionRef.get());
     }
   }

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/TransactionalKafkaWriter.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/TransactionalKafkaWriter.java
@@ -126,7 +126,7 @@ class TransactionalKafkaWriter implements FileSinkOperator.RecordWriter, RecordW
         producer.abortTransaction();
       }
       LOG.error("Closing writer [{}] caused by ERROR [{}]", producer.getTransactionalId(), exception.getMessage());
-      producer.close(0, TimeUnit.MILLISECONDS);
+      producer.close(DURATION_0);
       throw exception;
     }
     writerIdTopicId = String.format("WriterId [%s], Kafka Topic [%s]", producer.getTransactionalId(), topic);
@@ -151,7 +151,7 @@ class TransactionalKafkaWriter implements FileSinkOperator.RecordWriter, RecordW
         // producer.send() may throw a KafkaException which wraps a FencedException re throw its wrapped inner cause.
         producer.abortTransaction();
       }
-      producer.close(0, TimeUnit.MILLISECONDS);
+      producer.close(DURATION_0);
       sendExceptionRef.compareAndSet(null, e);
       checkExceptions();
     }
@@ -278,7 +278,7 @@ class TransactionalKafkaWriter implements FileSinkOperator.RecordWriter, RecordW
         producer.abortTransaction();
       }
       LOG.error("Closing writer [{}] caused by ERROR [{}]", writerIdTopicId, exception.getMessage());
-      producer.close(0, TimeUnit.MILLISECONDS);
+      producer.close(DURATION_0);
       throw new IOException(exception);
     }
   }

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaBrokerResource.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaBrokerResource.java
@@ -74,7 +74,7 @@ class KafkaBrokerResource extends ExternalResource {
     kafkaServer.zkClient();
     adminZkClient = new AdminZkClient(kafkaServer.zkClient());
     LOG.info("Creating kafka TOPIC [{}]", TOPIC);
-    adminZkClient.createTopic(TOPIC, 1, 1, new Properties(), RackAwareMode.Disabled$.MODULE$);
+    adminZkClient.createTopic(TOPIC, 1, 1, new Properties(), RackAwareMode.Disabled$.MODULE$, false);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <junit.vintage.version>5.6.3</junit.vintage.version>
-    <kafka.version>2.5.0</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <kryo.version>5.0.3</kryo.version>
     <reflectasm.version>1.11.9</reflectasm.version>
     <kudu.version>1.12.0</kudu.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1102,6 +1102,7 @@
                   <include>com.esri.geometry:esri-geometry-api</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>org.roaringbitmap:shims</include>
+                  <include>com.github.luben:zstd-jni</include>
                 </includes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
…ka-client to latest version which uses zstd-jni version close to the version in parquet. Shading zstd-jni into hive-exec to avoid failure when Hive code is called by Tez application.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Upgrading kafka-client to the latest version and shading zstd-jni into hive-exec.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Parquet and kafka-client both use zstd-jni. Upgrading kafka-client to latest version which uses zstd-jni version close to the version in parquet. Shading zstd-jni into hive-exec to avoid failure when Hive code is called by Tez application.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
precommit CI pipeline and testing on local dev env with Hadoop/Tez/Hive.