### PR TITLE
HIVE-27148: Disable flaky test TestJdbcGenericUDTFGetSplits

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits.java
@@ -52,10 +52,12 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
 
+@Ignore("HIVE-27148")
 public class TestJdbcGenericUDTFGetSplits {
   protected static MiniHS2 miniHS2 = null;
   protected static String dataFileDir;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR disables flaky test TestJdbcGenericUDTFGetSplits on branch-3. The test was seen intermittently failing on unrelated PRs and also on the flaky test runner: http://ci.hive.apache.org/job/hive-flaky-check/614/


### Why are the changes needed?
To stablize branch-3 and reopen it for commits.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Confirmed that test is being skipped locally.
