### PR TITLE
HIVE-27174 : Disabled sysdb.q

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
@@ -226,6 +226,7 @@ public class CliConfigs {
         includesFrom(testConfigProps, "minillaplocal.shared.query.files");
         excludeQuery("bucket_map_join_tez1.q"); // Disabled in HIVE-19509
         excludeQuery("special_character_in_tabnames_1.q"); // Disabled in HIVE-19509
+        excludeQuery("sysdb.q"); // Disabled in HIVE-19509
         excludeQuery("tez_smb_1.q"); // Disabled in HIVE-19509
         excludeQuery("union_fast_stats.q"); // Disabled in HIVE-19509
         excludeQuery("schema_evol_orc_acidvec_part.q"); // Disabled in HIVE-19509

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
@@ -226,7 +226,7 @@ public class CliConfigs {
         includesFrom(testConfigProps, "minillaplocal.shared.query.files");
         excludeQuery("bucket_map_join_tez1.q"); // Disabled in HIVE-19509
         excludeQuery("special_character_in_tabnames_1.q"); // Disabled in HIVE-19509
-        excludeQuery("sysdb.q"); // Disabled in HIVE-19509
+        excludeQuery("sysdb.q"); // Disabled in HIVE-HIVE-27174. To be fixed in HIVE-27057
         excludeQuery("tez_smb_1.q"); // Disabled in HIVE-19509
         excludeQuery("union_fast_stats.q"); // Disabled in HIVE-19509
         excludeQuery("schema_evol_orc_acidvec_part.q"); // Disabled in HIVE-19509


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Disabled sysdb.q test. The test is failing because of diff in BASIC_COLUMN_STATS json string. 
Client Execution succeeded but contained differences (error code = 1) after executing sysdb.q
3803,3807c3803,3807
< COLUMN_STATS_ACCURATE org.apache.derby.impl.jdbc.EmbedClob@125b285b
< COLUMN_STATS_ACCURATE org.apache.derby.impl.jdbc.EmbedClob@471246f3
< COLUMN_STATS_ACCURATE org.apache.derby.impl.jdbc.EmbedClob@57c013
< COLUMN_STATS_ACCURATE org.apache.derby.impl.jdbc.EmbedClob@59f1d7ac
< COLUMN_STATS_ACCURATE org.apache.derby.impl.jdbc.EmbedClob@717777a0
—
> COLUMN_STATS_ACCURATE {"BASIC_STATS":"true","COLUMN_STATS":{"c_boolean":"true","c_float":"true","c_int":"true","key":"true","value":"true"}}
> COLUMN_STATS_ACCURATE {"BASIC_STATS":"true","COLUMN_STATS":{"c_boolean":"true","c_float":"true","c_int":"true","key":"true","value":"true"}}
> COLUMN_STATS_ACCURATE {"BASIC_STATS":"true","COLUMN_STATS":{"key":"true","value":"true"}}
> COLUMN_STATS_ACCURATE {"BASIC_STATS":"true","COLUMN_STATS":{"key":"true","value":"true"}}
> COLUMN_STATS_ACCURATE {"BASIC_STATS":"true","COLUMN_STATS":

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There is no issue in the test. The current code prints the COL_STATS as an Object instead of a json string. Not sure why is this case. Tried a lot of ways but seems like this is not fixable at the moment. So, disabling it for now. Note that, in Hive 3.1.3 release this test was disabled so there should not be any issue in disabling it here.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Jenkins pipeline



Created a followup ticket to fix this test that can be taken up later - [HIVE-27057](https://issues.apache.org/jira/browse/HIVE-27057) Test fix for sysdb.q - ASF JIRA (apache.org)