### PR TITLE
HIVE-27267: choose correct partition columns from bigTableRS

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -659,15 +659,16 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
       // Prepare updated partition columns for small table(s).
       // Get the positions of bucketed columns
 
-      int i = 0;
+      int bigTableExprPos = 0;
       Map<String, ExprNodeDesc> colExprMap = bigTableRS.getColumnExprMap();
       for (ExprNodeDesc bigTableExpr : bigTablePartitionCols) {
         // It is guaranteed there is only 1 list within listBucketCols.
         for (String colName : listBucketCols.get(0)) {
           if (colExprMap.get(colName).isSame(bigTableExpr)) {
-            positions.add(i++);
+            positions.add(bigTableExprPos);
           }
         }
+        bigTableExprPos = bigTableExprPos + 1;
       }
     }
 

--- a/ql/src/test/queries/clientpositive/bucket_map_join_tez3.q
+++ b/ql/src/test/queries/clientpositive/bucket_map_join_tez3.q
@@ -1,0 +1,139 @@
+-- Test for HIVE-27267
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+drop table if exists test_external_source;
+create external table test_external_source (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true');
+insert into table test_external_source values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067');
+
+drop table if exists test_external_target;
+create external table test_external_target (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true');
+insert into table test_external_target values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687');
+
+drop table if exists target_table;
+drop table if exists source_table;
+create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default');
+create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default');
+
+insert into table target_table select * from test_external_target;
+insert into table source_table select * from test_external_source;
+
+
+-- Test 2 queries in 4 configs.
+
+-- Each query has 1 join that can be converted to bucket join.
+-- One of the query receives the small table from Map vertex while the other recives it from Reducer vertex.
+
+-- 4 configs enfoce MapJoin to be converted to one of the following joins:
+-- 1. BucketMapJoin, 2. MapJoin, 3. VectorBucketMapJoin, 4. VectorMapJoin
+
+set hive.auto.convert.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+
+-- 1. BucketMapJoin
+set hive.convert.join.bucket.mapjoin.tez=true;
+set hive.vectorized.execution.enabled=false;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 2. MapJoin
+set hive.convert.join.bucket.mapjoin.tez=false;
+set hive.vectorized.execution.enabled=false;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 3. VectorBucketMapJoin
+set hive.convert.join.bucket.mapjoin.tez=true;
+set hive.vectorized.execution.enabled=true;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+-- 4. VectorMapJoin
+set hive.convert.join.bucket.mapjoin.tez=false;
+set hive.vectorized.execution.enabled=true;
+
+explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+
+explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col;

--- a/ql/src/test/results/clientpositive/llap/bucket_map_join_tez3.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_map_join_tez3.q.out
@@ -1,0 +1,1078 @@
+PREHOOK: query: drop table if exists test_external_source
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_external_source
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_external_source (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_external_source
+POSTHOOK: query: create external table test_external_source (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_external_source
+PREHOOK: query: insert into table test_external_source values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_external_source
+POSTHOOK: query: insert into table test_external_source values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_external_source
+POSTHOOK: Lineage: test_external_source.date_col SCRIPT []
+POSTHOOK: Lineage: test_external_source.decimal_col SCRIPT []
+POSTHOOK: Lineage: test_external_source.string_col SCRIPT []
+PREHOOK: query: drop table if exists test_external_target
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_external_target
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_external_target (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_external_target
+POSTHOOK: query: create external table test_external_target (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_external_target
+PREHOOK: query: insert into table test_external_target values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_external_target
+POSTHOOK: query: insert into table test_external_target values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_external_target
+POSTHOOK: Lineage: test_external_target.date_col SCRIPT []
+POSTHOOK: Lineage: test_external_target.decimal_col SCRIPT []
+POSTHOOK: Lineage: test_external_target.string_col SCRIPT []
+PREHOOK: query: drop table if exists target_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists target_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: drop table if exists source_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists source_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@target_table
+POSTHOOK: query: create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@target_table
+PREHOOK: query: create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source_table
+POSTHOOK: query: create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source_table
+PREHOOK: query: insert into table target_table select * from test_external_target
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_external_target
+PREHOOK: Output: default@target_table
+POSTHOOK: query: insert into table target_table select * from test_external_target
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_external_target
+POSTHOOK: Output: default@target_table
+POSTHOOK: Lineage: target_table.date_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:date_col, type:date, comment:null), ]
+POSTHOOK: Lineage: target_table.decimal_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:decimal_col, type:decimal(38,0), comment:null), ]
+POSTHOOK: Lineage: target_table.string_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:string_col, type:string, comment:null), ]
+PREHOOK: query: insert into table source_table select * from test_external_source
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_external_source
+PREHOOK: Output: default@source_table
+POSTHOOK: query: insert into table source_table select * from test_external_source
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_external_source
+POSTHOOK: Output: default@source_table
+POSTHOOK: Lineage: source_table.date_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:date_col, type:date, comment:null), ]
+POSTHOOK: Lineage: source_table.decimal_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:decimal_col, type:decimal(38,0), comment:null), ]
+POSTHOOK: Lineage: source_table.string_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:string_col, type:string, comment:null), ]
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Map 2 (CUSTOM_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 3 (CUSTOM_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Reducer 3
+                        Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: date_col (type: date), decimal_col (type: decimal(38,0))
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col1 (type: decimal(38,0))
+                  Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 3 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Reducer 3
+                        Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: date_col (type: date), decimal_col (type: decimal(38,0))
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                  Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Map 2 (CUSTOM_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 3 (CUSTOM_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Reducer 3
+                        Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: date_col (type: date), decimal_col (type: decimal(38,0))
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col1 (type: decimal(38,0))
+                  Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
+PREHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Reducer 3 (BROADCAST_EDGE)
+        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: target_table
+                  filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: date_col (type: date), decimal_col (type: decimal(38,0))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 10 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col0 (type: date), _col1 (type: decimal(38,0))
+                          1 _col0 (type: date), _col1 (type: decimal(38,0))
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        input vertices:
+                          1 Reducer 3
+                        Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                          Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: date_col (type: date), decimal_col (type: decimal(38,0))
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                        Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
+                  Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Input: default@target_table
+#### A masked pattern was here ####
+POSTHOOK: query: select * from target_table inner join
+(select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
+on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Input: default@target_table
+#### A masked pattern was here ####
+2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
+2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593

--- a/ql/src/test/results/clientpositive/llap/bucket_map_join_tez3.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_map_join_tez3.q.out
@@ -1,111 +1,3 @@
-PREHOOK: query: drop table if exists test_external_source
-PREHOOK: type: DROPTABLE
-POSTHOOK: query: drop table if exists test_external_source
-POSTHOOK: type: DROPTABLE
-PREHOOK: query: create external table test_external_source (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
-PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:default
-PREHOOK: Output: default@test_external_source
-POSTHOOK: query: create external table test_external_source (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
-POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:default
-POSTHOOK: Output: default@test_external_source
-PREHOOK: query: insert into table test_external_source values
-('2022-08-30', 'pipeline', '50000000000000000005905545593'),
-('2022-08-16', 'pipeline', '50000000000000000005905545593'),
-('2022-09-01', 'pipeline', '50000000000000000006008686831'),
-('2022-08-30', 'pipeline', '50000000000000000005992620837'),
-('2022-09-01', 'pipeline', '50000000000000000005992620837'),
-('2022-09-01', 'pipeline', '50000000000000000005992621067'),
-('2022-08-30', 'pipeline', '50000000000000000005992621067')
-PREHOOK: type: QUERY
-PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: default@test_external_source
-POSTHOOK: query: insert into table test_external_source values
-('2022-08-30', 'pipeline', '50000000000000000005905545593'),
-('2022-08-16', 'pipeline', '50000000000000000005905545593'),
-('2022-09-01', 'pipeline', '50000000000000000006008686831'),
-('2022-08-30', 'pipeline', '50000000000000000005992620837'),
-('2022-09-01', 'pipeline', '50000000000000000005992620837'),
-('2022-09-01', 'pipeline', '50000000000000000005992621067'),
-('2022-08-30', 'pipeline', '50000000000000000005992621067')
-POSTHOOK: type: QUERY
-POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: default@test_external_source
-POSTHOOK: Lineage: test_external_source.date_col SCRIPT []
-POSTHOOK: Lineage: test_external_source.decimal_col SCRIPT []
-POSTHOOK: Lineage: test_external_source.string_col SCRIPT []
-PREHOOK: query: drop table if exists test_external_target
-PREHOOK: type: DROPTABLE
-POSTHOOK: query: drop table if exists test_external_target
-POSTHOOK: type: DROPTABLE
-PREHOOK: query: create external table test_external_target (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
-PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:default
-PREHOOK: Output: default@test_external_target
-POSTHOOK: query: create external table test_external_target (date_col date, string_col string, decimal_col decimal(38,0)) stored as orc tblproperties ('external.table.purge'='true')
-POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:default
-POSTHOOK: Output: default@test_external_target
-PREHOOK: query: insert into table test_external_target values
-('2017-05-17', 'pipeline', '50000000000000000000441610525'),
-('2018-12-20', 'pipeline', '50000000000000000001048981030'),
-('2020-06-30', 'pipeline', '50000000000000000002332575516'),
-('2021-08-16', 'pipeline', '50000000000000000003897973989'),
-('2017-06-06', 'pipeline', '50000000000000000000449148729'),
-('2017-09-08', 'pipeline', '50000000000000000000525378314'),
-('2022-08-30', 'pipeline', '50000000000000000005905545593'),
-('2022-08-16', 'pipeline', '50000000000000000005905545593'),
-('2018-05-03', 'pipeline', '50000000000000000000750826355'),
-('2020-01-10', 'pipeline', '50000000000000000001816579677'),
-('2021-11-01', 'pipeline', '50000000000000000004269423714'),
-('2017-11-07', 'pipeline', '50000000000000000000585901787'),
-('2019-10-15', 'pipeline', '50000000000000000001598843430'),
-('2020-04-01', 'pipeline', '50000000000000000002035795461'),
-('2020-02-24', 'pipeline', '50000000000000000001932600185'),
-('2020-04-27', 'pipeline', '50000000000000000002108160849'),
-('2016-07-05', 'pipeline', '50000000000000000000054405114'),
-('2020-06-02', 'pipeline', '50000000000000000002234387967'),
-('2020-08-21', 'pipeline', '50000000000000000002529168758'),
-('2021-02-17', 'pipeline', '50000000000000000003158511687')
-PREHOOK: type: QUERY
-PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: default@test_external_target
-POSTHOOK: query: insert into table test_external_target values
-('2017-05-17', 'pipeline', '50000000000000000000441610525'),
-('2018-12-20', 'pipeline', '50000000000000000001048981030'),
-('2020-06-30', 'pipeline', '50000000000000000002332575516'),
-('2021-08-16', 'pipeline', '50000000000000000003897973989'),
-('2017-06-06', 'pipeline', '50000000000000000000449148729'),
-('2017-09-08', 'pipeline', '50000000000000000000525378314'),
-('2022-08-30', 'pipeline', '50000000000000000005905545593'),
-('2022-08-16', 'pipeline', '50000000000000000005905545593'),
-('2018-05-03', 'pipeline', '50000000000000000000750826355'),
-('2020-01-10', 'pipeline', '50000000000000000001816579677'),
-('2021-11-01', 'pipeline', '50000000000000000004269423714'),
-('2017-11-07', 'pipeline', '50000000000000000000585901787'),
-('2019-10-15', 'pipeline', '50000000000000000001598843430'),
-('2020-04-01', 'pipeline', '50000000000000000002035795461'),
-('2020-02-24', 'pipeline', '50000000000000000001932600185'),
-('2020-04-27', 'pipeline', '50000000000000000002108160849'),
-('2016-07-05', 'pipeline', '50000000000000000000054405114'),
-('2020-06-02', 'pipeline', '50000000000000000002234387967'),
-('2020-08-21', 'pipeline', '50000000000000000002529168758'),
-('2021-02-17', 'pipeline', '50000000000000000003158511687')
-POSTHOOK: type: QUERY
-POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: default@test_external_target
-POSTHOOK: Lineage: test_external_target.date_col SCRIPT []
-POSTHOOK: Lineage: test_external_target.decimal_col SCRIPT []
-POSTHOOK: Lineage: test_external_target.string_col SCRIPT []
-PREHOOK: query: drop table if exists target_table
-PREHOOK: type: DROPTABLE
-POSTHOOK: query: drop table if exists target_table
-POSTHOOK: type: DROPTABLE
-PREHOOK: query: drop table if exists source_table
-PREHOOK: type: DROPTABLE
-POSTHOOK: query: drop table if exists source_table
-POSTHOOK: type: DROPTABLE
 PREHOOK: query: create table target_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -114,6 +6,57 @@ POSTHOOK: query: create table target_table(date_col date, string_col string, dec
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@target_table
+PREHOOK: query: insert into table target_table values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@target_table
+POSTHOOK: query: insert into table target_table values
+('2017-05-17', 'pipeline', '50000000000000000000441610525'),
+('2018-12-20', 'pipeline', '50000000000000000001048981030'),
+('2020-06-30', 'pipeline', '50000000000000000002332575516'),
+('2021-08-16', 'pipeline', '50000000000000000003897973989'),
+('2017-06-06', 'pipeline', '50000000000000000000449148729'),
+('2017-09-08', 'pipeline', '50000000000000000000525378314'),
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2018-05-03', 'pipeline', '50000000000000000000750826355'),
+('2020-01-10', 'pipeline', '50000000000000000001816579677'),
+('2021-11-01', 'pipeline', '50000000000000000004269423714'),
+('2017-11-07', 'pipeline', '50000000000000000000585901787'),
+('2019-10-15', 'pipeline', '50000000000000000001598843430'),
+('2020-04-01', 'pipeline', '50000000000000000002035795461'),
+('2020-02-24', 'pipeline', '50000000000000000001932600185'),
+('2020-04-27', 'pipeline', '50000000000000000002108160849'),
+('2016-07-05', 'pipeline', '50000000000000000000054405114'),
+('2020-06-02', 'pipeline', '50000000000000000002234387967'),
+('2020-08-21', 'pipeline', '50000000000000000002529168758'),
+('2021-02-17', 'pipeline', '50000000000000000003158511687')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@target_table
+POSTHOOK: Lineage: target_table.date_col SCRIPT []
+POSTHOOK: Lineage: target_table.decimal_col SCRIPT []
+POSTHOOK: Lineage: target_table.string_col SCRIPT []
 PREHOOK: query: create table source_table(date_col date, string_col string, decimal_col decimal(38,0)) clustered by (decimal_col) into 7 buckets stored as orc tblproperties ('bucketing_version'='2', 'transactional'='true', 'transactional_properties'='default')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -122,29 +65,32 @@ POSTHOOK: query: create table source_table(date_col date, string_col string, dec
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@source_table
-PREHOOK: query: insert into table target_table select * from test_external_target
+PREHOOK: query: insert into table source_table values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
 PREHOOK: type: QUERY
-PREHOOK: Input: default@test_external_target
-PREHOOK: Output: default@target_table
-POSTHOOK: query: insert into table target_table select * from test_external_target
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@test_external_target
-POSTHOOK: Output: default@target_table
-POSTHOOK: Lineage: target_table.date_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:date_col, type:date, comment:null), ]
-POSTHOOK: Lineage: target_table.decimal_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:decimal_col, type:decimal(38,0), comment:null), ]
-POSTHOOK: Lineage: target_table.string_col SIMPLE [(test_external_target)test_external_target.FieldSchema(name:string_col, type:string, comment:null), ]
-PREHOOK: query: insert into table source_table select * from test_external_source
-PREHOOK: type: QUERY
-PREHOOK: Input: default@test_external_source
+PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@source_table
-POSTHOOK: query: insert into table source_table select * from test_external_source
+POSTHOOK: query: insert into table source_table values
+('2022-08-30', 'pipeline', '50000000000000000005905545593'),
+('2022-08-16', 'pipeline', '50000000000000000005905545593'),
+('2022-09-01', 'pipeline', '50000000000000000006008686831'),
+('2022-08-30', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992620837'),
+('2022-09-01', 'pipeline', '50000000000000000005992621067'),
+('2022-08-30', 'pipeline', '50000000000000000005992621067')
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@test_external_source
+POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@source_table
-POSTHOOK: Lineage: source_table.date_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:date_col, type:date, comment:null), ]
-POSTHOOK: Lineage: source_table.decimal_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:decimal_col, type:decimal(38,0), comment:null), ]
-POSTHOOK: Lineage: source_table.string_col SIMPLE [(test_external_source)test_external_source.FieldSchema(name:string_col, type:string, comment:null), ]
-PREHOOK: query: explain
+POSTHOOK: Lineage: source_table.date_col SCRIPT []
+POSTHOOK: Lineage: source_table.decimal_col SCRIPT []
+POSTHOOK: Lineage: source_table.string_col SCRIPT []
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -152,7 +98,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -160,6 +106,13 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t2`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t2`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t2` ON `t0`.`date_col` = `t2`.`date_col` AND `t0`.`decimal_col` = `t2`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -178,7 +131,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -188,33 +143,97 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Map 2 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Map 2
+                        Position of Big Table: 0
                         Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        BucketMapJoin: true
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -222,13 +241,59 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col1 (type: decimal(38,0))
                         Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
+                        auto parallelism: false
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
 
   Stage: Stage-0
     Fetch Operator
@@ -252,7 +317,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -260,7 +325,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -268,6 +333,14 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t3`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t3`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)
+GROUP BY `date_col`, `decimal_col`) AS `t3` ON `t0`.`date_col` = `t3`.`date_col` AND `t0`.`decimal_col` = `t3`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -287,7 +360,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -297,33 +372,97 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Reducer 3 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Reducer 3
+                        Position of Big Table: 0
                         Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        BucketMapJoin: true
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -333,15 +472,62 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: -1
+                        auto parallelism: true
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
         Reducer 3 
             Execution mode: llap
+            Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator
                 keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
@@ -349,11 +535,15 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
+                  bucketingVersion: 2
                   key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                   null sort order: zz
+                  numBuckets: -1
                   sort order: ++
                   Map-reduce partition columns: _col1 (type: decimal(38,0))
                   Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                  tag: 1
+                  auto parallelism: false
 
   Stage: Stage-0
     Fetch Operator
@@ -377,7 +567,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -385,7 +575,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -393,6 +583,13 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t2`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t2`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t2` ON `t0`.`date_col` = `t2`.`date_col` AND `t0`.`decimal_col` = `t2`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -411,7 +608,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -421,33 +620,96 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Map 2 => 3
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Map 2
+                        Position of Big Table: 0
                         Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -455,13 +717,59 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
+                        auto parallelism: true
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
 
   Stage: Stage-0
     Fetch Operator
@@ -485,7 +793,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -493,7 +801,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -501,6 +809,14 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t3`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t3`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)
+GROUP BY `date_col`, `decimal_col`) AS `t3` ON `t0`.`date_col` = `t3`.`date_col` AND `t0`.`decimal_col` = `t3`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -520,7 +836,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -530,33 +848,96 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Reducer 3 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Reducer 3
+                        Position of Big Table: 0
                         Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -566,15 +947,62 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: -1
+                        auto parallelism: true
             Execution mode: llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
         Reducer 3 
             Execution mode: llap
+            Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator
                 keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
@@ -582,11 +1010,15 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
+                  bucketingVersion: 2
                   key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                   null sort order: zz
+                  numBuckets: -1
                   sort order: ++
                   Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                   Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                  tag: 1
+                  auto parallelism: true
 
   Stage: Stage-0
     Fetch Operator
@@ -610,7 +1042,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -618,7 +1050,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -626,6 +1058,13 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t2`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t2`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t2` ON `t0`.`date_col` = `t2`.`date_col` AND `t0`.`decimal_col` = `t2`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -644,7 +1083,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -654,33 +1095,97 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Map 2 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Map 2
+                        Position of Big Table: 0
                         Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
+                        BucketMapJoin: true
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -688,13 +1193,59 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col1 (type: decimal(38,0))
                         Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
+                        auto parallelism: false
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
 
   Stage: Stage-0
     Fetch Operator
@@ -718,7 +1269,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -726,7 +1277,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -734,6 +1285,14 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t3`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t3`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)
+GROUP BY `date_col`, `decimal_col`) AS `t3` ON `t0`.`date_col` = `t3`.`date_col` AND `t0`.`decimal_col` = `t3`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -753,7 +1312,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -763,33 +1324,97 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Reducer 3 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Reducer 3
+                        Position of Big Table: 0
                         Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
+                        BucketMapJoin: true
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -799,15 +1424,62 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: -1
+                        auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
         Reducer 3 
             Execution mode: vectorized, llap
+            Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator
                 keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
@@ -815,11 +1487,15 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
+                  bucketingVersion: 2
                   key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                   null sort order: zz
+                  numBuckets: -1
                   sort order: ++
                   Map-reduce partition columns: _col1 (type: decimal(38,0))
                   Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                  tag: 1
+                  auto parallelism: false
 
   Stage: Stage-0
     Fetch Operator
@@ -843,7 +1519,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -851,7 +1527,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -859,6 +1535,13 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t2`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t2`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t2` ON `t0`.`date_col` = `t2`.`date_col` AND `t0`.`decimal_col` = `t2`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -877,7 +1560,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -887,33 +1572,96 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Map 2 => 3
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Map 2
+                        Position of Big Table: 0
                         Statistics: Num rows: 30 Data size: 10080 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 30 Data size: 15600 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -921,13 +1669,59 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
+                        auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
 
   Stage: Stage-0
     Fetch Operator
@@ -951,7 +1745,7 @@ POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
 2022-08-16	pipeline	50000000000000000005905545593	2022-08-16	pipeline	50000000000000000005905545593
 2022-08-30	pipeline	50000000000000000005905545593	2022-08-30	pipeline	50000000000000000005905545593
-PREHOOK: query: explain
+PREHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -959,7 +1753,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@source_table
 PREHOOK: Input: default@target_table
 #### A masked pattern was here ####
-POSTHOOK: query: explain
+POSTHOOK: query: explain extended
 select * from target_table inner join
 (select distinct date_col, 'pipeline' string_col, decimal_col from source_table where coalesce(decimal_col,'') = '50000000000000000005905545593') s
 on s.date_col = target_table.date_col AND s.string_col = target_table.string_col AND s.decimal_col = target_table.decimal_col
@@ -967,6 +1761,14 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@source_table
 POSTHOOK: Input: default@target_table
 #### A masked pattern was here ####
+OPTIMIZED SQL: SELECT `t0`.`date_col`, CAST('pipeline' AS STRING) AS `string_col`, `t0`.`decimal_col`, `t3`.`date_col` AS `date_col1`, 'pipeline' AS `string_col1`, `t3`.`decimal_col` AS `decimal_col1`
+FROM (SELECT `date_col`, `decimal_col`
+FROM `default`.`target_table`
+WHERE `string_col` = 'pipeline' AND CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)) AS `t0`
+INNER JOIN (SELECT `date_col`, `decimal_col`
+FROM `default`.`source_table`
+WHERE CASE WHEN `decimal_col` IS NOT NULL THEN CAST(`decimal_col` AS STRING) = '50000000000000000005905545593' ELSE FALSE END AND (`date_col` IS NOT NULL AND `decimal_col` IS NOT NULL)
+GROUP BY `date_col`, `decimal_col`) AS `t3` ON `t0`.`date_col` = `t3`.`date_col` AND `t0`.`decimal_col` = `t3`.`decimal_col`
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -986,7 +1788,9 @@ STAGE PLANS:
                   alias: target_table
                   filterExpr: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 20 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: ((string_col = 'pipeline') and if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 10 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -996,33 +1800,96 @@ STAGE PLANS:
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
+                        Estimated key counts: Reducer 3 => 1
                         keys:
                           0 _col0 (type: date), _col1 (type: decimal(38,0))
                           1 _col0 (type: date), _col1 (type: decimal(38,0))
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Reducer 3
+                        Position of Big Table: 0
                         Statistics: Num rows: 10 Data size: 3360 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: date), 'pipeline' (type: string), _col1 (type: decimal(38,0)), _col2 (type: date), 'pipeline' (type: string), _col3 (type: decimal(38,0))
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
                           Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
+                            bucketingVersion: 2
                             compressed: false
+                            GlobalTableId: 0
+#### A masked pattern was here ####
+                            NumFilesPerFileSink: 1
                             Statistics: Num rows: 10 Data size: 5200 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                properties:
+                                  bucketing_version -1
+                                  columns _col0,_col1,_col2,_col3,_col4,_col5
+                                  columns.types date:string:decimal(38,0):date:string:decimal(38,0)
+                                  escape.delim \
+                                  hive.serialization.extend.additional.nesting.levels true
+                                  serialization.escape.crlf true
+                                  serialization.format 1
+                                  serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
                                 serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            TotalFiles: 1
+                            GatherStats: false
+                            MultiFileSpray: false
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: target_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.target_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.target_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.target_table
+                  name: default.target_table
+            Truncated Path -> Alias:
+              /target_table [target_table]
         Map 2 
             Map Operator Tree:
                 TableScan
                   alias: source_table
                   filterExpr: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
                   Filter Operator
+                    isSamplingPred: false
                     predicate: (if(decimal_col is not null, (CAST( decimal_col AS STRING) = '50000000000000000005905545593'), false) and date_col is not null and decimal_col is not null) (type: boolean)
                     Statistics: Num rows: 3 Data size: 504 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -1032,15 +1899,62 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
+                        bucketingVersion: 2
                         key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                         null sort order: zz
+                        numBuckets: -1
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                         Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: -1
+                        auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: source_table
+                  input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                  properties:
+                    bucket_count 7
+                    bucket_field_name decimal_col
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns date_col,string_col,decimal_col
+                    columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                    name default.source_table
+                    serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    transactional true
+                    transactional_properties default
+                  serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                
+                    input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                    properties:
+                      bucket_count 7
+                      bucket_field_name decimal_col
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns date_col,string_col,decimal_col
+                      columns.comments 
+                      columns.types date:string:decimal(38,0)
+#### A masked pattern was here ####
+                      name default.source_table
+                      serialization.lib org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      transactional true
+                      transactional_properties default
+                    serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                    name: default.source_table
+                  name: default.source_table
+            Truncated Path -> Alias:
+              /source_table [source_table]
         Reducer 3 
             Execution mode: vectorized, llap
+            Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator
                 keys: KEY._col0 (type: date), KEY._col1 (type: decimal(38,0))
@@ -1048,11 +1962,15 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
+                  bucketingVersion: 2
                   key expressions: _col0 (type: date), _col1 (type: decimal(38,0))
                   null sort order: zz
+                  numBuckets: -1
                   sort order: ++
                   Map-reduce partition columns: _col0 (type: date), _col1 (type: decimal(38,0))
                   Statistics: Num rows: 1 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                  tag: 1
+                  auto parallelism: true
 
   Stage: Stage-0
     Fetch Operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Gather correct indices of bucket expression from big table side ReduceSinkOperator's partition columns.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As HIVE-27267 reportes, BucketMapJoin returns wrong result.
Current BucketMapJoin conversion algorithm sets incorrect expression to partition column, and this leads to mismatch between bucket id of MapJoinOprator and that of rows from small table RS. As a consequence, BucketMapJoin returns a subset of correct result as it does not have complete small table for corresponding bucket.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a qfile test that compares BucketMapJoin and MapJoin.
