### PR TITLE
HIVE-26779: UNION ALL throws SemanticException when trying to remove partition predicates: fail to find child from parent

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -445,6 +445,7 @@ public class GenTezUtils {
           replacementMap.put(current, current.getChildOperators().get(0));
         } else {
           parent.removeChildAndAdoptItsChildren(current);
+          operators.remove(current);
         }
       }
 

--- a/ql/src/test/queries/clientpositive/lateral_view_unionall.q
+++ b/ql/src/test/queries/clientpositive/lateral_view_unionall.q
@@ -1,0 +1,29 @@
+create table tez_test_t1(md_exper string);
+insert into tez_test_t1 values('tez_test_t1-md_expr');
+
+create table tez_test_t5(md_exper string, did string);
+insert into tez_test_t5 values('tez_test_t5-md_expr','tez_test_t5-did');
+
+create table tez_test_t2(did string);
+insert into tez_test_t2 values('tez_test_t2-did');
+
+explain
+SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2;
+
+SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2;

--- a/ql/src/test/results/clientpositive/llap/lateral_view_unionall.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_unionall.q.out
@@ -1,0 +1,225 @@
+PREHOOK: query: create table tez_test_t1(md_exper string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tez_test_t1
+POSTHOOK: query: create table tez_test_t1(md_exper string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tez_test_t1
+PREHOOK: query: insert into tez_test_t1 values('tez_test_t1-md_expr')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tez_test_t1
+POSTHOOK: query: insert into tez_test_t1 values('tez_test_t1-md_expr')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tez_test_t1
+POSTHOOK: Lineage: tez_test_t1.md_exper SCRIPT []
+PREHOOK: query: create table tez_test_t5(md_exper string, did string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tez_test_t5
+POSTHOOK: query: create table tez_test_t5(md_exper string, did string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tez_test_t5
+PREHOOK: query: insert into tez_test_t5 values('tez_test_t5-md_expr','tez_test_t5-did')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tez_test_t5
+POSTHOOK: query: insert into tez_test_t5 values('tez_test_t5-md_expr','tez_test_t5-did')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tez_test_t5
+POSTHOOK: Lineage: tez_test_t5.did SCRIPT []
+POSTHOOK: Lineage: tez_test_t5.md_exper SCRIPT []
+PREHOOK: query: create table tez_test_t2(did string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tez_test_t2
+POSTHOOK: query: create table tez_test_t2(did string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tez_test_t2
+PREHOOK: query: insert into tez_test_t2 values('tez_test_t2-did')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tez_test_t2
+POSTHOOK: query: insert into tez_test_t2 values('tez_test_t2-did')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tez_test_t2
+POSTHOOK: Lineage: tez_test_t2.did SCRIPT []
+PREHOOK: query: explain
+SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tez_test_t1
+PREHOOK: Input: default@tez_test_t2
+PREHOOK: Input: default@tez_test_t5
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tez_test_t1
+POSTHOOK: Input: default@tez_test_t2
+POSTHOOK: Input: default@tez_test_t5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Union 2 (CONTAINS)
+        Map 3 <- Union 2 (CONTAINS)
+        Map 4 <- Union 2 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tez_test_t5
+                  Statistics: Num rows: 1 Data size: 35 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 1 Data size: 35 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col6
+                        Statistics: Num rows: 1 Data size: 416 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: null (type: string)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 2 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 3 Data size: 183 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: split('0,6', ',') (type: array<string>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col6
+                          Statistics: Num rows: 1 Data size: 416 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: null (type: string)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 2 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                              File Output Operator
+                                compressed: false
+                                Statistics: Num rows: 3 Data size: 183 Basic stats: COMPLETE Column stats: COMPLETE
+                                table:
+                                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: tez_test_t1
+                  Statistics: Num rows: 1 Data size: 19 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: null (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 3 Data size: 183 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: tez_test_t2
+                  Statistics: Num rows: 1 Data size: 99 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: did (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 99 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 3 Data size: 183 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Union 2 
+            Vertex: Union 2
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tez_test_t1
+PREHOOK: Input: default@tez_test_t2
+PREHOOK: Input: default@tez_test_t5
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT NULL AS first_login_did
+   FROM tez_test_t5
+   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
+UNION ALL
+SELECT  null as first_login_did
+    FROM tez_test_t1
+UNION ALL
+   SELECT did AS first_login_did
+   FROM tez_test_t2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tez_test_t1
+POSTHOOK: Input: default@tez_test_t2
+POSTHOOK: Input: default@tez_test_t5
+#### A masked pattern was here ####
+NULL
+NULL
+NULL
+tez_test_t2-did


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
`GenTezUtils.removeUnionOperators` tries to remove union operators from union branches of the plan. I assume it is done because each branch has its own Map vertex and the Union vertex takes the union of the result these.

Let's see the following query
```
SELECT NULL AS first_login_did
   FROM tez_test_t5
   LATERAL VIEW explode(split('0,6', ',')) gaps AS ads_h5_gap
UNION ALL
SELECT  null as first_login_did
    FROM tez_test_t1
UNION ALL
   SELECT did AS first_login_did
   FROM tez_test_t2
;
```
The plan before `removeUnionOperators`
```
TS[0]-LVF[1]-SEL[2]        -LVJ[5]-SEL[6]-UNION[9]-SEL[12]-UNION[13]-FS[15]
            -SEL[3]-UDTF[4]-LVJ[5]
TS[7]-SEL[8]                             -UNION[9]
TS[10]-SEL[11]                                            -UNION[13]
```

The branch having lateral view 
```
TS[0]-LVF[1]-SEL[2]        -LVJ[5]-SEL[6]-UNION[9]-SEL[12]-UNION[13]-FS[15]
            -SEL[3]-UDTF[4]-LVJ[5]
```
has two sub branches from LVF (Lateral View Forward op) to LVJ (Lateral View Join op).
The `removeUnionOperators` traverse the branches and it tries to remove the UNION[9] operator twice. It fails the second time with the exception mentioned in the jira.

### Why are the changes needed?
Fix issue mentioned above.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=lateral_view_unionall.q -pl itests/qtest -Pitests
```