### PR TITLE
HIVE-27107 : Fix improper metrics count for RESUME/RESET workflow

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -3858,7 +3858,28 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
     // this will be completion cycle for RESET
     primary.dump(primaryDbName);
+    metric = collector.getMetrics().getLast();
+    assertEquals(metric.getProgress()
+                       .getStages()
+                       .get(0)
+                       .getMetrics()
+                       .stream()
+                       .filter(m -> Objects.equals(m.getName(), "TABLES"))
+                       .findFirst()
+                       .get()
+                       .getTotalCount(), 1);
+
     replica.load(replicatedDbName, primaryDbName);
+    metric = collector.getMetrics().getLast();
+    assertEquals(metric.getProgress()
+                       .getStages()
+                       .get(0)
+                       .getMetrics()
+                       .stream()
+                       .filter(m -> Objects.equals(m.getName(), "TABLES"))
+                       .findFirst()
+                       .get()
+                       .getTotalCount(), 1);
 
     // AFTER RESET : 1. New table got dropped
     //               2. Changes made on existing table got discarded.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -113,6 +113,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.UUID;
@@ -943,8 +944,14 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
       Map<String, Long> metricMap = new HashMap<>();
       metricMap.put(ReplUtils.MetricName.EVENTS.name(), estimatedNumEvents);
       int size = tablesForBootstrap.size();
+      if (db != null && db.getParameters()!=null &&
+        Boolean.parseBoolean(db.getParameters().get(REPL_RESUME_STARTED_AFTER_FAILOVER))) {
+        Collection<String> allTables = Utils.getAllTables(hiveDb, dbName, work.replScope);
+        allTables.retainAll(tablesForBootstrap);
+        size = allTables.size();
+      }
       if (size > 0) {
-        metricMap.put(ReplUtils.MetricName.TABLES.name(), (long) tablesForBootstrap.size());
+        metricMap.put(ReplUtils.MetricName.TABLES.name(), (long) size);
       }
       if (shouldFailover()) {
         Map<String, String> params = db.getParameters();


### PR DESCRIPTION


### What changes were proposed in this pull request?
This patch fixes the improper metrics (TABLE count) incase of RESUME/RESET by taking intersection of tables in ```table_diff_complete``` and actual ```tables on source```. 



### Why are the changes needed?
```REPL DUMP``` during RESET checks all the tables listed in ```table_diff_complete``` and persists
the table count in replication metrics. This is incorrect for RESET,
because table_diff_complete has those tables which needs to be dropped too.



### Does this PR introduce _any_ user-facing change?
NO



### How was this patch tested?
* Updated unit test for this scenario.
* Tested it in local setup.

