### PR TITLE
HIVE-27278: Simplify correlated queries with empty inputs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
@@ -83,4 +83,9 @@ public final class Bug {
    * Whether <a href="https://issues.apache.org/jira/browse/CALCITE-5337">CALCITE-5337</a> is fixed.
    */
   public static final boolean CALCITE_5337_FIXED = false;
+
+  /**
+   * Whether <a href="https://issues.apache.org/jira/browse/CALCITE-5669">CALCITE-5669</a> is fixed.
+   */
+  public static final boolean CALCITE_5669_FIXED = false;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRemoveEmptySingleRules.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRemoveEmptySingleRules.java
@@ -25,11 +25,13 @@ import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.Bug;
@@ -105,21 +107,13 @@ public class HiveRemoveEmptySingleRules extends PruneEmptyRules {
           }
 
           final Join join = call.rel(0);
-          final Values empty = call.rel(1);
           final RelNode right = call.rel(2);
           final RelBuilder relBuilder = call.builder();
           if (join.getJoinType().generatesNullsOnLeft()) {
             // If "emp" is empty, "select * from emp right join dept" will have
             // the same number of rows as "dept", and null values for the
             // columns from "emp". The left side of the join can be removed.
-            final List<RexNode> nullLiterals =
-                    Collections.nCopies(empty.getRowType().getFieldCount(),
-                            relBuilder.literal(null));
-            call.transformTo(
-                    relBuilder.push(right)
-                            .project(concat(nullLiterals, relBuilder.fields()))
-                            .convert(join.getRowType(), true)
-                            .build());
+            call.transformTo(padWithNulls(relBuilder, right, join.getRowType(), true));
             return;
           }
           call.transformTo(relBuilder.push(join).empty().build());
@@ -165,20 +159,12 @@ public class HiveRemoveEmptySingleRules extends PruneEmptyRules {
 
           final Join join = call.rel(0);
           final RelNode left = call.rel(1);
-          final Values empty = call.rel(2);
           final RelBuilder relBuilder = call.builder();
           if (join.getJoinType().generatesNullsOnRight()) {
             // If "dept" is empty, "select * from emp left join dept" will have
             // the same number of rows as "emp", and null values for the
             // columns from "dept". The right side of the join can be removed.
-            final List<RexNode> nullLiterals =
-                    Collections.nCopies(empty.getRowType().getFieldCount(),
-                            relBuilder.literal(null));
-            call.transformTo(
-                    relBuilder.push(left)
-                            .project(concat(relBuilder.fields(), nullLiterals))
-                            .convert(join.getRowType(), true)
-                            .build());
+            call.transformTo(padWithNulls(relBuilder, left, join.getRowType(), false));
             return;
           }
           if (join.getJoinType() == JoinRelType.ANTI) {
@@ -187,6 +173,79 @@ public class HiveRemoveEmptySingleRules extends PruneEmptyRules {
             return;
           }
           call.transformTo(relBuilder.push(join).empty().build());
+        }
+      };
+    }
+  }
+
+  private static RelNode padWithNulls(RelBuilder builder, RelNode input, RelDataType resultType,
+      boolean leftPadding) {
+    int padding = resultType.getFieldCount() - input.getRowType().getFieldCount();
+    List<RexNode> nullLiterals = Collections.nCopies(padding, builder.literal(null));
+    builder.push(input);
+    if (leftPadding) {
+      builder.project(concat(nullLiterals, builder.fields()));
+    } else {
+      builder.project(concat(builder.fields(), nullLiterals));
+    }
+    return builder.convert(resultType, true).build();
+  }
+
+  public static final RelOptRule CORRELATE_RIGHT_INSTANCE = RelRule.Config.EMPTY
+      .withOperandSupplier(b0 ->
+          b0.operand(Correlate.class).inputs(
+              b1 -> b1.operand(RelNode.class).anyInputs(),
+              b2 -> b2.operand(Values.class).predicate(Values::isEmpty).noInputs()))
+      .withDescription("PruneEmptyCorrelate(right)")
+      .withRelBuilderFactory(HiveRelFactories.HIVE_BUILDER)
+      .as(CorrelateEmptyRuleConfig.class)
+      .toRule();
+  public static final RelOptRule CORRELATE_LEFT_INSTANCE = RelRule.Config.EMPTY
+      .withOperandSupplier(b0 ->
+          b0.operand(Correlate.class).inputs(
+              b1 -> b1.operand(Values.class).predicate(Values::isEmpty).noInputs(),
+              b2 -> b2.operand(RelNode.class).anyInputs()))
+      .withDescription("PruneEmptyCorrelate(left)")
+      .withRelBuilderFactory(HiveRelFactories.HIVE_BUILDER)
+      .as(CorrelateEmptyRuleConfig.class)
+      .toRule();
+  
+  /** Configuration for rule that prunes a correlate if one of its inputs is empty. */
+  public interface CorrelateEmptyRuleConfig extends PruneEmptyRule.Config {
+    @Override
+    default PruneEmptyRule toRule() {
+      return new PruneEmptyRule(this) {
+        @Override
+        public void onMatch(RelOptRuleCall call) {
+          if (Bug.CALCITE_5669_FIXED) {
+            throw new IllegalStateException(
+                "Class is redundant after fix is merged into Calcite");
+          }
+          final Correlate corr = call.rel(0);
+          final RelNode left = call.rel(1);
+          final RelNode right = call.rel(2);
+          final RelNode newRel;
+          RelBuilder b = call.builder();
+          if (left instanceof Values) {
+            newRel = b.push(corr).empty().build();
+          } else {
+            assert right instanceof Values;
+            switch (corr.getJoinType()) {
+            case LEFT:
+              newRel = padWithNulls(b, left, corr.getRowType(), false);
+              break;
+            case INNER:
+            case SEMI:
+              newRel = b.push(corr).empty().build();
+              break;
+            case ANTI:
+              newRel = left;
+              break;
+            default:
+              throw new IllegalStateException("Correlate does not support " + corr.getJoinType());
+            }
+          }
+          call.transformTo(newRel);
         }
       };
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1956,7 +1956,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
               HiveRemoveEmptySingleRules.SORT_INSTANCE,
               HiveRemoveEmptySingleRules.SORT_FETCH_ZERO_INSTANCE,
               HiveRemoveEmptySingleRules.AGGREGATE_INSTANCE,
-              HiveRemoveEmptySingleRules.UNION_INSTANCE);
+              HiveRemoveEmptySingleRules.UNION_INSTANCE,
+              HiveRemoveEmptySingleRules.CORRELATE_LEFT_INSTANCE,
+              HiveRemoveEmptySingleRules.CORRELATE_RIGHT_INSTANCE);
 
       // Trigger program
       perfLogger.perfLogBegin(this.getClass().getName(), PerfLogger.OPTIMIZER);

--- a/ql/src/test/queries/clientpositive/empty_result_correlate.q
+++ b/ql/src/test/queries/clientpositive/empty_result_correlate.q
@@ -1,0 +1,4 @@
+create table t1 (id int, val varchar(10));
+create table t2 (id int, val varchar(10));
+
+EXPLAIN CBO SELECT id FROM t1 WHERE NULL IN (SELECT NULL FROM t2 where t1.id = t2.id);

--- a/ql/src/test/results/clientpositive/llap/empty_result_correlate.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result_correlate.q.out
@@ -1,0 +1,29 @@
+PREHOOK: query: create table t1 (id int, val varchar(10))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1 (id int, val varchar(10))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: create table t2 (id int, val varchar(10))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t2
+POSTHOOK: query: create table t2 (id int, val varchar(10))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t2
+PREHOOK: query: EXPLAIN CBO SELECT id FROM t1 WHERE NULL IN (SELECT NULL FROM t2 where t1.id = t2.id)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO SELECT id FROM t1 WHERE NULL IN (SELECT NULL FROM t2 where t1.id = t2.id)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveValues(tuples=[[]])
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add new pruning rules to remove correlate when inputs are empty. 
2. Refactor pruning rules for join to remove code duplication with the addition of new rules.

### Why are the changes needed?
Avoid redundant occurrences of `LogicalCorrelate` in the plan that cannot be handled by the compiler and may lead to exceptions and complation failures.

### Does this PR introduce _any_ user-facing change?
Fixes some queries that fail at compile time.

```sql
EXPLAIN CBO SELECT id FROM t1 WHERE NULL IN (SELECT NULL FROM t2 where t1.id = t2.id);
```
**Before**
```
HiveProject(id=[$0])
  LogicalCorrelate(correlation=[$cor0], joinType=[semi], requiredColumns=[{}])
    HiveTableScan(table=[[default, t1]], table:alias=[t1])
    HiveValues(tuples=[[]])
```
**After**
```
HiveValues(tuples=[[]])
```


### How was this patch tested?
```
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=.*subquery.*
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=empty.*
```