### PR TITLE
HIVE-27225: Speedup build by skipping SBOM generation by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <maven.versions.plugin.version>2.13.0</maven.versions.plugin.version>
     <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <maven.cyclonedx.plugin.version>2.7.3</maven.cyclonedx.plugin.version>
     <!-- Library Dependency Versions -->
     <accumulo.version>1.10.1</accumulo.version>
     <ant.version>1.10.12</ant.version>
@@ -1788,19 +1789,6 @@
         <artifactId>jamon-maven-plugin</artifactId>
         <version>${jamon.plugin.version}</version>
       </plugin>
-      <plugin>
-        <groupId>org.cyclonedx</groupId>
-        <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>makeBom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -2040,6 +2028,26 @@
           <name>hbase.version</name>
         </property>
       </activation>
+    </profile>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${maven.cyclonedx.plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Run SBOM generation only during release (dist profile) to speed-up every-day builds.

### Why are the changes needed?
The SBOM generation is costly and profiling shows that it consumes ~30% of CPU. Moreover, it is not necessary to run it in every build; it is sufficient to run it only during the release.

After the changes here the time for the default build drops from 14 minutes to 8 (measured locally).

### Does this PR introduce _any_ user-facing change?
Developers will notice a significantly faster build.

### How was this patch tested?
Before
```
mvn clean install -DskipTests -Pitests
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:15 min
```
After
```
mvn clean install -DskipTests -Pitests
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:19 min
```
After with dist profile activated
```
mvn clean install -DskipTests -Pitests -Pdist
INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13:32 min
```