### PR TITLE
HIVE-27200: Backport HIVE-24928 to branch-3

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
+import org.apache.hadoop.hive.ql.stats.Partish;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
@@ -171,6 +172,24 @@ public interface HiveStorageHandler extends Configurable {
 
   default LockType getLockType(WriteEntity writeEntity){
     return LockType.EXCLUSIVE;
+  }
+
+  /**
+   * Return some basic statistics (numRows, numFiles, totalSize) calculated by the underlying storage handler
+   * implementation.
+   * @param partish a partish wrapper class
+   * @return map of basic statistics, can be null
+   */
+  default Map<String, String> getBasicStatistics(Partish partish) {
+    return null;
+  }
+
+  /**
+   * Check if the storage handler can provide basic statistics.
+   * @return true if the storage handler can supply the basic statistics
+   */
+  default boolean canProvideBasicStatistics() {
+    return false;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRTableScan1.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.plan.StatsWork;
 import org.apache.hadoop.hive.ql.plan.BasicStatsWork;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
+import org.apache.hadoop.hive.ql.stats.BasicStatsNoJobTask;
 import org.apache.hadoop.mapred.InputFormat;
 
 /**
@@ -84,8 +85,7 @@ public class GenMRTableScan1 implements NodeProcessor {
 
         if (parseCtx.getQueryProperties().isAnalyzeCommand()) {
           boolean noScan = parseCtx.getQueryProperties().isNoScanAnalyzeCommand();
-          if (OrcInputFormat.class.isAssignableFrom(inputFormat) ||
-                  MapredParquetInputFormat.class.isAssignableFrom(inputFormat)) {
+          if (BasicStatsNoJobTask.canUseBasicStats(table, inputFormat)) {
             // For ORC and Parquet, all the following statements are the same
             // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS
             // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS noscan;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ProcessAnalyzeTable.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.stats.BasicStatsNoJobTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -86,8 +87,7 @@ public class ProcessAnalyzeTable implements NodeProcessor {
 
       assert alias != null;
       TezWork tezWork = context.currentTask.getWork();
-      if (OrcInputFormat.class.isAssignableFrom(inputFormat) ||
-          MapredParquetInputFormat.class.isAssignableFrom(inputFormat)) {
+      if (BasicStatsNoJobTask.canUseBasicStats(table, inputFormat)) {
         // For ORC & Parquet, all the following statements are the same
         // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS
         // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS noscan;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.hive.ql.plan.StatsWork;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
+import org.apache.hadoop.hive.ql.stats.BasicStatsNoJobTask;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.DefaultFetchFormatter;
 import org.apache.hadoop.hive.serde2.NoOpFetchFormatter;
@@ -408,7 +409,7 @@ public abstract class TaskCompiler {
     TableSpec tableSpec = new TableSpec(table, partitions);
     tableScan.getConf().getTableMetadata().setTableSpec(tableSpec);
 
-    if (inputFormat.equals(OrcInputFormat.class)) {
+    if (BasicStatsNoJobTask.canUseFooterScan(table, inputFormat)) {
       // For ORC, there is no Tez Job for table stats.
       StatsWork columnStatsWork = new StatsWork(table, parseContext.getConf());
       columnStatsWork.setFooterScan();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/SparkProcessAnalyzeTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/SparkProcessAnalyzeTable.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.stats.BasicStatsNoJobTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
@@ -96,8 +97,7 @@ public class SparkProcessAnalyzeTable implements NodeProcessor {
       Preconditions.checkArgument(alias != null, "AssertionError: expected alias to be not null");
 
       SparkWork sparkWork = context.currentTask.getWork();
-      if (OrcInputFormat.class.isAssignableFrom(inputFormat) ||
-          MapredParquetInputFormat.class.isAssignableFrom(inputFormat)) {
+      if (BasicStatsNoJobTask.canUseBasicStats(table, inputFormat)) {
         // For ORC & Parquet, all the following statements are the same
         // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS
         // ANALYZE TABLE T [PARTITION (...)] COMPUTE STATISTICS noscan;

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsNoJobTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsNoJobTask.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.stats;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -39,6 +41,8 @@ import org.apache.hadoop.hive.ql.exec.StatsTask;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.StatsProvidingRecordReader;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
@@ -86,6 +90,20 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     console = new LogHelper(LOG);
   }
 
+  public static boolean canUseBasicStats(
+      Table table, Class<? extends InputFormat> inputFormat) {
+    return canUseFooterScan(table, inputFormat) || useBasicStatsFromStorageHandler(table);
+  }
+
+  public static boolean canUseFooterScan(Table table, Class<? extends InputFormat> inputFormat) {
+    return (OrcInputFormat.class.isAssignableFrom(inputFormat) && !AcidUtils.isFullAcidTable(table))
+        || MapredParquetInputFormat.class.isAssignableFrom(inputFormat);
+  }
+
+  private static boolean useBasicStatsFromStorageHandler(Table table) {
+    return table.isNonNative() && table.getStorageHandler().canProvideBasicStatistics();
+  }
+
 
   @Override
   public void initialize(CompilationOpContext opContext) {
@@ -110,16 +128,74 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     return "STATS-NO-JOB";
   }
 
-  static class StatItem {
-    Partish partish;
-    Map<String, String> params;
-    Object result;
+  abstract static class StatCollector implements Runnable {
+
+    protected Partish partish;
+    protected Object result;
+    protected LogHelper console;
+
+    public static Function<StatCollector, String> SIMPLE_NAME_FUNCTION =
+        sc -> String.format("%s#%s", sc.partish.getTable().getCompleteName(),
+            sc.partish.getPartishType());
+
+    public static Function<StatCollector, Partition> EXTRACT_RESULT_FUNCTION = sc -> (Partition) sc.result;
+
+    protected void init(HiveConf conf, LogHelper console) throws IOException {
+      this.console = console;
+    }
+
+    protected final boolean isValid() {
+      return result != null;
+    }
+
+    protected final String toString(Map<String, String> parameters) {
+      StringBuilder builder = new StringBuilder();
+      for (String statType : StatsSetupConst.supportedStats) {
+        String value = parameters.get(statType);
+        if (value != null) {
+          if (builder.length() > 0) {
+            builder.append(", ");
+          }
+          builder.append(statType).append('=').append(value);
+        }
+      }
+      return builder.toString();
+    }
   }
 
-  static class FooterStatCollector implements Runnable {
+  static class HiveStorageHandlerStatCollector extends StatCollector {
 
-    private Partish partish;
-    private Object result;
+    public HiveStorageHandlerStatCollector(Partish partish) {
+      this.partish = partish;
+    }
+
+    @Override
+    public void run() {
+      try {
+        Table table = partish.getTable();
+        Map<String, String> parameters;
+        Map<String, String> basicStatistics = table.getStorageHandler().getBasicStatistics(partish);
+        if (partish.getPartition() != null) {
+          parameters = partish.getPartParameters();
+          result = new Partition(table, partish.getPartition().getTPartition());
+        } else {
+          parameters = table.getParameters();
+          result = new Table(table.getTTable());
+        }
+        parameters.putAll(basicStatistics);
+        StatsSetupConst.setBasicStatsState(parameters, StatsSetupConst.TRUE);
+        String msg = partish.getSimpleName() + " stats: [" + toString(parameters) + ']';
+        LOG.debug(msg);
+        console.printInfo(msg);
+      } catch (Exception e) {
+        console.printInfo("[Warning] could not update stats for " + partish.getSimpleName() + ".",
+            "Failed with exception " + e.getMessage() + "\n" + StringUtils.stringifyException(e));
+      }
+    }
+  }
+
+  static class FooterStatCollector extends StatCollector {
+
     private JobConf jc;
     private Path dir;
     private FileSystem fs;
@@ -128,24 +204,6 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     public FooterStatCollector(JobConf jc, Partish partish) {
       this.jc = jc;
       this.partish = partish;
-    }
-
-    public static final Function<FooterStatCollector, String> SIMPLE_NAME_FUNCTION = new Function<FooterStatCollector, String>() {
-
-      @Override
-      public String apply(FooterStatCollector sc) {
-        return String.format("%s#%s", sc.partish.getTable().getCompleteName(), sc.partish.getPartishType());
-      }
-    };
-    private static final Function<FooterStatCollector, Partition> EXTRACT_RESULT_FUNCTION = new Function<FooterStatCollector, Partition>() {
-      @Override
-      public Partition apply(FooterStatCollector input) {
-        return (Partition) input.result;
-      }
-    };
-
-    private boolean isValid() {
-      return result != null;
     }
 
     public void init(HiveConf conf, LogHelper console) throws IOException {
@@ -221,21 +279,31 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
         console.printInfo("[Warning] could not update stats for " + partish.getSimpleName() + ".", "Failed with exception " + e.getMessage() + "\n" + StringUtils.stringifyException(e));
       }
     }
+  }
 
-    private String toString(Map<String, String> parameters) {
-      StringBuilder builder = new StringBuilder();
-      for (String statType : StatsSetupConst.supportedStats) {
-        String value = parameters.get(statType);
-        if (value != null) {
-          if (builder.length() > 0) {
-            builder.append(", ");
-          }
-          builder.append(statType).append('=').append(value);
-        }
+  private Collection<Partition> getPartitions(Table table) {
+    Collection<Partition> partitions = null;
+    if (work.getPartitions() == null || work.getPartitions().isEmpty()) {
+      if (table.isPartitioned()) {
+        partitions = table.getTableSpec().partitions;
       }
-      return builder.toString();
+    } else {
+      partitions = work.getPartitions();
     }
+    return partitions;
+  }
 
+  private List<Partish> getPartishes(Table table) {
+    Collection<Partition> partitions = getPartitions(table);
+    List<Partish> partishes = Lists.newLinkedList();
+    if (partitions == null) {
+      partishes.add(Partish.buildFor(table));
+    } else {
+      for (Partition part : partitions) {
+        partishes.add(Partish.buildFor(table, part));
+      }
+    }
+    return partishes;
   }
 
   private int aggregateStats(ExecutorService threadPool, Hive db) {
@@ -251,30 +319,18 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
 
       Table table = tableSpecs.tableHandle;
 
-      Collection<Partition> partitions = null;
-      if (work.getPartitions() == null || work.getPartitions().isEmpty()) {
-        if (table.isPartitioned()) {
-          partitions = tableSpecs.partitions;
-        }
-      } else {
-        partitions = work.getPartitions();
-      }
+      List<Partish> partishes = getPartishes(table);
 
-      LinkedList<Partish> partishes = Lists.newLinkedList();
-      if (partitions == null) {
-        partishes.add(Partish.buildFor(table));
-      } else {
-        for (Partition part : partitions) {
-          partishes.add(Partish.buildFor(table, part));
-        }
-      }
-
-      List<FooterStatCollector> scs = Lists.newArrayList();
+      List<StatCollector> scs = new ArrayList();
       for (Partish partish : partishes) {
-        scs.add(new FooterStatCollector(jc, partish));
+        if (useBasicStatsFromStorageHandler(table)) {
+          scs.add(new HiveStorageHandlerStatCollector(partish));
+        } else {
+          scs.add(new FooterStatCollector(jc, partish));
+        }
       }
 
-      for (FooterStatCollector sc : scs) {
+      for (StatCollector sc : scs) {
         sc.init(conf, console);
         threadPool.execute(sc);
       }
@@ -298,7 +354,7 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     return ret;
   }
 
-  private int updatePartitions(Hive db, List<FooterStatCollector> scs, Table table) throws InvalidOperationException, HiveException {
+  private int updatePartitions(Hive db, List<StatCollector> scs, Table table) throws InvalidOperationException, HiveException {
 
     String tableFullName = table.getFullyQualifiedName();
 
@@ -306,15 +362,15 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
       return 0;
     }
     if (work.isStatsReliable()) {
-      for (FooterStatCollector statsCollection : scs) {
+      for (StatCollector statsCollection : scs) {
         if (statsCollection.result == null) {
           LOG.debug("Stats requested to be reliable. Empty stats found: {}", statsCollection.partish.getSimpleName());
           return -1;
         }
       }
     }
-    List<FooterStatCollector> validColectors = Lists.newArrayList();
-    for (FooterStatCollector statsCollection : scs) {
+    List<StatCollector> validColectors = Lists.newArrayList();
+    for (StatCollector statsCollection : scs) {
       if (statsCollection.isValid()) {
         validColectors.add(statsCollection);
       }
@@ -323,7 +379,7 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     EnvironmentContext environmentContext = new EnvironmentContext();
     environmentContext.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
 
-    ImmutableListMultimap<String, FooterStatCollector> collectorsByTable = Multimaps.index(validColectors, FooterStatCollector.SIMPLE_NAME_FUNCTION);
+    ImmutableListMultimap<String, StatCollector> collectorsByTable = Multimaps.index(validColectors, StatCollector.SIMPLE_NAME_FUNCTION);
 
     LOG.debug("Collectors.size(): {}", collectorsByTable.keySet());
 
@@ -337,7 +393,7 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
     LOG.debug("Updating stats for: {}", tableFullName);
 
     for (String partName : collectorsByTable.keySet()) {
-      ImmutableList<FooterStatCollector> values = collectorsByTable.get(partName);
+      ImmutableList<StatCollector> values = collectorsByTable.get(partName);
 
       if (values == null) {
         throw new RuntimeException("very intresting");
@@ -348,7 +404,7 @@ public class BasicStatsNoJobTask implements IStatsProcessor {
         LOG.debug("Updated stats for {}.", tableFullName);
       } else {
         if (values.get(0).result instanceof Partition) {
-          List<Partition> results = Lists.transform(values, FooterStatCollector.EXTRACT_RESULT_FUNCTION);
+          List<Partition> results = Lists.transform(values, StatCollector.EXTRACT_RESULT_FUNCTION);
           db.alterPartitions(tableFullName, results, environmentContext);
           LOG.debug("Bulk updated {} partitions of {}.", results.size(), tableFullName);
         } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
@@ -117,11 +117,16 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
     private boolean isMissingAcidState = false;
     private BasicStatsWork work;
     private boolean followedColStats1;
+    private Map<String, String> providedBasicStats;
 
     public BasicStatsProcessor(Partish partish, BasicStatsWork work, HiveConf conf, boolean followedColStats2) {
       this.partish = partish;
       this.work = work;
       followedColStats1 = followedColStats2;
+      Table table = partish.getTable();
+      if (table.isNonNative() && table.getStorageHandler().canProvideBasicStatistics()) {
+        providedBasicStats = table.getStorageHandler().getBasicStatistics(partish);
+      }
     }
 
     public Object process(StatsAggregator statsAggregator) throws HiveException, MetaException {
@@ -142,7 +147,7 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
         StatsSetupConst.clearColumnStatsState(parameters);
       }
 
-      if (partfileStatus == null) {
+      if (partfileStatus == null && providedBasicStats == null) {
         // This may happen if ACID state is absent from config.
         String spec =  partish.getPartition() == null ? partish.getTable().getTableName()
             :  partish.getPartition().getSpec().toString();
@@ -162,27 +167,33 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
         StatsSetupConst.setBasicStatsState(parameters, StatsSetupConst.FALSE);
       }
 
-      MetaStoreUtils.populateQuickStats(partfileStatus, parameters);
+      if (providedBasicStats == null) {
+        MetaStoreUtils.populateQuickStats(partfileStatus, parameters);
 
-      if (statsAggregator != null) {
+        if (statsAggregator != null) {
         // Update stats for transactional tables (MM, or full ACID with overwrite), even
         // though we are marking stats as not being accurate.
-        if (StatsSetupConst.areBasicStatsUptoDate(parameters) || p.isTransactionalTable()) {
-          String prefix = getAggregationPrefix(p.getTable(), p.getPartition());
-          updateStats(statsAggregator, parameters, prefix);
+          if (StatsSetupConst.areBasicStatsUptoDate(parameters) || p.isTransactionalTable()) {
+            String prefix = getAggregationPrefix(p.getTable(), p.getPartition());
+            updateStats(statsAggregator, parameters, prefix);
+          }
         }
+      } else {
+        parameters.putAll(providedBasicStats);
       }
 
       return p.getOutput();
     }
 
     public void collectFileStatus(Warehouse wh, HiveConf conf) throws MetaException, IOException {
-      if (!partish.isTransactionalTable()) {
-        partfileStatus = wh.getFileStatusesForSD(partish.getPartSd());
-      } else {
-        Path path = new Path(partish.getPartSd().getLocation());
-        partfileStatus = AcidUtils.getAcidFilesForStats(partish.getTable(), path, conf, null);
-        isMissingAcidState = true;
+      if (providedBasicStats == null) {
+        if (!partish.isTransactionalTable()) {
+          partfileStatus = wh.getFileStatusesForSD(partish.getPartSd());
+        } else {
+          Path path = new Path(partish.getPartSd().getLocation());
+          partfileStatus = AcidUtils.getAcidFilesForStats(partish.getTable(), path, conf, null);
+          isMissingAcidState = true;
+        }
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Backport HIVE-24928 to branch-3
HIVE-24928: In case of non-native tables use basic statistics from HiveStorageHandler
so that storagehandler run on branch-3 can benefit from this feature.


### Why are the changes needed?
backport HIVE-24928 so that storagehandler run on branch-3 can benefit from the feature of using BasicStatsNoJobTask for 'ANALYZE TABLE ... COMPUTE STATISTICS'


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested locally with customized storage handler
