### PR TITLE
HIVE-24706: add the HiveHBaseTableInputFormatV2 to fix the compatible…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3504,6 +3504,11 @@ public class HiveConf extends Configuration {
     HIVE_HBASE_GENERATE_HFILES("hive.hbase.generatehfiles", false,
         "True when HBaseStorageHandler should generate hfiles instead of operate against the online table."),
     HIVE_HBASE_SNAPSHOT_NAME("hive.hbase.snapshot.name", null, "The HBase table snapshot name to use."),
+
+    HIVE_HBASE_INPUTFORMAT_V2("hive.hbase.inputformat.v2", false, "If enabled, the new " +
+            "version (V2) of input format that inherits only mapred version of InputFormat will be used as input format " +
+            "for reading the Hbase table. By default, the old version (HiveHBaseTableInputFormat) is used that " +
+            "inherits both mapred and mapreduce version of InputFormat."),
     HIVE_HBASE_SNAPSHOT_RESTORE_DIR("hive.hbase.snapshot.restoredir", "/tmp", "The directory in which to " +
         "restore the HBase table snapshot."),
     HIVE_SECURITY_HBASE_URLENCODE_AUTHORIZATION_URI("hive.security.hbase.urlencode.authorization.uri", false,

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3506,9 +3506,10 @@ public class HiveConf extends Configuration {
     HIVE_HBASE_SNAPSHOT_NAME("hive.hbase.snapshot.name", null, "The HBase table snapshot name to use."),
 
     HIVE_HBASE_INPUTFORMAT_V2("hive.hbase.inputformat.v2", false, "If enabled, the new " +
-            "version (V2) of input format that inherits only mapred version of InputFormat will be used as input format " +
-            "for reading the Hbase table. By default, the old version (HiveHBaseTableInputFormat) is used that " +
-            "inherits both mapred and mapreduce version of InputFormat."),
+            "version (V2) of the input format, which inherits only the mapred version of InputFormat, will be " +
+            "utilized as the default input format for reading the Hbase table. " +
+            "Currently, the old version (HiveHBaseTableInputFormat) is used by default, " +
+            "which inherits both the mapred and mapreduce versions of InputFormat."),
     HIVE_HBASE_SNAPSHOT_RESTORE_DIR("hive.hbase.snapshot.restoredir", "/tmp", "The directory in which to " +
         "restore the HBase table snapshot."),
     HIVE_SECURITY_HBASE_URLENCODE_AUTHORIZATION_URI("hive.security.hbase.urlencode.authorization.uri", false,

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
@@ -143,6 +143,11 @@ public class HBaseStorageHandler extends DefaultStorageHandler
       LOG.debug("Using TableSnapshotInputFormat");
       return HiveHBaseTableSnapshotInputFormat.class;
     }
+
+    if (HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.HIVE_HBASE_INPUTFORMAT_V2)) {
+      LOG.debug("Using HiveHBaseTableInputFormatV2");
+      return HiveHBaseTableInputFormatV2.class;
+    }
     LOG.debug("Using HiveHBaseTableInputFormat");
     return HiveHBaseTableInputFormat.class;
   }

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatDelegate.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.hbase;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.mapreduce.TableInputFormatBase;
+
+import java.io.IOException;
+
+public class HiveHBaseTableInputFormatDelegate extends TableInputFormatBase {
+    void initializeTableDelegate(Connection connection, TableName tableName) throws IOException {
+        initializeTable(connection, tableName);
+    }
+
+    void closeTableDelegate() throws IOException {
+        closeTable();
+    }
+}

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatV2.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HiveHBaseTableInputFormatV2.java
@@ -94,7 +94,7 @@ public class HiveHBaseTableInputFormatV2 implements InputFormat<ImmutableBytesWr
       } catch (InterruptedException e) {
         delegate.closeTableDelegate(); // Free up the HTable connections
         conn.close();
-        throw new IOException("Failed to initialize RecordReader", e);
+        throw new IOException("Failed to initialize RecordReader: ", e);
       }
     }
 
@@ -237,22 +237,27 @@ public class HiveHBaseTableInputFormatV2 implements InputFormat<ImmutableBytesWr
     // BA representation of constant of filter condition.
     // We can do other comparisons only if storage format in hbase is either binary
     // or we are dealing with string types since there lexicographic ordering will suffice.
+    String genericUDFOPEqualClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual";
+    String genericUDFOPEqualOrGreaterThanClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan";
+    String genericUDFOPEqualOrLessThanClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrLessThan";
+    String genericUDFOPLessThanClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPLessThan";
+    String genericUDFOPGreaterThanClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPGreaterThan";
     if (isKeyComparable) {
-      analyzer.addComparisonOp(keyColumnName, "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrLessThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPLessThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPGreaterThan");
+      analyzer.addComparisonOp(keyColumnName, genericUDFOPEqualClass,
+              genericUDFOPEqualOrGreaterThanClass,
+              genericUDFOPEqualOrLessThanClass,
+              genericUDFOPLessThanClass,
+              genericUDFOPGreaterThanClass);
     } else {
-      analyzer.addComparisonOp(keyColumnName, "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual");
+      analyzer.addComparisonOp(keyColumnName, genericUDFOPEqualClass);
     }
 
     if (timestampColumn != null) {
-      analyzer.addComparisonOp(timestampColumn, "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrLessThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPLessThan",
-          "org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPGreaterThan");
+      analyzer.addComparisonOp(timestampColumn, genericUDFOPEqualClass,
+              genericUDFOPEqualOrGreaterThanClass,
+              genericUDFOPEqualOrLessThanClass,
+              genericUDFOPLessThanClass,
+              genericUDFOPGreaterThanClass);
     }
 
     return analyzer;

--- a/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHiveHBaseTableInputFormatV2.java
+++ b/hbase-handler/src/test/org/apache/hadoop/hive/hbase/TestHiveHBaseTableInputFormatV2.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.hbase;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ *  Test tot make sure the HiveHBaseTableInputFormatV2 can ONLY assignable to old version
+ */
+public class TestHiveHBaseTableInputFormatV2 {
+
+  @Test
+  public void testInstanceOfTestHiveHBaseTableInputFormatV2() {
+    assertTrue(org.apache.hadoop.mapred.InputFormat.class.isAssignableFrom(HiveHBaseTableInputFormatV2.class));
+    assertFalse(org.apache.hadoop.mapreduce.InputFormat.class.isAssignableFrom(HiveHBaseTableInputFormatV2.class));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

For HIVE-24706, the main issue here is the HiveHbaseTableInput format implements two version of InputFormat, which make the spark cannot get the correct version correctly, and this is indeed not very clear implementation.

So in this request, instead of directly extending TableInputFormatBase, I put it as a delegate which do the exactly the same as before, but avoid the confusing because the HbaseStorageHandler just need the old version InputFormat.

In the long term, I think hive should update the storage handler instead of keep mixing these two different API versions


### Why are the changes needed?

Its impacting the spark and hive compatible and reported by different uses in hive and spark


### Does this PR introduce _any_ user-facing change?
There is configuration parameter added hive.hbase.inputformat.v2, so maybe need update doc to keep the end user informed


### How was this patch tested?

create hbase table

```
echo "create 'students','account','address'" | sudo -u hbase hbase shell -n
echo "put 'students','student1','account:name','Alice'" |sudo -u hbase hbase shell -n
```

create hive table
```
hive -e "create external table test1 (key string, value string)
> stored by 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
> with serdeproperties ('hbase.columns.mapping' = ':key,account:name')
> tblproperties ('hbase.table.name' = 'students')"


SLF4J: Class path contains multiple SLF4J bindings.
Logging initialized using configuration in file:/etc/hive/conf.dist/hive-log4j2.properties Async: true
Hive Session ID = 05b4ec22-d15f-4614-9bc3-6c183e868728
OK
Time taken: 2.913 seconds
```

Spark test:

spark-sql --jars /usr/lib/hive/lib/hive-hbase-handler.jar,/usr/lib/hbase/hbase-common-2.4.4.jar,/usr/lib/hbase/hbase-client-2.4.4.jar,/usr/lib/hbase/lib/hbase-mapreduce-2.4.4.jar,/usr/lib/hbase/lib/shaded-clients/hbase-shaded-client-2.4.4.jar --conf spark.hive.hbase.inputformat.v2=true

```
spark-sql> select * from test1;

student1    Alice
```

Unit Test

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.hbase.TestHiveHBaseTableInputFormatV2
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.069 s - in org.apache.hadoop.hive.hbase.TestHiveHBaseTableInputFormatV2
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```