### PR TITLE
HIVE-27318: Backporting HIVE-21085 to HIVE-3

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -161,7 +161,9 @@ public final class HiveMaterializedViewsRegistry {
     @Override
     public void run() {
       try {
-        SessionState.start(db.getConf());
+        SessionState ss = new SessionState(db.getConf());
+        ss.setIsHiveServerQuery(true); // All is served from HS2, we do not need e.g. Tez sessions
+        SessionState.start(ss);
         for (String dbName : db.getAllDatabases()) {
           for (Table mv : db.getAllMaterializedViewObjects(dbName)) {
             addMaterializedView(db.getConf(), mv, OpType.LOAD);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is to backport https://issues.apache.org/jira/browse/HIVE-21085 to `branch-3.1`. FYI @jcamachor 

### Why are the changes needed?
Materialized views registry creates Tez session without checking external sessions pool. This causes double-session creation when Hive CLI is launched.

This is reported here https://issues.apache.org/jira/browse/HIVE-27318

The issue has been resolved for Hive-4, but remains in Hive-3.

### Does this PR introduce _any_ user-facing change?
No, this is internal functionality.

### How was this patch tested?
Built the project and made sure that there was only one session after Hive CLI launch.
