### PR TITLE
HIVE-27308: Avoid exposing client keystore and truststore passwords in the JDBC URL

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -778,12 +778,7 @@ public class HiveConnection implements java.sql.Connection {
     if (useSsl) {
       String useTwoWaySSL = sessConfMap.get(JdbcConnectionParams.USE_TWO_WAY_SSL);
       String sslTrustStorePath = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String sslTrustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      if (sslTrustStorePassword == null) {
-        sslTrustStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
-            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      }
+      String sslTrustStorePassword = Utils.getPassword(sessConfMap, JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
       KeyStore sslTrustStore;
       SSLConnectionSocketFactory socketFactory;
       SSLContext sslContext;
@@ -897,12 +892,7 @@ public class HiveConnection implements java.sql.Connection {
     if (isSslConnection()) {
       // get SSL socket
       String sslTrustStore = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String sslTrustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      if (sslTrustStorePassword == null) {
-        sslTrustStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
-            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      }
+      String sslTrustStorePassword = Utils.getPassword(sessConfMap, JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
 
       if (sslTrustStore == null || sslTrustStore.isEmpty()) {
         transport = HiveAuthUtils.getSSLSocket(host, port, loginTimeout, maxMessageSize);
@@ -1015,11 +1005,7 @@ public class HiveConnection implements java.sql.Connection {
         JdbcConnectionParams.SUNX509_ALGORITHM_STRING,
         JdbcConnectionParams.SUNJSSE_ALGORITHM_STRING);
       String keyStorePath = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE);
-      String keyStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
-      if (keyStorePassword == null) {
-        keyStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH), JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
-      }
+      String keyStorePassword = Utils.getPassword(sessConfMap, JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
       KeyStore sslKeyStore = KeyStore.getInstance(JdbcConnectionParams.SSL_KEY_STORE_TYPE);
 
       if (keyStorePath == null || keyStorePath.isEmpty()) {
@@ -1034,12 +1020,7 @@ public class HiveConnection implements java.sql.Connection {
       TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
         JdbcConnectionParams.SUNX509_ALGORITHM_STRING);
       String trustStorePath = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String trustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      if (trustStorePassword == null) {
-        trustStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
-            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
-      }
+      String trustStorePassword = Utils.getPassword(sessConfMap, JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
       String trustStoreType = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_TYPE);
       if (trustStoreType == null || trustStoreType.isEmpty()) {
         trustStoreType = KeyStore.getDefaultType();

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -778,8 +778,12 @@ public class HiveConnection implements java.sql.Connection {
     if (useSsl) {
       String useTwoWaySSL = sessConfMap.get(JdbcConnectionParams.USE_TWO_WAY_SSL);
       String sslTrustStorePath = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String sslTrustStorePassword = sessConfMap.get(
-        JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      String sslTrustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      if (sslTrustStorePassword == null) {
+        sslTrustStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
+            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      }
       KeyStore sslTrustStore;
       SSLConnectionSocketFactory socketFactory;
       SSLContext sslContext;
@@ -893,8 +897,12 @@ public class HiveConnection implements java.sql.Connection {
     if (isSslConnection()) {
       // get SSL socket
       String sslTrustStore = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String sslTrustStorePassword = sessConfMap.get(
-        JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      String sslTrustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      if (sslTrustStorePassword == null) {
+        sslTrustStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
+            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      }
 
       if (sslTrustStore == null || sslTrustStore.isEmpty()) {
         transport = HiveAuthUtils.getSSLSocket(host, port, loginTimeout, maxMessageSize);
@@ -1008,6 +1016,10 @@ public class HiveConnection implements java.sql.Connection {
         JdbcConnectionParams.SUNJSSE_ALGORITHM_STRING);
       String keyStorePath = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE);
       String keyStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
+      if (keyStorePassword == null) {
+        keyStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH), JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
+      }
       KeyStore sslKeyStore = KeyStore.getInstance(JdbcConnectionParams.SSL_KEY_STORE_TYPE);
 
       if (keyStorePath == null || keyStorePath.isEmpty()) {
@@ -1022,8 +1034,12 @@ public class HiveConnection implements java.sql.Connection {
       TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
         JdbcConnectionParams.SUNX509_ALGORITHM_STRING);
       String trustStorePath = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE);
-      String trustStorePassword = sessConfMap.get(
-        JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      String trustStorePassword = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      if (trustStorePassword == null) {
+        trustStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessConfMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
+            JdbcConnectionParams.SSL_TRUST_STORE_PASSWORD);
+      }
       String trustStoreType = sessConfMap.get(JdbcConnectionParams.SSL_TRUST_STORE_TYPE);
       if (trustStoreType == null || trustStoreType.isEmpty()) {
         trustStoreType = KeyStore.getDefaultType();

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -813,7 +813,7 @@ public class Utils {
    * @param key alias name
    * @return password
    */
-  public static String getPasswordFromCredentialProvider(String providerPath, String key) {
+  private static String getPasswordFromCredentialProvider(String providerPath, String key) {
     try {
       if (providerPath != null) {
         Configuration conf = new Configuration();
@@ -829,4 +829,17 @@ public class Utils {
     return null;
   }
 
+  /**
+   * Method to get the password from the configuration map if available. Otherwise, get it from the credential provider
+   * @param confMap configuration map
+   * @param key param
+   * @return password
+   */
+  public static String getPassword(Map<String, String> confMap, String key) {
+    String password = confMap.get(key);
+    if (password == null) {
+      password = getPasswordFromCredentialProvider(confMap.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH), key);
+    }
+    return password;
+  }
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hive.jdbc;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -31,6 +32,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.rpc.thrift.TStatus;
@@ -187,6 +189,8 @@ public class Utils {
     static final String SUNX509_ALGORITHM_STRING = "SunX509";
     static final String SUNJSSE_ALGORITHM_STRING = "SunJSSE";
    // --------------- End 2 way ssl options ----------------------------
+
+    static final String SSL_STORE_PASSWORD_PATH = "storePasswordPath";
 
     private static final String HIVE_VAR_PREFIX = "hivevar:";
     public static final String HIVE_CONF_PREFIX = "hiveconf:";
@@ -801,6 +805,28 @@ public class Utils {
       LOG.warn("Could not retrieve canonical hostname for " + hostName, exception);
       return hostName;
     }
+  }
+
+  /**
+   * Method to get the password from the credential provider
+   * @param providerPath provider path
+   * @param key alias name
+   * @return password
+   */
+  public static String getPasswordFromCredentialProvider(String providerPath, String key) {
+    try {
+      if (providerPath != null) {
+        Configuration conf = new Configuration();
+        conf.set("hadoop.security.credential.provider.path", providerPath);
+        char[] password = conf.getPassword(key);
+        if (password != null) {
+          return new String(password);
+        }
+      }
+    } catch(IOException exception) {
+      LOG.warn("Could not retrieve password for " + key, exception);
+    }
+    return null;
   }
 
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
@@ -100,24 +100,14 @@ class ZooKeeperHiveClientHelper {
     if (sslEnabled) {
       connParams.setZookeeperKeyStoreLocation(
           StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_LOCATION), ""));
-      String keyStorePassword = sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD);
-      if (keyStorePassword == null) {
-        keyStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessionConf.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
-            JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD);
-        keyStorePassword = StringUtils.defaultString(keyStorePassword, "");
-      }
-      connParams.setZookeeperKeyStorePassword(keyStorePassword);
+      connParams.setZookeeperKeyStorePassword(
+          StringUtils.defaultString(Utils.getPassword(sessionConf, JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD),
+              ""));
       connParams.setZookeeperTrustStoreLocation(
           StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_LOCATION), ""));
-      String trustStorePassword = sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD);
-      if (trustStorePassword == null) {
-        trustStorePassword = Utils.getPasswordFromCredentialProvider(
-            sessionConf.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
-            JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD);
-        trustStorePassword = StringUtils.defaultString(trustStorePassword, "");
-      }
-      connParams.setZookeeperTrustStorePassword(trustStorePassword);
+      connParams.setZookeeperTrustStorePassword(
+          StringUtils.defaultString(Utils.getPassword(sessionConf, JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD),
+              ""));
     }
   }
 

--- a/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
@@ -100,12 +100,24 @@ class ZooKeeperHiveClientHelper {
     if (sslEnabled) {
       connParams.setZookeeperKeyStoreLocation(
           StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_LOCATION), ""));
-      connParams.setZookeeperKeyStorePassword(
-          StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD), ""));
+      String keyStorePassword = sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD);
+      if (keyStorePassword == null) {
+        keyStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessionConf.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
+            JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD);
+        keyStorePassword = StringUtils.defaultString(keyStorePassword, "");
+      }
+      connParams.setZookeeperKeyStorePassword(keyStorePassword);
       connParams.setZookeeperTrustStoreLocation(
           StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_LOCATION), ""));
-      connParams.setZookeeperTrustStorePassword(
-          StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD), ""));
+      String trustStorePassword = sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD);
+      if (trustStorePassword == null) {
+        trustStorePassword = Utils.getPasswordFromCredentialProvider(
+            sessionConf.get(JdbcConnectionParams.SSL_STORE_PASSWORD_PATH),
+            JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD);
+        trustStorePassword = StringUtils.defaultString(trustStorePassword, "");
+      }
+      connParams.setZookeeperTrustStorePassword(trustStorePassword);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a new property `storePasswordPath` to JDBC URL that point to the local JCE keystore file storing the password aliases. When an existing password property is present in URL, ignores to fetch that particular alias from local jceks(i.e., giving preference to existing password property). And if password property is not present in URL, fetches the password from local jceks file specified in `storePasswordPath` property.  Hive JDBC can obtains the passwords with [Configuration.getPassword](https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/conf/Configuration.html#getPassword-java.lang.String-) API to read the password from jceks file.

JDBC URL would look like - 
`beeline -u "jdbc:hive2://kvr-host:10001/default;retries=5;ssl=true;sslTrustStore=/tmp/truststore.jks;transportMode=http;httpPath=cliservice;twoWay=true;sslKeyStore=/tmp/keystore.jks;storePasswordPath=localjceks://file/tmp/client_creds.jceks"`

### Why are the changes needed?
At present, we may have `trustStorePassword, keyStorePassword, zooKeeperTruststorePassword, zooKeeperKeystorePassword` passwords in the JDBC URL. Exposing these passwords in URL can be a security concern. We can hide all these passwords from JDBC URL when we protect these passwords in a local JCEKS keystore file and pass the JCEKS file path to URL instead.

### Does this PR introduce _any_ user-facing change?
Optional `storePasswordPath` property is supported in JDBC URL. Existing `trustStorePassword, keyStorePassword, zooKeeperTruststorePassword, zooKeeperKeystorePassword` properties continue to exist and are supported in JDBC URL without any change in their behavior. When both password(s) and storePasswordPath properties are present in URL, password(s) property is preferred. `storePasswordPath` property is effective only when password(s) property is not in JDBC URL.

### How was this patch tested?
Tested manually