### PR TITLE
HIVE-27238: Avoid Calcite Code generation for MetadataHandler on ever…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveDefaultRelMetadataProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveDefaultRelMetadataProvider.java
@@ -17,12 +17,15 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.calcite;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
 import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.optimizer.calcite.cost.HiveDefaultCostModel;
 import org.apache.hadoop.hive.ql.optimizer.calcite.cost.HiveOnTezCostModel;
@@ -43,8 +46,17 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.stats.HiveRelMdSize;
 import org.apache.hadoop.hive.ql.optimizer.calcite.stats.HiveRelMdUniqueKeys;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class HiveDefaultRelMetadataProvider {
+
+  // Set the number of providers allowed to be cached. A RelMetadataProvider provides Calcite
+  // generated code. Each instance generates new code so we want to limit the amount stored.
+  // The key to the provider contains various configuration variables since they are used in
+  // the calculations. These will most likely rarely be changed.
+  private static final int MAX_PROVIDERS = 20;
+  private static Map<Map<HiveConf.ConfVars, Object>, HiveDefaultRelMetadataProvider> ALL_PROVIDERS =
+      new LRUMap(MAX_PROVIDERS);
 
   /**
    * The default metadata provider can be instantiated statically since
@@ -127,5 +139,29 @@ public class HiveDefaultRelMetadataProvider {
   public static void initializeMetadataProviderClass(List<Class<? extends RelNode>> nodeClasses) {
     // This will register the classes in the default Hive implementation
     DEFAULT.register(nodeClasses);
+  }
+
+  public static synchronized HiveDefaultRelMetadataProvider get(HiveConf hiveConf,
+      List<Class<? extends RelNode>> nodeClasses) {
+    Map<HiveConf.ConfVars, Object> confKey = getConfKey(hiveConf);
+    if (ALL_PROVIDERS.containsKey(confKey)) {
+      return ALL_PROVIDERS.get(confKey);
+    }
+
+    HiveDefaultRelMetadataProvider newProvider =
+        new HiveDefaultRelMetadataProvider(hiveConf, nodeClasses);
+    ALL_PROVIDERS.put(confKey, newProvider);
+    return newProvider;
+  }
+
+  private static Map<HiveConf.ConfVars, Object> getConfKey(HiveConf conf) {
+    ImmutableMap.Builder<HiveConf.ConfVars, Object> bldr = new ImmutableMap.Builder<>();
+    bldr.put(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE,
+        conf.getVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE));
+    bldr.put(HiveConf.ConfVars.HIVE_CBO_EXTENDED_COST_MODEL,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_CBO_EXTENDED_COST_MODEL));
+    bldr.put(HiveConf.ConfVars.MAPREDMAXSPLITSIZE,
+        conf.getLongVar(HiveConf.ConfVars.MAPREDMAXSPLITSIZE));
+    return bldr.build();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveDefaultRelMetadataProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveDefaultRelMetadataProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.calcite;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +55,7 @@ public class HiveDefaultRelMetadataProvider {
   // the calculations. These will most likely rarely be changed.
   private static final int MAX_PROVIDERS = 20;
   private static Map<Map<HiveConf.ConfVars, Object>, HiveDefaultRelMetadataProvider> ALL_PROVIDERS =
-      new LRUMap(MAX_PROVIDERS);
+      new LRUMap<>(MAX_PROVIDERS);
 
   /**
    * The default metadata provider can be instantiated statically since

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1667,7 +1667,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
       calcitePlan.getCluster().getPlanner().setExecutor(executorProvider);
 
       // Create and set MD provider
-      HiveDefaultRelMetadataProvider mdProvider = new HiveDefaultRelMetadataProvider(conf, HIVE_REL_NODE_CLASSES);
+      HiveDefaultRelMetadataProvider mdProvider =
+          HiveDefaultRelMetadataProvider.get(conf, HIVE_REL_NODE_CLASSES);
       RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(mdProvider.getMetadataProvider()));
       optCluster.invalidateMetadataQuery();
 
@@ -2438,9 +2439,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       List<RelMetadataProvider> list = Lists.newArrayList();
       list.add(mdProvider);
       planner.registerMetadataProviders(list);
-      RelMetadataProvider chainedProvider = ChainedRelMetadataProvider.of(list);
-      cluster.setMetadataProvider(
-          new CachingRelMetadataProvider(chainedProvider, planner));
+      cluster.setMetadataProvider(mdProvider);
 
       if (executorProvider != null) {
         // basePlan.getCluster.getPlanner is the VolcanoPlanner from apply()

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -84,8 +84,6 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.metadata.CachingRelMetadataProvider;
-import org.apache.calcite.rel.metadata.ChainedRelMetadataProvider;
 import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;


### PR DESCRIPTION
…y query

In the current code base, a new CachingRelMetadataProvider is created on every query.  This causes a cache miss within JaninoRelMetadataProvider, which stores the provider in the key. As a result, a new MetadataHandler is created multiple times in every query, which causes code generation and is a small hit on performance

This commit caches HiveDefaultRelMetadataProviders globally which stores a RelMetadataProvider that can be reused. Ultimately, this class could most likely be removed as well, but this commit limits the scope of the change in a first pass.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Stated in commit message

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This will help performance and possibly have a smaller memory footprint.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
 No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This doesn't introduce new functionality, so current regression tests should be good. I ran this through the debugger and made sure the Calcite JaninoMetadataProvider.load3 method was not called after the first query was called with the same conf variables.
