### PR TITLE
HIVE-27192 Use normal import instead of shaded import in TestSchemaTo…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolCatalogOps.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolCatalogOps.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.metastore.tools.schematool;
 
+import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hive.metastore.client.builder.FunctionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
-import org.apache.hive.com.google.common.io.Files;
 import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/pom.xml
+++ b/pom.xml
@@ -1615,6 +1615,8 @@
                     <bannedImport>**.shaded.**</bannedImport>
                     <bannedImport>jersey.repackaged.com.google.**</bannedImport>
                     <bannedImport>org.codehaus.jackson.**</bannedImport>
+                    <bannedImport>org.apache.hive.com.**</bannedImport>
+                    <bannedImport>org.apache.hive.org.**</bannedImport>
                   </bannedImports>
                   <allowedImports>
                     <allowedImport>org.apache.hadoop.hbase.shaded.protobuf.**</allowedImport>


### PR DESCRIPTION
…olCatalogOps.java

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Eliminated the shaded usage of com.google.common.io.Files;


### Why are the changes needed?
We do not need shaded usage here. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Jenkins test.
