### PR TITLE
HIVE-27120: Warn when Authorizer V2 is configured

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -255,8 +255,8 @@ public class SessionState implements ISessionAuthState{
 
   private String currentCatalog;
 
-  private final String CONFIG_AUTHZ_SETTINGS_APPLIED_MARKER =
-      "hive.internal.ss.authz.settings.applied.marker";
+  private static final String CONFIG_AUTHZ_SETTINGS_APPLIED_MARKER =
+      "_hive.ss.authz.settings.applied.marker";
 
   private String userIpAddress;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

This PR will change an internal param name defined in SessionState.

### Why are the changes needed?

The param causes WARN unless we disable `hive.conf.validation`.

```
pod/hive-hiveserver2-7fc4df88b6-dmn8v: 2023-03-01T13:50:38,959  WARN [main] conf.HiveConf: HiveConf of name hive.internal.ss.authz.settings.applied.marker does not exist 
```

That's because it is not listed in HiveConf even though it starts with `hive.`.
https://github.com/apache/hive/blob/rel/release-4.0.0-alpha-2/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L6429-L6440

So, this PR will change the prefix from `hive.internal.` into `_hive.`. This manner is inherited from some other private params.
https://github.com/apache/hive/blob/rel/release-4.0.0-alpha-2/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java#L130-L132

Other options I considered.
- To put `hive.internal.ss.authz.settings.applied.marker` in HiveConf
    - It is weird to me because users must not configure it
- To add `hive.internal.ss.authz.settings.applied.marker` to the allowlist
    - It sounds too adhoc
- To let HiveConf skip validation when a key starts with `hive.internal.`
    - I think the approach of this PR is more consistent with other private params

### Does this PR introduce _any_ user-facing change?

I assume we can say NO. Precisely, it might change a behavior when a user explicity configures `hive.internal.ss.authz.settings.applied.marker`. However, I assume this param must not be configured by users.

### How was this patch tested?

I have confirmed I don't see the WARN log with this change on my local environment.