### PR TITLE
HIVE-27223: Show Compactions failing with NPE.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
@@ -187,7 +187,7 @@ public class ShowCompactionsOperation extends DDLOperation<ShowCompactionsDesc> 
     os.write(Utilities.tabCode);
     os.writeBytes(getThreadIdFromId(e.getInitiatorId()));
     os.write(Utilities.tabCode);
-    os.writeBytes(e.getPoolName());
+    os.writeBytes(e.isSetPoolName() ? e.getPoolName() : NO_VAL);
     os.write(Utilities.tabCode);
     os.writeBytes(e.isSetTxnId() ? Long.toString(e.getTxnId()) : NO_VAL);
     os.write(Utilities.tabCode);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a check for poolId before adding it in.

### Why are the changes needed?

To Avoid NPE in case of Show Compactions post upgrade

### Does this PR introduce _any_ user-facing change?

Show Compactions doesn't throw NPE for older entries post upgrade
