### PR TITLE
HIVE-27317: Temporary (local) session files cleanup improvements

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/session/ClearDanglingScratchDir.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/ClearDanglingScratchDir.java
@@ -17,10 +17,13 @@
  */
 package org.apache.hadoop.hive.ql.session;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -53,6 +56,9 @@ import org.slf4j.LoggerFactory;
  *    lease after 10 min, ie, the HDFS file hold by the dead HiveCli/HiveServer2 is writable
  *    again after 10 min. Once it become writable, cleardanglingscratchDir will be able to
  *    remove it
+ * 4. Additional functionality; once it is decided which session scratch dirs are residual,
+ *    while removing them from hdfs, we will remove them from local tmp location as well.
+ *    Please see {@link ClearDanglingScratchDir#removeLocalTmpFiles(String, String)}.
  */
 public class ClearDanglingScratchDir implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(ClearDanglingScratchDir.class);
@@ -141,24 +147,25 @@ public class ClearDanglingScratchDir implements Runnable {
             // if the file is currently held by a writer
             if(AlreadyBeingCreatedException.class.getName().equals(eAppend.getClassName())){
               inuse = true;
-            } else if (UnsupportedOperationException.class.getName().equals(eAppend.getClassName())) {
-              // Append is not supported in the cluster, try to use create
-              try {
-                IOUtils.closeStream(fs.create(lockFilePath, false));
-              } catch (RemoteException eCreate) {
-                if (AlreadyBeingCreatedException.class.getName().equals(eCreate.getClassName())){
-                  // If the file is held by a writer, will throw AlreadyBeingCreatedException
-                  inuse = true;
-                }  else {
-                  consoleMessage("Unexpected error:" + eCreate.getMessage());
-                }
-              } catch (FileAlreadyExistsException eCreateNormal) {
-                  // Otherwise, throw FileAlreadyExistsException, which means the file owner is
-                  // dead
-                  removable = true;
-              }
             } else {
               consoleMessage("Unexpected error:" + eAppend.getMessage());
+            }
+          } catch (UnsupportedOperationException eUnsupported) {
+            // In Hadoop-3, append method is not supported.
+            // This is an alternative check to make sure whether a file is in use or not.
+            // Trying to open the file. If it is in use, it will throw IOException.
+            try {
+              IOUtils.closeStream(fs.create(lockFilePath, false));
+            } catch (RemoteException eCreate) {
+              if (AlreadyBeingCreatedException.class.getName().equals(eCreate.getClassName())){
+                // If the file is held by a writer, will throw AlreadyBeingCreatedException
+                inuse = true;
+              }  else {
+                consoleMessage("Unexpected error:" + eCreate.getMessage());
+              }
+            } catch (FileAlreadyExistsException eCreateNormal) {
+              // Otherwise, throw FileAlreadyExistsException, which means the file owner is dead
+              removable = true;
             }
           }
           if (inuse) {
@@ -179,6 +186,7 @@ public class ClearDanglingScratchDir implements Runnable {
         return;
       }
       consoleMessage("Removing " + scratchDirToRemove.size() + " scratch directories");
+      String localTmpDir = HiveConf.getVar(conf, HiveConf.ConfVars.LOCALSCRATCHDIR);
       for (Path scratchDir : scratchDirToRemove) {
         if (dryRun) {
           System.out.println(scratchDir);
@@ -192,6 +200,8 @@ public class ClearDanglingScratchDir implements Runnable {
               consoleMessage(message);
             }
           }
+          // cleaning up on local file system as well
+          removeLocalTmpFiles(scratchDir.getName(), localTmpDir);
         }
       }
     } catch (IOException e) {
@@ -235,5 +245,30 @@ public class ClearDanglingScratchDir implements Runnable {
         .create('h'));
 
     return result;
+  }
+
+  /**
+   * While deleting dangling scratch dirs from hdfs, we can clean corresponding local files as well
+   * @param sessionName prefix to determine removable tmp files
+   * @param localTmpdir local tmp file location
+   */
+  private void removeLocalTmpFiles(String sessionName, String localTmpdir) {
+    File[] files = new File(localTmpdir).listFiles(fn -> fn.getName().startsWith(sessionName));
+    boolean success;
+    if (files != null) {
+      for (File file : files) {
+        success = false;
+        if (file.canWrite()) {
+          success = file.delete();
+        }
+        if (success) {
+          consoleMessage("While removing '" + sessionName + "' dangling scratch dir from HDFS, "
+                  + "local tmp session file '" + file.getPath() + "' has been cleaned as well.");
+        } else if (file.getName().startsWith(sessionName)) {
+          consoleMessage("Even though '" + sessionName + "' is marked as dangling session dir, "
+                  + "local tmp session file '" + file.getPath() + "' could not be removed.");
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `ClearDanglingScratchDir` service identifies the dangling sessions to clean HDFS, we will be cleaning files/dirs in `HiveConf.ConfVars.LOCALSCRATCHDIR` (local FS) as well.

### Why are the changes needed?
When Hive session is killed, no chance for shutdown hook to clean-up tmp files. This causes accumulation of tmp files/dirs in local FS as below;
```
> ll /tmp/user/97c4ef50-5e80-480e-a6f0-4f779050852b*
drwx------ 2 user user 4096 Oct 29 10:09 97c4ef50-5e80-480e-a6f0-4f779050852b
-rw------- 1 user user    0 Oct 29 10:09 97c4ef50-5e80-480e-a6f0-4f779050852b10571819313894728966.pipeout
-rw------- 1 user user    0 Oct 29 10:09 97c4ef50-5e80-480e-a6f0-4f779050852b16013956055489853961.pipeout
-rw------- 1 user user    0 Oct 29 10:09 97c4ef50-5e80-480e-a6f0-4f779050852b4383913570068173450.pipeout
-rw------- 1 user user    0 Oct 29 10:09 97c4ef50-5e80-480e-a6f0-4f779050852b889740171428672108.pipeout 
```

### Does this PR introduce _any_ user-facing change?
No. The same service will have additional functionality. 

### How was this patch tested?
Unit test.
