### PR TITLE
HIVE-27189. Remove duplicate debug log in Hive.isSubDIr

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4705,7 +4705,6 @@ private void constructOneLBLocationMap(FileStatus fSta,
       return false;
     }
 
-    LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);
     return fullF1.startsWith(fullF2);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove duplicate debug log in Hive.isSubDIr


### Why are the changes needed?
In class org.apache.hadoop.hive.ql.metadata.HIve, invoke method isSubDir will print twice

`LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);`

we should remove the duplicate debug log.

Below is an example in log file,

`23/03/27 05:11:08 DEBUG Hive: The source path is /projects/hive/table_test/.hive-staging_hive_2023-03-27_05-09-17_848_8941157515106120269-1/-ext-10000/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000/ and the destination path is /projects/hive/table_test/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000/`

`23/03/27 05:11:08 DEBUG Hive: The source path is /projects/hive/table_test/.hive-staging_hive_2023-03-27_05-09-17_848_8941157515106120269-1/-ext-10000/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000/ and the destination path is /projects/hive/table_test/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000/`

`23/03/27 05:11:08 INFO Hive: Renaming src: hdfs://R2/projects/hive/table_test/.hive-staging_hive_2023-03-27_05-09-17_848_8941157515106120269-1/-ext-10000/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000, dest: hdfs://R2/projects/hive/table_test/dt=20230327/country=SG/part-00179-51723c84-5be6-428e-862e-c4716e9536cc.c000, Status:true
23/03/27 05:11:09 DEBUG Hive: altering partition for table tale_test with partition spec : {dt=20230327, country=SG}`

`23/03/27 05:11:09 INFO Hive: New loading path = hdfs://R2/projects/hive/table_test/.hive-staging_hive_2023-03-27_05-09-17_848_8941157515106120269-1/-ext-10000/dt=20230327/country=SG with partSpec {dt=20230327, country=SG}`


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
No need
