### PR TITLE
HIVE-27202: Disable flaky test testComplexQuery

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
@@ -92,6 +92,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.apache.hadoop.mapred.InputFormat;
 
@@ -451,6 +452,7 @@ public abstract class BaseJdbcWithMiniLlap {
 
 
   @Test(timeout = 60000)
+  @Ignore("HIVE-27202")
   public void testComplexQuery() throws Exception {
     createTestTable("testtab1");
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`TestJdbcWithMiniLlapRow#testComplexQuery` is flaky and fails intermittently on branch-3. Here is the flaky test run http://ci.hive.apache.org/job/hive-flaky-check/634/


### Why are the changes needed?
branch-3 stability and green runs.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested locally that the test is skipped.
