### PR TITLE
Disable JIRA worklog notifications for GitHub PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,4 +39,4 @@ notifications:
   commits:      commits@hive.apache.org
   issues:       gitbox@hive.apache.org
   pullrequests: gitbox@hive.apache.org
-  jira_options: link label worklog
+  jira_options: link label


### PR DESCRIPTION
### Why are the changes needed?
Reduce noise and avoid receiving the same notification multiple times.

Currently we receive the notification from four places:
* jira@apache.org
* notifications@github.com
* issues@hive.apache.org
* gitbox@hive.apache.org

After the changes the jira@ and issues@ entries for worklog will go away.

### Does this PR introduce _any_ user-facing change?
Some notification entries will go away

### How was this patch tested?
Same change in place in other ASF repos.