### PR TITLE
HIVE-27259: Enhancing Hive Metastore common library support for Leader Election

### DIFF
--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -314,6 +314,12 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/Participant.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/Participant.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.common;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * This represents a participant or contestant for a Leader Selection at a given path, i.e. Leadership Group.
+ * <p>
+ * This also defines a bunch of important aspects of a participant, i.e., name of the participant, responsibilities
+ * if elected as the Leader, how to react to state change, how to relinquish leadership after being selected as
+ * a leader.
+ * </p>
+ * <p>
+ * Please note, if the assumed responsibilities are short/transient, the leadership is automatically forgone once the
+ * responsibilities are taken care of, or if the process/thread (aka participant) crashes or is killed.
+ * <br> If the responsibilities are long running or the leader does not willingly relinquish the power, external
+ * entities can request for the same, although it's upto the individual Leader whether to consider such requests.
+ * </p>
+ *
+ */
+public interface Participant {
+  /**
+   * This returns the Participant's name or identifier
+   *
+   * @return participant's name or identifier
+   */
+  String getParticipantName();
+
+  /**
+   * Defines the responsibilities if the participant is elected as the Leader.
+   *
+   * @return Responsibilities or the tasks to be executed if elected as the leader, we need to define a {@link Consumer}
+   * that has the {@link CuratorFramework} at its disposal, it should define the tasks
+   */
+  Consumer<CuratorFramework> getResponsibility();
+
+  /**
+   * This defines how to react to a connection state change notification.
+   *
+   * @return A {@link BiConsumer} implementation that accepts the {@link CuratorFramework} instance and the
+   * new {@link ConnectionState} and decides how to react to this change
+   */
+  BiConsumer<CuratorFramework, ConnectionState> getHowToReactToStateChange();
+
+  /**
+   * This sends a signal or request to the Leader to relinquish leadership.
+   * <br>It's upto the leader whether to honour such requests.
+   */
+  default void relinquishLeadershipResponsibility() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/SelectionCoordinator.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/SelectionCoordinator.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.common;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderSelector;
+import org.apache.curator.framework.recipes.leader.LeaderSelectorListener;
+import org.apache.curator.framework.state.ConnectionState;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * This is an abstraction over @{@link LeaderSelector} that enables participants to participate in 'Leader Selection'
+ * process in a distributed environment where there could be multiple similar contenders. Essentially it depends on
+ * a fault-tolerant distributed consensus algorithm or Atomic Broadcast. Here we are relying on Zookeeper's Atomic
+ * Broadcast protocol under through.
+ * <p>
+ * There are well defined <a href="https://zookeeper.apache.org/doc/current/recipes.html#sc_leaderElection">recipes</a>
+ * to use Zookeeper to implement higher order functions, i.e. Leader Election. Apache Curator has already implemented
+ * all the recipes, please refer here: https://curator.apache.org/curator-recipes/index.html
+ * </p>
+ * <p>
+ * Under the hood we are relying on Apache Curator's implementation of Leader Election recipe. In this implementation,
+ * once a leader is selected, the next election won't happen until the leader relinquishes its responsibility or the
+ * leader process is crashed or killed. Please note that this algorithm is 'fair', each participant will become leader
+ * in the same order Zookeeper received the participation requests.
+ * </p>
+ * <p>
+ * In a distributed environment, we often need to select one node as leader to coordinate the execution of a
+ * complex job.
+ * </p>
+ */
+public class SelectionCoordinator {
+  private final CuratorFramework client;
+
+  /**
+   * Instantiates a Selection Coordinator
+   *
+   * @param client this is the client to interact with Zookeeper
+   */
+  public SelectionCoordinator(CuratorFramework client) {
+    this.client = client;
+  }
+
+  /**
+   * The {@code executorService} defaults to null here.
+   * Otherwise, it is just another overloaded version of
+   * {@link SelectionCoordinator#participateInSelection(String, Participant, ExecutorService)}.
+   *
+   * @see SelectionCoordinator#participateInSelection(String, Participant, ExecutorService)
+   */
+  public LeaderSelector participateInSelection(String atPath, Participant participant) {
+    return participateInSelection(atPath, participant, null);
+  }
+
+  /**
+   * Enables a {@link Participant} to contest for an election at the given path.
+   *
+   * @param atPath the path for this leadership group, please note that each selection process should have a
+   *               dedicated path. This represents a node in Zookeeper's storage.
+   * @param participant a concrete implementation of {@link Participant}
+   * @param executorService the {@link ExecutorService} that would be used to execute the callbacks or change
+   *                        notifications, if null, the executor service would be managed by Curator
+   * @return the {@link LeaderSelector} object
+   */
+  public LeaderSelector participateInSelection(String atPath, Participant participant,
+      ExecutorService executorService) {
+    LeaderSelectorListener listener = new LeaderSelectorListener() {
+      @Override public void takeLeadership(CuratorFramework client) {
+        Consumer<CuratorFramework> responsibility = participant.getResponsibility();
+        responsibility.accept(client);
+      }
+
+      @Override public void stateChanged(CuratorFramework client, ConnectionState newState) {
+        BiConsumer<CuratorFramework, ConnectionState> reactor = participant.getHowToReactToStateChange();
+        reactor.accept(client, newState);
+      }
+    };
+
+    LeaderSelector leaderSelector =
+        (executorService != null) ? new LeaderSelector(client, atPath, executorService, listener) : new LeaderSelector(
+            client, atPath, listener);
+
+    leaderSelector.start();
+
+    return leaderSelector;
+  }
+}

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/ZooKeeperHiveHelper.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/ZooKeeperHiveHelper.java
@@ -416,4 +416,22 @@ public class ZooKeeperHiveHelper {
       throw e;
     }
   }
+
+  /**
+   * Returns an instance of {@link SelectionCoordinator} that enables a process/thread to participate in a Leader
+   * Election in a distributed setup.
+   *
+   * @param zooKeeperAclProvider {@link ACLProvider instance}, needed to interact with the Zookeeper
+   * @return an instance of {@link SelectionCoordinator}
+   * @throws Exception that may arise while instantiating the Zookeeper Client
+   *
+   * @see CuratorFramework
+   * @see SelectionCoordinator
+   * @see Participant
+   *
+   */
+  public SelectionCoordinator getSelectionCoordinator(ACLProvider zooKeeperAclProvider) throws Exception {
+    zooKeeperClient = startZookeeperClient(zooKeeperAclProvider, true);
+    return new SelectionCoordinator(zooKeeperClient);
+  }
 }

--- a/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/common/SelectionCoordinatorTest.java
+++ b/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/common/SelectionCoordinatorTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.common;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.leader.LeaderSelector;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.utils.CloseableUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+public class SelectionCoordinatorTest {
+
+  private static final String SELECTION_PATH = "/mutex/select/leader/for/test";
+  private final int BASE_SLEEP_TIME_MS = 1000;
+  private final int MAX_RETRIES = 3;
+  private final AtomicInteger leadershipChangeCount = new AtomicInteger();
+  private final List<CuratorFramework> clients = new ArrayList<>();
+  private TestingServer server = null;
+
+  @Before public void setUp() throws Exception {
+    server = new TestingServer();
+  }
+
+  @Test public void testLeadershipTransfer() throws InterruptedException {
+    CountDownLatch uberLatch = new CountDownLatch(3);
+    try {
+      simulateCrash(uberLatch);
+      simulateRelinquishingLeadership(uberLatch);
+      simulateAnotherThread(uberLatch);
+      uberLatch.await(1, TimeUnit.MINUTES);
+    } finally {
+      for (CuratorFramework client : clients)
+        CloseableUtils.closeQuietly(client);
+    }
+    assertEquals(3, leadershipChangeCount.get());
+  }
+
+  private void simulateAnotherThread(CountDownLatch uberLatch) {
+    new Thread(() -> {
+      CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(),
+          new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES));
+      client.start();
+      clients.add(client);
+
+      LeaderSelector selector = null;
+      CountDownLatch latch = new CountDownLatch(1);
+
+      try {
+        SelectionCoordinator coordinator = new SelectionCoordinator(client);
+        selector = coordinator.participateInSelection(SELECTION_PATH, new Participant() {
+          @Override public String getParticipantName() {
+            return "Client-3";
+          }
+
+          @Override public Consumer<CuratorFramework> getResponsibility() {
+            return curatorFramework -> {
+              System.out.printf("[Thread %s] %s is now the leader. Going to execute a long running task.%n",
+                  Thread.currentThread().getName(), this.getParticipantName());
+              System.out.printf("Number of leader selection so far %d%n", leadershipChangeCount.incrementAndGet());
+
+              takeAPause(2, TimeUnit.SECONDS);
+
+              latch.countDown();
+
+            };
+          }
+
+          @Override public BiConsumer<CuratorFramework, ConnectionState> getHowToReactToStateChange() {
+            return (curatorFramework, connectionState) -> System.out.println(
+                this.getParticipantName() + " - current state after state change: [" + connectionState + "]");
+          }
+        });
+        latch.await();
+      } catch (Exception e) {
+        System.err.println("Error in simulateAnotherThread: " + e.getMessage());
+      } finally {
+        CloseableUtils.closeQuietly(selector);
+        uberLatch.countDown();
+      }
+    }).start();
+  }
+
+  private void simulateRelinquishingLeadership(CountDownLatch uberLatch) {
+    new Thread(() -> {
+      CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(),
+          new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES));
+      client.start();
+      clients.add(client);
+
+      LeaderSelector selector = null;
+      CountDownLatch latch = new CountDownLatch(1);
+
+      try {
+        SelectionCoordinator coordinator = new SelectionCoordinator(client);
+        Participant participant = new Participant() {
+          private volatile boolean shouldRelinquishResponsibility = false;
+
+          @Override public String getParticipantName() {
+            return "Client-2";
+          }
+
+          @Override public Consumer<CuratorFramework> getResponsibility() {
+            return curatorFramework -> {
+              System.out.printf("%n[Thread %s] %s is now the leader. Going to execute the leadership responsibility.%n",
+                  Thread.currentThread().getName(), this.getParticipantName());
+              System.out.printf("%nNumber of leader selection so far %d%n", leadershipChangeCount.incrementAndGet());
+
+              stopMeAfterTimeout(100, TimeUnit.MILLISECONDS, this);
+
+              String[] words = new String[] { "Quick", "Brown", "Fox", "Dog", "Hello", "World" };
+              Random r = new Random();
+
+              while (!shouldRelinquishResponsibility) {
+                System.out.printf("[Thread %s] Current Process: %s, Word: %s%n", Thread.currentThread(),
+                    this.getParticipantName(), words[r.nextInt(6)]);
+              }
+
+              latch.countDown();
+
+            };
+          }
+
+          @Override public BiConsumer<CuratorFramework, ConnectionState> getHowToReactToStateChange() {
+            return (curatorFramework, connectionState) -> System.out.println(
+                this.getParticipantName() + " - current state after state change: [" + connectionState + "]");
+          }
+
+          @Override public synchronized void relinquishLeadershipResponsibility() {
+            this.shouldRelinquishResponsibility = true;
+          }
+        };
+
+        selector = coordinator.participateInSelection(SELECTION_PATH, participant);
+        latch.await();
+
+      } catch (Exception e) {
+        System.err.println("Error in simulateRelinquishingLeadership: " + e.getMessage());
+      } finally {
+        CloseableUtils.closeQuietly(selector);
+        uberLatch.countDown();
+      }
+    }).start();
+  }
+
+  private void simulateCrash(CountDownLatch uberLatch) {
+    new Thread(() -> {
+      CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(),
+          new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES));
+      client.start();
+      clients.add(client);
+
+      LeaderSelector selector = null;
+      CountDownLatch latch = new CountDownLatch(1);
+
+      try {
+        SelectionCoordinator coordinator = new SelectionCoordinator(client);
+        Participant participant = new Participant() {
+          @Override public String getParticipantName() {
+            return "Client-1";
+          }
+
+          @Override public Consumer<CuratorFramework> getResponsibility() {
+            return curatorFramework -> {
+              System.out.printf("%n[Thread %s] %s is now the leader. Going to perform a long running task.%n",
+                  Thread.currentThread().getName(), this.getParticipantName());
+              System.out.printf("%nNumber of leader selection so far %d%n", leadershipChangeCount.incrementAndGet());
+
+              try {
+                interruptMeAfterTimeout(500, TimeUnit.MILLISECONDS, Thread.currentThread());
+                takeAPause(2, TimeUnit.MINUTES);
+              } finally {
+                latch.countDown();
+              }
+
+            };
+          }
+
+          @Override public BiConsumer<CuratorFramework, ConnectionState> getHowToReactToStateChange() {
+            return (curatorFramework, connectionState) -> System.out.println(
+                this.getParticipantName() + " - current state after state change: [" + connectionState + "]");
+          }
+
+        };
+
+        selector = coordinator.participateInSelection(SELECTION_PATH, participant);
+        latch.await();
+        throw new RuntimeException("Emulating a crash");
+      } catch (Exception e) {
+        System.err.println("Error in simulateCrash: " + e.getMessage());
+
+      } finally {
+        CloseableUtils.closeQuietly(selector);
+        uberLatch.countDown();
+      }
+
+    }).start();
+  }
+
+  private void takeAPause(long timeout, TimeUnit timeUnit) {
+    try {
+      timeUnit.sleep(timeout);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void stopMeAfterTimeout(long timeout, TimeUnit timeUnit, Participant participant) {
+    new Thread(() -> {
+      takeAPause(timeout, timeUnit);
+      participant.relinquishLeadershipResponsibility();
+    }).start();
+  }
+
+  private void interruptMeAfterTimeout(long timeout, TimeUnit timeUnit, Thread thread) {
+    new Thread(() -> {
+      takeAPause(timeout, timeUnit);
+      thread.interrupt();
+    }).start();
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request? Why is this needed?
In a distributed environment, we often need to select a node as the leader to coordinate the execution of complex jobs. Working on a Hive Replication enhancement where we need to spawn threads with specialized work but we need to make sure that such an HS2 thread is running strictly on a single HS2 instance at a given moment.
We must enhance HMS common libraries to include the 'Leader Election' recipe.

### How was this tested?
I have included relevant unit tests in this PR and did manual verification.

### Does this PR introduce _any_ user-facing change?
No
