### PR TITLE
HIVE-27286: Upgrade jettison version to 1.5.4 to address CVE-2023-1436

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -209,6 +209,12 @@
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-api</artifactId>
       <version>${tez.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>
     <javolution.version>5.5.1</javolution.version>
-    <jettison.version>1.5.3</jettison.version>
+    <jettison.version>1.5.4</jettison.version>
     <jetty.version>9.4.40.v20210413</jetty.version>
     <jersey.version>1.19</jersey.version>
     <jline.version>2.14.6</jline.version>


### PR DESCRIPTION
What changes were proposed in this pull request?
Upgrade jettison version to 1.5.4

Why are the changes needed?
To fix CVE-2023-1436 

Does this PR introduce any user-facing change?
No

How was this patch tested?
Existing tests