### PR TITLE
HIVE-27316: Map int2,int4,float4,float8,character,bool,binary varying and varbinary remotedb datatypes to hive

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
@@ -346,6 +346,8 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       case "longblob":
       case "bytea":
       case "binary":
+      case "varbinary":
+      case "binary varying":
         return ColumnType.BINARY_TYPE_NAME;
       case "tinyint":
         return ColumnType.TINYINT_TYPE_NAME;
@@ -380,6 +382,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       case "timestampz":
       case "timez":
         return ColumnType.TIMESTAMPTZ_TYPE_NAME;
+      case "bool":
       case "boolean":
         return ColumnType.BOOLEAN_TYPE_NAME;
       default:

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/PostgreSQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/PostgreSQLConnectorProvider.java
@@ -69,10 +69,23 @@ public class PostgreSQLConnectorProvider extends AbstractJDBCConnectorProvider {
     switch (dbDataType.toLowerCase())
     {
     case "bpchar":
+    case "character":
       mappedType = ColumnType.CHAR_TYPE_NAME + wrapSize(size);
+      break;
+    case "int2":
+      mappedType = ColumnType.SMALLINT_TYPE_NAME;
+      break;
+    case "int4":
+      mappedType = ColumnType.INT_TYPE_NAME;
       break;
     case "int8":
       mappedType = ColumnType.BIGINT_TYPE_NAME;
+      break;
+    case "float4":
+      mappedType = ColumnType.FLOAT_TYPE_NAME;
+      break;
+    case "float8":
+      mappedType = ColumnType.DOUBLE_TYPE_NAME;
       break;
     default:
       mappedType = ColumnType.VOID_TYPE_NAME;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mapping int2, int4, float4, float8, character, bool, binary varying and varbinary remotedb datatypes to hive datatypes.

### Why are the changes needed?
Select query on table in remote database returns NULL values with postgreSQL and Redshift data connectors. This is happening because few datatypes are not mapped from postgres/redshift to hive data types. Thus values for unmapped columns are shown as null.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested manually
