### PR TITLE
HIVE-27320: Mask total size in materialized_view_create_acid.q.out

### DIFF
--- a/ql/src/test/queries/clientpositive/materialized_view_create_acid.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_acid.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
 SET hive.support.concurrency=true;
 SET hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
@@ -55,7 +55,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	5                   
 	rawDataSize         	0                   
-	totalSize           	931                 
+	totalSize           	#Masked#                 
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
See jira

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_acid.q -pl itests/qtest -Pitests
```