### PR TITLE
HIVE-27263: Upgrade `cyclonedx-maven-plugin` to 2.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <maven.versions.plugin.version>2.13.0</maven.versions.plugin.version>
     <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
-    <maven.cyclonedx.plugin.version>2.7.3</maven.cyclonedx.plugin.version>
+    <maven.cyclonedx.plugin.version>2.7.6</maven.cyclonedx.plugin.version>
     <!-- Library Dependency Versions -->
     <accumulo.version>1.10.1</accumulo.version>
     <ant.version>1.10.12</ant.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `cyclonedx-maven-plugin` to 2.7.6.

### Why are the changes needed?

2.7.6 will bring the latest bug fixes.

- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.6
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.5
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.4

Historically, there were some issue reports on the previous versions with the latest Maven.
- https://github.com/apache/spark/pull/40065
- https://github.com/apache/arrow/issues/35086

As of today, 2.7.6 is verified in Apache ORC/Parquet/Avro/Arrow/Spark communities.
- [ORC-1407: Upgrade cyclonedx-maven-plugin to 2.7.6](https://github.com/apache/orc/pull/1463)
- [PARQUET-2275: Upgrade cyclonedx-maven-plugin to 2.7.6](https://github.com/apache/parquet-mr/pull/1057)
- [AVRO: Bump cyclonedx-maven-plugin to 2.7.6](https://github.com/apache/avro/pull/2174)
- [GH-35086: Upgrade CycloneDX Maven plugin version](https://github.com/apache/arrow/pull/35092)
- [SPARK-42382: Upgrade cyclonedx-maven-plugin to 2.7.6](https://github.com/apache/spark/pull/40726)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.