### PR TITLE
HIVE-23548 : TestActivePassiveHA is unstable

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestActivePassiveHA.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestActivePassiveHA.java
@@ -69,9 +69,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.Ignore;
 
-@Ignore("HIVE-23548")
+
 public class TestActivePassiveHA {
   private MiniHS2 miniHS2_1 = null;
   private MiniHS2 miniHS2_2 = null;
@@ -619,6 +618,8 @@ public class TestActivePassiveHA {
 
   private String sendAuthMethod(HttpRequestBase method, boolean enableAuth, boolean enableCORS) throws Exception {
     CloseableHttpResponse httpResponse = null;
+    String response = null;
+    int statusCode = -1;
 
     try (
         CloseableHttpClient client = HttpClients.createDefault();
@@ -641,8 +642,8 @@ public class TestActivePassiveHA {
         if (httpResponse != null) {
           StatusLine statusLine = httpResponse.getStatusLine();
           if (statusLine != null) {
-            String response = httpResponse.getStatusLine().getReasonPhrase();
-            int statusCode = httpResponse.getStatusLine().getStatusCode();
+            response = httpResponse.getStatusLine().getReasonPhrase();
+            statusCode = httpResponse.getStatusLine().getStatusCode();
 
             if (statusCode == 200) {
               Header originHeader = httpResponse.getFirstHeader("Access-Control-Allow-Origin");
@@ -665,7 +666,18 @@ public class TestActivePassiveHA {
 
       httpResponse = client.execute(method);
 
-      return EntityUtils.toString(httpResponse.getEntity());
+      if (httpResponse != null) {
+        StatusLine statusLine = httpResponse.getStatusLine();
+        if (statusLine != null) {
+           response = httpResponse.getStatusLine().getReasonPhrase();
+           statusCode = httpResponse.getStatusLine().getStatusCode();
+          if (statusCode == 200) {
+            return EntityUtils.toString(httpResponse.getEntity());
+          }
+        }
+      }
+
+        return response;
     } finally {
       httpResponse.close();
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
HIVE-23548
TestActivePassiveHA was disables and reason was -
testManualFailoverUnauthorized failing at assertTrue(sendDelete(url1, false).contains("Unauthorized"));
As not sending any Auth header should get HTTP 401 with empty response. Empty response was not handled in sendAuthMethod(...)
This has been fixed in this PR 


### Why are the changes needed?
Enabling TestActivePassiveHA  in test suite


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
via test. Tested with flakey jenkins job as well
http://ci.hive.apache.org/job/hive-flaky-check/639/
