### PR TITLE
HIVE-27109: Upgrade jackson version to 2.12.7.1 to fix CVE-2022-42003

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <ivy.version>2.5.1</ivy.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.12.7.1</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <javaewah.version>0.3.2</javaewah.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -79,7 +79,7 @@
     <guava.version>19.0</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.12.7.1</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jackson version to 2.12.7.1


### Why are the changes needed?
To fix CVE-2022-42003


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests
