### PR TITLE
HIVE-27247: Backport of HIVE-24436: Fix Avro NULL_DEFAULT_VALUE compatibility issue

### DIFF
--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -225,7 +225,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.7.6</version>
+      <version>${avro.version}</version>
 	</dependency>
   </dependencies>
 
@@ -247,7 +247,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${avro.version}</version>
         <executions>
            <execution>
                <phase>generate-test-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <!-- Include arrow for LlapOutputFormatService -->
     <arrow.version>0.11.0</arrow.version>
     <avatica.version>1.12.0</avatica.version>
-    <avro.version>1.7.7</avro.version>
+    <avro.version>1.8.2</avro.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <calcite.version>1.17.0</calcite.version>
     <datanucleus-api-jdo.version>4.2.4</datanucleus-api-jdo.version>

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/TypeInfoToSchema.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/TypeInfoToSchema.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.serde2.avro;
 
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
@@ -73,7 +74,7 @@ public class TypeInfoToSchema {
   }
 
   private Schema.Field createAvroField(String name, TypeInfo typeInfo, String comment) {
-    return new Schema.Field(name, createAvroSchema(typeInfo), comment, null);
+    return new Schema.Field(name, createAvroSchema(typeInfo), comment, JsonProperties.NULL_VALUE);
   }
 
   private Schema createAvroSchema(TypeInfo typeInfo) {
@@ -235,7 +236,7 @@ public class TypeInfoToSchema {
   private List<Schema.Field> getFields(Schema.Field schemaField) {
     List<Schema.Field> fields = new ArrayList<Schema.Field>();
 
-    JsonNode nullDefault = JsonNodeFactory.instance.nullNode();
+    JsonProperties.Null nullDefault = JsonProperties.NULL_VALUE;
     if (schemaField.schema().getType() == Schema.Type.RECORD) {
       for (Schema.Field field : schemaField.schema().getFields()) {
         fields.add(new Schema.Field(field.name(), field.schema(), field.doc(), nullDefault));


### PR DESCRIPTION
JIRA Link: [https://issues.apache.org/jira/browse/HIVE-27247](https://github.com/apache/hive/pull/url)
These commits were already done in branch-3.1 using this [https://issues.apache.org/jira/browse/HIVE-24436](https://github.com/apache/hive/pull/url), [https://issues.apache.org/jira/browse/HIVE-24414](url) so we need to backport the same to branch-3.