### PR TITLE
HIVE-27129: Add enhanced support for Hive Metastore Client http support

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -693,10 +693,6 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     try {
       if (useSSL) {
         String trustStorePath = MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_PATH).trim();
-        if (trustStorePath.isEmpty()) {
-          throw new IllegalArgumentException(ConfVars.SSL_TRUSTSTORE_PATH
-              + " Not configured for SSL connection");
-        }
         String trustStorePassword =
             MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.SSL_TRUSTSTORE_PASSWORD);
         String trustStoreType =

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -686,8 +686,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         @Override public void process(HttpRequest httpRequest, HttpContext httpContext)
             throws HttpException, IOException {
           httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken);
-          for (String key : additionalHeaders.keySet()) {
-            httpRequest.addHeader(key, additionalHeaders.get(key));
+          for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            httpRequest.addHeader(entry.getKey(), entry.getValue());
           }
         }
       });
@@ -705,8 +705,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         @Override public void process(HttpRequest httpRequest, HttpContext httpContext)
             throws HttpException, IOException {
           httpRequest.addHeader(MetaStoreUtils.USER_NAME_HTTP_HEADER, httpUser);
-          for (String key : additionalHeaders.keySet()) {
-            httpRequest.addHeader(key, additionalHeaders.get(key));
+          for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            httpRequest.addHeader(entry.getKey(), entry.getValue());
           }
         }
       });

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -35,19 +35,8 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -649,7 +638,13 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   private THttpClient createHttpClient(URI store, boolean useSSL) throws MetaException,
       TTransportException {
     String path = MetaStoreUtils.getHttpPath(MetastoreConf.getVar(conf, ConfVars.THRIFT_HTTP_PATH));
-    String httpUrl = (useSSL ? "https://" : "http://") + store.getHost() + ":" + store.getPort() + path;
+    String urlScheme;
+    if (useSSL || Objects.equals(store.getScheme(), "https")) {
+      urlScheme = "https://";
+    } else {
+      urlScheme = "http://";
+    }
+    String httpUrl = urlScheme + store.getHost() + ":" + store.getPort() + path;
 
     HttpClientBuilder httpClientBuilder = createHttpClientBuilder();
     THttpClient tHttpClient;

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -656,14 +656,18 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     try {
       if (useSSL) {
         String trustStorePath = MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_PATH).trim();
+        if (trustStorePath.isEmpty()) {
+          throw new IllegalArgumentException(ConfVars.SSL_TRUSTSTORE_PATH
+                  + " Not configured for SSL connection");
+        }
         String trustStorePassword =
-            MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.SSL_TRUSTSTORE_PASSWORD);
+                MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.SSL_TRUSTSTORE_PASSWORD);
         String trustStoreType =
-            MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_TYPE).trim();
+                MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_TYPE).trim();
         String trustStoreAlgorithm =
-            MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTMANAGERFACTORY_ALGORITHM).trim();
+                MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTMANAGERFACTORY_ALGORITHM).trim();
         tHttpClient = SecurityUtils.getThriftHttpsClient(httpUrl, trustStorePath, trustStorePassword,
-            trustStoreAlgorithm, trustStoreType, httpClientBuilder);
+                trustStoreAlgorithm, trustStoreType, httpClientBuilder);
       }  else {
         tHttpClient = new THttpClient(httpUrl, httpClientBuilder.build());
       }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -615,10 +615,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     Map<String, String> headers = new HashMap<>();
     String keyValuePairs = MetastoreConf.getVar(conf, ConfVars.METASTORE_CLIENT_ADDITIONAL_HEADERS);
     try {
-      List<String> headerKeyValues = Splitter
-              .on(',')
-              .trimResults()
-              .splitToList(keyValuePairs);
+      List<String> headerKeyValues = Splitter.on(',').trimResults().splitToList(keyValuePairs);
       for (String header : headerKeyValues) {
         String[] parts = header.split("=");
         headers.put(parts[0].trim(), parts[1].trim());
@@ -635,8 +632,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   then the method fetches JWT from environment variable: HMS_JWT and sets in auth
   header in http request
    */
-  private THttpClient createHttpClient(URI store, boolean useSSL) throws MetaException,
-      TTransportException {
+  private THttpClient createHttpClient(URI store, boolean useSSL) throws MetaException, TTransportException {
     String path = MetaStoreUtils.getHttpPath(MetastoreConf.getVar(conf, ConfVars.THRIFT_HTTP_PATH));
     String urlScheme;
     if (useSSL || Objects.equals(store.getScheme(), "https")) {
@@ -652,26 +648,22 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (useSSL) {
         String trustStorePath = MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_PATH).trim();
         if (trustStorePath.isEmpty()) {
-          throw new IllegalArgumentException(ConfVars.SSL_TRUSTSTORE_PATH
-                  + " Not configured for SSL connection");
+          throw new IllegalArgumentException(ConfVars.SSL_TRUSTSTORE_PATH + " Not configured for SSL connection");
         }
-        String trustStorePassword =
-                MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.SSL_TRUSTSTORE_PASSWORD);
-        String trustStoreType =
-                MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_TYPE).trim();
-        String trustStoreAlgorithm =
-                MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTMANAGERFACTORY_ALGORITHM).trim();
-        tHttpClient = SecurityUtils.getThriftHttpsClient(httpUrl, trustStorePath, trustStorePassword,
-                trustStoreAlgorithm, trustStoreType, httpClientBuilder);
-      }  else {
+        String trustStorePassword = MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.SSL_TRUSTSTORE_PASSWORD);
+        String trustStoreType = MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTSTORE_TYPE).trim();
+        String trustStoreAlgorithm = MetastoreConf.getVar(conf, ConfVars.SSL_TRUSTMANAGERFACTORY_ALGORITHM).trim();
+        tHttpClient =
+            SecurityUtils.getThriftHttpsClient(httpUrl, trustStorePath, trustStorePassword, trustStoreAlgorithm,
+                trustStoreType, httpClientBuilder);
+      } else {
         tHttpClient = new THttpClient(httpUrl, httpClientBuilder.build());
       }
     } catch (Exception e) {
       if (e instanceof TTransportException) {
-        throw (TTransportException)e;
+        throw (TTransportException) e;
       } else {
-        throw new MetaException("Failed to create http transport client to url: " + httpUrl
-            + ". Error:" + e);
+        throw new MetaException("Failed to create http transport client to url: " + httpUrl + ". Error:" + e);
       }
     }
     LOG.debug("Created thrift http client for URL: " + httpUrl);
@@ -687,13 +679,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       String jwtToken = System.getenv("HMS_JWT");
       if (jwtToken == null || jwtToken.isEmpty()) {
         LOG.debug("No jwt token set in environment variable: HMS_JWT");
-        throw new MetaException("For auth mode JWT, valid signed jwt token must be provided in the "
-                + "environment variable HMS_JWT");
+        throw new MetaException(
+            "For auth mode JWT, valid signed jwt token must be provided in the " + "environment variable HMS_JWT");
       }
       httpClientBuilder.addInterceptorFirst(new HttpRequestInterceptor() {
-        @Override
-        public void process(HttpRequest httpRequest, HttpContext httpContext)
-                throws HttpException, IOException {
+        @Override public void process(HttpRequest httpRequest, HttpContext httpContext)
+            throws HttpException, IOException {
           httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken);
           for (String key : additionalHeaders.keySet()) {
             httpRequest.addHeader(key, additionalHeaders.get(key));
@@ -711,9 +702,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       }
       final String httpUser = user;
       httpClientBuilder.addInterceptorFirst(new HttpRequestInterceptor() {
-        @Override
-        public void process(HttpRequest httpRequest, HttpContext httpContext)
-                throws HttpException, IOException {
+        @Override public void process(HttpRequest httpRequest, HttpContext httpContext)
+            throws HttpException, IOException {
           httpRequest.addHeader(MetaStoreUtils.USER_NAME_HTTP_HEADER, httpUser);
           for (String key : additionalHeaders.keySet()) {
             httpRequest.addHeader(key, additionalHeaders.get(key));

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -646,7 +646,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   then the method fetches JWT from environment variable: HMS_JWT and sets in auth
   header in http request
    */
-  private THttpClient createHttpClient(URI store, boolean useSSL) throws MetaException, TTransportException {
+  private THttpClient createHttpClient(URI store, boolean useSSL) throws MetaException,
+      TTransportException {
     String path = MetaStoreUtils.getHttpPath(MetastoreConf.getVar(conf, ConfVars.THRIFT_HTTP_PATH));
     String urlScheme;
     if (useSSL || Objects.equals(store.getScheme(), "https")) {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1588,6 +1588,13 @@ public class MetastoreConf {
                     " and password. Any other value is ignored right now but may be used later."
                 + "If JWT- Supported only in HTTP transport mode. If set, HMS Client will pick the value of JWT from "
                 + "environment variable HMS_JWT and set it in Authorization header in http request"),
+
+    METASTORE_CLIENT_ADDITIONAL_HEADERS("metastore.client.http.additional.headers",
+            "hive.metastore.client.http.additional.headers",
+            "",
+            "Comma separated list of headers which are passed to the " +
+                    "metastore service in the http headers"
+    ),
     METASTORE_CLIENT_PLAIN_USERNAME("metastore.client.plain.username",
             "hive.metastore.client.plain.username",  "",
         "The username used by the metastore client when " +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1590,11 +1590,8 @@ public class MetastoreConf {
                 + "environment variable HMS_JWT and set it in Authorization header in http request"),
 
     METASTORE_CLIENT_ADDITIONAL_HEADERS("metastore.client.http.additional.headers",
-            "hive.metastore.client.http.additional.headers",
-            "",
-            "Comma separated list of headers which are passed to the " +
-                    "metastore service in the http headers"
-    ),
+        "hive.metastore.client.http.additional.headers", "",
+        "Comma separated list of headers which are passed to the metastore service in the http headers"),
     METASTORE_CLIENT_PLAIN_USERNAME("metastore.client.plain.username",
             "hive.metastore.client.plain.username",  "",
         "The username used by the metastore client when " +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1588,7 +1588,6 @@ public class MetastoreConf {
                     " and password. Any other value is ignored right now but may be used later."
                 + "If JWT- Supported only in HTTP transport mode. If set, HMS Client will pick the value of JWT from "
                 + "environment variable HMS_JWT and set it in Authorization header in http request"),
-
     METASTORE_CLIENT_ADDITIONAL_HEADERS("metastore.client.http.additional.headers",
         "hive.metastore.client.http.additional.headers", "",
         "Comma separated list of headers which are passed to the metastore service in the http headers"),

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/SecurityUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/SecurityUtils.java
@@ -297,21 +297,17 @@ public class SecurityUtils {
       KeyStoreException, NoSuchAlgorithmException, CertificateException,
       KeyManagementException {
     Preconditions.checkNotNull(underlyingHttpClientBuilder, "httpClientBuilder should not be null");
-    SSLContext sslContext;
-    if (trustStorePath.isEmpty()) {
-      sslContext = SSLContext.getDefault();
-    } else {
-      if (trustStoreType == null || trustStoreType.isEmpty()) {
-        trustStoreType = KeyStore.getDefaultType();
-      }
-      KeyStore sslTrustStore = KeyStore.getInstance(trustStoreType);
-      try (FileInputStream fis = new FileInputStream(trustStorePath)) {
-        sslTrustStore.load(fis, trustStorePasswd.toCharArray());
-      }
-
-      sslContext = SSLContexts.custom().setTrustManagerFactoryAlgorithm(trustStoreAlgorithm)
-              .loadTrustMaterial(sslTrustStore, null).build();
+    if (trustStoreType == null || trustStoreType.isEmpty()) {
+      trustStoreType = KeyStore.getDefaultType();
     }
+    KeyStore sslTrustStore = KeyStore.getInstance(trustStoreType);
+    try (FileInputStream fis = new FileInputStream(trustStorePath)) {
+      sslTrustStore.load(fis, trustStorePasswd.toCharArray());
+    }
+
+    SSLContext sslContext =
+        SSLContexts.custom().setTrustManagerFactoryAlgorithm(trustStoreAlgorithm).
+            loadTrustMaterial(sslTrustStore, null).build();
     SSLConnectionSocketFactory socketFactory =
         new SSLConnectionSocketFactory(sslContext, new DefaultHostnameVerifier(null));
     final Registry<ConnectionSocketFactory> registry =

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreHttpHeaders.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreHttpHeaders.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@Category(MetastoreCheckinTest.class)
+public class TestHiveMetastoreHttpHeaders {
+    private static Configuration conf;
+    private static HiveMetaStoreClient msc;
+    private static int port;
+    private static final String testHeaderKey1 = "X-XXXX";
+    private static final String testHeaderVal1 = "yyyy";
+    private static final String testHeaderKey2 = "X-ZZZZ";
+    private static final String testHeaderVal2 = "aaaa";
+
+    static class TestHiveMetaStoreClient extends HiveMetaStoreClient {
+        public TestHiveMetaStoreClient(Configuration conf) throws MetaException {
+            super(conf);
+        }
+
+        @Override
+        protected HttpClientBuilder createHttpClientBuilder() throws MetaException {
+            HttpClientBuilder builder = super.createHttpClientBuilder();
+            builder.addInterceptorLast(new HttpRequestInterceptor() {
+                @Override
+                public void process(HttpRequest httpRequest, HttpContext httpContext)
+                        throws HttpException, IOException {
+                    Header header1 = httpRequest.getFirstHeader(testHeaderKey1);
+                    assertEquals(testHeaderVal1, header1.getValue());
+                    Header header2 = httpRequest.getFirstHeader(testHeaderKey2);
+                    assertEquals(testHeaderVal2, header2.getValue());
+                }
+            });
+            return builder;
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        conf = MetastoreConf.newMetastoreConf();
+
+        MetaStoreTestUtils.setConfForStandloneMode(conf);
+        MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.EXECUTE_SET_UGI, false);
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.THRIFT_TRANSPORT_MODE, "http");
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_THRIFT_TRANSPORT_MODE, "http");
+        port = MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(), conf);
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.THRIFT_URIS, "thrift://localhost:" + port);
+    }
+
+    @Test
+    public void testHttpHeaders() throws Exception {
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_ADDITIONAL_HEADERS,
+                String.format("%s=%s,%s=%s", testHeaderKey1, testHeaderVal1, testHeaderKey2, testHeaderVal2));
+        msc = new TestHiveMetaStoreClient(conf);
+        Database db = new DatabaseBuilder().setName("testHttpHeader").create(msc, conf);
+        msc.dropDatabase(db.getName());
+    }
+
+    @Test
+    public void testIllegalHttpHeaders() throws Exception {
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_ADDITIONAL_HEADERS, String.format("%s%s", testHeaderKey1, testHeaderVal1));
+        msc = new TestHiveMetaStoreClient(conf);
+        boolean exceptionThrown = false;
+        try {
+            Database db = new DatabaseBuilder().setName("testHttpHeader").create(msc, conf);
+            msc.dropDatabase(db.getName());
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        assertTrue("Illegal header should invoke thrown exception", exceptionThrown);
+    }
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreHttpHeaders.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreHttpHeaders.java
@@ -37,9 +37,10 @@ import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import org.junit.Assert;
 
-@Category(MetastoreCheckinTest.class) public class TestHiveMetastoreHttpHeaders {
+@Category(MetastoreCheckinTest.class)
+public class TestHiveMetastoreHttpHeaders {
   private static Configuration conf;
   private static HiveMetaStoreClient msc;
   private static int port;
@@ -53,22 +54,24 @@ import static org.junit.Assert.*;
       super(conf);
     }
 
-    @Override protected HttpClientBuilder createHttpClientBuilder() throws MetaException {
+    @Override
+    protected HttpClientBuilder createHttpClientBuilder() throws MetaException {
       HttpClientBuilder builder = super.createHttpClientBuilder();
       builder.addInterceptorLast(new HttpRequestInterceptor() {
-        @Override public void process(HttpRequest httpRequest, HttpContext httpContext)
-            throws HttpException, IOException {
+        @Override
+        public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
           Header header1 = httpRequest.getFirstHeader(testHeaderKey1);
-          assertEquals(testHeaderVal1, header1.getValue());
+          Assert.assertEquals(testHeaderVal1, header1.getValue());
           Header header2 = httpRequest.getFirstHeader(testHeaderKey2);
-          assertEquals(testHeaderVal2, header2.getValue());
+          Assert.assertEquals(testHeaderVal2, header2.getValue());
         }
       });
       return builder;
     }
   }
 
-  @Before public void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     conf = MetastoreConf.newMetastoreConf();
 
     MetaStoreTestUtils.setConfForStandloneMode(conf);
@@ -79,7 +82,8 @@ import static org.junit.Assert.*;
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.THRIFT_URIS, "thrift://localhost:" + port);
   }
 
-  @Test public void testHttpHeaders() throws Exception {
+  @Test
+  public void testHttpHeaders() throws Exception {
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_ADDITIONAL_HEADERS,
         String.format("%s=%s,%s=%s", testHeaderKey1, testHeaderVal1, testHeaderKey2, testHeaderVal2));
     msc = new TestHiveMetaStoreClient(conf);
@@ -87,7 +91,8 @@ import static org.junit.Assert.*;
     msc.dropDatabase(db.getName());
   }
 
-  @Test public void testIllegalHttpHeaders() throws Exception {
+  @Test
+  public void testIllegalHttpHeaders() throws Exception {
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_ADDITIONAL_HEADERS,
         String.format("%s%s", testHeaderKey1, testHeaderVal1));
     msc = new TestHiveMetaStoreClient(conf);
@@ -98,6 +103,6 @@ import static org.junit.Assert.*;
     } catch (Exception e) {
       exceptionThrown = true;
     }
-    assertTrue("Illegal header should invoke thrown exception", exceptionThrown);
+    Assert.assertTrue("Illegal header should invoke thrown exception", exceptionThrown);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR targets to improve the usability of the http hive metastore client, by adding support for custom headers and also, supporting default trust store for https.

Add a new hive conf to allow users to inject custom headers
Do not force the headers to be http when the useSSL is turned off, so that if the users are able to use https if they want, w/o a custom truststore.


### Why are the changes needed?
Improved user experience for http mode in HMS client.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ut for the http headers
