### PR TITLE
HIVE-26900: Error message not representing the correct line number wi…

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -1366,15 +1366,22 @@ public class BeeLine implements Closeable {
 
     while (!exit) {
       try {
-        // Execute one instruction; terminate on executing a script if there is an error
-        // in silent mode, prevent the query and prompt being echoed back to terminal
-        String line = (getOpts().isSilent() && getOpts().getScriptFile() != null) ? reader
-            .readLine(null, mask) : reader.readLine(getPrompt());
-
-        // trim line
-        if (line != null) {
-          line = line.trim();
+        String line;
+        StringBuilder qsb = new StringBuilder();
+        while ((line = (getOpts().isSilent() && getOpts().getScriptFile() != null) ? reader
+                .readLine(null, mask) : reader.readLine(getPrompt())) != null) {
+          // Skipping through comments
+          if (! line.startsWith("--")) {
+            qsb.append(line + "\n");
+          }
         }
+
+        if (line == null)
+        {
+          exit = true;
+          lastExecutionResult = ERRNO_OTHER;
+        }
+        line = qsb.toString();
 
         if (!dispatch(line)) {
           lastExecutionResult = ERRNO_OTHER;
@@ -1499,8 +1506,6 @@ public class BeeLine implements Closeable {
     if (line.trim().length() == 0) {
       return true;
     }
-
-    line = line.trim();
 
     // save it to the current script, if any
     if (scriptOutputFile != null) {

--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -1208,10 +1208,9 @@ public class Commands {
       beeLine.handleException(e);
     }
 
-    line = line.trim();
     List<String> cmdList = getCmdList(line, entireLineAsCommand);
     for (int i = 0; i < cmdList.size(); i++) {
-      String sql = cmdList.get(i).trim();
+      String sql = cmdList.get(i);
       if (sql.length() != 0) {
         if (!executeInternal(sql, call)) {
           return false;


### PR DESCRIPTION
…th a syntax error in a HQL File

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the Beeline class: 
- the execute method (at line 1362) has been modified to make one string out of all the contents of the hql file separated by newline characters (the comments are excluded).
- if the final string is null, the code exits the while loop (it implies that there is no command to be executed).

In both the classes (Beeline and Commands), the trim() method has been removed from a few places. This is done so that the whitespaces and empty lines are not ignored while counting the line numbers.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
Hive Cli throws error line number correctly when reading HQL files, but Beeline does not. These changes are needed so that the error line number is thrown correctly and there is no discrepancy between the functioning of Beeline and Hive Cli. 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Error message in Beeline was not representing the correct line number prior to the changes. Now Beeline prints the correct error line number.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The testing was done locally on Beeline with multiple scenarios. The test were verified against the correctly functioning Hive Cli.
As an example, for the given hql file:
<img width="438" alt="Screenshot 2023-03-05 at 11 12 29 PM" src="https://user-images.githubusercontent.com/50237152/222977016-e8a72f33-2f47-4ad4-aeff-2afb6f4a3bc9.png">
Error message prior to the changes:
<img width="1495" alt="Screenshot 2023-03-05 at 11 12 05 PM" src="https://user-images.githubusercontent.com/50237152/222977044-90f746ee-1958-4c6a-9627-c1c1e2a173cc.png">
Error message after the changes:
<img width="1496" alt="Screenshot 2023-03-05 at 11 10 57 PM" src="https://user-images.githubusercontent.com/50237152/222977064-d19b6bb8-b2bc-4292-a24a-1a14d04ab3eb.png">


