### PR TITLE
HIVE-26900: Error message not representing the correct line number wi…

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -1359,22 +1359,53 @@ public class BeeLine implements Closeable {
     }
   }
 
+  public String executeReader(ConsoleReader reader, Character mask) {
+    String line = null;
+    StringBuilder qsb = new StringBuilder();
+    try {
+      while ((line = (getOpts().isSilent() && getOpts().getScriptFile() != null) ? reader
+              .readLine(null, mask) : reader.readLine(getPrompt())) != null) {
+        // Skipping through comments
+        if (!line.startsWith("--")) {
+          qsb.append(line + "\n");
+        }
+      }
+      if (qsb.length() > 0) {
+        qsb.delete(qsb.length() - 2, qsb.length());
+      }
+      line = qsb.toString();
+    }
+    catch (Throwable t) {
+      handleException(t);
+    }
+    return line;
+  }
+
   private int execute(ConsoleReader reader, boolean exitOnError) {
     int lastExecutionResult = ERRNO_OK;
     Character mask = (System.getProperty("jline.terminal", "").equals("jline.UnsupportedTerminal")) ? null
                        : ConsoleReader.NULL_MASK;
+    String line = null;
+    String fileName = getOpts().getScriptFile();
 
     while (!exit) {
       try {
-        // Execute one instruction; terminate on executing a script if there is an error
-        // in silent mode, prevent the query and prompt being echoed back to terminal
-        String line = (getOpts().isSilent() && getOpts().getScriptFile() != null) ? reader
-            .readLine(null, mask) : reader.readLine(getPrompt());
-
-        // trim line
-        if (line != null) {
-          line = line.trim();
+        if ((fileName != null) && (!fileName.endsWith("temp")))
+        {
+          line = executeReader(reader, mask);
+          exit = true;
         }
+        else if ((fileName == null) || (fileName.endsWith("temp"))) {
+            // Execute one instruction; terminate on executing a script if there is an error
+            // in silent mode, prevent the query and prompt being echoed back to terminal
+            line = (getOpts().isSilent() && fileName != null) ? reader
+                    .readLine(null, mask) : reader.readLine(getPrompt());
+
+            // trim line
+            if (line != null) {
+              line = line.trim();
+            }
+          }
 
         if (!dispatch(line)) {
           lastExecutionResult = ERRNO_OTHER;
@@ -1500,7 +1531,9 @@ public class BeeLine implements Closeable {
       return true;
     }
 
-    line = line.trim();
+    if ((getOpts().getScriptFile() == null) || (getOpts().getScriptFile().endsWith("temp"))){
+      line = line.trim();
+    }
 
     // save it to the current script, if any
     if (scriptOutputFile != null) {

--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -1202,16 +1202,24 @@ public class Commands {
     // bug 879518.
 
     // use multiple lines for statements not terminated by the delimiter
-    try {
-      line = handleMultiLineCmd(line);
-    } catch (Exception e) {
-      beeLine.handleException(e);
+    if ((beeLine.getOpts().getScriptFile() == null) || (beeLine.getOpts().getScriptFile().endsWith("temp"))){
+      try {
+        line = handleMultiLineCmd(line);
+      } catch (Exception e) {
+        beeLine.handleException(e);
+      }
+      line = line.trim();
     }
 
-    line = line.trim();
     List<String> cmdList = getCmdList(line, entireLineAsCommand);
+    String sql = null;
     for (int i = 0; i < cmdList.size(); i++) {
-      String sql = cmdList.get(i).trim();
+      if ((beeLine.getOpts().getScriptFile() == null) || (beeLine.getOpts().getScriptFile().endsWith("temp"))){
+        sql = cmdList.get(i).trim();
+      }
+      else {
+        sql = cmdList.get(i);
+      }
       if (sql.length() != 0) {
         if (!executeInternal(sql, call)) {
           return false;


### PR DESCRIPTION
…th a syntax error in a HQL File

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the Beeline class: 
- A new method executeReader() has been introduced specifically to read hql files. It makes one string out of all the contents of the hql file separated by newline characters (the comments are excluded).

In the Commands class:
- Since handling multiple lines of query for hql files has already been addressed in the executeReader method, we limit the handleMultipleLineCmd() method to every other scenario besides when reading an hql file.

In both Beeline.java and Commands.java:
- Trimming of the string/sql has been removed while reading hql file contents. This is achieved whenever getOpts().getScriptFile() equals null (ie this is for every situation except when reading an hql file). This is done so that the whitespaces and empty lines are not ignored while counting the line numbers.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
- Hive Cli throws error line number correctly when reading HQL files, but Beeline does not. These changes are needed so that the error line number is thrown correctly and there is no discrepancy between the functioning of Beeline and Hive Cli. 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
- Error message in Beeline was not representing the correct line number prior to the changes. Now Beeline prints the correct error line number.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- The testing was done locally on Beeline with multiple scenarios. The test were verified against the correctly functioning Hive Cli.
- As an example, for the given hql file:
<img width="438" alt="Screenshot 2023-03-05 at 11 12 29 PM" src="https://user-images.githubusercontent.com/50237152/222977016-e8a72f33-2f47-4ad4-aeff-2afb6f4a3bc9.png">
Error message prior to the changes:
<img width="1495" alt="Screenshot 2023-03-05 at 11 12 05 PM" src="https://user-images.githubusercontent.com/50237152/222977044-90f746ee-1958-4c6a-9627-c1c1e2a173cc.png">
Error message after the changes:
<img width="1496" alt="Screenshot 2023-03-05 at 11 10 57 PM" src="https://user-images.githubusercontent.com/50237152/222977064-d19b6bb8-b2bc-4292-a24a-1a14d04ab3eb.png">