### PR TITLE
HIVE-27150: Drop single partition can also support direct sql

### DIFF
--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
@@ -361,6 +361,17 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   }
 
   @Override
+  public boolean dropPartition(String catName, String dbName, String tableName, List<String> partVals)
+      throws MetaException, NoSuchObjectException,
+      InvalidObjectException, InvalidInputException {
+    if (shouldEventSucceed) {
+      return objectStore.dropPartition(catName, dbName, tableName, partVals);
+    } else {
+      throw new RuntimeException("Event failed.");
+    }
+  }
+
+  @Override
   public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException, NoSuchObjectException,
       InvalidObjectException, InvalidInputException {

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
@@ -361,11 +361,11 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   }
 
   @Override
-  public boolean dropPartition(String catName, String dbName, String tableName, List<String> partVals)
+  public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException, NoSuchObjectException,
       InvalidObjectException, InvalidInputException {
     if (shouldEventSucceed) {
-      return objectStore.dropPartition(catName, dbName, tableName, partVals);
+      return objectStore.dropPartition(catName, dbName, tableName, partName);
     } else {
       throw new RuntimeException("Event failed.");
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5027,20 +5027,17 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
 
       String partName = Warehouse.makePartName(tbl.getPartitionKeys(), part_vals);
-      if (!ms.dropPartition(catName, db_name, tbl_name, partName)) {
-        throw new MetaException("Unable to drop partition");
-      } else {
-        if (!transactionalListeners.isEmpty()) {
+      ms.dropPartition(catName, db_name, tbl_name, partName);
 
-          transactionalListenerResponses =
-              MetaStoreListenerNotifier.notifyEvent(transactionalListeners,
-                  EventType.DROP_PARTITION,
-                  new DropPartitionEvent(tbl, part, true, deleteData, this),
-                  envContext);
-        }
-        needsCm = ReplChangeManager.shouldEnableCm(ms.getDatabase(catName, db_name), tbl);
-        success = ms.commitTransaction();
+      if (!transactionalListeners.isEmpty()) {
+        transactionalListenerResponses =
+            MetaStoreListenerNotifier.notifyEvent(transactionalListeners,
+                EventType.DROP_PARTITION,
+                new DropPartitionEvent(tbl, part, true, deleteData, this),
+                envContext);
       }
+      needsCm = ReplChangeManager.shouldEnableCm(ms.getDatabase(catName, db_name), tbl);
+      success = ms.commitTransaction();
     } finally {
       if (!success) {
         ms.rollbackTransaction();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -4903,7 +4903,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         ms.addPartition(destPartition);
         destPartitions.add(destPartition);
         ms.dropPartition(parsedSourceDbName[CAT_NAME], partition.getDbName(), sourceTable.getTableName(),
-            partition.getValues());
+            Warehouse.makePartName(sourceTable.getPartitionKeys(), partition.getValues()));
       }
       Path destParentPath = destPath.getParent();
       if (!wh.isDir(destParentPath)) {
@@ -5026,7 +5026,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         verifyIsWritablePath(partPath);
       }
 
-      if (!ms.dropPartition(catName, db_name, tbl_name, part_vals)) {
+      String partName = Warehouse.makePartName(tbl.getPartitionKeys(), part_vals);
+      if (!ms.dropPartition(catName, db_name, tbl_name, partName)) {
         throw new MetaException("Unable to drop partition");
       } else {
         if (!transactionalListeners.isEmpty()) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -459,16 +459,15 @@ public interface RawStore extends Configurable {
    * @param catName catalog name.
    * @param dbName database name.
    * @param tableName table name.
-   * @param part_vals list of partition values.
+   * @param partName partition name.
    * @return true if the partition was dropped.
    * @throws MetaException Error accessing the RDBMS.
    * @throws NoSuchObjectException no partition matching this description exists
    * @throws InvalidObjectException error dropping the statistics for the partition
    * @throws InvalidInputException error dropping the statistics for the partition
    */
-  boolean dropPartition(String catName, String dbName, String tableName,
-      List<String> part_vals) throws MetaException, NoSuchObjectException, InvalidObjectException,
-      InvalidInputException;
+  boolean dropPartition(String catName, String dbName, String tableName, String partName)
+      throws MetaException, NoSuchObjectException, InvalidObjectException, InvalidInputException;
 
   /**
    * Get some or all partitions for a table.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -459,6 +459,23 @@ public interface RawStore extends Configurable {
    * @param catName catalog name.
    * @param dbName database name.
    * @param tableName table name.
+   * @param part_vals list of partition values.
+   * @return true if the partition was dropped.
+   * @throws MetaException Error accessing the RDBMS.
+   * @throws NoSuchObjectException no partition matching this description exists
+   * @throws InvalidObjectException error dropping the statistics for the partition
+   * @throws InvalidInputException error dropping the statistics for the partition
+   */
+  @Deprecated
+  boolean dropPartition(String catName, String dbName, String tableName,
+      List<String> part_vals) throws MetaException, NoSuchObjectException, InvalidObjectException,
+      InvalidInputException;
+
+  /**
+   * Drop a partition.
+   * @param catName catalog name.
+   * @param dbName database name.
+   * @param tableName table name.
    * @param partName partition name.
    * @return true if the partition was dropped.
    * @throws MetaException Error accessing the RDBMS.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -1420,18 +1420,17 @@ public class CachedStore implements RawStore, Configurable {
     return sharedCache.existPartitionFromCache(catName, dbName, tblName, partVals);
   }
 
-  @Override public boolean dropPartition(String catName, String dbName, String tblName, List<String> partVals)
+  @Override public boolean dropPartition(String catName, String dbName, String tblName, String partName)
       throws MetaException, NoSuchObjectException, InvalidObjectException, InvalidInputException {
-    boolean succ = rawStore.dropPartition(catName, dbName, tblName, partVals);
+    boolean succ = rawStore.dropPartition(catName, dbName, tblName, partName);
     // in case of event based cache update, cache will be updated during commit.
     if (succ && !canUseEvents) {
       catName = normalizeIdentifier(catName);
       dbName = normalizeIdentifier(dbName);
       tblName = normalizeIdentifier(tblName);
-      if (!shouldCacheTable(catName, dbName, tblName)) {
-        return succ;
+      if (shouldCacheTable(catName, dbName, tblName)) {
+        sharedCache.removePartitionFromCache(catName, dbName, tblName, partNameToVals(partName));
       }
-      sharedCache.removePartitionFromCache(catName, dbName, tblName, partVals);
     }
     return succ;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -1420,6 +1420,22 @@ public class CachedStore implements RawStore, Configurable {
     return sharedCache.existPartitionFromCache(catName, dbName, tblName, partVals);
   }
 
+  @Override public boolean dropPartition(String catName, String dbName, String tblName, List<String> partVals)
+      throws MetaException, NoSuchObjectException, InvalidObjectException, InvalidInputException {
+    boolean succ = rawStore.dropPartition(catName, dbName, tblName, partVals);
+    // in case of event based cache update, cache will be updated during commit.
+    if (succ && !canUseEvents) {
+      catName = normalizeIdentifier(catName);
+      dbName = normalizeIdentifier(dbName);
+      tblName = normalizeIdentifier(tblName);
+      if (!shouldCacheTable(catName, dbName, tblName)) {
+        return succ;
+      }
+      sharedCache.removePartitionFromCache(catName, dbName, tblName, partVals);
+    }
+    return succ;
+  }
+
   @Override public boolean dropPartition(String catName, String dbName, String tblName, String partName)
       throws MetaException, NoSuchObjectException, InvalidObjectException, InvalidInputException {
     boolean succ = rawStore.dropPartition(catName, dbName, tblName, partName);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -334,6 +334,13 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
+  public boolean dropPartition(String catName, String dbName, String tableName, List<String> partVals)
+      throws MetaException, NoSuchObjectException,
+      InvalidObjectException, InvalidInputException {
+    return objectStore.dropPartition(catName, dbName, tableName, partVals);
+  }
+
+  @Override
   public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException, NoSuchObjectException,
       InvalidObjectException, InvalidInputException {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -334,10 +334,10 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
-  public boolean dropPartition(String catName, String dbName, String tableName, List<String> partVals)
+  public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException, NoSuchObjectException,
       InvalidObjectException, InvalidInputException {
-    return objectStore.dropPartition(catName, dbName, tableName, partVals);
+    return objectStore.dropPartition(catName, dbName, tableName, partName);
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -345,6 +345,13 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
+  public boolean dropPartition(String catName, String dbName, String tableName, List<String> part_vals)
+      throws MetaException {
+
+    return false;
+  }
+
+  @Override
   public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException {
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -345,7 +345,7 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
-  public boolean dropPartition(String catName, String dbName, String tableName, List<String> part_vals)
+  public boolean dropPartition(String catName, String dbName, String tableName, String partName)
       throws MetaException {
 
     return false;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
 import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
-import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.StoredProcedure;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -439,14 +438,14 @@ public class TestObjectStore {
     Assert.assertEquals(2, numPartitions);
 
     try (AutoCloseable c = deadline()) {
-      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/state=CA");
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, value1);
       partitions = objectStore.getPartitions(DEFAULT_CATALOG_NAME, DB1, TABLE1, 10);
     }
     Assert.assertEquals(1, partitions.size());
     Assert.assertEquals(222, partitions.get(0).getCreateTime());
 
     try (AutoCloseable c = deadline()) {
-      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/state=MA");
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, value2);
       objectStore.dropTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
       objectStore.dropDatabase(db1.getCatalogName(), DB1);
     }
@@ -498,6 +497,68 @@ public class TestObjectStore {
     }
   }
 
+  @Test
+  public void testDropPartitionByName() throws Exception {
+    Database db1 = new DatabaseBuilder()
+        .setName(DB1)
+        .setDescription("description")
+        .setLocation("locationurl")
+        .build(conf);
+    try (AutoCloseable c = deadline()) {
+      objectStore.createDatabase(db1);
+    }
+    StorageDescriptor sd = createFakeSd("location");
+    HashMap<String, String> tableParams = new HashMap<>();
+    tableParams.put("EXTERNAL", "false");
+    FieldSchema partitionKey1 = new FieldSchema("Country", ColumnType.STRING_TYPE_NAME, "");
+    FieldSchema partitionKey2 = new FieldSchema("State", ColumnType.STRING_TYPE_NAME, "");
+    Table tbl1 =
+        new Table(TABLE1, DB1, "owner", 1, 2, 3, sd, Arrays.asList(partitionKey1, partitionKey2),
+            tableParams, null, null, "MANAGED_TABLE");
+    try (AutoCloseable c = deadline()) {
+      objectStore.createTable(tbl1);
+    }
+    HashMap<String, String> partitionParams = new HashMap<>();
+    partitionParams.put("PARTITION_LEVEL_PRIVILEGE", "true");
+    List<String> value1 = Arrays.asList("US", "CA");
+    Partition part1 = new Partition(value1, DB1, TABLE1, 111, 111, sd, partitionParams);
+    part1.setCatName(DEFAULT_CATALOG_NAME);
+    try (AutoCloseable c = deadline()) {
+      objectStore.addPartition(part1);
+    }
+    List<String> value2 = Arrays.asList("US", "MA");
+    Partition part2 = new Partition(value2, DB1, TABLE1, 222, 222, sd, partitionParams);
+    part2.setCatName(DEFAULT_CATALOG_NAME);
+    try (AutoCloseable c = deadline()) {
+      objectStore.addPartition(part2);
+    }
+
+    List<Partition> partitions;
+    try (AutoCloseable c = deadline()) {
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/state=CA");
+      partitions = objectStore.getPartitions(DEFAULT_CATALOG_NAME, DB1, TABLE1, 10);
+    }
+    Assert.assertEquals(1, partitions.size());
+    Assert.assertEquals(222, partitions.get(0).getCreateTime());
+    try (AutoCloseable c = deadline()) {
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/state=MA");
+      partitions = objectStore.getPartitions(DEFAULT_CATALOG_NAME, DB1, TABLE1, 10);
+    }
+    Assert.assertEquals(0, partitions.size());
+
+    try (AutoCloseable c = deadline()) {
+      // Illegal partName will do nothing, it doesn't matter
+      // because the real HMSHandler will guarantee the partName is legal and exists.
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/state=NON_EXIST");
+      objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, "country=US/st=CA");
+    }
+
+    try (AutoCloseable c = deadline()) {
+      objectStore.dropTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
+      objectStore.dropDatabase(db1.getCatalogName(), DB1);
+    }
+  }
+
   /**
    * Test the concurrent drop of same partition would leak transaction.
    * https://issues.apache.org/jira/browse/HIVE-16839
@@ -519,9 +580,8 @@ public class TestObjectStore {
     tableParams.put("EXTERNAL", "false");
     FieldSchema partitionKey1 = new FieldSchema("Country", ColumnType.STRING_TYPE_NAME, "");
     FieldSchema partitionKey2 = new FieldSchema("State", ColumnType.STRING_TYPE_NAME, "");
-    List<FieldSchema> partCols = Arrays.asList(partitionKey1, partitionKey2);
     Table tbl1 =
-      new Table(TABLE1, DB1, "owner", 1, 2, 3, sd, partCols,
+      new Table(TABLE1, DB1, "owner", 1, 2, 3, sd, Arrays.asList(partitionKey1, partitionKey2),
         tableParams, null, null, "MANAGED_TABLE");
     objectStore.createTable(tbl1);
     HashMap<String, String> partitionParams = new HashMap<>();
@@ -546,11 +606,10 @@ public class TestObjectStore {
         () -> {
           ObjectStore threadObjectStore = new ObjectStore();
           threadObjectStore.setConf(conf);
-          for (List<String> partVals : partNames) {
+          for (List<String> p : partNames) {
             try {
-              String partName = Warehouse.makePartName(partCols, partVals);
-              threadObjectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, partName);
-              System.out.println("Dropping partition: " + partName);
+              threadObjectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, p);
+              System.out.println("Dropping partition: " + p.get(0));
             } catch (Exception e) {
               throw new RuntimeException(e);
             }
@@ -951,8 +1010,10 @@ public class TestObjectStore {
         for (String db : dbs) {
           List<String> tbls = store.getAllTables(DEFAULT_CATALOG_NAME, db);
           for (String tbl : tbls) {
-            List<String> partNames = store.listPartitionNames(DEFAULT_CATALOG_NAME, db, tbl, (short) -1);
-            store.dropPartitions(DEFAULT_CATALOG_NAME, db, tbl, partNames);
+            List<Partition> parts = store.getPartitions(DEFAULT_CATALOG_NAME, db, tbl, 100);
+            for (Partition part : parts) {
+              store.dropPartition(DEFAULT_CATALOG_NAME, db, tbl, part.getValues());
+            }
             // Find any constraints and drop them
             Set<String> constraints = new HashSet<>();
             List<SQLPrimaryKey> pk = store.getPrimaryKeys(DEFAULT_CATALOG_NAME, db, tbl);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestOldSchema.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestOldSchema.java
@@ -221,10 +221,8 @@ public class TestOldSchema {
         String db = dbs.get(i);
         List<String> tbls = store.getAllTables(DEFAULT_CATALOG_NAME, db);
         for (String tbl : tbls) {
-          List<Partition> parts = store.getPartitions(DEFAULT_CATALOG_NAME, db, tbl, 100);
-          for (Partition part : parts) {
-            store.dropPartition(DEFAULT_CATALOG_NAME, db, tbl, part.getValues());
-          }
+          List<String> partNames = store.listPartitionNames(DEFAULT_CATALOG_NAME, db, tbl, (short) -1);
+          store.dropPartitions(DEFAULT_CATALOG_NAME, db, tbl, partNames);
           store.dropTable(DEFAULT_CATALOG_NAME, db, tbl);
         }
         store.dropDatabase(DEFAULT_CATALOG_NAME, db);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
@@ -1030,8 +1030,8 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
         Warehouse.makePartName(tbl.getPartitionKeys(), partVals1), partVals1, colName, CacheUtils.HIVE_ENGINE);
     objectStore.deletePartitionColumnStatistics(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(),
         Warehouse.makePartName(tbl.getPartitionKeys(), partVals2), partVals2, colName, CacheUtils.HIVE_ENGINE);
-    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals1);
-    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals2);
+    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), "col=1");
+    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), "col=2");
     objectStore.dropTable(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName());
     objectStore.dropDatabase(DEFAULT_CATALOG_NAME, db.getName());
     cachedStore.shutdown();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
@@ -1030,8 +1030,8 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
         Warehouse.makePartName(tbl.getPartitionKeys(), partVals1), partVals1, colName, CacheUtils.HIVE_ENGINE);
     objectStore.deletePartitionColumnStatistics(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(),
         Warehouse.makePartName(tbl.getPartitionKeys(), partVals2), partVals2, colName, CacheUtils.HIVE_ENGINE);
-    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), "col=1");
-    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), "col=2");
+    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals1);
+    objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals2);
     objectStore.dropTable(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName());
     objectStore.dropDatabase(DEFAULT_CATALOG_NAME, db.getName());
     cachedStore.shutdown();

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkTool.java
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkTool.java
@@ -272,7 +272,7 @@ public class BenchmarkTool implements Runnable {
         .add("dropTableWithPartitions",
             () -> benchmarkDeleteWithPartitions(bench, bData, 1, nParameters[0]))
         .add("addPartition", () -> benchmarkCreatePartition(bench, bData))
-        .add("dropPartition", () -> benchmarkDropPartition(bench, bData))
+        .add("dropPartition", () -> benchmarkDropPartition(bench, bData, 1))
         .add("listPartition", () -> benchmarkListPartition(bench, bData))
         .add("getPartition",
             () -> benchmarkGetPartitions(bench, bData, 1))
@@ -310,6 +310,8 @@ public class BenchmarkTool implements Runnable {
               () -> benchmarkRenameTable(bench, bData, howMany))
           .add("dropDatabase" + '.' + howMany,
               () -> benchmarkDropDatabase(bench, bData, howMany))
+          .add("dropPartition" + '.' + howMany,
+              () -> benchmarkDropPartition(bench, bData, howMany))
           .add("openTxns" + '.' + howMany,
               () -> benchmarkOpenTxns(bench, bData, howMany))
           .add("PartitionManagementTask" + "." + howMany,

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSBenchmarks.java
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSBenchmarks.java
@@ -246,26 +246,24 @@ final class HMSBenchmarks {
   }
 
   static DescriptiveStatistics benchmarkDropPartition(@NotNull MicroBenchmark bench,
-                                                      @NotNull BenchData data) {
+                                                      @NotNull BenchData data,
+                                                      int count) {
     final HMSClient client = data.getClient();
     String dbName = data.dbName;
     String tableName = data.tableName;
 
     BenchmarkUtils.createPartitionedTable(client, dbName, tableName);
-    final List<String> values = Collections.singletonList("d1");
     try {
-      Table t = client.getTable(dbName, tableName);
-      Partition partition = new Util.PartitionBuilder(t)
-          .withValues(values)
-          .build();
-
       return bench.measure(
-          () -> throwingSupplierWrapper(() -> client.addPartition(partition)),
-          () -> throwingSupplierWrapper(() -> client.dropPartition(dbName, tableName, values)),
+          () -> addManyPartitionsNoException(client, dbName, tableName, null,
+                  Collections.singletonList("d"), count),
+          () -> throwingSupplierWrapper(() -> {
+            List<String> partNames = client.getPartitionNames(dbName, tableName);
+            partNames.forEach(partName ->
+                throwingSupplierWrapper(() -> client.dropPartition(dbName, tableName, partName)));
+            return null;
+          }),
           null);
-    } catch (TException e) {
-      e.printStackTrace();
-      return new DescriptiveStatistics();
     } finally {
       throwingSupplierWrapper(() -> client.dropTable(dbName, tableName));
     }

--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSClient.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/HMSClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.tools;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AbortTxnsRequest;
 import org.apache.hadoop.hive.metastore.api.AllocateTableWriteIdsRequest;
 import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
@@ -289,6 +290,13 @@ final class HMSClient implements AutoCloseable {
                                @NotNull List<String> arguments)
       throws TException {
     return client.drop_partition(dbName, tableName, arguments, true);
+  }
+
+  public boolean dropPartition(@NotNull String dbName, @NotNull String tableName,
+                               @NotNull String arguments)
+          throws TException {
+    List<String> partVals = Warehouse.getPartValuesFromPartName(arguments);
+    return dropPartition(dbName, tableName, partVals);
   }
 
   List<Partition> getPartitions(@NotNull String dbName, @NotNull String tableName) throws TException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
We want to reuse the `dropPartitionsInternal()` method for `drop_partition_common` api to enjoy the high performance, to achieve this we will refactor the `RawStore#dropPartition` api.


### Why are the changes needed?
1. support direct sql for drop single partition
2. reduce one query to the DB, that is MPartition query in `ObjectStore#dropPartition`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
1. Pass all existing tests.
2. Add the benchmark test for `dropPartition`:
```bash
java -jar hmsbench-jar-with-dependencies.jar -H localhost --savedata /tmp/benchdata --sanitize -N 10 -N 100 -o bench_results.csv -C -d testbench --params=100 -E 'list.*' -E 'createTable' -E 'dropTable.*' -E 'get.*' -E 'add.*' -E 'renameTable.*' -E 'dropDatabase.*' -E 'openTxn.*' -E 'PartitionManagementTask'
```
**Before use direct sql:**
```bash
Operation                      Mean     Med      Min      Max      Err%
dropPartition                  29.60    28.32    27.38    57.81    13.86
dropPartition.10               263.1    272.3    160.7    292.5    12.09
dropPartition.100              2461     2735     1610     4381     22.36
dropPartitions.10              22.97    22.46    21.56    36.05    8.306
dropPartitions.100             26.97    26.35    24.71    35.25    7.569
```
**After use direct sql:**
```bash
Operation                      Mean     Med      Min      Max      Err%
dropPartition                  24.76    24.56    20.86    36.23    11.47
dropPartition.10               190.1    165.7    153.5    275.1    23.76
dropPartition.100              2181     2591     1482     4831     28.61
dropPartitions.10              17.71    17.43    15.84    25.37    7.857
dropPartitions.100             34.42    33.10    31.61    58.97    11.98
```

