### PR TITLE
HIVE-27289: Check for proxy hosts with subnet in IP results in exception

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -22,9 +22,11 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -795,7 +797,15 @@ public class MetaStoreServerUtils {
     Map<String, Collection<String>> proxyHosts = sip.getProxyHosts();
     Collection<String> hostEntries = proxyHosts.get(sip.getProxySuperuserIpConfKey(user));
     MachineList machineList = new MachineList(hostEntries);
-    ipAddress = (ipAddress == null) ? StringUtils.EMPTY : ipAddress;
+    // when schematool or metatool use this, its possible that the saslServer.getRemoteAddress() returns null
+    // use localhost address first to see if it part of hadoop.proxyuser hosts.
+    if (ipAddress == null) {
+      try {
+        ipAddress = InetAddress.getLocalHost().getHostAddress();
+      } catch (UnknownHostException e) {
+        ipAddress = StringUtils.EMPTY;
+      }
+    }
     return machineList.includes(ipAddress);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In MetastoreServerUtils.checkUserHasHostProxyPrivileges(), the check is to see if hadoop.proxyuser* settings in core-site.xml allow this user to execute this. One of the arguments to this method is an IpAddress that it is being executed on, which is fetched from HMSHandler.getIpAddress(). However, when running schematool, this is never is set during initialization. In this case, because it is not HMS server, the SaslServer is not initialized. 
When the core-site.xml has CIDR configurations, SubnetInfo.inRange() check throws an exception when the ip we are checking on in EMPTY.
So in case of schematool, try to use the hostaddress before resorting to empty ip address.

### Why are the changes needed?
HIVE-27289. To avoid exception during upgrades.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually.