### PR TITLE
HIVE-27153 : Revert "HIVE-20182: Backport HIVE-20067 to branch-3"

### DIFF
--- a/ql/src/test/queries/clientpositive/mm_all.q
+++ b/ql/src/test/queries/clientpositive/mm_all.q
@@ -3,7 +3,6 @@
 
 -- MASK_LINEAGE
 
-set hive.metastore.dml.events=true;
 set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/events/InsertEvent.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/events/InsertEvent.java
@@ -18,9 +18,7 @@
 
 package org.apache.hadoop.hive.metastore.events;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.collect.Lists;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
@@ -35,7 +33,8 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.thrift.TException;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
 @InterfaceAudience.Public
 @InterfaceStability.Stable
@@ -66,7 +65,7 @@ public class InsertEvent extends ListenerEvent {
     // TODO MS-SPLIT Switch this back once HiveMetaStoreClient is moved.
     //req.setCapabilities(HiveMetaStoreClient.TEST_VERSION);
     req.setCapabilities(new ClientCapabilities(
-        Lists.newArrayList(ClientCapability.TEST_CAPABILITY, ClientCapability.INSERT_ONLY_TABLES)));
+      Lists.newArrayList(ClientCapability.TEST_CAPABILITY)));
     try {
       this.tableObj = handler.get_table_req(req).getTable();
       if (partVals != null) {


### PR DESCRIPTION
JIRA : https://issues.apache.org/jira/browse/HIVE-27153

The mm_all.q test was failing because of the following error :
`java.lang.AssertionError: 
Client execution failed with error code = 1 running "
insert into table part_mm_n0 partition(key_mm=455) select key from intermediate_n0" fname=mm_all.q 
See ./ql/target/tmp/log/hive.log or ./itests/qtest/target/tmp/log/hive.log, or check ./ql/target/surefire-reports or ./itests/qtest/target/surefire-reports/ for specific test cases logs.
	at org.junit.Assert.fail(Assert.java:88)
	at org.apache.hadoop.hive.ql.QTestUtil.failed(QTestUtil.java:2232)
	at org.apache.hadoop.hive.cli.control.CoreCliDriver.runTest(CoreCliDriver.java:180)
	at org.apache.hadoop.hive.cli.control.CliAdapter.runTest(CliAdapter.java:104)
	at org.apache.hadoop.hive.cli.split8.TestCliDriver.testCliDriver(TestCliDriver.java:62)
	at sun.reflect.GeneratedMethodAccessor204.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)`
This reverts commit b429edbdfef3e6d609f0f3e226240b9be94797bf.

The actual error :
`2023-03-19T15:18:07,705 DEBUG [699603ee-f4a1-43b7-b160-7faf858ca4b4 main] converters.ArrayConverter: Converting 'java.net.URL[]' value '[Ljava.net.URL;@7535f28' to type 'java.net.URL[]'
2023-03-19T15:18:07,705 DEBUG [699603ee-f4a1-43b7-b160-7faf858ca4b4 main] converters.ArrayConverter:     No conversion required, value is already a java.net.URL[]
2023-03-19T15:18:07,819  INFO [699603ee-f4a1-43b7-b160-7faf858ca4b4 main] beanutils.FluentPropertyBeanIntrospector: Error when creating PropertyDescriptor for public final void org.apache.commons.configuration2.AbstractConfiguration.setProperty(java.lang.String,java.lang.Object)! Ignoring this property.
2023-03-19T15:18:07,819 DEBUG [699603ee-f4a1-43b7-b160-7faf858ca4b4 main] beanutils.FluentPropertyBeanIntrospector: Exception is:
java.beans.IntrospectionException: bad write method arg count: public final void org.apache.commons.configuration2.AbstractConfiguration.setProperty(java.lang.String,java.lang.Object)
	at java.beans.PropertyDescriptor.findPropertyType(PropertyDescriptor.java:657) ~[?:1.8.0_342]
	at java.beans.PropertyDescriptor.setWriteMethod(PropertyDescriptor.java:327) ~[?:1.8.0_342]
	at java.beans.PropertyDescriptor.<init>(PropertyDescriptor.java:139) ~[?:1.8.0_342]
	at org.apache.commons.beanutils.FluentPropertyBeanIntrospector.createFluentPropertyDescritor(FluentPropertyBeanIntrospector.java:178) ~[commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.beanutils.FluentPropertyBeanIntrospector.introspect(FluentPropertyBeanIntrospector.java:141) [commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.beanutils.PropertyUtilsBean.fetchIntrospectionData(PropertyUtilsBean.java:2245) [commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.beanutils.PropertyUtilsBean.getIntrospectionData(PropertyUtilsBean.java:2226) [commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.beanutils.PropertyUtilsBean.getPropertyDescriptor(PropertyUtilsBean.java:954) [commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.beanutils.PropertyUtilsBean.isWriteable(PropertyUtilsBean.java:1478) [commons-beanutils-1.9.3.jar:1.9.3]
	at org.apache.commons.configuration2.beanutils.BeanHelper.isPropertyWriteable(BeanHelper.java:521) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.initProperty(BeanHelper.java:357) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.initBeanProperties(BeanHelper.java:273) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.initBean(BeanHelper.java:192) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper$BeanCreationContextImpl.initBean(BeanHelper.java:669) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.DefaultBeanFactory.initBeanInstance(DefaultBeanFactory.java:162) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.DefaultBeanFactory.createBean(DefaultBeanFactory.java:116) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.createBean(BeanHelper.java:459) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.createBean(BeanHelper.java:479) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.beanutils.BeanHelper.createBean(BeanHelper.java:492) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.builder.BasicConfigurationBuilder.createResultInstance(BasicConfigurationBuilder.java:447) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.builder.BasicConfigurationBuilder.createResult(BasicConfigurationBuilder.java:417) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.commons.configuration2.builder.BasicConfigurationBuilder.getConfiguration(BasicConfigurationBuilder.java:285) [commons-configuration2-2.1.1.jar:2.1.1]
	at org.apache.hadoop.metrics2.impl.MetricsConfig.loadFirst(MetricsConfig.java:119) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.impl.MetricsConfig.create(MetricsConfig.java:98) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.configure(MetricsSystemImpl.java:478) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.start(MetricsSystemImpl.java:188) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.init(MetricsSystemImpl.java:163) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.init(DefaultMetricsSystem.java:62) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.initialize(DefaultMetricsSystem.java:58) [hadoop-common-3.1.0.jar:?]
	at org.apache.hadoop.mapred.LocalJobRunnerMetrics.create(LocalJobRunnerMetrics.java:45) [hadoop-mapreduce-client-common-3.1.0.jar:?]
	at org.apache.hadoop.mapred.LocalJobRunner.<init>(LocalJobRunner.java:771) [hadoop-mapreduce-client-common-3.1.0.jar:?]
	at org.apache.hadoop.mapred.LocalJobRunner.<init>(LocalJobRunner.java:764) [hadoop-mapreduce-client-common-3.1.0.jar:?]
	at org.apache.hadoop.mapred.LocalClientProtocolProvider.create(LocalClientProtocolProvider.java:42) [hadoop-mapreduce-client-common-3.1.0.jar:?]
	at org.apache.hadoop.mapreduce.Cluster.initialize(Cluster.java:130) [hadoop-mapreduce-client-core-3.1.0.jar:?]
	at org.apache.hadoop.mapreduce.Cluster.<init>(Cluster.java:109) [hadoop-mapreduce-client-core-3.1.0.jar:?]
	at org.apache.hadoop.mapreduce.Cluster.<init>(Cluster.java:102) [hadoop-mapreduce-client-core-3.1.0.jar:?]
	at org.apache.hadoop.mapred.JobClient.init(JobClient.java:475) [hadoop-mapreduce-client-core-3.1.0.jar:?]
	at org.apache.hadoop.mapred.JobClient.<init>(JobClient.java:454) [hadoop-mapreduce-client-core-3.1.0.jar:?]
	at org.apache.hadoop.hive.ql.exec.mr.ExecDriver.execute(ExecDriver.java:381) [classes/:?]
	at org.apache.hadoop.hive.ql.exec.mr.MapRedTask.execute(MapRedTask.java:149) [classes/:?]
	at org.apache.hadoop.hive.ql.exec.Task.executeTask(Task.java:210) [classes/:?]
	at org.apache.hadoop.hive.ql.exec.TaskRunner.runSequential(TaskRunner.java:97) [classes/:?]
	at org.apache.hadoop.hive.ql.Driver.launchTask(Driver.java:2692) [classes/:?]
	at org.apache.hadoop.hive.ql.Driver.execute(Driver.java:2363) [classes/:?]
	at org.apache.hadoop.hive.ql.Driver.runInternal(Driver.java:2039) [classes/:?]
	at org.apache.hadoop.hive.ql.Driver.run(Driver.java:1737) [classes/:?]
	at org.apache.hadoop.hive.ql.Driver.run(Driver.java:1731) [classes/:?]
	at org.apache.hadoop.hive.ql.reexec.ReExecDriver.run(ReExecDriver.java:157) [classes/:?]
	at org.apache.hadoop.hive.ql.reexec.ReExecDriver.run(ReExecDriver.java:218) [classes/:?]
	at org.apache.hadoop.hive.cli.CliDriver.processLocalCmd(CliDriver.java:239) [classes/:?]
	at org.apache.hadoop.hive.cli.CliDriver.processCmd(CliDriver.java:188) [classes/:?]
	at org.apache.hadoop.hive.cli.CliDriver.processLine(CliDriver.java:402) [classes/:?]
	at org.apache.hadoop.hive.cli.CliDriver.processLine(CliDriver.java:335) [classes/:?]
	at org.apache.hadoop.hive.ql.QTestUtil.initFromScript(QTestUtil.java:1216) [classes/:?]
	at org.apache.hadoop.hive.ql.QTestUtil.createSources(QTestUtil.java:1201) [classes/:?]
	at org.apache.hadoop.hive.ql.QTestUtil.createSources(QTestUtil.java:1188) [classes/:?]
	at org.apache.hadoop.hive.cli.control.CoreCliDriver$3.invokeInternal(CoreCliDriver.java:83) [classes/:?]
	at org.apache.hadoop.hive.cli.control.CoreCliDriver$3.invokeInternal(CoreCliDriver.java:80) [classes/:?]
	at org.apache.hadoop.hive.util.ElapsedTimeLoggingWrapper.invoke(ElapsedTimeLoggingWrapper.java:33) [classes/:?]
	at org.apache.hadoop.hive.cli.control.CoreCliDriver.beforeClass(CoreCliDriver.java:86) [classes/:?]
	at org.apache.hadoop.hive.cli.control.CliAdapter$1$1.evaluate(CliAdapter.java:71) [classes/:?]
	at org.junit.rules.RunRules.evaluate(RunRules.java:20) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:?]
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365) [surefire-junit4-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273) [surefire-junit4-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238) [surefire-junit4-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159) [surefire-junit4-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:379) [surefire-booter-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:340) [surefire-booter-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125) [surefire-booter-2.21.0.jar:2.21.0]
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:413) [surefire-booter-2.21.0.jar:2.21.0]`

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
