### PR TITLE
HIVE-27330: Compaction entry dequeue order

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -258,6 +258,7 @@ class CompactionTxnHandler extends TxnHandler {
           sb.append("\"CQ_POOL_NAME\" IS NULL OR  \"CQ_ENQUEUE_TIME\" < (")
             .append(getEpochFn(dbProduct)).append(" - ").append(poolTimeout).append(")");
         }
+        sb.append(" ORDER BY \"CQ_ID\" ASC");
         String query = sb.toString();
         stmt = dbConn.prepareStatement(query);
         if (hasPoolName) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compaction requests are now dequeued ordered by their id ascending

### Why are the changes needed?
The unordered dequeue resulted in unpredictable process order.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually and through unit tests