### PR TITLE
HIVE-26930: Support for increased retention of Notification Logs and Change Manager entries

### DIFF
--- a/cli/src/test/org/apache/hadoop/hive/cli/TestCliSessionState.java
+++ b/cli/src/test/org/apache/hadoop/hive/cli/TestCliSessionState.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hive.cli;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ public class TestCliSessionState {
   @Test
   public void testgetDbName() throws Exception {
     SessionState.start(new HiveConf());
-    assertEquals(Warehouse.DEFAULT_DATABASE_NAME,
+    assertEquals(WarehouseUtils.DEFAULT_DATABASE_NAME,
         SessionState.get().getCurrentDatabase());
   }
 }

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/cli/HCatDriver.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/cli/HCatDriver.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -118,7 +119,7 @@ public class HCatDriver {
       }
     } else {
       // looks like a db operation
-      if (dbName.isEmpty() || dbName.equals(Warehouse.DEFAULT_DATABASE_NAME)) {
+      if (dbName.isEmpty() || dbName.equals(WarehouseUtils.DEFAULT_DATABASE_NAME)) {
         // We dont set perms or groups for default dir.
         return 0;
       } else {

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
@@ -45,11 +45,11 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
@@ -437,7 +437,7 @@ public class HCatUtil {
   public static Pair<String, String> getDbAndTableName(String tableName) throws IOException {
     String[] dbTableNametokens = tableName.split("\\.");
     if (dbTableNametokens.length == 1) {
-      return new Pair<String, String>(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+      return new Pair<String, String>(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
     } else if (dbTableNametokens.length == 2) {
       return new Pair<String, String>(dbTableNametokens[0], dbTableNametokens[1]);
     } else {

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
@@ -24,8 +24,8 @@ import java.io.Serializable;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hive.hcatalog.common.HCatUtil;
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
 import org.apache.hive.hcatalog.data.schema.HCatSchema;
@@ -76,7 +76,7 @@ public class HCatTableInfo implements Serializable {
     HCatSchema partitionColumns,
     StorerInfo storerInfo,
     Table table) {
-    this.databaseName = (databaseName == null) ? Warehouse.DEFAULT_DATABASE_NAME : databaseName;
+    this.databaseName = (databaseName == null) ? WarehouseUtils.DEFAULT_DATABASE_NAME : databaseName;
     this.tableName = tableName;
     this.dataColumns = dataColumns;
     this.table = table;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/InputJobInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/InputJobInfo.java
@@ -20,7 +20,7 @@ package org.apache.hive.hcatalog.mapreduce;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -86,7 +86,7 @@ public class InputJobInfo implements Serializable {
              String filter,
              Properties properties) {
     this.databaseName = (databaseName == null) ?
-      Warehouse.DEFAULT_DATABASE_NAME : databaseName;
+      WarehouseUtils.DEFAULT_DATABASE_NAME : databaseName;
     this.tableName = tableName;
     this.filter = filter;
     this.properties = properties == null ? new Properties() : properties;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/OutputJobInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/OutputJobInfo.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hive.hcatalog.data.schema.HCatSchema;
 
 /** The class used to serialize and store the output related information  */
@@ -95,7 +95,7 @@ public class OutputJobInfo implements Serializable {
   private OutputJobInfo(String databaseName,
               String tableName,
               Map<String, String> partitionValues) {
-    this.databaseName = (databaseName == null) ? Warehouse.DEFAULT_DATABASE_NAME : databaseName;
+    this.databaseName = (databaseName == null) ? WarehouseUtils.DEFAULT_DATABASE_NAME : databaseName;
     this.tableName = tableName;
     this.partitionValues = partitionValues;
     this.properties = new Properties();

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestPermsGrp.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestPermsGrp.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.Type;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -117,7 +118,7 @@ public class TestPermsGrp {
   @Test
   public void testCustomPerms() throws Exception {
 
-    String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     String tblName = "simptbl";
     String typeName = "Person";
 
@@ -156,7 +157,7 @@ public class TestPermsGrp {
 
       // And no metadata gets created.
       try {
-        msc.getTable(Warehouse.DEFAULT_DATABASE_NAME, tblName);
+        msc.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tblName);
         fail();
       } catch (Exception e) {
         assertTrue(e instanceof NoSuchObjectException);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestSemanticAnalysis.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/cli/TestSemanticAnalysis.java
@@ -20,10 +20,10 @@ package org.apache.hive.hcatalog.cli;
 
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -90,7 +90,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
   public void testCreateTblWithLowerCasePartNames() throws Exception {
     driver.run("drop table junit_sem_analysis");
     CommandProcessorResponse resp = driver.run("create table junit_sem_analysis (a int) partitioned by (B string) stored as TEXTFILE");
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     assertEquals("Partition key name case problem", "b", tbl.getPartitionKeys().get(0).getName());
     driver.run("drop table junit_sem_analysis");
   }
@@ -103,13 +103,13 @@ public class TestSemanticAnalysis extends HCatBaseTest {
     driver.run("alter table junit_sem_analysis add partition (b='2010-10-10')");
     hcatDriver.run("alter table junit_sem_analysis partition (b='2010-10-10') set fileformat RCFILE");
 
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     assertEquals(TextInputFormat.class.getName(), tbl.getSd().getInputFormat());
     assertEquals(HiveIgnoreKeyTextOutputFormat.class.getName(), tbl.getSd().getOutputFormat());
 
     List<String> partVals = new ArrayList<String>(1);
     partVals.add("2010-10-10");
-    Partition part = client.getPartition(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME, partVals);
+    Partition part = client.getPartition(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME, partVals);
 
     assertEquals(RCFileInputFormat.class.getName(), part.getSd().getInputFormat());
     assertEquals(RCFileOutputFormat.class.getName(), part.getSd().getOutputFormat());
@@ -160,7 +160,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
 
     hcatDriver.run("drop table " + TBL_NAME);
     hcatDriver.run("create table " + TBL_NAME + " (a int) stored as RCFILE");
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     List<FieldSchema> cols = tbl.getSd().getCols();
     assertEquals(1, cols.size());
     assertTrue(cols.get(0).equals(new FieldSchema("a", "int", null)));
@@ -168,7 +168,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
     assertEquals(RCFileOutputFormat.class.getName(), tbl.getSd().getOutputFormat());
 
     hcatDriver.run("create table if not exists junit_sem_analysis (a int) stored as RCFILE");
-    tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     cols = tbl.getSd().getCols();
     assertEquals(1, cols.size());
     assertTrue(cols.get(0).equals(new FieldSchema("a", "int", null)));
@@ -217,7 +217,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
     hcatDriver.run("alter table junit_sem_analysis add columns (d tinyint)");
 
     hcatDriver.run("describe extended junit_sem_analysis");
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     List<FieldSchema> cols = tbl.getSd().getCols();
     assertEquals(2, cols.size());
     assertTrue(cols.get(0).equals(new FieldSchema("a1", "tinyint", null)));
@@ -239,11 +239,11 @@ public class TestSemanticAnalysis extends HCatBaseTest {
     hcatDriver.run("drop table oldname");
     hcatDriver.run("drop table newname");
     hcatDriver.run("create table oldname (a int)");
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, "oldname");
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "oldname");
     assertTrue("The old table location is: " + tbl.getSd().getLocation(), tbl.getSd().getLocation().contains("oldname"));
 
     hcatDriver.run("alter table oldname rename to newNAME");
-    tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, "newname");
+    tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "newname");
     // since the oldname table is not under its database (See HIVE-15059), the renamed oldname table will keep
     // its location after HIVE-14909. I changed to check the existence of the newname table and its name instead
     // of verifying its location
@@ -260,7 +260,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
     hcatDriver.run("drop table " + TBL_NAME);
     hcatDriver.run("create table " + TBL_NAME + " (a int) partitioned by (b string) stored as RCFILE");
 
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     assertEquals(RCFileInputFormat.class.getName(), tbl.getSd().getInputFormat());
     assertEquals(RCFileOutputFormat.class.getName(), tbl.getSd().getOutputFormat());
 
@@ -272,7 +272,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
         "outputdriver 'yourdriver'");
     hcatDriver.run("desc extended " + TBL_NAME);
 
-    tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     assertEquals(RCFileInputFormat.class.getName(), tbl.getSd().getInputFormat());
     assertEquals(RCFileOutputFormat.class.getName(), tbl.getSd().getOutputFormat());
 
@@ -329,7 +329,7 @@ public class TestSemanticAnalysis extends HCatBaseTest {
         "'org.apache.hadoop.hive.ql.io.RCFileOutputFormat' inputdriver 'mydriver' outputdriver 'yourdriver' ";
     hcatDriver.run(query);
 
-    Table tbl = client.getTable(Warehouse.DEFAULT_DATABASE_NAME, TBL_NAME);
+    Table tbl = client.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, TBL_NAME);
     assertEquals(RCFileInputFormat.class.getName(), tbl.getSd().getInputFormat());
     assertEquals(RCFileOutputFormat.class.getName(), tbl.getSd().getOutputFormat());
 

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -38,12 +38,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.StorageFormats;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.hive.serde.serdeConstants;
@@ -91,7 +91,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
   private static final Path TEST_TMP_DIR = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));
 
-  protected static String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+  protected static String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
   protected static final String TABLE_NAME = "testHCatMapReduceTable";
 
   private static List<HCatRecord> writeRecords = new ArrayList<HCatRecord>();
@@ -158,7 +158,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
   @After
   public void deleteTable() throws Exception {
     try {
-      String databaseName = (dbName == null) ? Warehouse.DEFAULT_DATABASE_NAME : dbName;
+      String databaseName = (dbName == null) ? WarehouseUtils.DEFAULT_DATABASE_NAME : dbName;
 
       client.dropTable(databaseName, tableName);
       // in case of external table, drop the table contents as well
@@ -181,7 +181,7 @@ public abstract class HCatMapReduceTest extends HCatBaseTest {
     // SerDe is in the disabled serdes list.
     Assume.assumeTrue(!DISABLED_SERDES.contains(serdeClass));
 
-    String databaseName = (dbName == null) ? Warehouse.DEFAULT_DATABASE_NAME : dbName;
+    String databaseName = (dbName == null) ? WarehouseUtils.DEFAULT_DATABASE_NAME : dbName;
     try {
       client.dropTable(databaseName, tableName);
     } catch (Exception e) {

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatPartitionPublish.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatPartitionPublish.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
@@ -38,13 +39,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
-import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileOutputFormat;
 import org.apache.hadoop.hive.serde.serdeConstants;
@@ -234,7 +233,7 @@ public class TestHCatPartitionPublish {
   }
 
   private void createTable(String dbName, String tableName) throws Exception {
-    String databaseName = (dbName == null) ? Warehouse.DEFAULT_DATABASE_NAME
+    String databaseName = (dbName == null) ? WarehouseUtils.DEFAULT_DATABASE_NAME
         : dbName;
     try {
       msc.dropTable(databaseName, tableName);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestPassProperties.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestPassProperties.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -101,7 +101,7 @@ public class TestPassProperties {
       TextInputFormat.setInputPaths(job, INPUT_FILE_NAME);
 
       HCatOutputFormat.setOutput(job, OutputJobInfo.create(
-          Warehouse.DEFAULT_DATABASE_NAME, "bad_props_table", null));
+          WarehouseUtils.DEFAULT_DATABASE_NAME, "bad_props_table", null));
       job.setOutputFormatClass(HCatOutputFormat.class);
       HCatOutputFormat.setSchema(job, getSchema());
       job.setNumReduceTasks(0);

--- a/hcatalog/hcatalog-pig-adapter/src/main/java/org/apache/hive/hcatalog/pig/PigHCatUtil.java
+++ b/hcatalog/hcatalog-pig-adapter/src/main/java/org/apache/hive/hcatalog/pig/PigHCatUtil.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hive.hcatalog.common.HCatConstants;
@@ -71,7 +71,7 @@ class PigHCatUtil {
   private static final Logger LOG = LoggerFactory.getLogger(PigHCatUtil.class);
 
   static final int PIG_EXCEPTION_CODE = 1115; // http://wiki.apache.org/pig/PigErrorHandlingFunctionalSpecification#Error_codes
-  private static final String DEFAULT_DB = Warehouse.DEFAULT_DATABASE_NAME;
+  private static final String DEFAULT_DB = WarehouseUtils.DEFAULT_DATABASE_NAME;
 
   private final Map<Pair<String, String>, Table> hcatTableCache =
     new HashMap<Pair<String, String>, Table>();

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderEncryption.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderEncryption.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.common.io.SessionStream;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.io.StorageFormats;
@@ -331,7 +331,7 @@ public class TestHCatLoaderEncryption {
     job.setInputFormatClass(HCatInputFormat.class);
     job.setOutputFormatClass(TextOutputFormat.class);
 
-    HCatInputFormat.setInput(job, Warehouse.DEFAULT_DATABASE_NAME, ENCRYPTED_TABLE, null);
+    HCatInputFormat.setInput(job, WarehouseUtils.DEFAULT_DATABASE_NAME, ENCRYPTED_TABLE, null);
 
     job.setMapOutputKeyClass(BytesWritable.class);
     job.setMapOutputValueClass(Text.class);

--- a/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
+++ b/hcatalog/server-extensions/src/main/java/org/apache/hive/hcatalog/listener/DbNotificationListener.java
@@ -23,7 +23,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +46,6 @@ import org.apache.hadoop.hive.metastore.RawStore;
 import org.apache.hadoop.hive.metastore.RawStoreProxy;
 import org.apache.hadoop.hive.metastore.ReplChangeManager;
 import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -136,6 +134,7 @@ import org.apache.hadoop.hive.metastore.messaging.DeletePartitionColumnStatMessa
 import org.apache.hadoop.hive.metastore.tools.SQLGenerator;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hive.hcatalog.data.Pair;
 import org.slf4j.Logger;
@@ -407,7 +406,7 @@ public class DbNotificationListener extends TransactionalMetaStoreEventListener 
           fileIterator = Collections.emptyIterator();
         }
         PartitionFiles partitionFiles =
-            new PartitionFiles(Warehouse.makePartName(t.getPartitionKeys(), p.getValues()), fileIterator);
+            new PartitionFiles(WarehouseUtils.makePartName(t.getPartitionKeys(), p.getValues()), fileIterator);
         return partitionFiles;
       } catch (MetaException e) {
         throw new RuntimeException(e);

--- a/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
+++ b/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatClientHMSImpl.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -53,6 +52,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.api.UnknownTableException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -891,7 +891,7 @@ public class HCatClientHMSImpl extends HCatClient {
 
   private String checkDB(String name) {
     if (StringUtils.isEmpty(name)) {
-      return Warehouse.DEFAULT_DATABASE_NAME;
+      return WarehouseUtils.DEFAULT_DATABASE_NAME;
     } else {
       return name;
     }

--- a/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatPartition.java
+++ b/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatPartition.java
@@ -27,12 +27,12 @@ import java.util.Map;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hive.hcatalog.common.HCatException;
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
 import org.apache.hive.hcatalog.data.schema.HCatSchemaUtils;
@@ -50,7 +50,7 @@ public class HCatPartition {
 
   private HCatTable hcatTable;
   private String tableName;
-  private String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+  private String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
   private List<String> values;
   private int createTime;
   private int lastAccessTime;
@@ -138,7 +138,7 @@ public class HCatPartition {
     if (sd.getLocation() == null) {
       LOG.warn("Partition location is not set! Attempting to construct default partition location.");
       try {
-        String partName = Warehouse.makePartName(HCatSchemaUtils.getFieldSchemas(hcatTable.getPartCols()), values);
+        String partName = WarehouseUtils.makePartName(HCatSchemaUtils.getFieldSchemas(hcatTable.getPartCols()), values);
         sd.setLocation(new Path(hcatTable.getSd().getLocation(), partName).toString());
       }
       catch(MetaException exception) {

--- a/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatTable.java
+++ b/hcatalog/webhcat/java-client/src/main/java/org/apache/hive/hcatalog/api/HCatTable.java
@@ -31,12 +31,12 @@ import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileOutputFormat;
@@ -108,7 +108,7 @@ public class HCatTable {
   public static final String DEFAULT_INPUT_FORMAT_CLASS = org.apache.hadoop.mapred.TextInputFormat.class.getName();
   public static final String DEFAULT_OUTPUT_FORMAT_CLASS = org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat.class.getName();
 
-  private String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+  private String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
   private String tableName;
   private HiveConf conf;
   private String tableType;
@@ -122,7 +122,7 @@ public class HCatTable {
   private String owner;
 
   public HCatTable(String dbName, String tableName) {
-    this.dbName = StringUtils.isBlank(dbName)? Warehouse.DEFAULT_DATABASE_NAME : dbName;
+    this.dbName = StringUtils.isBlank(dbName)? WarehouseUtils.DEFAULT_DATABASE_NAME : dbName;
     this.tableName = tableName;
     this.sd = new StorageDescriptor();
     this.sd.setInputFormat(DEFAULT_INPUT_FORMAT_CLASS);

--- a/hcatalog/webhcat/java-client/src/test/java/org/apache/hive/hcatalog/api/TestHCatClient.java
+++ b/hcatalog/webhcat/java-client/src/test/java/org/apache/hive/hcatalog/api/TestHCatClient.java
@@ -38,13 +38,13 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
 import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.PartitionEventType;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
 import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileOutputFormat;
@@ -54,9 +54,7 @@ import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe;
-import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hive.hcatalog.DerbyPolicy;
 import org.apache.hive.hcatalog.api.repl.Command;
 import org.apache.hive.hcatalog.api.repl.ReplicationTask;
@@ -156,7 +154,7 @@ public class TestHCatClient {
   }
 
   public static String makePartLocation(HCatTable table, Map<String, String> partitionSpec) throws MetaException {
-    return (new Path(table.getSd().getLocation(), Warehouse.makePartPath(partitionSpec))).toUri().toString();
+    return (new Path(table.getSd().getLocation(), WarehouseUtils.makePartPath(partitionSpec))).toUri().toString();
   }
 
   @Test

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/mapreduce/TestSequenceFileReadWrite.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/mapreduce/TestSequenceFileReadWrite.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.Ignore;
 import java.util.Iterator;
 
@@ -32,7 +34,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -178,7 +179,7 @@ public class TestSequenceFileReadWrite {
     TextInputFormat.setInputPaths(job, inputFileName);
 
     HCatOutputFormat.setOutput(job, OutputJobInfo.create(
-        Warehouse.DEFAULT_DATABASE_NAME, "demo_table_2", null));
+        WarehouseUtils.DEFAULT_DATABASE_NAME, "demo_table_2", null));
     job.setOutputFormatClass(HCatOutputFormat.class);
     HCatOutputFormat.setSchema(job, getSchema());
     job.setNumReduceTasks(0);
@@ -225,7 +226,7 @@ public class TestSequenceFileReadWrite {
     TextInputFormat.setInputPaths(job, inputFileName);
 
     HCatOutputFormat.setOutput(job, OutputJobInfo.create(
-        Warehouse.DEFAULT_DATABASE_NAME, "demo_table_3", null));
+        WarehouseUtils.DEFAULT_DATABASE_NAME, "demo_table_3", null));
     job.setOutputFormatClass(HCatOutputFormat.class);
     HCatOutputFormat.setSchema(job, getSchema());
     assertTrue(job.waitForCompletion(true));

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStoreUpdateUsingEvents.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStoreUpdateUsingEvents.java
@@ -43,7 +43,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.apache.hadoop.hive.metastore.StatisticsTestUtils.assertEqualStatistics;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 public class TestCachedStoreUpdateUsingEvents {
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolCatalogOps.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolCatalogOps.java
@@ -51,8 +51,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 public class TestSchemaToolCatalogOps {
   private static MetastoreSchemaTool schemaTool;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/history/TestHiveHistory.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/history/TestHiveHistory.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hive.common.LogUtils.LogInitializationException;
 import org.apache.hadoop.hive.common.io.SessionStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.history.HiveHistory.Keys;
@@ -108,7 +108,7 @@ public class TestHiveHistory {
       cols.add("key");
       cols.add("value");
       for (String src : srctables) {
-        db.dropTable(Warehouse.DEFAULT_DATABASE_NAME, src, true, true);
+        db.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, src, true, true);
         db.createTable(src, cols, null, TextInputFormat.class,
             IgnoreKeyTextOutputFormat.class);
         db.loadTable(hadoopDataFile[i], src,

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/metadata/TestSemanticAnalyzerHookLoading.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/metadata/TestSemanticAnalyzerHookLoading.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
@@ -53,7 +53,7 @@ public class TestSemanticAnalyzerHookLoading {
 
     run("create table testDL (a int)", conf);
 
-    Map<String,String> params = Hive.get(conf).getTable(Warehouse.DEFAULT_DATABASE_NAME, "testDL").getParameters();
+    Map<String,String> params = Hive.get(conf).getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "testDL").getParameters();
 
     assertEquals(DummyCreateTableHook.class.getName(),params.get("createdBy"));
     assertEquals("Open Source rocks!!", params.get("Message"));

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -136,7 +136,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.apache.hadoop.hive.common.repl.ReplConst.SOURCE_OF_REPLICATION;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_ACKNOWLEDGEMENT;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestStatsReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestStatsReplicationScenarios.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.parse;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -32,6 +31,7 @@ import org.apache.hadoop.hive.metastore.messaging.json.gzip.GzipJSONMessageEncod
 import org.apache.hadoop.hive.metastore.InjectableBehaviourObjectStore;
 import org.apache.hadoop.hive.metastore.InjectableBehaviourObjectStore.BehaviourInjection;
 import org.apache.hadoop.hive.metastore.InjectableBehaviourObjectStore.CallerArguments;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveMetaStoreClientWithLocalCache;
 import org.apache.hadoop.hive.shims.Utils;
 import org.apache.hadoop.fs.FileSystem;
@@ -199,7 +199,7 @@ public class TestStatsReplicationScenarios {
 
       Map<String, String> rParams = collectStatsParams(rPart.getParameters());
       Map<String, String> pParams = collectStatsParams(pPart.getParameters());
-      String partName = Warehouse.makePartName(partKeys, pPart.getValues());
+      String partName = WarehouseUtils.makePartName(partKeys, pPart.getValues());
       Assert.assertEquals("Mismatch in stats parameters for partition " + partName + " of table " + tableName,
                           pParams, rParams);
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hive.metastore.api.SQLUniqueConstraint;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UniqueConstraintsRequest;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.exec.repl.ReplDumpWork;
@@ -572,12 +572,12 @@ public class WarehouseInstance implements Closeable {
   }
 
   public List<SQLUniqueConstraint> getUniqueConstraintList(String dbName, String tblName) throws Exception {
-    return client.getUniqueConstraints(new UniqueConstraintsRequest(Warehouse.DEFAULT_CATALOG_NAME, dbName, tblName));
+    return client.getUniqueConstraints(new UniqueConstraintsRequest(WarehouseUtils.DEFAULT_CATALOG_NAME, dbName, tblName));
   }
 
   public List<SQLNotNullConstraint> getNotNullConstraintList(String dbName, String tblName) throws Exception {
     return client.getNotNullConstraints(
-            new NotNullConstraintsRequest(Warehouse.DEFAULT_CATALOG_NAME, dbName, tblName));
+            new NotNullConstraintsRequest(WarehouseUtils.DEFAULT_CATALOG_NAME, dbName, tblName));
   }
 
   ReplicationV1CompatRule getReplivationV1CompatRule(List<String> testsToSkip) {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestUtil.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 import java.io.BufferedOutputStream;
 import java.io.File;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/create/CreateMacroAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/create/CreateMacroAnalyzer.java
@@ -27,9 +27,9 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionUtils;
@@ -80,7 +80,7 @@ public class CreateMacroAnalyzer extends BaseSemanticAnalyzer {
     CreateMacroDesc desc = new CreateMacroDesc(macroName, macroColumnNames, macroColumnTypes, body);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
 
-    Database database = getDatabase(Warehouse.DEFAULT_DATABASE_NAME);
+    Database database = getDatabase(WarehouseUtils.DEFAULT_DATABASE_NAME);
     // This restricts macro creation to privileged users.
     outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_NO_LOCK));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/drop/DropMacroAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/macro/drop/DropMacroAnalyzer.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.ddl.function.macro.drop;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
@@ -60,7 +60,7 @@ public class DropMacroAnalyzer extends BaseSemanticAnalyzer {
     DropMacroDesc desc = new DropMacroDesc(macroName);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
 
-    Database database = getDatabase(Warehouse.DEFAULT_DATABASE_NAME);
+    Database database = getDatabase(WarehouseUtils.DEFAULT_DATABASE_NAME);
     // This restricts macro dropping to privileged users.
     outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_NO_LOCK));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionAnalyzer.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.ddl.table.partition.add;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.TableName;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
@@ -101,7 +101,7 @@ public class AlterTableAddPartitionAnalyzer extends AbstractAddPartitionAnalyzer
         loadTableWork.setInheritTableSpecs(true);
         try {
           partitionDesc.setLocation(new Path(table.getDataLocation(),
-              Warehouse.makePartPath(partitionDesc.getPartSpec())).toString());
+              WarehouseUtils.makePartPath(partitionDesc.getPartSpec())).toString());
         } catch (MetaException ex) {
           throw new SemanticException("Could not determine partition path due to: " + ex.getMessage(), ex);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/add/AlterTableAddPartitionOperation.java
@@ -27,12 +27,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidReaderWriteIdList;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;
@@ -42,7 +42,6 @@ import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Table;
-import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 
 /**
  * Operation process of adding a partition to a table.
@@ -224,7 +223,7 @@ public class AlterTableAddPartitionOperation extends DDLOperation<AlterTableAddP
 
   private String getPartitionName(Table table, Partition partition) throws HiveException {
     try {
-      return Warehouse.makePartName(table.getPartitionKeys(), partition.getValues());
+      return WarehouseUtils.makePartName(table.getPartitionKeys(), partition.getValues());
     } catch (MetaException e) {
       throw new HiveException(e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/archive/AlterTableArchiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/archive/AlterTableArchiveUtils.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.exec.ArchiveUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
@@ -71,7 +72,7 @@ final class AlterTableArchiveUtils {
   static boolean partitionInCustomLocation(Table table, Partition partition) throws HiveException {
     String subdir = null;
     try {
-      subdir = Warehouse.makePartName(table.getPartCols(), partition.getValues());
+      subdir = WarehouseUtils.makePartName(table.getPartCols(), partition.getValues());
     } catch (MetaException e) {
       throw new HiveException("Unable to get partition's directory", e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ArchiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ArchiveUtils.java
@@ -31,10 +31,10 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
@@ -100,7 +100,7 @@ public final class ArchiveUtils {
     public Path createPath(Table tbl) throws HiveException {
       String prefixSubdir;
       try {
-        prefixSubdir = Warehouse.makePartName(fields, values);
+        prefixSubdir = WarehouseUtils.makePartName(fields, values);
       } catch (MetaException e) {
         throw new HiveException("Unable to get partitions directories prefix", e);
       }
@@ -115,7 +115,7 @@ public final class ArchiveUtils {
      */
     public String getName() throws HiveException {
       try {
-        return Warehouse.makePartName(fields, values);
+        return WarehouseUtils.makePartName(fields, values);
       } catch (MetaException e) {
         throw new HiveException("Unable to create partial name", e);
       }
@@ -225,7 +225,7 @@ public final class ArchiveUtils {
     List<FieldSchema> fields = p.getTable().getPartCols().subList(0, level);
     List<String> values = p.getValues().subList(0, level);
     try {
-      return Warehouse.makePartName(fields, values);
+      return WarehouseUtils.makePartName(fields, values);
     } catch (MetaException e) {
       throw new HiveException("Wasn't able to generate name" +
                                 " for partial specification");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.BinaryColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.SkewedInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ddl.ShowUtils;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableOperation;
 import org.apache.hadoop.hive.ql.metadata.CheckConstraint;
@@ -1048,7 +1048,7 @@ public class DDLPlanUtils {
     Map<String, String> serdeParams = serdeInfo.getParameters();
     if (table.getStorageHandler() == null) {
       // If serialization.format property has the default value, it will not to be included in SERDE properties
-      if (Warehouse.DEFAULT_SERIALIZATION_FORMAT.equals(serdeParams.get(serdeConstants.SERIALIZATION_FORMAT))) {
+      if (WarehouseUtils.DEFAULT_SERIALIZATION_FORMAT.equals(serdeParams.get(serdeConstants.SERIALIZATION_FORMAT))) {
         serdeParams.remove(serdeConstants.SERIALIZATION_FORMAT);
       }
       if (!serdeParams.isEmpty()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -111,6 +111,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.DriverState;
@@ -2904,7 +2905,7 @@ public final class Utilities {
       for (Map.Entry<Path, Optional<List<Path>>> partEntry : allPartition.entrySet()) {
         Path partPath = partEntry.getKey();
         Map<String, String> fullPartSpec = Maps.newLinkedHashMap(partSpec);
-        String staticParts =  Warehouse.makeDynamicPartName(partSpec);
+        String staticParts =  WarehouseUtils.makeDynamicPartName(partSpec);
         Path computedPath = partPath;
         if (!staticParts.isEmpty() ) {
           computedPath = new Path(new Path(partPath.getParent(), staticParts), partPath.getName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -99,6 +99,7 @@ import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_DB_UNDER_FAILOVER_REV_SYNC_PENDING;
 import static org.apache.hadoop.hive.ql.hooks.EnforceReadOnlyDatabaseHook.READONLY;
 import static org.apache.hadoop.hive.common.repl.ReplConst.READ_ONLY_HOOK;
 import static org.apache.hadoop.hive.common.repl.ReplConst.REPL_RESUME_STARTED_AFTER_FAILOVER;
@@ -651,12 +652,14 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
               LOG.debug("Database {} properties before removal {}", work.getTargetDatabase(), params);
               params.remove(REPL_RESUME_STARTED_AFTER_FAILOVER);
               params.remove(SOURCE_OF_REPLICATION);
+              params.remove(REPL_DB_UNDER_FAILOVER_REV_SYNC_PENDING); // This database property needs to be unset once optimized
+                                                                      // bootstrap is completed
               if (!work.shouldFailover()) {
                 params.remove(REPL_FAILOVER_ENDPOINT);
               }
 
-              LOG.info("Removed {} property from database {} after successful optimised bootstrap load.",
-                  SOURCE_OF_REPLICATION, work.getTargetDatabase());
+              LOG.info("Removed properties [{}, {}] from database {} after successful optimised bootstrap load.",
+                  SOURCE_OF_REPLICATION, REPL_DB_UNDER_FAILOVER_REV_SYNC_PENDING, work.getTargetDatabase());
 
               int failbackCount = 1 + NumberUtils.toInt(params.getOrDefault(ReplConst.REPL_METRICS_FAILBACK_COUNT, "0"), 0);
               LOG.info("Replication Metrics: Setting replication metrics failback count for database: {} to: {} ", db.getName(), failbackCount);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/events/filesystem/FSTableEvent.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/events/filesystem/FSTableEvent.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ddl.table.partition.add.AlterTableAddPartitionDesc;
 import org.apache.hadoop.hive.ql.exec.repl.bootstrap.events.TableEvent;
 import org.apache.hadoop.hive.ql.metadata.Table;
@@ -137,7 +137,7 @@ public class FSTableEvent implements TableEvent {
     List<String> partitions = new ArrayList<>();
     try {
       for (Partition partition : metadata.getPartitions()) {
-        String partName = Warehouse.makePartName(tblDesc.getPartCols(), partition.getValues());
+        String partName = WarehouseUtils.makePartName(tblDesc.getPartCols(), partition.getValues());
         partitions.add(partName);
       }
     } catch (MetaException e) {
@@ -158,7 +158,7 @@ public class FSTableEvent implements TableEvent {
          * this is required for file listing of all files in a partition for managed table as described in
          * {@link org.apache.hadoop.hive.ql.exec.repl.bootstrap.events.filesystem.BootstrapEventsIterator}
          */
-        location = new Path(fromPath, Warehouse.makePartName(tblDesc.getPartCols(), partition.getValues())).toString();
+        location = new Path(fromPath, WarehouseUtils.makePartName(tblDesc.getPartCols(), partition.getValues())).toString();
       }
 
       ColumnStatistics columnStatistics = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.table.partition.add.AlterTableAddPartitionDesc;
 import org.apache.hadoop.hive.ql.ddl.table.partition.drop.AlterTableDropPartitionDesc;
@@ -302,7 +302,7 @@ public class LoadPartitions {
       boolean copyAtLoad = context.hiveConf.getBoolVar(HiveConf.ConfVars.REPL_RUN_DATA_COPY_TASKS_ON_TARGET);
       Task<?> copyTask = ReplCopyTask.getLoadCopyTask(
         event.replicationSpec(),
-        new Path(event.dataPath() + Path.SEPARATOR + Warehouse.makePartPath(partSpec.getPartSpec())),
+        new Path(event.dataPath() + Path.SEPARATOR + WarehouseUtils.makePartPath(partSpec.getPartSpec())),
         replicaWarehousePartitionLocation,
         context.hiveConf, copyAtLoad, false, (new Path(context.dumpDirectory)).getParent().toString(),
         this.metricCollector
@@ -324,7 +324,7 @@ public class LoadPartitions {
 
   private Path locationOnReplicaWarehouse(Table table, AlterTableAddPartitionDesc.PartitionDesc partSpec)
       throws MetaException, HiveException {
-    String child = Warehouse.makePartPath(partSpec.getPartSpec());
+    String child = WarehouseUtils.makePartPath(partSpec.getPartSpec());
     if (tableDesc.isExternal()) {
       String externalLocation =
           ReplExternalTables.externalTableLocation(context.hiveConf, partSpec.getLocation());

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/EnforceReadOnlyTables.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/EnforceReadOnlyTables.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.hooks;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 import java.util.Arrays;
 import java.util.List;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -90,10 +90,10 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.TxnType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.txn.CompactionState;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
@@ -3426,7 +3426,7 @@ public class AcidUtils {
     String partitionName = null;
     if (partitionSpec != null) {
       try {
-        partitionName = Warehouse.makePartName(partitionSpec, false);
+        partitionName = WarehouseUtils.makePartName(partitionSpec, false);
       } catch (MetaException e) {
         throw new SemanticException("partition " + partitionSpec.toString() + " not found");
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.UpdateTransactionalStatsRequest;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
 import org.apache.hadoop.hive.ql.io.HdfsUtils;
 import org.apache.hadoop.hive.metastore.HiveMetaException;
@@ -126,7 +127,6 @@ import org.apache.hadoop.hive.metastore.PartitionDropOptions;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.SynchronizedMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
 import org.apache.hadoop.hive.metastore.api.AllTableConstraintsRequest;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
@@ -2905,7 +2905,7 @@ public class Hive {
 
   private static Path genPartPathFromTable(Table tbl, Map<String, String> partSpec,
       Path tblDataLocationPath) throws MetaException {
-    Path partPath = new Path(tbl.getDataLocation(), Warehouse.makePartPath(partSpec));
+    Path partPath = new Path(tbl.getDataLocation(), WarehouseUtils.makePartPath(partSpec));
     return new Path(tblDataLocationPath.toUri().getScheme(),
         tblDataLocationPath.toUri().getAuthority(), partPath.toUri().getPath());
   }
@@ -3173,7 +3173,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
       List<String> partitionNames = new LinkedList<>();
       for(PartitionDetails details : partitionDetailsMap.values()) {
         if (details.fullSpec != null && !details.fullSpec.isEmpty()) {
-          partitionNames.add(Warehouse.makeDynamicPartNameNoTrailingSeperator(details.fullSpec));
+          partitionNames.add(WarehouseUtils.makeDynamicPartNameNoTrailingSeperator(details.fullSpec));
         }
       }
       List<Partition> partitions = Hive.get().getPartitionsByNames(tbl, partitionNames);
@@ -4383,7 +4383,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
               || partitionWithoutSD.getRelativePath().isEmpty()) {
             if (tbl.getDataLocation() != null) {
               Path partPath = new Path(tbl.getDataLocation(),
-                  Warehouse.makePartName(tbl.getPartCols(),
+                  WarehouseUtils.makePartName(tbl.getPartCols(),
                       partitionWithoutSD.getValues()));
               partitionLocation = partPath.toString();
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Partition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Partition.java
@@ -32,13 +32,13 @@ import java.util.Properties;
 import org.apache.hadoop.hive.common.StringInternUtils;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Order;
@@ -172,7 +172,7 @@ public class Partition implements Serializable {
           // set default if location is not set and this is a physical
           // table partition (not a view partition)
           if (table.getDataLocation() != null) {
-            Path partPath = new Path(table.getDataLocation(), Warehouse.makePartName(table.getPartCols(), tPartition.getValues()));
+            Path partPath = new Path(table.getDataLocation(), WarehouseUtils.makePartName(table.getPartCols(), tPartition.getValues()));
             tPartition.getSd().setLocation(partPath.toString());
           }
         }
@@ -199,7 +199,7 @@ public class Partition implements Serializable {
 
   public String getName() {
     try {
-      return Warehouse.makePartName(table.getPartCols(), tPartition.getValues());
+      return WarehouseUtils.makePartName(table.getPartCols(), tPartition.getValues());
     } catch (MetaException e) {
       throw new RuntimeException(e);
     }
@@ -451,7 +451,7 @@ public class Partition implements Serializable {
   public String toString() {
     String pn = "Invalid Partition";
     try {
-      pn = Warehouse.makePartName(getSpec(), false);
+      pn = WarehouseUtils.makePartName(getSpec(), false);
     } catch (MetaException e) {
       // ignore as we most probably in an exception path already otherwise this
       // error wouldn't occur

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionTree.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionTree.java
@@ -35,8 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.LOG;
-import static org.apache.hadoop.hive.metastore.Warehouse.makePartName;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.makePartNameMatcher;
 
 /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -111,6 +111,7 @@ import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
 import org.apache.hadoop.hive.metastore.parser.ExpressionTree;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.parse.SemanticAnalyzer;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
@@ -124,7 +125,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hive.metastore.Warehouse.getCatalogQualifiedTableName;
-import static org.apache.hadoop.hive.metastore.Warehouse.makePartName;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.Warehouse.makeSpecFromName;
 import static org.apache.hadoop.hive.metastore.Warehouse.makeValsFromName;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.compareFieldColumns;
@@ -1248,7 +1249,7 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
     Collections.sort(partitionList, new PartitionNamesComparator(table, req));
     short maxParts = req.getMaxParts();
     for(int i = 0; i < ((maxParts < 0 || maxParts > partitionList.size()) ? partitionList.size() : maxParts); i++) {
-      results.add(Warehouse.makePartName(table.getPartitionKeys(), partitionList.get(i).getValues()));
+      results.add(WarehouseUtils.makePartName(table.getPartitionKeys(), partitionList.get(i).getValues()));
     }
     return results;
   }
@@ -1284,8 +1285,8 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
       }
 
       try {
-        return Warehouse.makePartName(table.getPartitionKeys(), o1.getValues()).compareTo(
-            Warehouse.makePartName(table.getPartitionKeys(), o2.getValues()));
+        return WarehouseUtils.makePartName(table.getPartitionKeys(), o1.getValues()).compareTo(
+            WarehouseUtils.makePartName(table.getPartitionKeys(), o2.getValues()));
       } catch (MetaException e) {
         throw new RuntimeException(e);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/TempTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/TempTable.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.makePartName;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.Warehouse.makeSpecFromName;
 
 /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.ReplChangeManager;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
-import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.ql.QueryState;
@@ -89,8 +89,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-
 
 /**
  * ImportSemanticAnalyzer.
@@ -399,7 +397,7 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
       location = ReplExternalTables.externalTableLocation(conf, partition.getSd().getLocation());
       LOG.debug("partition {} has data location: {}", partition, location);
     } else {
-      location = new Path(fromPath, Warehouse.makePartName(tblDesc.getPartCols(), partition.getValues())).toString();
+      location = new Path(fromPath, WarehouseUtils.makePartName(tblDesc.getPartCols(), partition.getValues())).toString();
     }
 
     long writeId = -1;
@@ -767,16 +765,16 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
     if (tblDesc.getLocation() == null) {
       if (table.getDataLocation() != null) {
         tgtPath = new Path(table.getDataLocation().toString(),
-            Warehouse.makePartPath(partSpec.getPartSpec()));
+            WarehouseUtils.makePartPath(partSpec.getPartSpec()));
       } else {
         Database parentDb = x.getHive().getDatabase(tblDesc.getDatabaseName());
         tgtPath = new Path(
             wh.getDefaultTablePath( parentDb, tblDesc.getTableName(), tblDesc.isExternal()),
-            Warehouse.makePartPath(partSpec.getPartSpec()));
+            WarehouseUtils.makePartPath(partSpec.getPartSpec()));
       }
     } else {
       tgtPath = new Path(tblDesc.getLocation(),
-          Warehouse.makePartPath(partSpec.getPartSpec()));
+          WarehouseUtils.makePartPath(partSpec.getPartSpec()));
     }
     FileSystem tgtFs = FileSystem.get(tgtPath.toUri(), x.getConf());
     checkTargetLocationEmpty(tgtFs, tgtPath, replicationSpec, x.getLOG());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -109,6 +109,7 @@ import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -8342,7 +8343,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     if (dest_part != null) {
       try {
-        String staticSpec = Warehouse.makePartPath(dest_part.getSpec());
+        String staticSpec = WarehouseUtils.makePartPath(dest_part.getSpec());
         fileSinkDesc.setStaticSpec(staticSpec);
       } catch (MetaException e) {
         throw new SemanticException(e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPartitionCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPartitionCtx.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -118,7 +118,7 @@ public class DynamicPartitionCtx implements Serializable {
     this.numDPCols = dpNames.size();
     this.numSPCols = spNames.size();
     if (this.numSPCols > 0) {
-      this.spPath = Warehouse.makeDynamicPartName(partSpec);
+      this.spPath = WarehouseUtils.makeDynamicPartName(partSpec);
     } else {
       this.spPath = null;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/sqlstd/SQLAuthorizationUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/sqlstd/SQLAuthorizationUtils.java
@@ -29,8 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.hadoop.hive.metastore.Warehouse;
-import org.apache.hadoop.hive.shims.Utils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +286,7 @@ public class SQLAuthorizationUtils {
       return userName.equals(thriftTableObj.getOwner());
     }
     case DATABASE: {
-      if (Warehouse.DEFAULT_DATABASE_NAME.equalsIgnoreCase(hivePrivObject.getDbname())) {
+      if (WarehouseUtils.DEFAULT_DATABASE_NAME.equalsIgnoreCase(hivePrivObject.getDbname())) {
         return true;
       }
       Database db = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -17,7 +17,7 @@
  */
 
 package org.apache.hadoop.hive.ql.session;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.apache.hadoop.hive.shims.HadoopShims.USER_ID;
 
 import java.io.Closeable;

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.UpdateTransactionalStatsRequest;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -540,7 +541,7 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
     // FIXME: this is a secret contract; reusein getAggrKey() creates a more closer relation to the StatsGatherer
     // prefix = work.getAggKey();
     if (partition != null) {
-      return Utilities.join(prefix, Warehouse.makePartPath(partition.getSpec()));
+      return Utilities.join(prefix, WarehouseUtils.makePartPath(partition.getSpec()));
     }
     return prefix;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/ColStatsProcessor.java
@@ -30,13 +30,13 @@ import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.conf.Constants;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
 import org.apache.hadoop.hive.ql.exec.FetchOperator;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
@@ -147,7 +147,7 @@ public class ColStatsProcessor implements IStatsProcessor {
             partVals.add(partVal == null ? // could be null for default partition
               this.conf.getVar(ConfVars.DEFAULTPARTITIONNAME) : partVal.toString());
           }
-          partName = Warehouse.makePartName(partColSchema, partVals);
+          partName = WarehouseUtils.makePartName(partColSchema, partVals);
         }
 
         ColumnStatisticsDesc statsDesc = buildColumnStatsDesc(tbl, partName, isTblLevel);

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUpdaterThread.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUpdaterThread.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hive.metastore.MetaStoreThread;
 import org.apache.hadoop.hive.metastore.ObjectStore;
 import org.apache.hadoop.hive.metastore.RawStore;
 import org.apache.hadoop.hive.metastore.RawStoreProxy;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -57,6 +56,7 @@ import org.apache.hadoop.hive.metastore.txn.TxnCommonUtils;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.DriverUtils;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -341,7 +341,7 @@ public class StatsUpdaterThread extends Thread implements MetaStoreThread {
       }
       int currentIxInBatch = nextIxInBatch++;
       Partition part = currentBatch.get(currentIxInBatch);
-      String partName = Warehouse.makePartName(t.getPartitionKeys(), part.getValues());
+      String partName = WarehouseUtils.makePartName(t.getPartitionKeys(), part.getValues());
       LOG.debug("Processing partition ({} in batch), {}", currentIxInBatch, partName);
 
       // Skip the partitions in progress, and the ones for which stats update is disabled.
@@ -426,7 +426,7 @@ public class StatsUpdaterThread extends Thread implements MetaStoreThread {
     }
     // Current match may be out of order w.r.t. the global name list, so add specific parts.
     for (int i = 0; i < currentIxInBatch; ++i) {
-      String name = Warehouse.makePartName(t.getPartitionKeys(), currentBatch.get(i).getValues());
+      String name = WarehouseUtils.makePartName(t.getPartitionKeys(), currentBatch.get(i).getValues());
       LOG.trace("Adding previous {}, {}", name, cols);
       partsToAnalyze.put(name, cols);
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestExecDriver.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestExecDriver.java
@@ -24,9 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-
-
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.util.NullOrdering;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +140,7 @@ public class TestExecDriver {
       cols.add("key");
       cols.add("value");
       for (String src : srctables) {
-        db.dropTable(Warehouse.DEFAULT_DATABASE_NAME, src, true, true);
+        db.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, src, true, true);
         db.createTable(src, cols, null, TextInputFormat.class,
             HiveIgnoreKeyTextOutputFormat.class);
         db.loadTable(hadoopDataFile[i], src, LoadFileType.KEEP_EXISTING,
@@ -501,7 +499,7 @@ public class TestExecDriver {
   public void testMapPlan1() throws Exception {
 
     LOG.info("Beginning testMapPlan1");
-    populateMapPlan1(db.getTable(Warehouse.DEFAULT_DATABASE_NAME, "src"));
+    populateMapPlan1(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "src"));
     executePlan();
     fileDiff("lt100.txt.deflate", "mapplan1.out");
   }
@@ -510,7 +508,7 @@ public class TestExecDriver {
   public void testMapPlan2() throws Exception {
 
     LOG.info("Beginning testMapPlan2");
-    populateMapPlan2(db.getTable(Warehouse.DEFAULT_DATABASE_NAME, "src"));
+    populateMapPlan2(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "src"));
     executePlan();
     fileDiff("lt100.txt", "mapplan2.out");
   }
@@ -519,7 +517,7 @@ public class TestExecDriver {
   public void testMapRedPlan1() throws Exception {
 
     LOG.info("Beginning testMapRedPlan1");
-    populateMapRedPlan1(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+    populateMapRedPlan1(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
         "src"));
     executePlan();
     fileDiff("kv1.val.sorted.txt", "mapredplan1.out");
@@ -529,7 +527,7 @@ public class TestExecDriver {
   public void testMapRedPlan2() throws Exception {
 
     LOG.info("Beginning testMapPlan2");
-    populateMapRedPlan2(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+    populateMapRedPlan2(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
         "src"));
     executePlan();
     fileDiff("lt100.sorted.txt", "mapredplan2.out");
@@ -539,8 +537,8 @@ public class TestExecDriver {
   public void testMapRedPlan3() throws Exception {
 
     LOG.info("Beginning testMapPlan3");
-    populateMapRedPlan3(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
-        "src"), db.getTable(Warehouse.DEFAULT_DATABASE_NAME, "src2"));
+    populateMapRedPlan3(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
+        "src"), db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, "src2"));
     executePlan();
     fileDiff("kv1kv2.cogroup.txt", "mapredplan3.out");
   }
@@ -549,7 +547,7 @@ public class TestExecDriver {
   public void testMapRedPlan4() throws Exception {
 
     LOG.info("Beginning testMapPlan4");
-    populateMapRedPlan4(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+    populateMapRedPlan4(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
         "src"));
     executePlan();
     fileDiff("kv1.string-sorted.txt", "mapredplan4.out");
@@ -559,7 +557,7 @@ public class TestExecDriver {
   public void testMapRedPlan5() throws Exception {
 
     LOG.info("Beginning testMapPlan5");
-    populateMapRedPlan5(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+    populateMapRedPlan5(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
         "src"));
     executePlan();
     fileDiff("kv1.string-sorted.txt", "mapredplan5.out");
@@ -569,7 +567,7 @@ public class TestExecDriver {
   public void testMapRedPlan6() throws Exception {
 
     LOG.info("Beginning testMapPlan6");
-    populateMapRedPlan6(db.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+    populateMapRedPlan6(db.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
         "src"));
     executePlan();
     fileDiff("lt100.sorted.txt", "mapredplan6.out");

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.metadata;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -51,6 +51,7 @@ import org.apache.hadoop.hive.metastore.api.WMResourcePlanStatus;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.events.InsertEvent;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
@@ -148,13 +149,13 @@ public class TestHive {
       // create a simple table and test create, drop, get
       String tableName = "table_for_testtable";
       try {
-        hm.dropTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+        hm.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       } catch (HiveException e1) {
         e1.printStackTrace();
         assertTrue("Unable to drop table", false);
       }
 
-      Table tbl = new Table(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+      Table tbl = new Table(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       List<FieldSchema> fields = tbl.getCols();
 
       fields.add(new FieldSchema("col1", serdeConstants.INT_TYPE_NAME, "int -- first column"));
@@ -214,9 +215,9 @@ public class TestHive {
       validateTable(tbl, tableName);
 
       try {
-        hm.dropTable(Warehouse.DEFAULT_DATABASE_NAME, tableName, true,
+        hm.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName, true,
             false);
-        Table ft2 = hm.getTable(Warehouse.DEFAULT_DATABASE_NAME,
+        Table ft2 = hm.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME,
             tableName, false);
         assertNull("Unable to drop table ", ft2);
       } catch (HiveException e) {
@@ -247,12 +248,12 @@ public class TestHive {
     String tableName = "table_for_test_thrifttable";
     try {
       try {
-        hm.dropTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+        hm.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       } catch (HiveException e1) {
         System.err.println(StringUtils.stringifyException(e1));
         assertTrue("Unable to drop table", false);
       }
-      Table tbl = new Table(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+      Table tbl = new Table(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       tbl.setInputFormatClass(SequenceFileInputFormat.class.getName());
       tbl.setOutputFormatClass(SequenceFileOutputFormat.class.getName());
       tbl.setSerializationLib(ThriftDeserializer.class.getName());
@@ -340,7 +341,7 @@ public class TestHive {
       // (create table sets it to empty (non null) structures)
       tbl.getTTable().setPrivilegesIsSet(false);
 
-      ft = hm.getTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+      ft = hm.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       Assert.assertTrue(ft.getTTable().isSetId());
       ft.getTTable().unsetId();
 
@@ -625,7 +626,7 @@ public class TestHive {
    */
   @Test
   public void testDropPartitionsWithPurge() throws Exception {
-    String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     String tableName = "table_for_testDropPartitionsWithPurge";
 
     try {
@@ -689,7 +690,7 @@ public class TestHive {
   @Test
   public void testAutoPurgeTablesAndPartitions() throws Throwable {
 
-    String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     String tableName = "table_for_testAutoPurgeTablesAndPartitions";
     try {
 
@@ -744,7 +745,7 @@ public class TestHive {
     try {
       String tableName = "table_for_testpartition";
       try {
-        hm.dropTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+        hm.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       } catch (HiveException e) {
         System.err.println(StringUtils.stringifyException(e));
         assertTrue("Unable to drop table: " + tableName, false);
@@ -765,7 +766,7 @@ public class TestHive {
       }
       Table tbl = null;
       try {
-        tbl = hm.getTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+        tbl = hm.getTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
       } catch (HiveException e) {
         System.err.println(StringUtils.stringifyException(e));
         assertTrue("Unable to fetch table: " + tableName, false);
@@ -838,7 +839,7 @@ public class TestHive {
       partialSpec.put("hr", "14");
       assertEquals(1, hm.getPartitions(tbl, partialSpec).size());
 
-      hm.dropTable(Warehouse.DEFAULT_DATABASE_NAME, tableName);
+      hm.dropTable(WarehouseUtils.DEFAULT_DATABASE_NAME, tableName);
     } catch (Throwable e) {
       System.err.println(StringUtils.stringifyException(e));
       System.err.println("testPartition() failed");

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestTempAcidTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestTempAcidTable.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.hive.ql.metadata;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -67,7 +67,7 @@ public class TestTempAcidTable {
   @Test
   public void testTempInsertOnlyTableTranslate() throws Throwable {
     try {
-      String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+      String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
       String tableName = "temp_table";
       hive.dropTable(dbName, tableName);
       Table table = new Table(dbName, tableName);
@@ -99,7 +99,7 @@ public class TestTempAcidTable {
   @Test
   public void testTempFullAcidTableTranslate() throws Throwable {
     try {
-      String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+      String dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
       String tableName = "temp_table";
       hive.dropTable(dbName, tableName);
       Table table = new Table(dbName, tableName);

--- a/ql/src/test/org/apache/hadoop/hive/ql/session/TestSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/session/TestSessionState.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -36,7 +35,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -124,7 +123,7 @@ public class TestSessionState {
   @Test
   public void testgetDbName() throws Exception {
     //check that we start with default db
-    assertEquals(Warehouse.DEFAULT_DATABASE_NAME,
+    assertEquals(WarehouseUtils.DEFAULT_DATABASE_NAME,
         SessionState.get().getCurrentDatabase());
     final String newdb = "DB_2";
 
@@ -135,7 +134,7 @@ public class TestSessionState {
 
     //verify that a new sessionstate has default db
     SessionState.start(new HiveConf());
-    assertEquals(Warehouse.DEFAULT_DATABASE_NAME,
+    assertEquals(WarehouseUtils.DEFAULT_DATABASE_NAME,
         SessionState.get().getCurrentDatabase());
 
   }

--- a/service/src/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/service/src/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 /**
  * HiveSession

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/repl/ReplConst.java
@@ -102,4 +102,10 @@ public class ReplConst {
   public static final String REPL_METRICS_FAILBACK_COUNT = "repl.metrics.failback.count";
   public static final String REPL_METRICS_LAST_FAILBACK_STARTTIME = "repl.metrics.last.failback.starttime";
   public static final String REPL_METRICS_LAST_FAILBACK_ENDTIME = "repl.metrics.last.failback.endtime";
+
+  /**
+   * A database level property to signify that the database is in failover state and the
+   * reverse sync, i.e. the optimised boostrap, is not yet performed.
+   */
+  public static final String REPL_DB_UNDER_FAILOVER_REV_SYNC_PENDING = "repl.db.under.failover.reverse.sync.pending";
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CheckResult.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/CheckResult.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.metastore;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.util.Map;
 import java.util.Set;
@@ -178,7 +179,7 @@ public class CheckResult {
 
     public Path getLocation(Path tablePath, Map<String, String> partSpec) throws MetaException {
       if (this.path == null) {
-        return new Path(tablePath, Warehouse.makePartPath(partSpec));
+        return new Path(tablePath, WarehouseUtils.makePartPath(partSpec));
       }
 
       return this.path;

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.hive.metastore;
 
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.convertToGetPartitionsByNamesRequest;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.prependCatalogToDbName;

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/partition/spec/CompositePartitionSpecProxy.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/partition/spec/CompositePartitionSpecProxy.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 /**
  * Implementation of PartitionSpecProxy that composes a list of PartitionSpecProxy.

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -426,7 +425,7 @@ public class MetaStoreUtils {
     // or a regex of the form ".*"
     // This works because the "=" and "/" separating key names and partition key/values
     // are not escaped.
-    String partNameMatcher = Warehouse.makePartName(partCols, partVals, defaultStr);
+    String partNameMatcher = WarehouseUtils.makePartName(partCols, partVals, defaultStr);
     // add ".*" to the regex to match anything else afterwards the partial spec.
     if (partVals.size() < numPartKeys) {
       partNameMatcher += defaultStr;
@@ -1058,11 +1057,11 @@ public class MetaStoreUtils {
   public static String getDefaultCatalog(Configuration conf) {
     if (conf == null) {
       LOG.warn("Configuration is null, so going with default catalog.");
-      return Warehouse.DEFAULT_CATALOG_NAME;
+      return WarehouseUtils.DEFAULT_CATALOG_NAME;
     }
     String catName = MetastoreConf.getVar(conf, MetastoreConf.ConfVars.CATALOG_DEFAULT);
     if (catName == null || "".equals(catName)) {
-      catName = Warehouse.DEFAULT_CATALOG_NAME;
+      catName = WarehouseUtils.DEFAULT_CATALOG_NAME;
     }
     return catName;
   }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/StringUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.utils;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -128,5 +129,15 @@ public class StringUtils {
    */
   public static boolean isEmpty(CharSequence cs) {
     return cs == null || cs.length() == 0;
+  }
+
+  /**
+   * A utility method to check the occurrence of a sample string in a collection of strings.
+   * @param sample the sample string
+   * @param strings the collection of strings
+   * @return true if the string exists, false otherwise
+   */
+  public static boolean matchesAnyStringInCollection(String sample, String... strings) {
+    return Arrays.stream(strings).anyMatch(sample::equals);
   }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/ThrowingFunction.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/ThrowingFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore.utils;
+
+import java.util.function.Function;
+
+/**
+ * This functional interface represents a function and very similar to {@link Function}, the only
+ * difference is this represents a function that throws Unchecked Exceptions.
+ * <br>Currently, the standard functional interfaces do not deal with checked exceptions well. This representation of function
+ * has a utility method to suppress checked exception and in turn throw {@link RuntimeException}. This could be very useful
+ * while dealing with exceptions in functional programming without losing the brevity and simplicity.
+ *
+ * @param <T> the parameterized type of the input to the function
+ * @param <R> the type of result of the function
+ * @param <E> the type of exception that could be thrown while executing the function
+ *
+ * @see Function
+ *
+ */
+@FunctionalInterface public interface ThrowingFunction<T, R, E extends Exception> {
+  R apply(T t) throws E;
+
+  static <T, R, E extends Exception> Function<T, R> unchecked(ThrowingFunction<T, R, E> throwingFunction) {
+    return T -> {
+      try {
+        return throwingFunction.apply(T);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+}

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/WarehouseUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/WarehouseUtils.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.utils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class WarehouseUtils {
+  private WarehouseUtils() {
+  }
+
+  public static final String DEFAULT_CATALOG_NAME = "hive";
+  public static final String DEFAULT_CATALOG_COMMENT = "Default catalog, for Hive";
+  public static final String DEFAULT_DATABASE_NAME = "default";
+  public static final String DEFAULT_DATABASE_COMMENT = "Default Hive database";
+  public static final String DEFAULT_SERIALIZATION_FORMAT = "1";
+  public static final String DATABASE_WAREHOUSE_SUFFIX = ".db";
+
+  public static String escapePathName(String path) {
+    return FileUtils.escapePathName(path);
+  }
+
+  /**
+   * Makes a partition name from a specification
+   * @param spec The partition specification, key and value pairs.
+   * @param addTrailingSeperator If true, adds a trailing separator e.g. 'ds=1/'.
+   * @param dynamic If true, create a dynamic partition name.
+   * @return partition name
+   * @throws MetaException
+   */
+  public static String makePartNameUtil(Map<String, String> spec, boolean addTrailingSeperator, boolean dynamic)
+      throws MetaException {
+    StringBuilder suffixBuf = new StringBuilder();
+    int i = 0;
+    for (Map.Entry<String, String> e : spec.entrySet()) {
+      // Throw an exception if it is not a dynamic partition.
+      if (e.getValue() == null || e.getValue().length() == 0) {
+        if (dynamic) {
+          break;
+        } else {
+          throw new MetaException("Partition spec is incorrect. " + spec);
+        }
+      }
+
+      if (i > 0) {
+        suffixBuf.append(Path.SEPARATOR);
+      }
+      suffixBuf.append(escapePathName(e.getKey()));
+      suffixBuf.append('=');
+      suffixBuf.append(escapePathName(e.getValue()));
+      i++;
+    }
+
+    if (addTrailingSeperator && i > 0) {
+      suffixBuf.append(Path.SEPARATOR);
+    }
+
+    return suffixBuf.toString();
+  }
+
+  /**
+   * Makes a partition name from a specification
+   * @param spec
+   * @param addTrailingSeperator if true, adds a trailing separator e.g. 'ds=1/'
+   * @return partition name
+   * @throws MetaException
+   */
+  public static String makePartName(Map<String, String> spec, boolean addTrailingSeperator) throws MetaException {
+    return makePartNameUtil(spec, addTrailingSeperator, false);
+  }
+
+  /**
+   * Given a dynamic partition specification, return the path corresponding to the
+   * static part of partition specification. This is basically similar to makePartName
+   * but we get rid of MetaException since it is not serializable.
+   * @param spec
+   * @return string representation of the static part of the partition specification.
+   */
+  public static String makeDynamicPartName(Map<String, String> spec) {
+    String partName = null;
+    try {
+      partName = makePartNameUtil(spec, true, true);
+    } catch (MetaException e) {
+      // This exception is not thrown when dynamic=true. This is a Noop and
+      // can be ignored.
+    }
+    return partName;
+  }
+
+  /**
+   * Given a dynamic partition specification, return the path corresponding to the
+   * static part of partition specification. This is basically similar to makePartName
+   * but we get rid of MetaException since it is not serializable. This method skips
+   * the trailing path seperator also.
+   *
+   * @param spec
+   * @return string representation of the static part of the partition specification.
+   */
+  public static String makeDynamicPartNameNoTrailingSeperator(Map<String, String> spec) {
+    String partName = null;
+    try {
+      partName = makePartNameUtil(spec, false, true);
+    } catch (MetaException e) {
+      // This exception is not thrown when dynamic=true. This is a Noop and
+      // can be ignored.
+    }
+    return partName;
+  }
+
+  public static String makePartName(List<FieldSchema> partCols, List<String> vals) throws MetaException {
+    return makePartName(partCols, vals, null);
+  }
+
+  /**
+   * Makes a valid partition name.
+   * @param partCols The partition columns
+   * @param vals The partition values
+   * @param defaultStr
+   *    The default name given to a partition value if the respective value is empty or null.
+   * @return An escaped, valid partition name.
+   * @throws MetaException
+   */
+  public static String makePartName(List<FieldSchema> partCols, List<String> vals, String defaultStr)
+      throws MetaException {
+    if ((partCols.size() != vals.size()) || (partCols.size() == 0)) {
+      StringBuilder errorStrBuilder = new StringBuilder("Invalid partition key & values; keys [");
+      for (FieldSchema fs : partCols) {
+        errorStrBuilder.append(fs.getName()).append(", ");
+      }
+      errorStrBuilder.append("], values [");
+      for (String val : vals) {
+        errorStrBuilder.append(val).append(", ");
+      }
+      throw new MetaException(errorStrBuilder.append("]").toString());
+    }
+    List<String> colNames = new ArrayList<>();
+    for (FieldSchema col : partCols) {
+      colNames.add(col.getName());
+    }
+    return FileUtils.makePartName(colNames, vals, defaultStr);
+  }
+
+  /**
+   * Given a partition specification, return the path corresponding to the
+   * partition spec. By default, the specification does not include dynamic partitions.
+   * @param spec
+   * @return string representation of the partition specification.
+   * @throws MetaException
+   */
+  public static String makePartPath(Map<String, String> spec)
+      throws MetaException {
+    return makePartName(spec, true);
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AcidEventListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AcidEventListener.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;
 import org.apache.hadoop.hive.metastore.events.DropTableEvent;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -126,7 +127,7 @@ public class AcidEventListener extends TransactionalMetaStoreEventListener {
 
               List<FieldSchema> partCols = partitionEvent.getTable().getPartitionKeys();  // partition columns
               List<String> partVals = p.getValues();
-              rqst.setPartitionname(Warehouse.makePartName(partCols, partVals));
+              rqst.setPartitionname(WarehouseUtils.makePartName(partCols, partVals));
               rqst.putToProperties("location", p.getSd().getLocation());
 
               txnHandler.submitForCleanup(rqst, writeId, currentTxn);
@@ -163,8 +164,8 @@ public class AcidEventListener extends TransactionalMetaStoreEventListener {
     Partition oldPart = partitionEvent.getOldPartition();
     Partition newPart = partitionEvent.getNewPartition();
     Table t = partitionEvent.getTable();
-    String oldPartName = Warehouse.makePartName(t.getPartitionKeys(), oldPart.getValues());
-    String newPartName = Warehouse.makePartName(t.getPartitionKeys(), newPart.getValues());
+    String oldPartName = WarehouseUtils.makePartName(t.getPartitionKeys(), oldPart.getValues());
+    String newPartName = WarehouseUtils.makePartName(t.getPartitionKeys(), newPart.getValues());
     if (!oldPartName.equals(newPartName)) {
       txnHandler = getTxnHandler();
       txnHandler.onRename(t.getCatName(), t.getDbName(), t.getTableName(), oldPartName,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.metastore.messaging.EventMessage;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -758,7 +759,7 @@ public class HiveAlterHandler implements AlterHandler {
             new_part, tbl, wh, false, true, environmentContext, false);
       }
 
-      String newPartName = Warehouse.makePartName(tbl.getPartitionKeys(), new_part.getValues());
+      String newPartName = WarehouseUtils.makePartName(tbl.getPartitionKeys(), new_part.getValues());
       List<ColumnStatistics> multiColumnStats = updateOrGetPartitionColumnStats(msdb, catName, dbname, name, oldPart.getValues(),
           oldPart.getSd().getCols(), tbl, new_part, null, null);
       msdb.alterPartition(catName, dbname, name, part_vals, new_part, validWriteIds);
@@ -826,7 +827,7 @@ public class HiveAlterHandler implements AlterHandler {
     // Get list of partition values
     List<String> partValues = new LinkedList<>();
     for (Partition tmpPart : new_parts) {
-      partValues.add(Warehouse.makePartName(tbl.getPartitionKeys(), tmpPart.getValues()));
+      partValues.add(WarehouseUtils.makePartName(tbl.getPartitionKeys(), tmpPart.getValues()));
     }
 
     // Get existing partitions from store
@@ -1144,8 +1145,8 @@ public class HiveAlterHandler implements AlterHandler {
       if (newCols == null) {
         newCols = part.getSd() == null ? new ArrayList<>() : part.getSd().getCols();
       }
-      String oldPartName = Warehouse.makePartName(table.getPartitionKeys(), partVals);
-      String newPartName = Warehouse.makePartName(table.getPartitionKeys(), part.getValues());
+      String oldPartName = WarehouseUtils.makePartName(table.getPartitionKeys(), partVals);
+      String newPartName = WarehouseUtils.makePartName(table.getPartitionKeys(), part.getValues());
       boolean rename = !part.getDbName().equals(dbname) || !part.getTableName().equals(tblname)
           || !oldPartName.equals(newPartName);
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hive.common.AcidConstants.DELETE_DELTA_PREFIX;
 import static org.apache.hadoop.hive.common.AcidConstants.DELTA_PREFIX;
 import static org.apache.hadoop.hive.common.AcidConstants.VISIBILITY_PREFIX;
 import static org.apache.hadoop.hive.metastore.PartFilterExprUtil.createExpressionProxy;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getAllPartitionsOf;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getDataLocation;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPartColNames;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getPartCols;
@@ -36,7 +35,6 @@ import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.isPart
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -60,9 +58,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.GetPartitionsFilterSpec;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
-import org.apache.hadoop.hive.metastore.api.GetProjectionsSpec;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.MetastoreException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -73,6 +69,7 @@ import org.apache.hadoop.hive.metastore.client.builder.GetPartitionProjectionsSp
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.util.functional.RemoteIterators;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -138,7 +135,7 @@ public class HiveMetaStoreChecker {
       throws MetastoreException, IOException {
     CheckResult result = new CheckResult();
     if (dbName == null || "".equalsIgnoreCase(dbName)) {
-      dbName = Warehouse.DEFAULT_DATABASE_NAME;
+      dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     }
 
     try {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.RetryUtilities;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -515,9 +516,9 @@ public class Msck {
       if (i > 0) {
         suffixBuf.append(" AND ");
       }
-      suffixBuf.append(Warehouse.escapePathName(e.getKey()));
+      suffixBuf.append(WarehouseUtils.escapePathName(e.getKey()));
       suffixBuf.append('=');
-      suffixBuf.append("'").append(Warehouse.escapePathName(e.getValue())).append("'");
+      suffixBuf.append("'").append(WarehouseUtils.escapePathName(e.getValue())).append("'");
       i++;
     }
     suffixBuf.append(")");

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.ColStatsObjWithSourceInfo;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -536,7 +537,7 @@ public class CachedStore implements RawStore, Configurable {
                 cacheObjects.setPartitions(partitions);
                 List<String> partNames = new ArrayList<>(partitions.size());
                 for (Partition p : partitions) {
-                  partNames.add(Warehouse.makePartName(table.getPartitionKeys(), p.getValues()));
+                  partNames.add(WarehouseUtils.makePartName(table.getPartitionKeys(), p.getValues()));
                 }
                 if (!partNames.isEmpty()) {
                   // Get partition column stats for this table
@@ -1611,7 +1612,7 @@ public class CachedStore implements RawStore, Configurable {
     int count = 0;
     for (Partition part : sharedCache.listCachedPartitions(catName, dbName, tblName, maxParts)) {
       if (maxParts == -1 || count < maxParts) {
-        partitionNames.add(Warehouse.makePartName(tbl.getPartitionKeys(), part.getValues()));
+        partitionNames.add(WarehouseUtils.makePartName(tbl.getPartitionKeys(), part.getValues()));
       }
     }
     return partitionNames;
@@ -1670,7 +1671,7 @@ public class CachedStore implements RawStore, Configurable {
         StringUtils.normalizeIdentifier(table.getDbName()), StringUtils.normalizeIdentifier(table.getTableName()),
         maxParts);
     for (Partition part : parts) {
-      result.add(Warehouse.makePartName(table.getPartitionKeys(), part.getValues()));
+      result.add(WarehouseUtils.makePartName(table.getPartitionKeys(), part.getValues()));
     }
     if (defaultPartName == null || defaultPartName.isEmpty()) {
       defaultPartName = MetastoreConf.getVar(getConf(), ConfVars.DEFAULTPARTITIONNAME);
@@ -1931,7 +1932,7 @@ public class CachedStore implements RawStore, Configurable {
     }
     Partition p = sharedCache.getPartitionFromCache(catName, dbName, tblName, partVals);
     if (p != null) {
-      String partName = Warehouse.makePartName(table.getPartitionKeys(), partVals);
+      String partName = WarehouseUtils.makePartName(table.getPartitionKeys(), partVals);
       PrincipalPrivilegeSet privs = getPartitionPrivilegeSet(catName, dbName, tblName, partName, userName, groupNames);
       p.setPrivileges(privs);
     } else {
@@ -1957,7 +1958,7 @@ public class CachedStore implements RawStore, Configurable {
     int count = 0;
     for (Partition part : sharedCache.listCachedPartitions(catName, dbName, tblName, maxParts)) {
       if (maxParts == -1 || count < maxParts) {
-        String partName = Warehouse.makePartName(table.getPartitionKeys(), part.getValues());
+        String partName = WarehouseUtils.makePartName(table.getPartitionKeys(), part.getValues());
         PrincipalPrivilegeSet privs =
             getPartitionPrivilegeSet(catName, dbName, tblName, partName, userName, groupNames);
         part.setPrivileges(privs);
@@ -1986,7 +1987,7 @@ public class CachedStore implements RawStore, Configurable {
     List<Partition> allPartitions = sharedCache.listCachedPartitions(catName, dbName, tblName, maxParts);
     int count = 0;
     for (Partition part : allPartitions) {
-      String partName = Warehouse.makePartName(table.getPartitionKeys(), part.getValues());
+      String partName = WarehouseUtils.makePartName(table.getPartitionKeys(), part.getValues());
       if (partName.matches(partNameMatcher) && (maxParts == -1 || count < maxParts)) {
         partitionNames.add(partName);
         count++;
@@ -2020,7 +2021,7 @@ public class CachedStore implements RawStore, Configurable {
     List<Partition> allPartitions = sharedCache.listCachedPartitions(catName, dbName, tblName, maxParts);
     int count = 0;
     for (Partition part : allPartitions) {
-      String partName = Warehouse.makePartName(table.getPartitionKeys(), part.getValues());
+      String partName = WarehouseUtils.makePartName(table.getPartitionKeys(), part.getValues());
       if (partName.matches(partNameMatcher) && (maxParts == -1 || count < maxParts)) {
         PrincipalPrivilegeSet privs =
             getPartitionPrivilegeSet(catName, dbName, tblName, partName, userName, groupNames);
@@ -2045,7 +2046,7 @@ public class CachedStore implements RawStore, Configurable {
     // or a regex of the form ".*"
     // This works because the "=" and "/" separating key names and partition key/values
     // are not escaped.
-    String partNameMatcher = Warehouse.makePartName(partCols, partSpecs, ".*");
+    String partNameMatcher = WarehouseUtils.makePartName(partCols, partSpecs, ".*");
     // add ".*" to the regex to match anything else afterwards the partial spec.
     if (partSpecs.size() < numPartKeys) {
       partNameMatcher += ".*";

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/ConstraintBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/ConstraintBuilder.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hadoop.hive.metastore.client.builder;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +42,7 @@ abstract class ConstraintBuilder<T> {
     nextSeq = 1;
     enable = true;
     validate = rely = false;
-    dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     columns = new ArrayList<>();
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/FunctionBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/FunctionBuilder.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.metastore.client.builder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.FunctionType;
@@ -29,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.ResourceUri;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class FunctionBuilder {
     createTime = (int) (System.currentTimeMillis() / 1000);
     funcType = FunctionType.JAVA;
     resourceUris = new ArrayList<>();
-    dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
   }
 
   public FunctionBuilder setCatName(String catName) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/ISchemaBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/ISchemaBuilder.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.hive.metastore.client.builder;
 
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.ISchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.SchemaCompatibility;
 import org.apache.hadoop.hive.metastore.api.SchemaType;
 import org.apache.hadoop.hive.metastore.api.SchemaValidation;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 public class ISchemaBuilder {
   private SchemaType schemaType; // required
@@ -39,8 +39,8 @@ public class ISchemaBuilder {
     compatibility = SchemaCompatibility.BACKWARD;
     validationLevel = SchemaValidation.ALL;
     canEvolve = true;
-    dbName = Warehouse.DEFAULT_DATABASE_NAME;
-    catName = Warehouse.DEFAULT_CATALOG_NAME;
+    dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
+    catName = WarehouseUtils.DEFAULT_CATALOG_NAME;
   }
 
   public ISchemaBuilder setSchemaType(SchemaType schemaType) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/PartitionBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/PartitionBuilder.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hive.metastore.client.builder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ public class PartitionBuilder extends StorageDescriptorBuilder<PartitionBuilder>
     // Set some reasonable defaults
     partParams = new HashMap<>();
     createTime = lastAccessTime = (int)(System.currentTimeMillis() / 1000);
-    dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     super.setChild(this);
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/SQLForeignKeyBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/SQLForeignKeyBuilder.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hive.metastore.client.builder;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
 import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +40,7 @@ public class SQLForeignKeyBuilder extends ConstraintBuilder<SQLForeignKeyBuilder
     super.setChild(this);
     updateRule = deleteRule = 0;
     pkColumns = new ArrayList<>();
-    pkDb = Warehouse.DEFAULT_DATABASE_NAME;
+    pkDb = WarehouseUtils.DEFAULT_DATABASE_NAME;
   }
 
   public SQLForeignKeyBuilder setPkDb(String pkDb) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/SchemaVersionBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/SchemaVersionBuilder.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.SchemaVersion;
 import org.apache.hadoop.hive.metastore.api.SchemaVersionState;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 public class SchemaVersionBuilder extends SerdeAndColsBuilder<SchemaVersionBuilder> {
   private String schemaName, dbName, catName; // required

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 
 import org.apache.hadoop.hive.metastore.api.CreationMetadata;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -33,12 +32,12 @@ import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class TableBuilder extends StorageDescriptorBuilder<TableBuilder> {
 
   public TableBuilder() {
     // Set some reasonable defaults
-    dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    dbName = WarehouseUtils.DEFAULT_DATABASE_NAME;
     tableParams = new HashMap<>();
     createTime = lastAccessTime = (int)(System.currentTimeMillis() / 1000);
     retention = 0;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionContext.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionContext.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.leader.LeaderElection.LeadershipStateListener;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,11 +42,11 @@ public class LeaderElectionContext {
    * For those tasks which belong to the same type, they will be running in the same leader.
    */
   public enum TTYPE {
-    HOUSEKEEPING(new TableName(Warehouse.DEFAULT_CATALOG_NAME, "sys",
+    HOUSEKEEPING(new TableName(WarehouseUtils.DEFAULT_CATALOG_NAME, "sys",
         "metastore_housekeeping_leader"), "housekeeping"),
-    WORKER(new TableName(Warehouse.DEFAULT_CATALOG_NAME, "sys",
+    WORKER(new TableName(WarehouseUtils.DEFAULT_CATALOG_NAME, "sys",
         "metastore_worker_leader"), "compactor_worker"),
-    ALWAYS_TASKS(new TableName(Warehouse.DEFAULT_CATALOG_NAME, "sys",
+    ALWAYS_TASKS(new TableName(WarehouseUtils.DEFAULT_CATALOG_NAME, "sys",
         "metastore_always_tasks_leader"), "always_tasks");
     // Mutex of TTYPE, which can be a nonexistent table
     private final TableName mutex;
@@ -90,7 +90,7 @@ public class LeaderElectionContext {
         MetastoreConf.ConfVars.METASTORE_HOUSEKEEPING_LEADER_AUDITTABLE);
     if (StringUtils.isNotEmpty(tableName)) {
       TableName table = TableName.fromString(tableName, MetaStoreUtils.getDefaultCatalog(conf),
-          Warehouse.DEFAULT_DATABASE_NAME);
+          WarehouseUtils.DEFAULT_DATABASE_NAME);
       auditLeaderListener = new AuditLeaderListener(table, handler);
     }
     this.listeners = listeners;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
@@ -29,7 +29,6 @@ import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CharStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.ColumnType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 /**
  * The Class representing the filter as a  binary tree. The tree has TreeNode's
@@ -531,7 +531,7 @@ public class ExpressionTree {
     // If a partition has multiple partition keys, we make the assumption that
     // makePartName with one key will return a substring of the name made
     // with both all the keys.
-    String escapedNameFragment = Warehouse.makePartName(partKeyToVal, false);
+    String escapedNameFragment = WarehouseUtils.makePartName(partKeyToVal, false);
     if (keyCount == 1) {
       // Case where this is no other partition columns
       params.put(paramName, escapedNameFragment);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskListExtTblLocs.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/metatool/MetaToolTaskListExtTblLocs.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONArray;
@@ -114,7 +115,7 @@ public class MetaToolTaskListExtTblLocs extends MetaToolTask {
             }
             else {
               partLocation = partLocation + Path.SEPARATOR +
-                      Warehouse.makePartName(Warehouse.makeSpecFromName(partitionName), false);
+                      WarehouseUtils.makePartName(Warehouse.makeSpecFromName(partitionName), false);
               Path partPath = new Path(partLocation);
               long partDataSize = getDataSize(partPath, conf);
               if (isPathWithinSubtree(partPath, defaultDbExtPath)) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/SchemaToolTaskDrop.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/SchemaToolTaskDrop.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hive.metastore.tools.schematool;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hive.metastore.HiveMetaException;
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -60,7 +60,7 @@ public class SchemaToolTaskDrop extends SchemaToolTask {
     Connection conn = schemaTool.getConnectionToMetastore(true);
     try {
       try (Statement stmt = conn.createStatement()) {
-        final String def = Warehouse.DEFAULT_DATABASE_NAME;
+        final String def = WarehouseUtils.DEFAULT_DATABASE_NAME;
 
         // List databases
         List<String> databases = new ArrayList<>();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -59,7 +59,6 @@ import java.util.stream.Stream;
 
 import javax.sql.DataSource;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.lang3.ArrayUtils;
@@ -80,7 +79,6 @@ import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.common.classification.RetrySemantics;
 import org.apache.hadoop.hive.common.repl.ReplConst;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.MetaStoreListenerNotifier;
 import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
 import org.apache.hadoop.hive.metastore.LockTypeComparator;
@@ -166,6 +164,7 @@ import org.apache.hadoop.hive.metastore.utils.LockTypeUtil;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.StringableMap;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -4453,7 +4452,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
             while (partitionIterator.hasNext()) {
               Partition p = partitionIterator.next();
               partVals = p.getValues();
-              partName = Warehouse.makePartName(partCols, partVals);
+              partName = WarehouseUtils.makePartName(partCols, partVals);
 
               buff.setLength(0);
               buff.append("DELETE FROM \"TXN_COMPONENTS\" WHERE \"TC_DATABASE\"='");

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1490,7 +1489,7 @@ public class MetaStoreServerUtils {
 
   public static String getPartitionName(Table table, Partition partition) {
     try {
-      return Warehouse.makePartName(getPartCols(table), partition.getValues());
+      return WarehouseUtils.makePartName(getPartCols(table), partition.getValues());
     } catch (MetaException e) {
       throw new RuntimeException(e);
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.hive.metastore;
 
 import static org.apache.hadoop.hive.metastore.HiveMetaStoreClient.callEmbeddedMetastore;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
 import java.io.IOException;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
@@ -47,7 +47,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 public class MetaStoreTestUtils {
   private static Map<Integer, Thread> map = new HashMap<>();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/NonCatCallsWithCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/NonCatCallsWithCatalog.java
@@ -78,7 +78,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 public abstract class NonCatCallsWithCatalog {
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestAggregateStatsCache.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestAggregateStatsCache.java
@@ -41,7 +41,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 @Category(MetastoreUnitTest.class)
 public class TestAggregateStatsCache {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestCatalogOldClient.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestCatalogOldClient.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hive.metastore;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 import org.apache.hadoop.hive.metastore.api.MetaException;
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestFilterHooks.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestFilterHooks.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -229,11 +230,11 @@ public class TestFilterHooks {
     client.dropDataConnector(DCNAME2, true, true);
     Database db1 = new DatabaseBuilder()
         .setName(DBNAME1)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(client, conf);
     Database db2 = new DatabaseBuilder()
         .setName(DBNAME2)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(client, conf);
     new TableBuilder()
         .setDbName(DBNAME1)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -55,12 +55,11 @@ import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.dataconnector.jdbc.AbstractJDBCConnectorProvider;
-import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetastoreVersionInfo;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
-import org.apache.orc.impl.OrcAcidUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.datanucleus.api.jdo.JDOPersistenceManager;
 import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
 import org.junit.Assert;
@@ -1157,7 +1156,7 @@ public abstract class TestHiveMetaStore {
           warehouse.getDatabasePath(db).toString(), db.getLocationUri());
       assertEquals(db.getOwnerName(), SecurityUtils.getUser());
       assertEquals(db.getOwnerType(), PrincipalType.USER);
-      assertEquals(Warehouse.DEFAULT_CATALOG_NAME, db.getCatalogName());
+      assertEquals(WarehouseUtils.DEFAULT_CATALOG_NAME, db.getCatalogName());
       Database db2 = new DatabaseBuilder()
           .setName(TEST_DB2_NAME)
           .create(client, conf);
@@ -3145,7 +3144,7 @@ public abstract class TestHiveMetaStore {
 
   @Test
   public void testDBOwner() throws TException {
-    Database db = client.getDatabase(Warehouse.DEFAULT_DATABASE_NAME);
+    Database db = client.getDatabase(WarehouseUtils.DEFAULT_DATABASE_NAME);
     assertEquals(db.getOwnerName(), HMSHandler.PUBLIC);
     assertEquals(db.getOwnerType(), PrincipalType.ROLE);
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreSchemaMethods.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreSchemaMethods.java
@@ -66,8 +66,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 // This does the testing using a remote metastore, as that finds more issues in thrift
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreWithEnvironmentContext.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreWithEnvironmentContext.java
@@ -46,7 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHmsServerAuthorization.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHmsServerAuthorization.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.events.PreEventContext;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
@@ -141,11 +142,11 @@ public class TestHmsServerAuthorization {
     client.dropDatabase(dbName2, true, true, true);
     Database db1 = new DatabaseBuilder()
         .setName(dbName1)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(client, conf);
     Database db2 = new DatabaseBuilder()
         .setName(dbName2)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(client, conf);
     new TableBuilder()
         .setDbName(dbName1)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEndFunctionListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEndFunctionListener.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
-import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -72,7 +72,7 @@ public class TestMetaStoreEndFunctionListener {
 
     Database db = new DatabaseBuilder()
         .setName(dbName)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(msc, conf);
 
     try {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListenerOnlyOnCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListenerOnlyOnCommit.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
@@ -32,6 +31,7 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.events.ListenerEvent;
 import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,7 +77,7 @@ public class TestMetaStoreEventListenerOnlyOnCommit {
     String dbName = "tmpDb";
     Database db = new DatabaseBuilder()
         .setName(dbName)
-        .setCatalogName(Warehouse.DEFAULT_CATALOG_NAME)
+        .setCatalogName(WarehouseUtils.DEFAULT_CATALOG_NAME)
         .create(msc, conf);
 
     listSize += 1;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStoreSchemaMethods.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStoreSchemaMethods.java
@@ -50,8 +50,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @Category(MetastoreCheckinTest.class)
 public class TestObjectStoreSchemaMethods {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestOldSchema.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestOldSchema.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.ndv.hll.HyperLogLog;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
-import org.apache.hadoop.hive.metastore.api.Catalog;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
@@ -55,7 +54,7 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 @Category(MetastoreUnitTest.class)
 public class TestOldSchema {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hive.metastore;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -52,6 +52,7 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -97,7 +98,7 @@ public class TestPartitionManagement {
         } else {
           List<String> databases = client.getAllDatabases(catName);
           for (String db : databases) {
-            if (!db.equalsIgnoreCase(Warehouse.DEFAULT_DATABASE_NAME)) {
+            if (!db.equalsIgnoreCase(WarehouseUtils.DEFAULT_DATABASE_NAME)) {
               client.dropDatabase(catName, db, true, false, true);
             }
           }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestStats.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestStats.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -61,8 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.convertToGetPartitionsByNamesRequest;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.prependCatalogToDbName;
 
@@ -98,7 +99,7 @@ public class TestStats {
       } else {
         List<String> databases = client.getAllDatabases(catName);
         for (String db : databases) {
-          if (!db.equalsIgnoreCase(Warehouse.DEFAULT_DATABASE_NAME)) {
+          if (!db.equalsIgnoreCase(WarehouseUtils.DEFAULT_DATABASE_NAME)) {
             client.dropDatabase(catName, db, true, false, true);
           }
         }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.metastore.columnstats.ColStatsBuilder;
 import org.apache.hadoop.hive.metastore.columnstats.cache.LongColumnStatsDataInspector;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.utils.FileUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,7 +50,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.apache.hadoop.hive.metastore.StatisticsTestUtils.assertEqualStatistics;
 import static org.apache.hadoop.hive.metastore.StatisticsTestUtils.createColumnStatistics;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 /**
  * Unit tests for CachedStore
@@ -1027,9 +1028,9 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
     Assert.assertEquals(100, aggrStats.getColStats().get(0).getStatsData().getLongStats().getNumNulls());
 
     objectStore.deletePartitionColumnStatistics(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(),
-        Warehouse.makePartName(tbl.getPartitionKeys(), partVals1), partVals1, colName, CacheUtils.HIVE_ENGINE);
+        WarehouseUtils.makePartName(tbl.getPartitionKeys(), partVals1), partVals1, colName, CacheUtils.HIVE_ENGINE);
     objectStore.deletePartitionColumnStatistics(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(),
-        Warehouse.makePartName(tbl.getPartitionKeys(), partVals2), partVals2, colName, CacheUtils.HIVE_ENGINE);
+        WarehouseUtils.makePartName(tbl.getPartitionKeys(), partVals2), partVals2, colName, CacheUtils.HIVE_ENGINE);
     objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals1);
     objectStore.dropPartition(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName(), partVals2);
     objectStore.dropTable(DEFAULT_CATALOG_NAME, db.getName(), tbl.getTableName());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCatalogCaching.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCatalogCaching.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -92,7 +93,7 @@ public class TestCatalogCaching {
     // Only the hive catalog should be cached
     List<String> cachedCatalogs = cachedStore.getCatalogs();
     Assert.assertEquals(1, cachedCatalogs.size());
-    Assert.assertEquals(Warehouse.DEFAULT_CATALOG_NAME, cachedCatalogs.get(0));
+    Assert.assertEquals(WarehouseUtils.DEFAULT_CATALOG_NAME, cachedCatalogs.get(0));
   }
 
   @Test
@@ -115,7 +116,7 @@ public class TestCatalogCaching {
     cachedCatalogs.sort(Comparator.naturalOrder());
     Assert.assertEquals(CAT1_NAME, cachedCatalogs.get(0));
     Assert.assertEquals(CAT2_NAME, cachedCatalogs.get(1));
-    Assert.assertEquals(Warehouse.DEFAULT_CATALOG_NAME, cachedCatalogs.get(2));
+    Assert.assertEquals(WarehouseUtils.DEFAULT_CATALOG_NAME, cachedCatalogs.get(2));
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAlterPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAlterPartitions.java
@@ -55,7 +55,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static java.util.stream.Collectors.joining;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCatalogs.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCatalogs.java
@@ -2,7 +2,6 @@ package org.apache.hadoop.hive.metastore.client;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.Catalog;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -13,6 +12,7 @@ import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -73,7 +73,7 @@ public class TestCatalogs extends MetaStoreClientTest {
     // Drop any left over catalogs
     List<String> catalogs = client.getCatalogs();
     for (String catName : catalogs) {
-      if (!catName.equalsIgnoreCase(Warehouse.DEFAULT_CATALOG_NAME)) {
+      if (!catName.equalsIgnoreCase(WarehouseUtils.DEFAULT_CATALOG_NAME)) {
         // First drop any databases in catalog
         List<String> databases = client.getAllDatabases(catName);
         for (String db : databases) {
@@ -141,7 +141,7 @@ public class TestCatalogs extends MetaStoreClientTest {
     Assert.assertEquals(4, catalogs.size());
     catalogs.sort(Comparator.naturalOrder());
     List<String> expected = new ArrayList<>(catNames.length + 1);
-    expected.add(Warehouse.DEFAULT_CATALOG_NAME);
+    expected.add(WarehouseUtils.DEFAULT_CATALOG_NAME);
     expected.addAll(Arrays.asList(catNames));
     expected.sort(Comparator.naturalOrder());
     for (int i = 0; i < catalogs.size(); i++) {
@@ -177,7 +177,7 @@ public class TestCatalogs extends MetaStoreClientTest {
 
     catalogs = client.getCatalogs();
     Assert.assertEquals(1, catalogs.size());
-    Assert.assertTrue(catalogs.get(0).equalsIgnoreCase(Warehouse.DEFAULT_CATALOG_NAME));
+    Assert.assertTrue(catalogs.get(0).equalsIgnoreCase(WarehouseUtils.DEFAULT_CATALOG_NAME));
   }
 
   @Test(expected = NoSuchObjectException.class)
@@ -202,7 +202,7 @@ public class TestCatalogs extends MetaStoreClientTest {
 
   @Test(expected = MetaException.class)
   public void dropHiveCatalog() throws TException {
-    client.dropCatalog(Warehouse.DEFAULT_CATALOG_NAME);
+    client.dropCatalog(WarehouseUtils.DEFAULT_CATALOG_NAME);
   }
 
   @Test(expected = InvalidOperationException.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCheckConstraint.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCheckConstraint.java
@@ -44,8 +44,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Catalog;
@@ -40,6 +39,7 @@ import org.apache.hadoop.hive.metastore.client.builder.FunctionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -57,7 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
 
 /**
  * Test class for IMetaStoreClient API. Testing the Database related functions.
@@ -587,12 +587,12 @@ public class TestDatabases extends MetaStoreClientTest {
 
     fetchedDbs = new HashSet<>(client.getAllDatabases());
     Assert.assertEquals(5, fetchedDbs.size());
-    Assert.assertTrue(fetchedDbs.contains(Warehouse.DEFAULT_DATABASE_NAME));
+    Assert.assertTrue(fetchedDbs.contains(WarehouseUtils.DEFAULT_DATABASE_NAME));
 
     // Intentionally using the deprecated method to make sure it returns correct results.
     fetchedDbs = new HashSet<>(client.getAllDatabases());
     Assert.assertEquals(5, fetchedDbs.size());
-    Assert.assertTrue(fetchedDbs.contains(Warehouse.DEFAULT_DATABASE_NAME));
+    Assert.assertTrue(fetchedDbs.contains(WarehouseUtils.DEFAULT_DATABASE_NAME));
 
     fetchedDbs = new HashSet<>(client.getDatabases(catName, "d*"));
     Assert.assertEquals(3, fetchedDbs.size());
@@ -600,12 +600,12 @@ public class TestDatabases extends MetaStoreClientTest {
 
     fetchedDbs = new HashSet<>(client.getDatabases("d*"));
     Assert.assertEquals(1, fetchedDbs.size());
-    Assert.assertTrue(fetchedDbs.contains(Warehouse.DEFAULT_DATABASE_NAME));
+    Assert.assertTrue(fetchedDbs.contains(WarehouseUtils.DEFAULT_DATABASE_NAME));
 
     // Intentionally using the deprecated method to make sure it returns correct results.
     fetchedDbs = new HashSet<>(client.getDatabases("d*"));
     Assert.assertEquals(1, fetchedDbs.size());
-    Assert.assertTrue(fetchedDbs.contains(Warehouse.DEFAULT_DATABASE_NAME));
+    Assert.assertTrue(fetchedDbs.contains(WarehouseUtils.DEFAULT_DATABASE_NAME));
 
     fetchedDbs = new HashSet<>(client.getDatabases(catName, "*1"));
     Assert.assertEquals(1, fetchedDbs.size());
@@ -661,12 +661,12 @@ public class TestDatabases extends MetaStoreClientTest {
 
   @Test(expected = NoSuchObjectException.class)
   public void fetchDatabaseInNonExistentCatalog() throws TException {
-    client.getDatabase("nosuch", Warehouse.DEFAULT_DATABASE_NAME);
+    client.getDatabase("nosuch", WarehouseUtils.DEFAULT_DATABASE_NAME);
   }
 
   @Test(expected = NoSuchObjectException.class)
   public void dropDatabaseInNonExistentCatalog() throws TException {
-    client.dropDatabase("nosuch", Warehouse.DEFAULT_DATABASE_NAME, true, false, false);
+    client.dropDatabase("nosuch", WarehouseUtils.DEFAULT_DATABASE_NAME, true, false, false);
   }
 
   private Database getDatabaseWithAllParametersSet() throws Exception {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDefaultConstraint.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDefaultConstraint.java
@@ -44,8 +44,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestExchangePartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestExchangePartitions.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -37,6 +36,7 @@ import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -135,8 +135,8 @@ public class TestExchangePartitions extends MetaStoreClientTest {
 
     Assert.assertEquals(1, exchangedPartitions.size());
     String partitionName =
-        Warehouse.makePartName(sourceTable.getPartitionKeys(), partitions[1].getValues());
-    String exchangedPartitionName = Warehouse.makePartName(sourceTable.getPartitionKeys(),
+        WarehouseUtils.makePartName(sourceTable.getPartitionKeys(), partitions[1].getValues());
+    String exchangedPartitionName = WarehouseUtils.makePartName(sourceTable.getPartitionKeys(),
         exchangedPartitions.get(0).getValues());
     Assert.assertEquals(partitionName, exchangedPartitionName);
 
@@ -185,7 +185,7 @@ public class TestExchangePartitions extends MetaStoreClientTest {
     List<String> exchangedPartNames = new ArrayList<>();
     for (Partition exchangedPartition : exchangedPartitions) {
       String partName =
-          Warehouse.makePartName(sourceTable.getPartitionKeys(), exchangedPartition.getValues());
+          WarehouseUtils.makePartName(sourceTable.getPartitionKeys(), exchangedPartition.getValues());
       exchangedPartNames.add(partName);
     }
     Assert.assertTrue(exchangedPartNames.contains("year=2017/month=march/day=15"));
@@ -1292,7 +1292,7 @@ public class TestExchangePartitions extends MetaStoreClientTest {
       // Check the location of the result partition. It should be located in the destination table
       // folder.
       String partName =
-          Warehouse.makePartName(sourceTable.getPartitionKeys(), partition.getValues());
+          WarehouseUtils.makePartName(sourceTable.getPartitionKeys(), partition.getValues());
       Assert.assertEquals(destTable.getSd().getLocation() + "/" + partName,
           resultPart.getSd().getLocation());
       Assert.assertTrue(metaStore.isPathExists(new Path(resultPart.getSd().getLocation())));
@@ -1336,7 +1336,7 @@ public class TestExchangePartitions extends MetaStoreClientTest {
         // Expected exception
       }
       String partName =
-          Warehouse.makePartName(sourceTable.getPartitionKeys(), partition.getValues());
+          WarehouseUtils.makePartName(sourceTable.getPartitionKeys(), partition.getValues());
       Assert.assertFalse(
           metaStore.isPathExists(new Path(destTable.getSd().getLocation() + "/" + partName)));
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestForeignKey.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestForeignKey.java
@@ -47,7 +47,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestFunctions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestFunctions.java
@@ -50,7 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 /**
  * Test class for IMetaStoreClient API. Testing the Function related functions.

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetAllTableConstraints.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetAllTableConstraints.java
@@ -53,7 +53,7 @@ import org.junit.runners.Parameterized;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestNotNullConstraint.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestNotNullConstraint.java
@@ -44,8 +44,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestPrimaryKey.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestPrimaryKey.java
@@ -45,7 +45,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesCreateDropAlterTruncate.java
@@ -85,8 +85,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.apache.hadoop.hive.metastore.TestHiveMetaStore.createSourceTable;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -41,7 +41,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.*;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 /**
  * Test class for IMetaStoreClient API. Testing the Table related functions for metadata

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesList.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesList.java
@@ -44,7 +44,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 /**
  * Test class for IMetaStoreClient API. Testing the Table related functions for metadata

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestUniqueConstraint.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestUniqueConstraint.java
@@ -44,8 +44,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
-import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_CATALOG_NAME;
+import static org.apache.hadoop.hive.metastore.utils.WarehouseUtils.DEFAULT_DATABASE_NAME;
 
 @RunWith(Parameterized.class)
 @Category(MetastoreCheckinTest.class)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolTaskDrop.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolTaskDrop.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.metastore.tools.schematool;
 
-import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class TestSchemaToolTaskDrop {
     // Return two databases: `mydb` and `default`
     ResultSet databasesResult = mock(ResultSet.class);
     when(databasesResult.next()).thenReturn(true, true, false);
-    when(databasesResult.getString(anyInt())).thenReturn("mydb", Warehouse.DEFAULT_DATABASE_NAME);
+    when(databasesResult.getString(anyInt())).thenReturn("mydb", WarehouseUtils.DEFAULT_DATABASE_NAME);
 
     // Return two tables: `table1` and `table2`
     ResultSet tablesResult = mock(ResultSet.class);
@@ -92,8 +92,8 @@ public class TestSchemaToolTaskDrop {
     uut.execute();
 
     Mockito.verify(stmtMock).execute("DROP DATABASE `mydb` CASCADE");
-    Mockito.verify(stmtMock).execute(String.format("DROP TABLE `%s`.`table1`", Warehouse.DEFAULT_DATABASE_NAME));
-    Mockito.verify(stmtMock).execute(String.format("DROP TABLE `%s`.`table2`", Warehouse.DEFAULT_DATABASE_NAME));
+    Mockito.verify(stmtMock).execute(String.format("DROP TABLE `%s`.`table1`", WarehouseUtils.DEFAULT_DATABASE_NAME));
+    Mockito.verify(stmtMock).execute(String.format("DROP TABLE `%s`.`table2`", WarehouseUtils.DEFAULT_DATABASE_NAME));
     Mockito.verify(stmtMock, times(3)).execute(anyString());
   }
 

--- a/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
+++ b/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
@@ -549,7 +550,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
       Map<String, String> partSpec = Warehouse.makeSpecFromValues(
           table.getPartitionKeys(), partitionValues);
       try {
-        destLocation = new Path(table.getDataLocation(), Warehouse.makePartPath(partSpec));
+        destLocation = new Path(table.getDataLocation(), WarehouseUtils.makePartPath(partSpec));
       } catch (MetaException e) {
         throw new StreamingException("Unable to retrieve the delta file location"
             + " for values: " + partitionValues

--- a/streaming/src/java/org/apache/hive/streaming/HiveStreamingConnection.java
+++ b/streaming/src/java/org/apache/hive/streaming/HiveStreamingConnection.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.HdfsUtils;
 import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
@@ -443,10 +444,10 @@ public class HiveStreamingConnection implements StreamingConnection {
     try {
       Map<String, String> partSpec = Warehouse.makeSpecFromValues(tableObject.getPartitionKeys(), partitionValues);
 
-      Path location = new Path(tableObject.getDataLocation(), Warehouse.makePartPath(partSpec));
+      Path location = new Path(tableObject.getDataLocation(), WarehouseUtils.makePartPath(partSpec));
       location = new Path(Utilities.getQualifiedPath(conf, location));
       partLocation = location.toString();
-      partName = Warehouse.makePartName(tableObject.getPartitionKeys(), partitionValues);
+      partName = WarehouseUtils.makePartName(tableObject.getPartitionKeys(), partitionValues);
       Partition partition =
           org.apache.hadoop.hive.ql.metadata.Partition.createMetaPartitionObject(tableObject, partSpec, location);
 

--- a/streaming/src/java/org/apache/hive/streaming/TransactionBatch.java
+++ b/streaming/src/java/org/apache/hive/streaming/TransactionBatch.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.metastore.LockComponentBuilder;
 import org.apache.hadoop.hive.metastore.LockRequestBuilder;
-import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AbortTxnRequest;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -35,6 +34,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchTxnException;
 import org.apache.hadoop.hive.metastore.api.TxnAbortedException;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
 import org.apache.hadoop.hive.metastore.txn.TxnErrorMsg;
+import org.apache.hadoop.hive.metastore.utils.WarehouseUtils;
 import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.thrift.TException;
@@ -107,7 +107,7 @@ public class TransactionBatch extends AbstractStreamingTransaction {
     try {
       if (conn.isPartitionedTable() && !conn.isDynamicPartitioning()) {
         List<FieldSchema> partKeys = conn.getTable().getPartitionKeys();
-        partNameForLock = Warehouse.makePartName(partKeys, conn.getStaticPartitionValues());
+        partNameForLock = WarehouseUtils.makePartName(partKeys, conn.getStaticPartitionValues());
       }
       this.conn = conn;
       this.username = conn.getUsername();


### PR DESCRIPTION
### What changes does this PR contain?
To support the Planned/Unplanned Failover, we need the capability to increase the retention period for both the Notification Logs and Change Manager entries until the successful reverse replication is done (i.e. the Optimized Bootstrap). A database-level property 'repl.db.under.failover.sync.pending' was introduced to signify this state. This PR contains the changes for,
1. selective deletion of notification events that are not relevant to the database(s) in failover
2. skipping the CM clearer thread execution until the time the Optimized Bootstrap is not done

### Why this change is needed?
The change is needed to make the Optimized Bootstrap and Point-in-time consistency possible. If the relevant Notification logs and Change Manager entries are not retained, we can't perform the Optimized Bootstrap.

### Were the changes tested?
I have included relevant unit tests in this PR, and will also perform manual verification after deploying the changes on a cluster.

### Does this PR introduce _any_ user-facing change?
No