### PR TITLE
HIVE-27345: Upgrade commons-dbcp2 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <commons-text.version>1.10.0</commons-text.version>
     <derby.version>10.14.2.0</derby.version>
     <dropwizard.version>3.1.0</dropwizard.version>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/datasource/DbCPDataSourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.metastore.datasource;
 
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -84,16 +85,16 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     boolean testOnBorrow = hdpConfig.getBoolean(CONNECTION_TEST_BORROW_PROPERTY,
         BaseObjectPoolConfig.DEFAULT_TEST_ON_BORROW);
     long evictionTimeMillis = hdpConfig.getLong(CONNECTION_MIN_EVICT_MILLIS_PROPERTY,
-        BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME.toMillis());
     boolean testWhileIdle = hdpConfig.getBoolean(CONNECTION_TEST_IDLEPROPERTY,
         BaseObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE);
     long timeBetweenEvictionRuns = hdpConfig.getLong(CONNECTION_TIME_BETWEEN_EVICTION_RUNS_MILLIS,
-        BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS);
+        BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS.toMillis());
     int numTestsPerEvictionRun = hdpConfig.getInt(CONNECTION_NUM_TESTS_PER_EVICTION_RUN,
         BaseObjectPoolConfig.DEFAULT_NUM_TESTS_PER_EVICTION_RUN);
     boolean testOnReturn = hdpConfig.getBoolean(CONNECTION_TEST_ON_RETURN, BaseObjectPoolConfig.DEFAULT_TEST_ON_RETURN);
     long softMinEvictableIdleTimeMillis = hdpConfig.getLong(CONNECTION_SOFT_MIN_EVICTABLE_IDLE_TIME,
-        BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_TIME.toMillis());
     boolean lifo = hdpConfig.getBoolean(CONNECTION_LIFO, BaseObjectPoolConfig.DEFAULT_LIFO);
 
     ConnectionFactory connFactory = new DataSourceConnectionFactory(dbcpDs);
@@ -106,11 +107,11 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     objectPool.setMinIdle(connectionMinIlde);
     objectPool.setTestOnBorrow(testOnBorrow);
     objectPool.setTestWhileIdle(testWhileIdle);
-    objectPool.setMinEvictableIdleTimeMillis(evictionTimeMillis);
-    objectPool.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRuns);
+    objectPool.setMinEvictableIdleTime(Duration.ofMillis(evictionTimeMillis));
+    objectPool.setTimeBetweenEvictionRuns(Duration.ofMillis(timeBetweenEvictionRuns));
     objectPool.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
     objectPool.setTestOnReturn(testOnReturn);
-    objectPool.setSoftMinEvictableIdleTimeMillis(softMinEvictableIdleTimeMillis);
+    objectPool.setSoftMinEvictableIdleTime(Duration.ofMillis(softMinEvictableIdleTimeMillis));
     objectPool.setLifo(lifo);
 
     // Enable TxnHandler#connPoolMutex to release the idle connection if possible,
@@ -120,10 +121,10 @@ public class DbCPDataSourceProvider implements DataSourceProvider {
     if ("mutex".equalsIgnoreCase(poolName)) {
       if (timeBetweenEvictionRuns < 0) {
         // When timeBetweenEvictionRunsMillis non-positive, no idle object evictor thread runs
-        objectPool.setTimeBetweenEvictionRunsMillis(30 * 1000);
+        objectPool.setTimeBetweenEvictionRuns(Duration.ofMillis(30 * 1000));
       }
       if (softMinEvictableIdleTimeMillis < 0) {
-        objectPool.setSoftMinEvictableIdleTimeMillis(600 * 1000);
+        objectPool.setSoftMinEvictableIdleTime(Duration.ofMillis(600 * 1000));
       }
     }
     String stmt = dbProduct.getPrepareTxnStmt();

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -61,7 +61,7 @@
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
+    <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <datasketches.version>1.1.0-incubating</datasketches.version>
     <datanucleus-api-jdo.version>5.2.8</datanucleus-api-jdo.version>
     <datanucleus-core.version>5.2.10</datanucleus-core.version>


### PR DESCRIPTION

### What changes were proposed in this pull request?
Upgrading commons-dbcp2 to 2.9.0


### Why are the changes needed?
To be on the latest version of commons-dbcp2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the Unit test of standalone-metastore/metastore-server on local machine