### PR TITLE
HIVE-27343: Fix flaky tests: TestHiveMetaStoreTimeout#testResetTimeout

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -117,11 +117,11 @@ public class TestHiveMetaStoreTimeout {
 
   @Test
   public void testResetTimeout() throws Exception {
-    HMSHandler.testTimeoutValue = 250;
     String dbName = "db";
 
     // no timeout before reset
     client.dropDatabase(dbName, true, true);
+    HMSHandler.testTimeoutValue = 250;
     Database db = new DatabaseBuilder()
         .setName(dbName)
         .build(conf);
@@ -130,6 +130,7 @@ public class TestHiveMetaStoreTimeout {
     } catch (Exception e) {
       Assert.fail("should not throw timeout exception: " + e.getMessage());
     }
+    HMSHandler.testTimeoutValue = -1;
     client.dropDatabase(dbName, true, true);
 
     // reset

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStoreTimeout.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -49,13 +50,14 @@ public class TestHiveMetaStoreTimeout {
   protected static Warehouse warehouse;
   protected static int port;
 
+  private final String dbName = "db";
+  
   @BeforeClass
   public static void startMetaStoreServer() throws Exception {
-    HMSHandler.testTimeoutEnabled = true;
     conf = MetastoreConf.newMetastoreConf();
     MetastoreConf.setClass(conf, ConfVars.EXPRESSION_PROXY_CLASS,
         MockPartitionExpressionForMetastore.class, PartitionExpressionProxy.class);
-    MetastoreConf.setTimeVar(conf, ConfVars.CLIENT_SOCKET_TIMEOUT, 1000,
+    MetastoreConf.setTimeVar(conf, ConfVars.CLIENT_SOCKET_TIMEOUT, 2000,
         TimeUnit.MILLISECONDS);
     MetaStoreTestUtils.setConfForStandloneMode(conf);
     warehouse = new Warehouse(conf);
@@ -64,29 +66,21 @@ public class TestHiveMetaStoreTimeout {
     MetastoreConf.setBoolVar(conf, ConfVars.EXECUTE_SET_UGI, false);
   }
 
-  @AfterClass
-  public static void tearDown() {
-    HMSHandler.testTimeoutEnabled = false;
-  }
-
   @Before
   public void setup() throws MetaException {
+    HMSHandler.testTimeoutEnabled = false;
+    HMSHandler.testTimeoutValue = -1;
     client = new HiveMetaStoreClient(conf);
   }
 
   @After
-  public void cleanup() {
+  public void cleanup() throws TException {
     client.close();
-    client = null;
+    client = null;    
   }
 
   @Test
   public void testNoTimeout() throws Exception {
-    HMSHandler.testTimeoutValue = 250;
-
-    String dbName = "db";
-    client.dropDatabase(dbName, true, true);
-
     new DatabaseBuilder()
         .setName(dbName)
         .create(client, conf);
@@ -96,10 +90,8 @@ public class TestHiveMetaStoreTimeout {
 
   @Test
   public void testTimeout() throws Exception {
-    HMSHandler.testTimeoutValue = 2 * 1000;
-
-    String dbName = "db";
-    client.dropDatabase(dbName, true, true);
+    HMSHandler.testTimeoutEnabled = true;
+    HMSHandler.testTimeoutValue = 4000;
 
     Database db = new DatabaseBuilder()
         .setName(dbName)
@@ -110,18 +102,10 @@ public class TestHiveMetaStoreTimeout {
     } catch (TTransportException e) {
       Assert.assertTrue("unexpected Exception", e.getMessage().contains("Read timed out"));
     }
-
-    // restore
-    HMSHandler.testTimeoutValue = 1;
   }
 
   @Test
   public void testResetTimeout() throws Exception {
-    String dbName = "db";
-
-    // no timeout before reset
-    client.dropDatabase(dbName, true, true);
-    HMSHandler.testTimeoutValue = 250;
     Database db = new DatabaseBuilder()
         .setName(dbName)
         .build(conf);
@@ -130,12 +114,11 @@ public class TestHiveMetaStoreTimeout {
     } catch (Exception e) {
       Assert.fail("should not throw timeout exception: " + e.getMessage());
     }
-    HMSHandler.testTimeoutValue = -1;
     client.dropDatabase(dbName, true, true);
 
     // reset
-    HMSHandler.testTimeoutValue = 2000;
-    client.setMetaConf(ConfVars.CLIENT_SOCKET_TIMEOUT.getVarname(), "1s");
+    HMSHandler.testTimeoutEnabled = true;
+    HMSHandler.testTimeoutValue = 4000;
 
     // timeout after reset
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the flaky test:
TestHiveMetaStoreTimeout#testResetTimeout


### Why are the changes needed?
This test was sensitive to network/DB speed, and slow CI builds were resulted in unexpected timeouts.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running TestHiveMetaStoreTimeout#testResetTimeout manually
