### PR TITLE
Backport of HIVE-25726: Upgrade velocity to 2.3 due to CVE-2020-13936 (Sourabh Goyal via Naveen Gangam)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <tempus-fugit.version>1.1</tempus-fugit.version>
     <snappy.version>1.1.4</snappy.version>
     <wadl-resourcedoc-doclet.version>1.4</wadl-resourcedoc-doclet.version>
-    <velocity.version>1.5</velocity.version>
+    <velocity.version>2.3</velocity.version>
     <xerces.version>2.9.1</xerces.version>
     <zookeeper.version>3.4.6</zookeeper.version>
     <jpam.version>1.1</jpam.version>
@@ -462,7 +462,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
+        <artifactId>velocity-engine-core</artifactId>
         <version>${velocity.version}</version>
       </dependency>
       <dependency>

--- a/vector-code-gen/pom.xml
+++ b/vector-code-gen/pom.xml
@@ -49,17 +49,6 @@
       <artifactId>ant</artifactId>
       <version>${ant.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>${velocity.version}</version>
-           <exclusions>
-             <exclusion>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-          </exclusion>
-           </exclusions>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This is a backport of HIVE-25726: Upgrade velocity to 2.3 due to CVE-2020-13936 (Sourabh Goyal via Naveen Gangam) 
for JIRA: [https://issues.apache.org/jira/browse/HIVE-27334](url)