### PR TITLE
HIVE-27284: Make HMSHandler proxy pluggable

### DIFF
--- a/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/iceberg/iceberg-catalog/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HMSHandler;
+import org.apache.hadoop.hive.metastore.HMSHandlerProxyFactory;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingHMSHandler;
 import org.apache.hadoop.hive.metastore.TSetIpAddressProcessor;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -67,8 +67,8 @@ public class TestHiveMetastore {
           .build();
 
   private static final DynMethods.StaticMethod GET_BASE_HMS_HANDLER = DynMethods.builder("getProxy")
-          .impl(RetryingHMSHandler.class, Configuration.class, IHMSHandler.class, boolean.class)
-          .impl(RetryingHMSHandler.class, HiveConf.class, IHMSHandler.class, boolean.class)
+          .impl(HMSHandlerProxyFactory.class, Configuration.class, IHMSHandler.class, boolean.class)
+          .impl(HMSHandlerProxyFactory.class, HiveConf.class, IHMSHandler.class, boolean.class)
           .buildStatic();
 
   // Hive3 introduces background metastore tasks (MetastoreTaskThread) for performing various cleanup duties. These

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -138,8 +138,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       "org.apache.hadoop.hive.metastore.HiveMetaStore";
 
   // Method used to create Hive Metastore client. It is called as
-  // HiveMetaStore.newRetryingHMSHandler("hive client", this.conf, true);
-  private static final String HIVE_METASTORE_CREATE_HANDLER_METHOD = "newRetryingHMSHandler";
+  // HiveMetaStore.newHMSHandler("hive client", this.conf, true);
+  private static final String HIVE_METASTORE_CREATE_HANDLER_METHOD = "newHMSHandler";
 
   ThriftHiveMetastore.Iface client = null;
   private TTransport transport = null;
@@ -292,10 +292,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     //
     // The code below simulates the following code
     //
-    // client = HiveMetaStore.newRetryingHMSHandler(this.conf);
+    // client = HiveMetaStore.newHMSHandler(this.conf);
     //
     // using reflection API. This is done to avoid dependency of MetastoreClient on Hive Metastore.
-    // Note that newRetryingHMSHandler is static method, so we pass null as the object reference.
+    // Note that newHMSHandler is static method, so we pass null as the object reference.
     //
     try {
       Class<?> clazz = Class.forName(HIVE_METASTORE_CLASS);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -105,6 +105,8 @@ public class MetastoreConf {
 
   public static final String METASTORE_AUTHENTICATION_LDAP_USERMEMBERSHIPKEY_NAME =
           "metastore.authentication.ldap.userMembershipKey";
+  public static final String METASTORE_RETRYING_HANDLER_CLASS =
+          "org.apache.hadoop.hive.metastore.RetryingHMSHandler";
 
   private static final Map<String, ConfVars> metaConfs = new HashMap<>();
   private static volatile URL hiveSiteURL = null;
@@ -874,6 +876,9 @@ public class MetastoreConf {
             "testing only."),
     HMS_HANDLER_INTERVAL("metastore.hmshandler.retry.interval", "hive.hmshandler.retry.interval",
         2000, TimeUnit.MILLISECONDS, "The time between HMSHandler retry attempts on failure."),
+    HMS_HANDLER_PROXY_CLASS("metastore.hmshandler.proxy", "hive.metastore.hmshandler.proxy",
+        METASTORE_RETRYING_HANDLER_CLASS,
+        "The proxy class name of HMSHandler, default is RetryingHMSHandler."),
     IDENTIFIER_FACTORY("datanucleus.identifierFactory",
         "datanucleus.identifierFactory", "datanucleus1",
         "Name of the identifier factory to use when generating table/column names etc. \n" +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/JavaUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/JavaUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.metastore.utils;
 
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,8 @@ public class JavaUtils {
           "Number of constructor parameter types doesn't match number of arguments");
     }
     for (int i = 0; i < parameterTypes.length; i++) {
-      Class<?> clazz = parameterTypes[i];
+      // initargs are boxed to Object, so we need to wrapper primitive types here.
+      Class<?> clazz = ClassUtils.primitiveToWrapper(parameterTypes[i]);
       if (initargs[i] != null && !(clazz.isInstance(initargs[i]))) {
         throw new IllegalArgumentException("Object : " + initargs[i]
             + " is not an instance of " + clazz);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AbstractHMSHandlerProxy.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AbstractHMSHandlerProxy.java
@@ -57,7 +57,7 @@ public abstract class AbstractHMSHandlerProxy implements InvocationHandler {
     initBaseHandler();
   }
 
-  static class Result {
+  static final class Result {
     static final Result ERROR_RESULT = new Result(null, "error=true");
     private final Object result;
     private final String additionalInfo;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AbstractHMSHandlerProxy.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AbstractHMSHandlerProxy.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.MetaStoreInit.MetaStoreInitData;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.metastore.metrics.PerfLogger;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractHMSHandlerProxy implements InvocationHandler {
+  protected final MetaStoreInitData metaStoreInitData = new MetaStoreInitData();
+  protected final IHMSHandler baseHandler;
+  protected final Configuration origConf;    // base configuration
+  protected final Configuration activeConf;  // active configuration
+  protected final boolean reloadConf;
+  protected final long timeout;
+
+  public AbstractHMSHandlerProxy(Configuration conf, IHMSHandler baseHandler, boolean local)
+      throws MetaException {
+    this.origConf = conf;
+    this.baseHandler = baseHandler;
+    if (local) {
+      baseHandler.setConf(origConf); // tests expect configuration changes applied directly to metastore
+    }
+    activeConf = baseHandler.getConf();
+    reloadConf = MetastoreConf.getBoolVar(origConf, ConfVars.HMS_HANDLER_FORCE_RELOAD_CONF);
+    timeout = MetastoreConf.getTimeVar(origConf,
+            ConfVars.CLIENT_SOCKET_TIMEOUT, TimeUnit.MILLISECONDS);
+
+    // This has to be called before initializing the instance of HMSHandler
+    // Using the hook on startup ensures that the hook always has priority
+    // over settings in *.xml.  The thread local conf needs to be used because at this point
+    // it has already been initialized using hiveConf.
+    MetaStoreInit.updateConnectionURL(origConf, getActiveConf(), null, metaStoreInitData);
+    initBaseHandler();
+  }
+
+  static class Result {
+    static final Result ERROR_RESULT = new Result(null, "error=true");
+    private final Object result;
+    private final String additionalInfo;
+
+    public Result(Object result, String additionalInfo) {
+      this.result = result;
+      this.additionalInfo = additionalInfo;
+    }
+  }
+
+  protected void initBaseHandler() throws MetaException {
+    baseHandler.init();
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] objects) throws Throwable {
+    PerfLogger perfLogger = PerfLogger.getPerfLogger(false);
+    perfLogger.perfLogBegin(this.getClass().getName(), method.getName());
+    Result result = Result.ERROR_RESULT;
+    Deadline.registerIfNot(timeout);
+    try {
+      result = invokeInternal(proxy, method, objects);
+      return result == null ? null : result.result;
+    } finally {
+      String info = result == null ? "" : result.additionalInfo;
+      perfLogger.perfLogEnd(this.getClass().getName(), method.getName(), info);
+    }
+  }
+
+  protected abstract Result invokeInternal(Object proxy, Method method, Object[] args)
+      throws Throwable;
+
+  public Configuration getActiveConf() {
+    return activeConf;
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -142,12 +142,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public static final String PARTITION_NUMBER_EXCEED_LIMIT_MSG =
       "Number of partitions scanned (=%d) on table '%s' exceeds limit (=%d). This is controlled on the metastore server by %s.";
 
-  // Used for testing to simulate method timeout.
-  @VisibleForTesting
-  static boolean testTimeoutEnabled = false;
-  @VisibleForTesting
-  static long testTimeoutValue = -1;
-
   public static final String ADMIN = "admin";
   public static final String PUBLIC = "public";
 
@@ -1344,14 +1338,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         // expected
       }
 
-      if (testTimeoutEnabled) {
-        try {
-          Thread.sleep(testTimeoutValue);
-        } catch (InterruptedException e) {
-          // do nothing
-        }
-        Deadline.checkTimeout();
-      }
       create_database_core(getMS(), db);
       success = true;
     } catch (Exception e) {
@@ -1890,14 +1876,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         }
       } catch (NoSuchObjectException e) {
         // expected
-      }
-      if (testTimeoutEnabled) {
-        try {
-          Thread.sleep(testTimeoutValue);
-        } catch (InterruptedException e) {
-          // do nothing
-        }
-        Deadline.checkTimeout();
       }
       create_dataconnector_core(getMS(), connector);
       success = true;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandlerProxyFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandlerProxyFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.metastore.utils.JavaUtils;
+
+import java.lang.reflect.Proxy;
+
+public class HMSHandlerProxyFactory {
+  public static IHMSHandler getProxy(Configuration conf, IHMSHandler handler, boolean local)
+      throws MetaException {
+    String hmsHandlerProxyName = MetastoreConf.getVar(conf, ConfVars.HMS_HANDLER_PROXY_CLASS);
+    Class<? extends AbstractHMSHandlerProxy> proxyClass =
+            JavaUtils.getClass(hmsHandlerProxyName, AbstractHMSHandlerProxy.class);
+    AbstractHMSHandlerProxy invacationHandler = JavaUtils.newInstance(proxyClass,
+        new Class[]{Configuration.class, IHMSHandler.class, boolean.class},
+            new Object[]{conf, handler, local});
+
+    return (IHMSHandler) Proxy.newProxyInstance(
+            HMSHandlerProxyFactory.class.getClassLoader(),
+            new Class[]{ IHMSHandler.class }, invacationHandler);
+  }
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -18,12 +18,13 @@
 
 package org.apache.hadoop.hive.metastore;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -82,8 +83,8 @@ public class TestHiveMetaStoreTimeout {
           }
         }
         return new Result(object, "error=false");
-      } catch (Exception e) {
-        throw new MetaException(ExceptionUtils.getStackTrace(e));
+      } catch (UndeclaredThrowableException | InvocationTargetException e) {
+        throw e.getCause();
       }
     }
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -20,8 +20,10 @@ package org.apache.hadoop.hive.metastore;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -32,7 +34,6 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -40,8 +41,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
- * Test long running request timeout functionality in MetaStore Server
- * HMSHandler.create_database() is used to simulate a long running method.
+ * Test long running request timeout functionality in MetaStore Server.
  */
 @Category(MetastoreCheckinTest.class)
 public class TestHiveMetaStoreTimeout {
@@ -52,6 +52,42 @@ public class TestHiveMetaStoreTimeout {
 
   private final String dbName = "db";
   
+  /** Test handler proxy used to simulate a long-running create_database() method */
+  static class DelayedHMSHandler extends AbstractHMSHandlerProxy {
+    static long testTimeoutValue = -1;
+    public DelayedHMSHandler(Configuration conf, IHMSHandler baseHandler, boolean local)
+        throws MetaException {
+      super(conf, baseHandler, local);
+    }
+
+    @Override
+    protected Result invokeInternal(Object proxy, Method method, Object[] args)
+        throws Throwable {
+      try {
+        boolean isStarted = Deadline.startTimer(method.getName());
+        Object object;
+        try {
+          if (testTimeoutValue > 0 && method.getName().equals("create_database")) {
+            try {
+              Thread.sleep(testTimeoutValue);
+            } catch (InterruptedException e) {
+              // do nothing.
+            }
+            Deadline.checkTimeout();
+          }
+          object = method.invoke(baseHandler, args);
+        } finally {
+          if (isStarted) {
+            Deadline.stopTimer();
+          }
+        }
+        return new Result(object, "error=false");
+      } catch (Exception e) {
+        throw new MetaException(ExceptionUtils.getStackTrace(e));
+      }
+    }
+  }
+
   @BeforeClass
   public static void startMetaStoreServer() throws Exception {
     conf = MetastoreConf.newMetastoreConf();
@@ -59,6 +95,7 @@ public class TestHiveMetaStoreTimeout {
         MockPartitionExpressionForMetastore.class, PartitionExpressionProxy.class);
     MetastoreConf.setTimeVar(conf, ConfVars.CLIENT_SOCKET_TIMEOUT, 2000,
         TimeUnit.MILLISECONDS);
+    MetastoreConf.setVar(conf, ConfVars.HMS_HANDLER_PROXY_CLASS, DelayedHMSHandler.class.getName());
     MetaStoreTestUtils.setConfForStandloneMode(conf);
     warehouse = new Warehouse(conf);
     port = MetaStoreTestUtils.startMetaStoreWithRetry(conf);
@@ -68,8 +105,7 @@ public class TestHiveMetaStoreTimeout {
 
   @Before
   public void setup() throws MetaException {
-    HMSHandler.testTimeoutEnabled = false;
-    HMSHandler.testTimeoutValue = -1;
+    DelayedHMSHandler.testTimeoutValue = -1;
     client = new HiveMetaStoreClient(conf);
   }
 
@@ -90,8 +126,7 @@ public class TestHiveMetaStoreTimeout {
 
   @Test
   public void testTimeout() throws Exception {
-    HMSHandler.testTimeoutEnabled = true;
-    HMSHandler.testTimeoutValue = 4000;
+    DelayedHMSHandler.testTimeoutValue = 4000;
 
     Database db = new DatabaseBuilder()
         .setName(dbName)
@@ -117,8 +152,7 @@ public class TestHiveMetaStoreTimeout {
     client.dropDatabase(dbName, true, true);
 
     // reset
-    HMSHandler.testTimeoutEnabled = true;
-    HMSHandler.testTimeoutValue = 4000;
+    DelayedHMSHandler.testTimeoutValue = 4000;
 
     // timeout after reset
     try {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -137,6 +137,9 @@ public class TestHiveMetaStoreTimeout {
     } catch (TTransportException e) {
       Assert.assertTrue("unexpected Exception", e.getMessage().contains("Read timed out"));
     }
+
+    // restore
+    DelayedHMSHandler.testTimeoutValue = -1;
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetriesInRetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetriesInRetryingHMSHandler.java
@@ -95,7 +95,7 @@ public class TestRetriesInRetryingHMSHandler {
     try {
       HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
       Assert.fail("should fail for mockBaseHandler init.");
-    } catch (RuntimeException e) {
+    } catch (MetaException e) {
       // expected
     }
     Mockito.verify(mockBaseHandler, Mockito.times(RETRY_ATTEMPTS + 1)).init();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetriesInRetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestRetriesInRetryingHMSHandler.java
@@ -48,6 +48,8 @@ public class TestRetriesInRetryingHMSHandler {
   @BeforeClass
   public static void setup() throws IOException {
     conf = MetastoreConf.newMetastoreConf();
+    MetastoreConf.setVar(conf, ConfVars.HMS_HANDLER_PROXY_CLASS,
+        MetastoreConf.METASTORE_RETRYING_HANDLER_CLASS);
     MetastoreConf.setLongVar(conf, ConfVars.HMS_HANDLER_ATTEMPTS, RETRY_ATTEMPTS);
     MetastoreConf.setTimeVar(conf, ConfVars.HMS_HANDLER_INTERVAL, 10, TimeUnit.MILLISECONDS);
     MetastoreConf.setBoolVar(conf, ConfVars.HMS_HANDLER_FORCE_RELOAD_CONF, false);
@@ -65,7 +67,7 @@ public class TestRetriesInRetryingHMSHandler {
     .doThrow(JDOException.class)
     .doNothing()
     .when(mockBaseHandler).init();
-    RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     Mockito.verify(mockBaseHandler, Mockito.times(2)).init();
   }
 
@@ -77,7 +79,7 @@ public class TestRetriesInRetryingHMSHandler {
     IHMSHandler mockBaseHandler = Mockito.mock(IHMSHandler.class);
     Mockito.when(mockBaseHandler.getConf()).thenReturn(conf);
     Mockito.doNothing().when(mockBaseHandler).init();
-    RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     Mockito.verify(mockBaseHandler, Mockito.times(1)).init();
   }
 
@@ -85,13 +87,18 @@ public class TestRetriesInRetryingHMSHandler {
    * If the init method in HMSHandler throws exception all the times it should be retried until
    * HiveConf.ConfVars.HMSHANDLERATTEMPTS is reached before giving up
    */
-  @Test(expected = MetaException.class)
+  @Test
   public void testRetriesLimit() throws MetaException {
     IHMSHandler mockBaseHandler = Mockito.mock(IHMSHandler.class);
     Mockito.when(mockBaseHandler.getConf()).thenReturn(conf);
     Mockito.doThrow(JDOException.class).when(mockBaseHandler).init();
-    RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
-    Mockito.verify(mockBaseHandler, Mockito.times(RETRY_ATTEMPTS)).init();
+    try {
+      HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
+      Assert.fail("should fail for mockBaseHandler init.");
+    } catch (RuntimeException e) {
+      // expected
+    }
+    Mockito.verify(mockBaseHandler, Mockito.times(RETRY_ATTEMPTS + 1)).init();
   }
 
   /*
@@ -110,7 +117,7 @@ public class TestRetriesInRetryingHMSHandler {
     .doThrow(me)
     .doNothing()
     .when(mockBaseHandler).init();
-    RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     Mockito.verify(mockBaseHandler, Mockito.times(2)).init();
   }
 
@@ -132,7 +139,7 @@ public class TestRetriesInRetryingHMSHandler {
     InvocationTargetException ex = new InvocationTargetException(me);
     Mockito.doThrow(me).when(mockBaseHandler).getMS();
 
-    IHMSHandler retryingHandler = RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    IHMSHandler retryingHandler = HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     try {
       retryingHandler.getMS();
       Assert.fail("should throw the mocked MetaException");
@@ -159,7 +166,7 @@ public class TestRetriesInRetryingHMSHandler {
     InvocationTargetException ex = new InvocationTargetException(me);
     Mockito.doThrow(me).when(mockBaseHandler).getMS();
 
-    IHMSHandler retryingHandler = RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    IHMSHandler retryingHandler = HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     try {
       retryingHandler.getMS();
       Assert.fail("should throw the mocked MetaException");
@@ -185,14 +192,13 @@ public class TestRetriesInRetryingHMSHandler {
     InvocationTargetException ex = new InvocationTargetException(me);
     Mockito.doThrow(me).when(mockBaseHandler).getMS();
 
-    IHMSHandler retryingHandler = RetryingHMSHandler.getProxy(conf, mockBaseHandler, false);
+    IHMSHandler retryingHandler = HMSHandlerProxyFactory.getProxy(conf, mockBaseHandler, false);
     try {
       retryingHandler.getMS();
       Assert.fail("should throw the mocked MetaException");
     } catch (MetaException e) {
       // expected
     }
-    int retryTimes = MetastoreConf.getIntVar(conf, ConfVars.HMS_HANDLER_ATTEMPTS);
-    Mockito.verify(mockBaseHandler, Mockito.times(retryTimes + 1)).getMS();
+    Mockito.verify(mockBaseHandler, Mockito.times(RETRY_ATTEMPTS + 1)).getMS();
   }
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -42,11 +42,12 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hive.metastore.DefaultStorageSchemaReader;
-import org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader;
 import org.apache.hadoop.hive.metastore.HiveAlterHandler;
 import org.apache.hadoop.hive.metastore.MaterializationsRebuildLockCleanerTask;
 import org.apache.hadoop.hive.metastore.MetastoreTaskThread;
+import org.apache.hadoop.hive.metastore.RetryingHMSHandler;
 import org.apache.hadoop.hive.metastore.RuntimeStatsCleanerTask;
+import org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader;
 import org.apache.hadoop.hive.metastore.events.EventCleanerTask;
 import org.apache.hadoop.hive.metastore.security.MetastoreDelegationTokenManager;
 import org.apache.hadoop.hive.metastore.txn.AcidHouseKeeperService;
@@ -491,6 +492,8 @@ public class TestMetastoreConf {
         MaterializationsRebuildLockCleanerTask.class.getName());
     Assert.assertEquals(MetastoreConf.METASTORE_TASK_THREAD_CLASS,
         MetastoreTaskThread.class.getName());
+    Assert.assertEquals(MetastoreConf.METASTORE_RETRYING_HANDLER_CLASS,
+        RetryingHMSHandler.class.getName());
     Assert.assertEquals(MetastoreConf.RUNTIME_STATS_CLEANER_TASK_CLASS,
         RuntimeStatsCleanerTask.class.getName());
     Assert.assertEquals(MetastoreConf.EVENT_CLEANER_TASK_CLASS,


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. make `HMSHandler` Proxy configurable by new metastore conf **"metastore.hmshandler.proxy"**
2. provide `AbstractHMSHandlerProxy` to extend customized handler
3. clean some hacked test codes in `HMSHandler`


### Why are the changes needed?
1. make the handler of metastore flexible to config and extend
2. improve the code of `HMSHandler`


### Does this PR introduce _any_ user-facing change?
Yes, user can use new conf and api to extend their own handler.


### How was this patch tested?
Passing all existing tests.
