### PR TITLE
HIVE-27346: Getting exception for wildcard (*) search for database and table name

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2162,7 +2162,7 @@ public class ObjectStore implements RawStore, Configurable {
 
       StringBuilder filterBuilder = new StringBuilder();
       List<String> parameterVals = new ArrayList<>();
-      appendSimpleCondition(filterBuilder, "database.name", new String[] {db}, parameterVals);
+      appendPatternCondition(filterBuilder, "database.name", new String[] {db}, parameterVals);
       appendSimpleCondition(filterBuilder, "database.catalogName", new String[] {catName}, parameterVals);
       if(tbl_names != null){
         appendSimpleCondition(filterBuilder, "tableName", lowered_tbl_names.toArray(new String[0]), parameterVals);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -271,6 +271,20 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     Assert.assertEquals("Found functions size", 1, tables.size());
     Assert.assertTrue("Comparing tablenames", tables.contains(testTables[6].getTableName()));
 
+    // Find tables by using the wildcard sign "*"
+    tables = client.getTables(DEFAULT_DATABASE, "*");
+    Assert.assertEquals("All tables size", 5, tables.size());
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[0].getTableName()));
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[1].getTableName()));
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[2].getTableName()));
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[3].getTableName()));
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[4].getTableName()));
+
+    tables = client.getTables(OTHER_DATABASE, "*");
+    Assert.assertEquals("All tables size", 2, tables.size());
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[5].getTableName()));
+    Assert.assertTrue("Comparing tablenames", tables.contains(testTables[6].getTableName()));
+
     // Look for tables but do not find any
     tables = client.getTables(DEFAULT_DATABASE, "*_not_such_function_*");
     Assert.assertEquals("No such table size", 0, tables.size());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -285,6 +285,13 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     Assert.assertTrue("Comparing tablenames", tables.contains(testTables[5].getTableName()));
     Assert.assertTrue("Comparing tablenames", tables.contains(testTables[6].getTableName()));
 
+    tables = client.getTables("*", "*");
+    Assert.assertEquals("All tables size", 7, tables.size());
+    tables = client.getTables("d*", "*");
+    Assert.assertEquals("All tables size", 7, tables.size());
+    tables = client.getTables("def*", "*");
+    Assert.assertEquals("All tables size", 5, tables.size());
+
     // Look for tables but do not find any
     tables = client.getTables(DEFAULT_DATABASE, "*_not_such_function_*");
     Assert.assertEquals("No such table size", 0, tables.size());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changed the function when user search database and table name in some certain pattern.

### Why are the changes needed?
To make sure that if * are used in searching for database and table name, there is no exception.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests.
