### PR TITLE
HIVE-27271: Client connection to HS2 fails when transportMode=http, ssl=true, sslTrustStore specified without trustStorePassword in the JDBC URL

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -803,7 +803,7 @@ public class HiveConnection implements java.sql.Connection {
           }
           sslTrustStore = KeyStore.getInstance(trustStoreType);
           try (FileInputStream fis = new FileInputStream(sslTrustStorePath)) {
-            sslTrustStore.load(fis, sslTrustStorePassword.toCharArray());
+            sslTrustStore.load(fis, sslTrustStorePassword != null ? sslTrustStorePassword.toCharArray() : null);
           }
           sslContext = SSLContexts.custom().loadTrustMaterial(sslTrustStore, null).build();
           socketFactory =
@@ -1035,7 +1035,7 @@ public class HiveConnection implements java.sql.Connection {
         + " Not configured for 2 way SSL connection");
       }
       try (FileInputStream fis = new FileInputStream(trustStorePath)) {
-        sslTrustStore.load(fis, trustStorePassword.toCharArray());
+        sslTrustStore.load(fis, trustStorePassword != null ? trustStorePassword.toCharArray() : null);
       }
       trustManagerFactory.init(sslTrustStore);
       SSLContext context = SSLContext.getInstance("TLS");


### PR DESCRIPTION
### What changes were proposed in this pull request?
keyStore.load() is invoked with null password when the trustStorePassword is not passed in JDBC URL.


### Why are the changes needed?
Client connection to HS2 fails with transportMode as http, ssl is enabled, sslTrustStore is specified without trustStorePassword in the JDBC URL. trustStorePassword is not a necessary parameter in connection URL. Connection can be established without it.

From the javadocs [Link](https://docs.oracle.com/javase/7/docs/api/java/security/KeyStore.html#load(java.io.InputStream,%20char%5B%5D)) A password may be given to unlock the keystore (e.g. the keystore resides on a hardware token device), or to check the integrity of the keystore data. If a password is not given for integrity checking, then integrity checking is not performed.

At present, org.apache.hive.jdbc.HiveConnection#getHttpClient() access sslTrustStorePassword null reference(NPE) and fails.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified manually with cluster
