### PR TITLE
HIVE-27169: New Locked List to prevent config change at runtime without throwing error

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConfUtil.java
@@ -97,6 +97,22 @@ public class HiveConfUtil {
   }
 
   /**
+   * Getting the set of locked configurations
+   * @param configuration The original configuration
+   * @return The list of the configuration values to be locked
+   */
+  public static Set<String> getLockedSet(Configuration configuration) {
+    Set<String> lockedSet = new HashSet<>();
+    String lockedListStr = HiveConf.getVar(configuration, ConfVars.HIVE_CONF_LOCKED_LIST);
+    if (lockedListStr != null) {
+      for (String entry : lockedListStr.split(",")) {
+        lockedSet.add(entry.trim());
+      }
+    }
+    return lockedSet;
+  }
+
+  /**
    * Strips hidden config entries from configuration
    * @param conf The configuration to strip from
    * @param hiddenSet The values to strip

--- a/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
@@ -177,6 +177,20 @@ public class TestHiveConf {
   }
 
   @Test
+  public void testLockedConfig() throws Exception {
+    HiveConf conf = new HiveConf();
+    // Get the default value of the config
+    String defaultVal = conf.get("hive.execution.engine");
+    // Update the lockedSet variable
+    conf.addToLockedSet("hive.execution.engine");
+    // Update the value of sample/test config
+    conf.verifyAndSet("hive.execution.engine", "tez");
+    String modifiedVal = conf.get("hive.execution.engine");
+    // Check if the value is changed.
+    Assert.assertEquals(defaultVal, modifiedVal);
+  }
+
+  @Test
   public void testEncodingDecoding() throws UnsupportedEncodingException {
     HiveConf conf = new HiveConf();
     String query = "select blah, '\u0001' from random_table";

--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/SetProcessor.java
@@ -52,6 +52,7 @@ import com.google.common.collect.Sets;
  */
 public class SetProcessor implements CommandProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(SetProcessor.class);
+  private static final SessionState.LogHelper console = SessionState.getConsole();
 
   private static final String prefix = "set: ";
   private static final Set<String> removedConfigs =
@@ -255,6 +256,10 @@ public class SetProcessor implements CommandProcessor {
       }
     }
     conf.verifyAndSet(key, value);
+    if (conf.isLockedConfig(key)) {
+      console.printWarn("Cannot modify " + key + " at runtime. "
+              + "It is in the list of locked configurations that can't be modified at runtime");
+    }
     if (HiveConf.ConfVars.HIVE_EXECUTION_ENGINE.varname.equals(key)) {
       if ("mr".equals(value)) {
         result = HiveConf.generateMrDeprecationWarning();

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1308,6 +1308,45 @@ public class SessionState implements ISessionAuthState{
     }
 
     /**
+     * Logs warn into the log file, and if the LogHelper is not silent then into the HiveServer2 or
+     * HiveCli info stream too.
+     * BeeLine uses the operation log file to show the logs to the user, so depending on the
+     * BeeLine settings it could be shown to the user.
+     * @param warn The log message
+     */
+    public void printWarn(String warn) {
+      printWarn(warn, null);
+    }
+
+    /**
+     * Logs warn into the log file, and if the LogHelper is not silent then into the HiveServer2 or
+     * HiveCli info stream too. Handles an extra detail which will not be printed if null.
+     * BeeLine uses the operation log file to show the logs to the user, so depending on the
+     * BeeLine settings it could be shown to the user.
+     * @param warn The log message
+     * @param detail Extra detail to log which will be not printed if null
+     */
+    public void printWarn(String warn, String detail) {
+      printWarn(warn, detail, getIsSilent());
+    }
+
+    /**
+     * Logs warn into the log file, and if not silent then into the HiveServer2 or HiveCli info
+     * stream too. Handles an extra detail which will not be printed if null.
+     * BeeLine uses the operation log file to show the logs to the user, so depending on the
+     * BeeLine settings it could be shown to the user.
+     * @param warn The log message
+     * @param detail Extra detail to log which will be not printed if null
+     * @param isSilent If true then the message will not be printed to the info stream
+     */
+    public void printWarn(String warn, String detail, boolean isSilent) {
+      if (!isSilent) {
+        getInfoStream().println(warn);
+      }
+      LOG.warn(warn + org.apache.commons.lang.StringUtils.defaultString(detail));
+    }
+
+    /**
      * Logs an error into the log file, and into the HiveServer2 or HiveCli error stream too.
      * BeeLine uses the operation log file to show the logs to the user, so depending on the
      * BeeLine settings it could be shown to the user.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create a new locked list called **_hive.conf.locked.list_** which contains comma separated configuration that won't be changed during runtime. If someone try to change them at runtime then it will give **_WARN_** log on beeline itself.


### Why are the changes needed?
In organisations, admin want to enforce some configs which user shouldn't be able to change at runtime and it shouldn't affect user's existing hive scripts. Therefore, this locked list will be useful as it will not allow user to change the value of particular configs and it will also not stop the execution of hive scripts.


### Does this PR introduce _any_ user-facing change?
This config can be documented.

### How was this patch tested?
On a cluster
