### PR TITLE
HIVE-26655: VectorUDAFBloomFilterMerge should take care of safe batch handling when working in parallel

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
@@ -1555,4 +1555,14 @@ public abstract class Operator<T extends OperatorDesc> implements Serializable,C
       c.replaceTabAlias(oldAlias, newAlias);
     }
   }
+
+  /**
+   * There are aggregate implementations where the contents of the batch are processed in an async way,
+   * (e.g. in executors/thread pool), in which cases we have to create a new batch every time. This leads to
+   * minor GC pressure, so this feature should be only used when you have the evidence that there is an expression
+   * which relies on this, and its implementation has benefits over the default, non-cloned approach.
+   */
+  public boolean batchNeedsClone() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorGroupByOperator.java
@@ -161,6 +161,7 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
 
   // tracks overall access count in map agg buffer any given time.
   private long totalAccessCount;
+  private boolean batchNeedsClone;
 
   /**
    * Interface for processing mode: global, hash, unsorted streaming, or group batch
@@ -1157,6 +1158,13 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
         objectInspectors.add(objInsp);
       }
 
+      for (VectorAggregateExpression aggregator : aggregators) {
+        if (aggregator.batchNeedsClone()) {
+          batchNeedsClone = true;
+          break;
+        }
+      }
+
       keyWrappersBatch = VectorHashKeyWrapperBatch.compileKeyWrapperBatch(keyExpressions);
       aggregationBatchInfo = new VectorAggregationBufferBatch();
       aggregationBatchInfo.compileAggregationBatchInfo(aggregators);
@@ -1432,5 +1440,9 @@ public class VectorGroupByOperator extends Operator<GroupByDesc>
 
   public long getMaxMemory() {
     return maxMemory;
+  }
+
+  public boolean batchNeedsClone() {
+    return batchNeedsClone;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/aggregates/VectorAggregateExpression.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/aggregates/VectorAggregateExpression.java
@@ -154,5 +154,13 @@ public abstract class VectorAggregateExpression  implements Serializable {
    */
   public void finish(AggregationBuffer aggregationBuffer, boolean aborted) {
   }
+
+  /**
+   * This method should return true, when the particular VectorAggregateExpression must use a cloned batch
+   * while processing one, see Operator.batchNeedsClone() for further details.
+   */
+  public boolean batchNeedsClone() {
+    return false;
+  }
 }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/aggregates/VectorUDAFBloomFilterMerge.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/aggregates/VectorUDAFBloomFilterMerge.java
@@ -223,9 +223,9 @@ public class VectorUDAFBloomFilterMerge extends VectorAggregateExpression {
           merge(currentBf);
         } catch (InterruptedException e) {// Executor.shutdownNow() is called
           if (!queue.isEmpty()){
-            LOG.debug(
-                "bloom filter merge was interrupted while processing and queue is still not empty"
-                    + ", this is fine in case of shutdownNow");
+            LOG.info(
+                "bloom filter merge was interrupted while processing and queue is still not empty (size: {})"
+                    + ", this is fine in case of shutdownNow", queue.size());
           }
           if (aborted.get()) {
             LOG.info("bloom filter merge was aborted, won't finish merging...");
@@ -601,5 +601,12 @@ public class VectorUDAFBloomFilterMerge extends VectorAggregateExpression {
 
     Aggregation bfAgg = (Aggregation) agg;
     outputColVector.setVal(batchIndex, bfAgg.bfBytes, 0, bfAgg.bfBytes.length);
+  }
+
+  /**
+   * Let's clone the batch when we're working in parallel, see HIVE-26655.
+   */
+  public boolean batchNeedsClone() {
+    return numThreads > 0;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce the ability for asking for cloned batches in the operator pipeline.


### Why are the changes needed?
Because VectorUDAFBloomFilterMerge can work outside of the main task thread.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
On cluster, 10TB, reproduced the correctness issue, then tested with the fix.

results for performance testing on a bloom filter with size 884337856 (that's the size which has been calculated on 10TB)
```
thread=0, no parallel processing: 62026ms
thread=1, with this patch 47092ms
```