### PR TITLE
HIVE-27287: Upgrade Commons-text to 1.10.0 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
-    <commons-text.version>1.8</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <derby.version>10.14.2.0</derby.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -207,7 +207,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>${commons-text.version}</version>
     </dependency>
     <dependency>
       <groupId>javolution</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Commons-text to 1.10.0 because of [CVE-2022-42889](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42889)

### Why are the changes needed?
Apache Commons Text versions prior to 1.8 is vulnerable to [CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889), which involves potential script execution when processing untrusted input using StringLookup. Direct and transitive references to Apache Commons Text prior to 1.10.0 should be upgraded to avoid the default interpolation behaviour.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
On Local Machine
