### PR TITLE
HIVE-27106. Improve TezSessionPoolManager#getSession Log.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionPoolManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionPoolManager.java
@@ -288,7 +288,7 @@ public class TezSessionPoolManager extends TezSessionPoolSession.AbstractTrigger
      */
     if (nonDefaultUser || !hasInitialSessions || hasQueue || jobNameSet) {
       LOG.info("QueueName: {} nonDefaultUser: {} defaultQueuePool: {} hasInitialSessions: {}" +
-                      " jobNameSet: ", queueName, nonDefaultUser, defaultSessionPool,
+                      " jobNameSet: {}.", queueName, nonDefaultUser, defaultSessionPool,
               hasInitialSessions, jobNameSet);
       return getNewSessionState(conf, queueName, doOpen);
     }


### PR DESCRIPTION
JIRA: HIVE-27106. Improve TezSessionPoolManager#getSession Log.

When reading the code, I found that the log placeholder of Tez Session Pool Manager#getSession is missing one, this jira will fix this problem.