### PR TITLE
HIVE-27140 : Set HADOOP_PROXY_USER cause hiveMetaStoreClient close everytime

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -457,10 +457,6 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     boolean compatible = true;
     for (ConfVars oneVar : MetastoreConf.metaVars) {
-      // METASTORE_TOKEN_SIGNATURE is no need to check
-      if (oneVar.equals(ConfVars.TOKEN_SIGNATURE)) {
-        continue;
-      }
       // Since metaVars are all of different types, use string for comparison
       String oldVar = currentMetaVarsCopy.get(oneVar.getVarname());
       String newVar = MetastoreConf.getAsString(conf, oneVar);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -457,6 +457,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     boolean compatible = true;
     for (ConfVars oneVar : MetastoreConf.metaVars) {
+      // METASTORE_TOKEN_SIGNATURE is no need to check
+      if (oneVar.equals(ConfVars.TOKEN_SIGNATURE)) {
+        continue;
+      }
       // Since metaVars are all of different types, use string for comparison
       String oldVar = currentMetaVarsCopy.get(oneVar.getVarname());
       String newVar = MetastoreConf.getAsString(conf, oneVar);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -186,7 +186,6 @@ public class MetastoreConf {
       ConfVars.USE_THRIFT_SASL,
       ConfVars.METASTORE_CLIENT_AUTH_MODE,
       ConfVars.METASTORE_CLIENT_PLAIN_USERNAME,
-      ConfVars.TOKEN_SIGNATURE,
       ConfVars.CACHE_PINOBJTYPES,
       ConfVars.CONNECTION_POOLING_TYPE,
       ConfVars.VALIDATE_TABLES,


### PR DESCRIPTION
HIVE-27140 : Set HADOOP_PROXY_USER cause hiveMetaStoreClient close everytime

### What changes were proposed in this pull request?

I this the issuse clearly described
https://issues.apache.org/jira/browse/HIVE-27140

### Why are the changes needed?

I this the issuse clearly described
https://issues.apache.org/jira/browse/HIVE-27140

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I this the issuse clearly described
https://issues.apache.org/jira/browse/HIVE-27140