### PR TITLE
HIVE-27154: Backport HIVE-20953 to branch-3

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -148,6 +148,91 @@ public class TestReplicationScenariosAcrossInstances {
   }
 
   @Test
+  public void testBootstrapReplLoadRetryAfterFailureForFunctions() throws Throwable {
+    String funcName1 = "f1";
+    String funcName2 = "f2";
+    WarehouseInstance.Tuple tuple = primary.run("use " + primaryDbName)
+            .run("CREATE FUNCTION " + primaryDbName + "." + funcName1 +
+                    " as 'hivemall.tools.string.StopwordUDF' " +
+                    "using jar  'ivy://io.github.myui:hivemall:0.4.0-2'")
+            .run("CREATE FUNCTION " + primaryDbName + "." + funcName2 +
+                    " as 'hivemall.tools.string.SplitWordsUDF' "+
+                    "using jar  'ivy://io.github.myui:hivemall:0.4.0-1'")
+            .dump(primaryDbName, null);
+
+    // Allow create function only on f1. Create should fail for the second function.
+    BehaviourInjection<CallerArguments, Boolean> callerVerifier
+            = new BehaviourInjection<CallerArguments, Boolean>() {
+              @Override
+              public Boolean apply(CallerArguments args) {
+                injectionPathCalled = true;
+                if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
+                  LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
+                  return false;
+                }
+                if (args.funcName != null) {
+                  LOG.debug("Verifier - Function: " + String.valueOf(args.funcName));
+                  return args.funcName.equals(funcName1);
+                }
+                return true;
+              }
+            };
+    InjectableBehaviourObjectStore.setCallerVerifier(callerVerifier);
+
+    // Trigger bootstrap dump which just creates function f1 but not f2
+    List<String> withConfigs = Arrays.asList("'hive.repl.approx.max.load.tasks'='1'",
+            "'hive.in.repl.test.files.sorted'='true'");
+    try {
+      replica.loadFailure(replicatedDbName, tuple.dumpLocation, withConfigs);
+      callerVerifier.assertInjectionsPerformed(true, false);
+    } finally {
+      InjectableBehaviourObjectStore.resetCallerVerifier(); // reset the behaviour
+    }
+
+    // Verify that only f1 got loaded
+    replica.run("use " + replicatedDbName)
+            .run("repl status " + replicatedDbName)
+            .verifyResult("null")
+            .run("show functions like '" + replicatedDbName + "*'")
+            .verifyResult(replicatedDbName + "." + funcName1);
+
+    // Verify no calls to load f1 only f2.
+    callerVerifier = new BehaviourInjection<CallerArguments, Boolean>() {
+      @Override
+      public Boolean apply(CallerArguments args) {
+        injectionPathCalled = true;
+        if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
+          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
+          return false;
+        }
+        if (args.funcName != null) {
+          LOG.debug("Verifier - Function: " + String.valueOf(args.funcName));
+          return args.funcName.equals(funcName2);
+        }
+        return true;
+      }
+    };
+    InjectableBehaviourObjectStore.setCallerVerifier(callerVerifier);
+
+    try {
+      // Retry with same dump with which it was already loaded should resume the bootstrap load.
+      // This time, it completes by adding just the function f2
+      replica.load(replicatedDbName, tuple.dumpLocation);
+      callerVerifier.assertInjectionsPerformed(true, false);
+    } finally {
+      InjectableBehaviourObjectStore.resetCallerVerifier(); // reset the behaviour
+    }
+
+    // Verify that both the functions are available.
+    replica.run("use " + replicatedDbName)
+            .run("repl status " + replicatedDbName)
+            .verifyResult(tuple.lastReplicationId)
+            .run("show functions like '" + replicatedDbName +"*'")
+            .verifyResults(new String[] {replicatedDbName + "." + funcName1,
+                                         replicatedDbName +"." +funcName2});
+  }
+
+  @Test
   public void testDropFunctionIncrementalReplication() throws Throwable {
     primary.run("CREATE FUNCTION " + primaryDbName
         + ".testFunctionAnother as 'hivemall.tools.string.StopwordUDF' "
@@ -1265,7 +1350,9 @@ public class TestReplicationScenariosAcrossInstances {
     };
     InjectableBehaviourObjectStore.setGetPartitionBehaviour(getPartitionStub);
 
-    List<String> withConfigs = Arrays.asList("'hive.repl.approx.max.load.tasks'='1'");
+    // Make sure that there's some order in which the objects are loaded.
+    List<String> withConfigs = Arrays.asList("'hive.repl.approx.max.load.tasks'='1'",
+            "'hive.in.repl.test.files.sorted'='true'");
     replica.loadFailure(replicatedDbName, tuple.dumpLocation, withConfigs);
     InjectableBehaviourObjectStore.resetGetPartitionBehaviour(); // reset the behaviour
     getPartitionStub.assertInjectionsPerformed(true, false);
@@ -1276,24 +1363,21 @@ public class TestReplicationScenariosAcrossInstances {
             .run("show tables")
             .verifyResults(new String[] {"t2" })
             .run("select country from t2 order by country")
-            .verifyResults(Arrays.asList("india"))
-            .run("show functions like '" + replicatedDbName + "*'")
-            .verifyResult(replicatedDbName + ".testFunctionOne");
+            .verifyResults(Collections.singletonList("india"));
 
     // Retry with different dump should fail.
     replica.loadFailure(replicatedDbName, tuple2.dumpLocation);
 
-    // Verify if no create table/function calls. Only add partitions.
+    // Verify if no create table calls. Add partitions and create function calls expected.
     BehaviourInjection<CallerArguments, Boolean> callerVerifier
             = new BehaviourInjection<CallerArguments, Boolean>() {
       @Nullable
       @Override
       public Boolean apply(@Nullable CallerArguments args) {
-        if (!args.dbName.equalsIgnoreCase(replicatedDbName) || (args.tblName != null) || (args.funcName != null)) {
+        if (!args.dbName.equalsIgnoreCase(replicatedDbName) || (args.tblName != null)) {
           injectionPathCalled = true;
           LOG.warn("Verifier - DB: " + String.valueOf(args.dbName)
-                  + " Table: " + String.valueOf(args.tblName)
-                  + " Func: " + String.valueOf(args.funcName));
+                  + " Table: " + String.valueOf(args.tblName));
           return false;
         }
         return true;
@@ -1303,7 +1387,7 @@ public class TestReplicationScenariosAcrossInstances {
 
     try {
       // Retry with same dump with which it was already loaded should resume the bootstrap load.
-      // This time, it completes by adding remaining partitions.
+      // This time, it completes by adding remaining partitions and function.
       replica.load(replicatedDbName, tuple.dumpLocation);
       callerVerifier.assertInjectionsPerformed(false, false);
     } finally {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
@@ -204,7 +204,16 @@ public class FunctionTask extends Task<FunctionWork> {
         org.apache.hadoop.hive.metastore.api.FunctionType.JAVA,
         resources
     );
-    db.createFunction(func);
+    try {
+      db.createFunction(func);
+    } catch (Exception e) {
+      // Addition to metastore failed, remove the function from the registry.
+      FunctionRegistry.unregisterPermanentFunction(registeredName);
+      setException(e);
+      LOG.error("Failed to add function " + createFunctionDesc.getFunctionName() +
+              " to the metastore.", e);
+      return 1;
+    }
     return 0;
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This PR backports HIVE-20953 which is needed to fix testBootstrapReplLoadRetryAfterFailureForPartitions


### Why are the changes needed?
Test fix

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI Job
