### PR TITLE
HIVE-27137: Remove HIVE_IN_TEST_ICEBERG flag

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -796,8 +796,6 @@ public class HiveConf extends Configuration {
         "If not set, defaults to the codec extension for text files (e.g. \".gz\"), or no extension otherwise."),
 
     HIVE_IN_TEST("hive.in.test", false, "internal usage only, true in test mode", true),
-    HIVE_IN_TEST_ICEBERG("hive.in.iceberg.test", false, "internal usage only, true when " +
-        "testing iceberg", true),
     HIVE_IN_TEST_SSL("hive.in.ssl.test", false, "internal usage only, true in SSL test mode", true),
     // TODO: this needs to be removed; see TestReplicationScenarios* comments.
     HIVE_IN_TEST_REPL("hive.in.repl.test", false, "internal usage only, true in replication test mode", true),

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -24,11 +24,6 @@
         <value>true</value>
         <description>Internal marker for test. Used for masking env-dependent values</description>
     </property>
-    <property>
-        <!-- set to true so that TxnManager#checkLock does not throw exception when using UNSET data type operation in the requested lock component -->
-        <name>hive.in.iceberg.test</name>
-        <value>true</value>
-    </property>
 
     <!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
     <!-- that are implied by Hadoop setup variables.                                                -->

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -24,11 +24,6 @@
   <value>true</value>
   <description>Internal marker for test. Used for masking env-dependent values</description>
 </property>
-<property>
-  <!-- set to true so that TxnManager#checkLock does not throw exception when using UNSET data type operation in the requested lock component -->
-  <name>hive.in.iceberg.test</name>
-  <value>true</value>
-</property>
 
 <!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
 <!-- that are implied by Hadoop setup variables.                                                -->

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1653,8 +1653,6 @@ public class MetastoreConf {
     HIVE_IN_TEST("hive.in.test", "hive.in.test", false, "internal usage only, true in test mode"),
     HIVE_IN_TEZ_TEST("hive.in.tez.test", "hive.in.tez.test", false,
         "internal use only, true when in testing tez"),
-    HIVE_IN_TEST_ICEBERG("hive.in.iceberg.test", "hive.in.iceberg.test", false,
-        "internal usage only, true when testing iceberg"),
     // We need to track this as some listeners pass it through our config and we need to honor
     // the system properties.
     HIVE_AUTHORIZATION_MANAGER("hive.security.authorization.manager",

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3194,17 +3194,6 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
 
     try (PreparedStatement pstmt = dbConn.prepareStatement(insertLocksQuery)) {
       for (LockComponent lc : rqst.getComponent()) {
-        if (lc.isSetOperationType() && lc.getOperationType() == DataOperationType.UNSET &&
-                (MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST) || MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEZ_TEST))) {
-          //Old version of thrift client should have (lc.isSetOperationType() == false), but they do not
-          //If you add a default value to a variable, isSet() for that variable is true regardless of the where the
-          //message was created (for object variables).
-          //It works correctly for boolean vars, e.g. LockComponent.isTransactional).
-          //in test mode, upgrades are not tested, so client version and server version of thrift always matches so
-          //we see UNSET here it means something didn't set the appropriate value.
-          throw new IllegalStateException("Bug: operationType=" + lc.getOperationType() + " for component "
-                  + lc + " agentInfo=" + rqst.getAgentInfo());
-        }
         intLockId++;
         String lockType = LockTypeUtil.getEncodingAsStr(lc.getType());
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -3195,9 +3195,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     try (PreparedStatement pstmt = dbConn.prepareStatement(insertLocksQuery)) {
       for (LockComponent lc : rqst.getComponent()) {
         if (lc.isSetOperationType() && lc.getOperationType() == DataOperationType.UNSET &&
-                ((MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST) ||
-                    MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEZ_TEST)) &&
-                    !MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST_ICEBERG))) {
+                (MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST) || MetastoreConf.getBoolVar(conf, ConfVars.HIVE_IN_TEZ_TEST))) {
           //Old version of thrift client should have (lc.isSetOperationType() == false), but they do not
           //If you add a default value to a variable, isSet() for that variable is true regardless of the where the
           //message was created (for object variables).


### PR DESCRIPTION
That test flag is not in use. And in the long term, using those flags leads to hard to test code so it is logical to remove them. And as it is unused, it is the best time to remove that. 

### What changes were proposed in this pull request?
Remove HIVE_IN_TEST_ICEBERG flag.


### Why are the changes needed?
It is unused.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running the tests in the pipeline.
