### PR TITLE
HIVE-22813: Hive query fails if table location is in remote EZ and it's readonly

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2589,15 +2589,17 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @throws HiveException If an error occurs while comparing key strengths.
    */
   private int comparePathKeyStrength(Path p1, Path p2) throws HiveException {
-    HadoopShims.HdfsEncryptionShim hdfsEncryptionShim;
+    try {
+      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim1;
+      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim2;
+      hdfsEncryptionShim1 = SessionState.get().getHdfsEncryptionShim(p1.getFileSystem(conf), conf);
+      hdfsEncryptionShim2 = SessionState.get().getHdfsEncryptionShim(p2.getFileSystem(conf), conf);
 
-    hdfsEncryptionShim = SessionState.get().getHdfsEncryptionShim();
-    if (hdfsEncryptionShim != null) {
-      try {
-        return hdfsEncryptionShim.comparePathKeyStrength(p1, p2);
-      } catch (Exception e) {
-        throw new HiveException("Unable to compare key strength for " + p1 + " and " + p2 + " : " + e, e);
+      if (hdfsEncryptionShim1 != null && hdfsEncryptionShim2 != null) {
+        return hdfsEncryptionShim1.comparePathKeyStrength(p1, p2, hdfsEncryptionShim2);
       }
+    } catch (Exception e) {
+      throw new HiveException("Unable to compare key strength for " + p1 + " and " + p2 + " : " + e, e);
     }
 
     return 0; // Non-encrypted path (or equals strength)

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2590,10 +2590,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    */
   private int comparePathKeyStrength(Path p1, Path p2) throws HiveException {
     try {
-      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim1;
-      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim2;
-      hdfsEncryptionShim1 = SessionState.get().getHdfsEncryptionShim(p1.getFileSystem(conf), conf);
-      hdfsEncryptionShim2 = SessionState.get().getHdfsEncryptionShim(p2.getFileSystem(conf), conf);
+      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim1 = SessionState.get().getHdfsEncryptionShim(p1.getFileSystem(conf), conf);
+      HadoopShims.HdfsEncryptionShim hdfsEncryptionShim2 = SessionState.get().getHdfsEncryptionShim(p2.getFileSystem(conf), conf);
 
       if (hdfsEncryptionShim1 != null && hdfsEncryptionShim2 != null) {
         return hdfsEncryptionShim1.comparePathKeyStrength(p1, p2, hdfsEncryptionShim2);

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1419,15 +1419,16 @@ public class Hadoop23Shims extends HadoopShimsSecure {
      *
      * @param path1 First  path to compare
      * @param path2 Second path to compare
+     * @param encryptionShim2 The encryption-shim corresponding to path2.
      * @return 1 if path1 is stronger; 0 if paths are equals; -1 if path1 is weaker.
      * @throws IOException If an error occurred attempting to get key metadata
      */
     @Override
-    public int comparePathKeyStrength(Path path1, Path path2) throws IOException {
+    public int comparePathKeyStrength(Path path1, Path path2, HadoopShims.HdfsEncryptionShim encryptionShim2) throws IOException {
       EncryptionZone zone1, zone2;
 
       zone1 = getEncryptionZoneForPath(path1);
-      zone2 = getEncryptionZoneForPath(path2);
+      zone2 = ((HdfsEncryptionShim)encryptionShim2).hdfsAdmin.getEncryptionZoneForPath(path2);
 
       if (zone1 == null && zone2 == null) {
         return 0;

--- a/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
@@ -608,10 +608,11 @@ public interface HadoopShims {
      *
      * @param path1 HDFS path to compare.
      * @param path2 HDFS path to compare.
+     * @param encryptionShim2 The encryption-shim corresponding to path2.
      * @return 1 if path1 is stronger; 0 if paths are equals; -1 if path1 is weaker.
      * @throws IOException If an error occurred attempting to get encryption/key metadata
      */
-    public int comparePathKeyStrength(Path path1, Path path2) throws IOException;
+    public int comparePathKeyStrength(Path path1, Path path2, HdfsEncryptionShim encryptionShim2) throws IOException;
 
     /**
      * Create encryption zone by path and keyname.
@@ -671,7 +672,7 @@ public interface HadoopShims {
     }
 
     @Override
-    public int comparePathKeyStrength(Path path1, Path path2) throws IOException {
+    public int comparePathKeyStrength(Path path1, Path path2, HdfsEncryptionShim encryptionShim2) throws IOException {
     /* not supported */
       return 0;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Comparios of HDFS path key strength is not possible if paths belong to different filesystems

### Why are the changes needed?
To allow such comparisons.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually
