### PR TITLE
HIVE-27253: Support array type when query does not produce any rows

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ASTConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ASTConverter.java
@@ -218,6 +218,13 @@ public class ASTConverter {
       return mapCallNode.node();
     }
 
+    if (fieldType.getSqlTypeName() == SqlTypeName.ARRAY) {
+      ASTBuilder arrayCallNode = ASTBuilder.construct(HiveParser.TOK_FUNCTION, "TOK_FUNCTION");
+      arrayCallNode.add(HiveParser.Identifier, "array");
+      arrayCallNode.add(createNullField(fieldType.getComponentType()));
+      return arrayCallNode.node();
+    }
+
     return createCastNull(fieldType);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/translator/TestASTConverter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/translator/TestASTConverter.java
@@ -129,7 +129,9 @@ class TestASTConverter {
           "               farray\n" +
           "               TOK_FUNCTION\n" +
           "                  array\n" +
-          "                  TOK_NULL\n" +
+          "                  TOK_FUNCTION\n" +
+          "                     TOK_INT\n" +
+          "                     TOK_NULL\n" +
           "               fmap\n" +
           "               TOK_FUNCTION\n" +
           "                  map\n" +

--- a/ql/src/test/queries/clientpositive/empty_result_ctas.q
+++ b/ql/src/test/queries/clientpositive/empty_result_ctas.q
@@ -1,0 +1,5 @@
+SET hive.cli.print.header=true;
+
+CREATE TABLE T1 (c1 int, c2 array<int>);
+CREATE TABLE T2 AS SELECT * FROM T1 LIMIT 0;
+DESCRIBE FORMATTED t2;

--- a/ql/src/test/queries/clientpositive/empty_result_ctas.q
+++ b/ql/src/test/queries/clientpositive/empty_result_ctas.q
@@ -1,5 +1,5 @@
 SET hive.cli.print.header=true;
 
-CREATE TABLE T1 (c1 int, c2 array<int>);
+CREATE TABLE T1 (c_primitive int, c_array array<int>, c_nested array<struct<f1:int, f2:map<int, double>, f3:array<char(10)>>>);
 CREATE TABLE T2 AS SELECT * FROM T1 LIMIT 0;
 DESCRIBE FORMATTED t2;

--- a/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
@@ -1,0 +1,59 @@
+PREHOOK: query: CREATE TABLE T1 (c1 int, c2 array<int>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@T1
+POSTHOOK: query: CREATE TABLE T1 (c1 int, c2 array<int>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@T1
+PREHOOK: query: CREATE TABLE T2 AS SELECT * FROM T1 LIMIT 0
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@T2
+POSTHOOK: query: CREATE TABLE T2 AS SELECT * FROM T1 LIMIT 0
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@T2
+POSTHOOK: Lineage: t2.c1 SIMPLE []
+POSTHOOK: Lineage: t2.c2 EXPRESSION []
+t1.c1	t1.c2
+PREHOOK: query: DESCRIBE FORMATTED t2
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@t2
+POSTHOOK: query: DESCRIBE FORMATTED t2
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@t2
+col_name	data_type	comment
+# col_name            	data_type           	comment             
+c1                  	int                 	                    
+c2                  	array<int>          	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   

--- a/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
@@ -1,8 +1,8 @@
-PREHOOK: query: CREATE TABLE T1 (c1 int, c2 array<int>)
+PREHOOK: query: CREATE TABLE T1 (c_primitive int, c_array array<int>, c_nested array<struct<f1:int, f2:map<int, double>, f3:array<char(10)>>>)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@T1
-POSTHOOK: query: CREATE TABLE T1 (c1 int, c2 array<int>)
+POSTHOOK: query: CREATE TABLE T1 (c_primitive int, c_array array<int>, c_nested array<struct<f1:int, f2:map<int, double>, f3:array<char(10)>>>)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@T1
@@ -18,9 +18,10 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@T2
-POSTHOOK: Lineage: t2.c1 SIMPLE []
-POSTHOOK: Lineage: t2.c2 EXPRESSION []
-t1.c1	t1.c2
+POSTHOOK: Lineage: t2.c_array EXPRESSION []
+POSTHOOK: Lineage: t2.c_nested EXPRESSION []
+POSTHOOK: Lineage: t2.c_primitive SIMPLE []
+t1.c_primitive	t1.c_array	t1.c_nested
 PREHOOK: query: DESCRIBE FORMATTED t2
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@t2
@@ -29,8 +30,9 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@t2
 col_name	data_type	comment
 # col_name            	data_type           	comment             
-c1                  	int                 	                    
-c2                  	array<int>          	                    
+c_primitive         	int                 	                    
+c_array             	array<int>          	                    
+c_nested            	array<struct<f1:int,f2:map<int,double>,f3:array<char(10)>>>	                    
 	 	 
 # Detailed Table Information	 	 
 Database:           	default             	 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When converting {{HiveValues([])}} which represents an operator never produces rows to AST handle array types.

AST representation of an array of int with NULL elements should be 
```
         TOK_SELEXPR
            TOK_FUNCTION
               array
               TOK_FUNCTION
                  TOK_INT
                  TOK_NULL
```


### Why are the changes needed?
Support array types

### Does this PR introduce _any_ user-facing change?
Yes. In case of CTAS statements when the query in the statement does not produce any rows and the source table has an array type column where the element type is other than string the target table still inherit the source table schema.

### How was this patch tested?
```
vn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=empty_result_ctas.q -pl itests/qtest -Pitests
```