### PR TITLE
HIVE-27013: Iceberg: Provide an option to enable iceberg manifest caching for all catalogs.

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -98,8 +98,12 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));
 
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-    this.fileIO = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
-
+    if (fileIOImpl == null) {
+      this.fileIO = new HadoopFileIO(conf);
+      this.fileIO.initialize(properties);
+    } else {
+      this.fileIO = CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
+    }
     this.clients = new CachedClientPool(conf, properties);
   }
 
@@ -535,7 +539,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   }
 
   @Override
-  protected Map<String, String> properties() {
+  public Map<String, String> properties() {
     return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -246,8 +246,8 @@ public final class Catalogs {
     String keyPrefix = InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName;
     for (Map.Entry<String, String> config : conf) {
       if (config.getKey().startsWith(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX)) {
-        defaultCatalogProperties.put(config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()),
-            config.getValue());
+        defaultCatalogProperties.put(
+            config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()), config.getValue());
       } else if (config.getKey().startsWith(keyPrefix)) {
         catalogProperties.put(config.getKey().substring(keyPrefix.length() + 1), config.getValue());
       }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -243,10 +243,13 @@ public final class Catalogs {
    * @return complete map of catalog properties
    */
   private static Map<String, String> getCatalogProperties(Configuration conf, String catalogName, String catalogType) {
-    String keyPrefix = InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName;
     Map<String, String> catalogProperties = Streams.stream(conf.iterator())
-            .filter(e -> e.getKey().startsWith(keyPrefix))
-            .collect(Collectors.toMap(e -> e.getKey().substring(keyPrefix.length() + 1), Map.Entry::getValue));
+        .filter(e -> e.getKey().startsWith(InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX)).collect(
+            Collectors.toMap(e -> e.getKey().substring(InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX.length()),
+                Map.Entry::getValue));
+    String keyPrefix = InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName;
+    catalogProperties.putAll(Streams.stream(conf.iterator()).filter(e -> e.getKey().startsWith(keyPrefix))
+        .collect(Collectors.toMap(e -> e.getKey().substring(keyPrefix.length() + 1), Map.Entry::getValue)));
     return addCatalogPropertiesIfMissing(conf, catalogType, catalogProperties);
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -245,7 +245,8 @@ public final class Catalogs {
     conf.forEach(config -> {
       if (config.getKey().startsWith(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX)) {
         catalogProperties.putIfAbsent(
-            config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()), config.getValue());
+            config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()),
+            config.getValue());
       } else if (config.getKey().startsWith(InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName)) {
         catalogProperties.put(
             config.getKey().substring((InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName).length() + 1),

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -241,12 +241,12 @@ public final class Catalogs {
    * @return complete map of catalog properties
    */
   private static Map<String, String> getCatalogProperties(Configuration conf, String catalogName, String catalogType) {
-    Map<String, String> globalCatalogProperties = Maps.newHashMap();
+    Map<String, String> defaultCatalogProperties = Maps.newHashMap();
     Map<String, String> catalogProperties = Maps.newHashMap();
     String keyPrefix = InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName;
     for (Map.Entry<String, String> config : conf) {
-      if (config.getKey().startsWith(InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX)) {
-        globalCatalogProperties.put(config.getKey().substring(InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX.length()),
+      if (config.getKey().startsWith(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX)) {
+        defaultCatalogProperties.put(config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()),
             config.getValue());
       } else if (config.getKey().startsWith(keyPrefix)) {
         catalogProperties.put(config.getKey().substring(keyPrefix.length() + 1), config.getValue());
@@ -254,8 +254,8 @@ public final class Catalogs {
     }
 
     // Add any catalog specific properties.
-    globalCatalogProperties.putAll(catalogProperties);
-    return addCatalogPropertiesIfMissing(conf, catalogType, globalCatalogProperties);
+    defaultCatalogProperties.putAll(catalogProperties);
+    return addCatalogPropertiesIfMissing(conf, catalogType, defaultCatalogProperties);
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -241,21 +241,19 @@ public final class Catalogs {
    * @return complete map of catalog properties
    */
   private static Map<String, String> getCatalogProperties(Configuration conf, String catalogName, String catalogType) {
-    Map<String, String> defaultCatalogProperties = Maps.newHashMap();
     Map<String, String> catalogProperties = Maps.newHashMap();
-    String keyPrefix = InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName;
-    for (Map.Entry<String, String> config : conf) {
+    conf.forEach(config -> {
       if (config.getKey().startsWith(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX)) {
-        defaultCatalogProperties.put(
+        catalogProperties.putIfAbsent(
             config.getKey().substring(InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX.length()), config.getValue());
-      } else if (config.getKey().startsWith(keyPrefix)) {
-        catalogProperties.put(config.getKey().substring(keyPrefix.length() + 1), config.getValue());
+      } else if (config.getKey().startsWith(InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName)) {
+        catalogProperties.put(
+            config.getKey().substring((InputFormatConfig.CATALOG_CONFIG_PREFIX + catalogName).length() + 1),
+            config.getValue());
       }
-    }
+    });
 
-    // Add any catalog specific properties.
-    defaultCatalogProperties.putAll(catalogProperties);
-    return addCatalogPropertiesIfMissing(conf, catalogType, defaultCatalogProperties);
+    return addCatalogPropertiesIfMissing(conf, catalogType, catalogProperties);
   }
 
   /**

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -106,6 +106,7 @@ public class InputFormatConfig {
   public static final String CATALOG_TYPE_TEMPLATE = "iceberg.catalog.%s.type";
   public static final String CATALOG_WAREHOUSE_TEMPLATE = "iceberg.catalog.%s.warehouse";
   public static final String CATALOG_CLASS_TEMPLATE = "iceberg.catalog.%s.catalog-impl";
+  public static final String GLOBAL_CATALOG_CONFIG_PREFIX = CATALOG_CONFIG_PREFIX + "global.";
 
   public enum InMemoryDataModel {
     PIG,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -106,7 +106,7 @@ public class InputFormatConfig {
   public static final String CATALOG_TYPE_TEMPLATE = "iceberg.catalog.%s.type";
   public static final String CATALOG_WAREHOUSE_TEMPLATE = "iceberg.catalog.%s.warehouse";
   public static final String CATALOG_CLASS_TEMPLATE = "iceberg.catalog.%s.catalog-impl";
-  public static final String GLOBAL_CATALOG_CONFIG_PREFIX = CATALOG_CONFIG_PREFIX + "global.";
+  public static final String CATALOG_DEFAULT_CONFIG_PREFIX = "iceberg.catalog-default.";
 
   public enum InMemoryDataModel {
     PIG,

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -339,11 +339,11 @@ public class TestCatalogs {
   }
 
   @Test
-  public void testGlobalCatalogProperties() {
+  public void testDefaultCatalogProperties() {
     String catalogProperty = "io.manifest.cache-enabled";
     // Set global property
-    final String globalCatalogProperty = InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX + catalogProperty;
-    conf.setBoolean(globalCatalogProperty, true);
+    final String defaultCatalogProperty = InputFormatConfig.CATALOG_DEFAULT_CONFIG_PREFIX + catalogProperty;
+    conf.setBoolean(defaultCatalogProperty, true);
     HiveCatalog defaultCatalog = (HiveCatalog) Catalogs.loadCatalog(conf, null).get();
     Assert.assertEquals("true", defaultCatalog.properties().get(catalogProperty));
     Assert.assertEquals("true",

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -338,6 +338,27 @@ public class TestCatalogs {
         "Unknown catalog type:", () -> Catalogs.loadCatalog(conf, catalogName));
   }
 
+  @Test
+  public void testGlobalCatalogProperties() {
+    String catalogProperty = "io.manifest.cache-enabled";
+    // Set global property
+    final String globalCatalogProperty = InputFormatConfig.GLOBAL_CATALOG_CONFIG_PREFIX + catalogProperty;
+    conf.setBoolean(globalCatalogProperty, true);
+    HiveCatalog defaultCatalog = (HiveCatalog) Catalogs.loadCatalog(conf, null).get();
+    Assert.assertEquals("true", defaultCatalog.properties().get(catalogProperty));
+    Assert.assertEquals("true",
+        defaultCatalog.newTableOps(TableIdentifier.of("default", "iceberg")).io().properties().get(catalogProperty));
+
+    // set property at catalog level, and that should take precedence over the global property.
+    conf.setBoolean(
+        String.format("%s%s.%s", InputFormatConfig.CATALOG_CONFIG_PREFIX, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
+            catalogProperty), false);
+    defaultCatalog = (HiveCatalog) Catalogs.loadCatalog(conf, null).get();
+    Assert.assertEquals("false", defaultCatalog.properties().get(catalogProperty));
+    Assert.assertEquals("false",
+        defaultCatalog.newTableOps(TableIdentifier.of("default", "iceberg")).io().properties().get(catalogProperty));
+  }
+
   public static class CustomHadoopCatalog extends HadoopCatalog {
 
     public CustomHadoopCatalog() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provide a config to set catalog level properties globally for all catalogs.

### Why are the changes needed?

User Ease

### Does this PR introduce _any_ user-facing change?

Yes, Iceberg Catalog level properties can be set at global level

### How was this patch tested?

UT