### PR TITLE
HIVE-27330: Compaction entry dequeue order

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -258,6 +258,7 @@ class CompactionTxnHandler extends TxnHandler {
           sb.append("\"CQ_POOL_NAME\" IS NULL OR  \"CQ_ENQUEUE_TIME\" < (")
             .append(getEpochFn(dbProduct)).append(" - ").append(poolTimeout).append(")");
         }
+        sb.append(" ORDER BY CQ_ID ASC");
         String query = sb.toString();
         stmt = dbConn.prepareStatement(query);
         if (hasPoolName) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -117,11 +117,11 @@ public class TestHiveMetaStoreTimeout {
 
   @Test
   public void testResetTimeout() throws Exception {
-    HMSHandler.testTimeoutValue = 250;
     String dbName = "db";
 
     // no timeout before reset
     client.dropDatabase(dbName, true, true);
+    HMSHandler.testTimeoutValue = 250;
     Database db = new DatabaseBuilder()
         .setName(dbName)
         .build(conf);
@@ -130,6 +130,7 @@ public class TestHiveMetaStoreTimeout {
     } catch (Exception e) {
       Assert.fail("should not throw timeout exception: " + e.getMessage());
     }
+    HMSHandler.testTimeoutValue = -1;
     client.dropDatabase(dbName, true, true);
 
     // reset


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compaction entries should be dequied in a FIFO ordering

### Why are the changes needed?
Currently there is no ordering during dequeue, which means the order is DB dependent

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually and through unit tests