### PR TITLE
HIVE-27167: Upgrade guava version in standalone-metastore and storage-api module

### DIFF
--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
@@ -549,9 +549,9 @@ public final class Util {
     HostAndPort hp = HostAndPort.fromString(host)
             .withDefaultPort(port);
 
-    LOG.info("Connecting to {}:{}", hp.getHostText(), hp.getPort());
+    LOG.info("Connecting to {}:{}", hp.getHost(), hp.getPort());
 
-    return new URI(THRIFT_SCHEMA, null, hp.getHostText(), hp.getPort(),
+    return new URI(THRIFT_SCHEMA, null, hp.getHost(), hp.getPort(),
             null, null, null);
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -76,7 +76,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>22.0</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <jackson.version>2.12.7</jackson.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>22.0</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The guava version is upgrade to 22.0 in standalone-metastore and storage-api module


### Why are the changes needed?
In HIVE-26484, the guava version is upgraded from 19.0 -> 22.0 in parent pom.xml but not in standalone-metastore/pom.xml and storage-api/pom.xml. The guava version in those 2 module is still 19.0. To be in-sync, hence making this change

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
The build is passing on my local machine
