### PR TITLE
HIVE-27299: Upgrade guava version to 31.1-jre to fix CVE

### DIFF
--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -25,7 +25,7 @@
   <name>Hive Druid Handler</name>
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <druid.guava.version>16.0.1</druid.guava.version>
+    <druid.guava.version>31.1-jre</druid.guava.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -35,7 +35,7 @@
     <druid.jersey.version>1.19.3</druid.jersey.version>
     <druid.jetty.version>9.4.40.v20210413</druid.jetty.version>
     <druid.derby.version>10.11.1.1</druid.derby.version>
-    <druid.guava.version>16.0.1</druid.guava.version>
+    <druid.guava.version>31.1-jre</druid.guava.version>
     <druid.guice.version>4.1.0</druid.guice.version>
     <kafka.test.version>2.5.0</kafka.test.version>
     <druid.guice.version>4.1.0</druid.guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <druid.version>0.17.1</druid.version>
     <esri.version>2.2.4</esri.version>
     <flatbuffers.version>1.9.0</flatbuffers.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <groovy.version>2.4.21</groovy.version>
     <h2database.version>2.1.214</h2database.version>
     <hadoop.version>3.3.1</hadoop.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -76,7 +76,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <jackson.version>2.13.5</jackson.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade guava to fix the CVE's


### Why are the changes needed?
The guava version in Hive master branch is 22.0 which has 2 Direct CVE:
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
[CVE-2018-10237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237)
Component like Tez 0.10.2 (used in hive) has also moved to 31.1-jre of guava version.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By building hive on local machine
