### PR TITLE
HIVE-27211: Backport HIVE-22453 to branch-3: Describe table unnecessarily fetches partitions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLTask.java
@@ -3666,34 +3666,36 @@ public class DDLTask extends Task<DDLWork> implements Serializable {
           cols.addAll(tbl.getPartCols());
         }
 
-        if (tbl.isPartitioned() && part == null) {
-          // No partitioned specified for partitioned table, lets fetch all.
-          Map<String,String> tblProps = tbl.getParameters() == null ? new HashMap<String,String>() : tbl.getParameters();
-          Map<String, Long> valueMap = new HashMap<>();
-          Map<String, Boolean> stateMap = new HashMap<>();
-          for (String stat : StatsSetupConst.supportedStats) {
-            valueMap.put(stat, 0L);
-            stateMap.put(stat, true);
-          }
-          PartitionIterable parts = new PartitionIterable(db, tbl, null, conf.getIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX));
-          int numParts = 0;
-          for (Partition partition : parts) {
-            Map<String, String> props = partition.getParameters();
-            Boolean state = StatsSetupConst.areBasicStatsUptoDate(props);
+        if (descTbl.isExt() || descTbl.isFormatted()) {
+          if (tbl.isPartitioned() && part == null) {
+            // No partitioned specified for partitioned table, lets fetch all.
+            Map<String,String> tblProps = tbl.getParameters() == null ? new HashMap<String,String>() : tbl.getParameters();
+            Map<String, Long> valueMap = new HashMap<>();
+            Map<String, Boolean> stateMap = new HashMap<>();
             for (String stat : StatsSetupConst.supportedStats) {
-              stateMap.put(stat, stateMap.get(stat) && state);
-              if (props != null && props.get(stat) != null) {
-                valueMap.put(stat, valueMap.get(stat) + Long.parseLong(props.get(stat)));
-              }
+              valueMap.put(stat, 0L);
+              stateMap.put(stat, true);
             }
-            numParts++;
+            PartitionIterable parts = new PartitionIterable(db, tbl, null, conf.getIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX));
+            int numParts = 0;
+            for (Partition partition : parts) {
+              Map<String, String> props = partition.getParameters();
+              Boolean state = StatsSetupConst.areBasicStatsUptoDate(props);
+              for (String stat : StatsSetupConst.supportedStats) {
+                stateMap.put(stat, stateMap.get(stat) && state);
+                if (props != null && props.get(stat) != null) {
+                  valueMap.put(stat, valueMap.get(stat) + Long.parseLong(props.get(stat)));
+                }
+              }
+              numParts++;
+            }
+            for (String stat : StatsSetupConst.supportedStats) {
+              StatsSetupConst.setBasicStatsState(tblProps, Boolean.toString(stateMap.get(stat)));
+              tblProps.put(stat, valueMap.get(stat).toString());
+            }
+            tblProps.put(StatsSetupConst.NUM_PARTITIONS, Integer.toString(numParts));
+            tbl.setParameters(tblProps);
           }
-          for (String stat : StatsSetupConst.supportedStats) {
-            StatsSetupConst.setBasicStatsState(tblProps, Boolean.toString(stateMap.get(stat)));
-            tblProps.put(stat, valueMap.get(stat).toString());
-          }
-          tblProps.put(StatsSetupConst.NUM_PARTITIONS, Integer.toString(numParts));
-          tbl.setParameters(tblProps);
         }
       } else {
         if (descTbl.isFormatted()) {


### PR DESCRIPTION
HIVE-22453: Describe table unnecessarily fetches partitions

Author: (Kevin Cheung, reviewed by Sankar Hariappan)

Signed-off-by: Sankar Hariappan <sankarh@apache.org>
Closes (#2140)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The simple describe table command without EXTENDED and FORMATTED (i.e., DESCRIBE table_name) fetches all partitions when no partition is specified, although it does not display partition statistics in nature.
The command should not fetch partitions since it can take a long time for a large amount of partitions.
For instance, in our environment, the command takes around 8 seconds for a table with 8760 (24 * 365) partitions.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This Backport was already done in branch-3.1 using this [HIVE-24964](https://issues.apache.org/jira/browse/HIVE-24964) so we need to backport the same to branch-3.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
