### PR TITLE
HIVE-27147: HS2 is not accessible to clients via zookeeper when hostname used is not FQDN

### DIFF
--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -663,7 +663,7 @@ public class HiveServer2 extends CompositeService {
     if ((thriftCLIService == null) || (thriftCLIService.getServerIPAddress() == null)) {
       throw new Exception("Unable to get the server address; it hasn't been initialized yet.");
     }
-    return thriftCLIService.getServerIPAddress().getHostName() + ":"
+    return thriftCLIService.getServerIPAddress().getCanonicalHostName() + ":"
         + thriftCLIService.getPortNumber();
   }
 
@@ -671,7 +671,7 @@ public class HiveServer2 extends CompositeService {
     if ((thriftCLIService == null) || (thriftCLIService.getServerIPAddress() == null)) {
       throw new Exception("Unable to get the server address; it hasn't been initialized yet.");
     }
-    return thriftCLIService.getServerIPAddress().getHostName();
+    return thriftCLIService.getServerIPAddress().getCanonicalHostName();
   }
 
   @Override

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -560,7 +560,7 @@ public class MetastoreConf {
         "means that the current metastore will run the housekeeping tasks. If configuration" +
         "metastore.thrift.bind.host is set on the intended leader metastore, this value should " +
         "match that configuration. Otherwise it should be same as the hostname returned by " +
-        "InetAddress#getLocalHost#getHostName(). Given the uncertainty in the later " +
+        "InetAddress#getLocalHost#getCanonicalHostName(). Given the uncertainty in the later " +
         "it is desirable to configure metastore.thrift.bind.host on the intended leader HMS."),
     METASTORE_HOUSEKEEPING_LEADER_ELECTION("metastore.housekeeping.leader.election",
         "metastore.housekeeping.leader.election",

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -788,7 +788,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     if (msHost != null && !msHost.trim().isEmpty()) {
       return msHost.trim();
     } else {
-      return InetAddress.getLocalHost().getHostName();
+      return InetAddress.getLocalHost().getCanonicalHostName();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `InetAddress.getCanonicalHostName()` method instead of `InetAddress.getHostName()` while registering HS2 and HMS instances to zookeeper.

### Why are the changes needed?
HS2 is not accessible to clients via zookeeper when hostname used during registration is InetAddress.getHostName() with JDK 11. This issue is happening due to change in behavior on JDK 11 and it is OS specific. Below link has more information - 
[https://stackoverflow.com/questions/61898627/inetaddress-getlocalhost-gethostname-different-behavior-between-jdk-11-and-j](https://stackoverflow.com/questions/61898627/inetaddress-getlocalhost-gethostname-different-behavior-between-jdk-11-and-j)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified with zookeeper in the cluster