### PR TITLE
HIVE-27272: Fix limit clause issue for iceberg qtests

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/negative/parquet_limit_negative.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/parquet_limit_negative.q
@@ -1,0 +1,7 @@
+create table icebergtable (id int, name string) stored by iceberg stored as parquet;
+
+insert into icebergtable values (1, 'Joe'), (2, 'Jack');
+
+select * from icebergtable limit 1;
+
+create table icebergtable (id int, name string) stored by iceberg stored as parquet;

--- a/iceberg/iceberg-handler/src/test/queries/positive/parquet_limit.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/parquet_limit.q
@@ -1,0 +1,5 @@
+create table icebergtable (id int, name string) stored by iceberg stored as parquet;
+
+insert into icebergtable values (1, 'Joe'), (2, 'Jack');
+
+select * from icebergtable limit 1;

--- a/iceberg/iceberg-handler/src/test/results/negative/parquet_limit_negative.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/parquet_limit_negative.q.out
@@ -1,0 +1,30 @@
+PREHOOK: query: create table icebergtable (id int, name string) stored by iceberg stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@icebergtable
+POSTHOOK: query: create table icebergtable (id int, name string) stored by iceberg stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@icebergtable
+PREHOOK: query: insert into icebergtable values (1, 'Joe'), (2, 'Jack')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@icebergtable
+POSTHOOK: query: insert into icebergtable values (1, 'Joe'), (2, 'Jack')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@icebergtable
+PREHOOK: query: select * from icebergtable limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@icebergtable
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from icebergtable limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@icebergtable
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	Joe
+PREHOOK: query: create table icebergtable (id int, name string) stored by iceberg stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@icebergtable
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. AlreadyExistsException(message:Table hive.default.icebergtable already exists)

--- a/iceberg/iceberg-handler/src/test/results/positive/parquet_limit.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/parquet_limit.q.out
@@ -1,0 +1,25 @@
+PREHOOK: query: create table icebergtable (id int, name string) stored by iceberg stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@icebergtable
+POSTHOOK: query: create table icebergtable (id int, name string) stored by iceberg stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@icebergtable
+PREHOOK: query: insert into icebergtable values (1, 'Joe'), (2, 'Jack')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@icebergtable
+POSTHOOK: query: insert into icebergtable values (1, 'Joe'), (2, 'Jack')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@icebergtable
+PREHOOK: query: select * from icebergtable limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@icebergtable
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from icebergtable limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@icebergtable
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	Joe

--- a/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergCliDriver.java
+++ b/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergCliDriver.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.util.List;
 import org.apache.hadoop.hive.cli.control.CliAdapter;
 import org.apache.hadoop.hive.cli.control.CliConfigs;
+import org.apache.hadoop.hive.ql.exec.tez.ObjectCache;
+import org.apache.tez.runtime.common.objectregistry.ObjectRegistryImpl;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +57,7 @@ public class TestIcebergCliDriver {
 
   @Test
   public void testCliDriver() throws Exception {
+    ObjectCache.setupObjectRegistry(new ObjectRegistryImpl());
     adapter.runTest(name, qfile);
   }
 }

--- a/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergNegativeCliDriver.java
+++ b/itests/qtest-iceberg/src/test/java/org/apache/hadoop/hive/cli/TestIcebergNegativeCliDriver.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.util.List;
 import org.apache.hadoop.hive.cli.control.CliAdapter;
 import org.apache.hadoop.hive.cli.control.CliConfigs;
+import org.apache.hadoop.hive.ql.exec.tez.ObjectCache;
+import org.apache.tez.runtime.common.objectregistry.ObjectRegistryImpl;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +57,7 @@ public class TestIcebergNegativeCliDriver {
 
   @Test
   public void testCliDriver() throws Exception {
+    ObjectCache.setupObjectRegistry(new ObjectRegistryImpl());
     adapter.runTest(name, qfile);
   }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?
ObjectCache set up for Iceber CLI drivers (both for positive and negative)


### Why are the changes needed?
Qtests failed if they had a `limit` clause. 
Example: 

```sql
create table icebergtable (id int, name string) stored by iceberg stored as parquet;

insert into icebergtable values (1, 'Joe'), (2, 'Jack');

select * from icebergtable limit 1;
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
With QTests