### PR TITLE
HIVE-27348: Encode database name when generating database path

### DIFF
--- a/ql/src/test/queries/clientpositive/special_character_in_tabnames_1.q
+++ b/ql/src/test/queries/clientpositive/special_character_in_tabnames_1.q
@@ -8,8 +8,8 @@ set hive.strict.checks.cartesian.product=false;
 
 -- SORT_QUERY_RESULTS
 
-create database `db~!@#$%^&*(),<>`;
-use `db~!@#$%^&*(),<>`;
+create database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`;
+use `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`;
 
 create table `c/b/o_t1`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE;
 create table `//cbo_t2`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE;
@@ -610,4 +610,4 @@ insert into `t//` values(null);
 analyze table `t//` compute statistics;
 explain select * from `t//`;
 
-drop database `db~!@#$%^&*(),<>` cascade;
+drop database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@` cascade;

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
@@ -1,65 +1,65 @@
-PREHOOK: query: create database `db~!@#$%^&*(),<>`
+PREHOOK: query: create database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`
 PREHOOK: type: CREATEDATABASE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: query: create database `db~!@#$%^&*(),<>`
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: query: create database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`
 POSTHOOK: type: CREATEDATABASE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: query: use `db~!@#$%^&*(),<>`
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: query: use `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`
 PREHOOK: type: SWITCHDATABASE
-PREHOOK: Input: database:db~!@#$%^&*(),<>
-POSTHOOK: query: use `db~!@#$%^&*(),<>`
+PREHOOK: Input: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: query: use `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@`
 POSTHOOK: type: SWITCHDATABASE
-POSTHOOK: Input: database:db~!@#$%^&*(),<>
+POSTHOOK: Input: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
 PREHOOK: query: create table `c/b/o_t1`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
 POSTHOOK: query: create table `c/b/o_t1`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
 PREHOOK: query: create table `//cbo_t2`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
 POSTHOOK: query: create table `//cbo_t2`(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
 PREHOOK: query: create table `cbo_/t3////`(key string, value string, c_int int, c_float float, c_boolean boolean)  row format delimited fields terminated by ',' STORED AS TEXTFILE
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 POSTHOOK: query: create table `cbo_/t3////`(key string, value string, c_int int, c_float float, c_boolean boolean)  row format delimited fields terminated by ',' STORED AS TEXTFILE
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 PREHOOK: query: load data local inpath '../../data/files/cbo_t1.txt' into table `c/b/o_t1` partition (dt='2014')
 PREHOOK: type: LOAD
 #### A masked pattern was here ####
-PREHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
 POSTHOOK: query: load data local inpath '../../data/files/cbo_t1.txt' into table `c/b/o_t1` partition (dt='2014')
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 PREHOOK: query: load data local inpath '../../data/files/cbo_t2.txt' into table `//cbo_t2` partition (dt='2014')
 PREHOOK: type: LOAD
 #### A masked pattern was here ####
-PREHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
 POSTHOOK: query: load data local inpath '../../data/files/cbo_t2.txt' into table `//cbo_t2` partition (dt='2014')
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
 PREHOOK: query: load data local inpath '../../data/files/cbo_t3.txt' into table `cbo_/t3////`
 PREHOOK: type: LOAD
 #### A masked pattern was here ####
-PREHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 POSTHOOK: query: load data local inpath '../../data/files/cbo_t3.txt' into table `cbo_/t3////`
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
-POSTHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 PREHOOK: query: CREATE TABLE `p/a/r/t`(
     p_partkey INT,
     p_name STRING,
@@ -72,8 +72,8 @@ PREHOOK: query: CREATE TABLE `p/a/r/t`(
     p_comment STRING
 )
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 POSTHOOK: query: CREATE TABLE `p/a/r/t`(
     p_partkey INT,
     p_name STRING,
@@ -86,16 +86,16 @@ POSTHOOK: query: CREATE TABLE `p/a/r/t`(
     p_comment STRING
 )
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/part.tbl.bz2' overwrite into table `p/a/r/t`
 PREHOOK: type: LOAD
 #### A masked pattern was here ####
-PREHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/part.tbl.bz2' overwrite into table `p/a/r/t`
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
-POSTHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 PREHOOK: query: CREATE TABLE `line/item` (L_ORDERKEY      INT,
                                 L_PARTKEY       INT,
                                 L_SUPPKEY       INT,
@@ -115,8 +115,8 @@ PREHOOK: query: CREATE TABLE `line/item` (L_ORDERKEY      INT,
 ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '|'
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@line/item
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 POSTHOOK: query: CREATE TABLE `line/item` (L_ORDERKEY      INT,
                                 L_PARTKEY       INT,
                                 L_SUPPKEY       INT,
@@ -136,105 +136,105 @@ POSTHOOK: query: CREATE TABLE `line/item` (L_ORDERKEY      INT,
 ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '|'
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@line/item
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/lineitem.tbl.bz2' OVERWRITE INTO TABLE `line/item`
 PREHOOK: type: LOAD
 #### A masked pattern was here ####
-PREHOOK: Output: db~!@#$%^&*(),<>@line/item
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/lineitem.tbl.bz2' OVERWRITE INTO TABLE `line/item`
 POSTHOOK: type: LOAD
 #### A masked pattern was here ####
-POSTHOOK: Output: db~!@#$%^&*(),<>@line/item
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 PREHOOK: query: create table `src/_/cbo` as select * from default.src
 PREHOOK: type: CREATETABLE_AS_SELECT
 PREHOOK: Input: default@src
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: query: create table `src/_/cbo` as select * from default.src
 POSTHOOK: type: CREATETABLE_AS_SELECT
 POSTHOOK: Input: default@src
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
 PREHOOK: query: analyze table `c/b/o_t1` compute statistics for columns key, value, c_int, c_float, c_boolean
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `c/b/o_t1` compute statistics for columns key, value, c_int, c_float, c_boolean
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 PREHOOK: query: analyze table `//cbo_t2` compute statistics for columns key, value, c_int, c_float, c_boolean
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `//cbo_t2` compute statistics for columns key, value, c_int, c_float, c_boolean
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
 #### A masked pattern was here ####
 PREHOOK: query: analyze table `cbo_/t3////` compute statistics for columns key, value, c_int, c_float, c_boolean
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
-PREHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `cbo_/t3////` compute statistics for columns key, value, c_int, c_float, c_boolean
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
-POSTHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 PREHOOK: query: analyze table `src/_/cbo` compute statistics for columns
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
-PREHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `src/_/cbo` compute statistics for columns
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
-POSTHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 PREHOOK: query: analyze table `p/a/r/t` compute statistics for columns
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
-PREHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `p/a/r/t` compute statistics for columns
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
-POSTHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 PREHOOK: query: analyze table `line/item` compute statistics for columns
 PREHOOK: type: ANALYZE_TABLE
-PREHOOK: Input: db~!@#$%^&*(),<>@line/item
-PREHOOK: Output: db~!@#$%^&*(),<>@line/item
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 POSTHOOK: query: analyze table `line/item` compute statistics for columns
 POSTHOOK: type: ANALYZE_TABLE
-POSTHOOK: Input: db~!@#$%^&*(),<>@line/item
-POSTHOOK: Output: db~!@#$%^&*(),<>@line/item
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 PREHOOK: query: select key, (c_int+1)+2 as x, sum(c_int) from `c/b/o_t1` group by c_float, `c/b/o_t1`.c_int, key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: select key, (c_int+1)+2 as x, sum(c_int) from `c/b/o_t1` group by c_float, `c/b/o_t1`.c_int, key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
  1	4	2
  1 	4	2
@@ -251,7 +251,7 @@ UNION  ALL
 
         select 'avg' as key,  avg(c_int) as value from `cbo_/t3////` s3) unionsrc order by unionsrc.key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 POSTHOOK: query: select unionsrc.key FROM (select 'max' as key, max(c_int) as value from `cbo_/t3////` s1
 
@@ -263,22 +263,22 @@ UNION  ALL
 
         select 'avg' as key,  avg(c_int) as value from `cbo_/t3////` s3) unionsrc order by unionsrc.key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 avg
 max
 min
 PREHOOK: query: explain select `c/b/o_t1`.key from `c/b/o_t1` join `cbo_/t3////`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 POSTHOOK: query: explain select `c/b/o_t1`.key from `c/b/o_t1` join `cbo_/t3////`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -342,17 +342,17 @@ STAGE PLANS:
 
 PREHOOK: query: explain select `c/b/o_t1`.c_int, `//cbo_t2`.c_int from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.key=`//cbo_t2`.key where (`c/b/o_t1`.c_int + `//cbo_t2`.c_int == 2) and (`c/b/o_t1`.c_int > 0 or `//cbo_t2`.c_float >= 0)
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select `c/b/o_t1`.c_int, `//cbo_t2`.c_int from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.key=`//cbo_t2`.key where (`c/b/o_t1`.c_int + `//cbo_t2`.c_int == 2) and (`c/b/o_t1`.c_int > 0 or `//cbo_t2`.c_float >= 0)
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -436,13 +436,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select key, (c_int+1)+2 as x, sum(c_int) from `c/b/o_t1` group by c_float, `c/b/o_t1`.c_int, key order by x limit 1
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select key, (c_int+1)+2 as x, sum(c_int) from `c/b/o_t1` group by c_float, `c/b/o_t1`.c_int, key order by x limit 1
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -533,17 +533,17 @@ STAGE PLANS:
 
 PREHOOK: query: explain select `c/b/o_t1`.c_int           from `c/b/o_t1` left semi join   `//cbo_t2` on `c/b/o_t1`.key=`//cbo_t2`.key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select `c/b/o_t1`.c_int           from `c/b/o_t1` left semi join   `//cbo_t2` on `c/b/o_t1`.key=`//cbo_t2`.key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -633,13 +633,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select * from `c/b/o_t1` as `c/b/o_t1`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select * from `c/b/o_t1` as `c/b/o_t1`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -658,13 +658,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select * from `c/b/o_t1` as `c/b/o_t1`  where `c/b/o_t1`.c_int >= 0 and c_float+c_int >= 0 or c_float <= 100
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select * from `c/b/o_t1` as `c/b/o_t1`  where `c/b/o_t1`.c_int >= 0 and c_float+c_int >= 0 or c_float <= 100
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -686,13 +686,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select * from (select * from `c/b/o_t1` where `c/b/o_t1`.c_int >= 0) as `c/b/o_t1`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select * from (select * from `c/b/o_t1` where `c/b/o_t1`.c_int >= 0) as `c/b/o_t1`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -714,11 +714,11 @@ STAGE PLANS:
 
 PREHOOK: query: explain select null from `cbo_/t3////`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 POSTHOOK: query: explain select null from `cbo_/t3////`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -737,13 +737,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select key from `c/b/o_t1` where c_int = -6  or c_int = +6
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select key from `c/b/o_t1` where c_int = -6  or c_int = +6
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -765,17 +765,17 @@ STAGE PLANS:
 
 PREHOOK: query: explain select count(`c/b/o_t1`.dt) from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.dt  = `//cbo_t2`.dt  where `c/b/o_t1`.dt = '2014'
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select count(`c/b/o_t1`.dt) from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.dt  = `//cbo_t2`.dt  where `c/b/o_t1`.dt = '2014'
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -883,15 +883,15 @@ STAGE PLANS:
 
 PREHOOK: query: explain select `c/b/o_t1`.value from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.key = `//cbo_t2`.key where `c/b/o_t1`.dt = '10' and `c/b/o_t1`.c_boolean = true
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
 #### A masked pattern was here ####
 POSTHOOK: query: explain select `c/b/o_t1`.value from `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.key = `//cbo_t2`.key where `c/b/o_t1`.dt = '10' and `c/b/o_t1`.c_boolean = true
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -983,7 +983,7 @@ where not exists
 
   )
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -999,7 +999,7 @@ where not exists
 
   )
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1109,7 +1109,7 @@ having not exists
 
   )
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -1127,7 +1127,7 @@ having not exists
 
   )
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1238,9 +1238,9 @@ where exists
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 PREHOOK: type: CREATEVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@cv1_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
 POSTHOOK: query: create view cv1_n0 as
 
 select *
@@ -1255,20 +1255,20 @@ where exists
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 POSTHOOK: type: CREATEVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@cv1_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
 POSTHOOK: Lineage: cv1_n0.key EXPRESSION [(src/_/cbo)b.FieldSchema(name:key, type:string, comment:null), ]
 POSTHOOK: Lineage: cv1_n0.value EXPRESSION [(src/_/cbo)b.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: select * from cv1_n0
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@cv1_n0
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: select * from cv1_n0
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@cv1_n0
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 90	val_90
 90	val_90
@@ -1297,7 +1297,7 @@ from (select *
 
      ) a
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -1315,7 +1315,7 @@ from (select *
 
      ) a
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1418,7 +1418,7 @@ from (select b.key, count(*)
 
 ) a
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -1440,7 +1440,7 @@ from (select b.key, count(*)
 
 ) a
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1546,7 +1546,7 @@ from `src/_/cbo`
 
 where `src/_/cbo`.key in (select key from `src/_/cbo` s1 where s1.key > '9') order by key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -1554,7 +1554,7 @@ from `src/_/cbo`
 
 where `src/_/cbo`.key in (select key from `src/_/cbo` s1 where s1.key > '9') order by key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1666,7 +1666,7 @@ where b.key in
 
         ) order by b.key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -1682,7 +1682,7 @@ where b.key in
 
         ) order by b.key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1798,7 +1798,7 @@ where li.l_linenumber = 1 and
 
  order by p.p_partkey
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@line/item
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 POSTHOOK: query: explain select p.p_partkey, li.l_suppkey
 
@@ -1810,7 +1810,7 @@ where li.l_linenumber = 1 and
 
  order by p.p_partkey
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@line/item
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -1963,7 +1963,7 @@ group by key, value
 
 having count(*) in (select count(*) from `src/_/cbo` s1 where s1.key > '9' group by s1.key ) order by key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select key, value, count(*)
 
@@ -1975,7 +1975,7 @@ group by key, value
 
 having count(*) in (select count(*) from `src/_/cbo` s1 where s1.key > '9' group by s1.key ) order by key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -2179,7 +2179,7 @@ having p_name in
 
   (select first_value(p_name) over(partition by p_mfgr order by p_size) from `p/a/r/t`) order by p_mfgr
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select p_mfgr, p_name, avg(p_size)
 
@@ -2191,7 +2191,7 @@ having p_name in
 
   (select first_value(p_name) over(partition by p_mfgr order by p_size) from `p/a/r/t`) order by p_mfgr
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -2351,7 +2351,7 @@ where `src/_/cbo`.key not in
 
   ) order by key
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: explain select *
 
@@ -2365,7 +2365,7 @@ where `src/_/cbo`.key not in
 
   ) order by key
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -2523,7 +2523,7 @@ where b.p_name not in
 
   ) order by p_mfgr,p_size
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select p_mfgr, b.p_name, p_size
 
@@ -2539,7 +2539,7 @@ where b.p_name not in
 
   ) order by p_mfgr,p_size
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -2697,7 +2697,7 @@ from
 
   ) order by p_name
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select p_name, p_size
 
@@ -2713,7 +2713,7 @@ from
 
   ) order by p_name
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -2874,7 +2874,7 @@ from `p/a/r/t` b where b.p_size not in
 
   ) order by  p_name
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select p_mfgr, p_name, p_size
 
@@ -2888,7 +2888,7 @@ from `p/a/r/t` b where b.p_size not in
 
   ) order by  p_name
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3070,7 +3070,7 @@ where li.l_linenumber = 1 and
 
 group by li.l_partkey order by li.l_partkey
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@line/item
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 POSTHOOK: query: explain select li.l_partkey, count(*)
 
@@ -3082,7 +3082,7 @@ where li.l_linenumber = 1 and
 
 group by li.l_partkey order by li.l_partkey
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@line/item
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3272,7 +3272,7 @@ having b.p_mfgr not in
 
   order by b.p_mfgr
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select b.p_mfgr, min(p_retailprice)
 
@@ -3292,7 +3292,7 @@ having b.p_mfgr not in
 
   order by b.p_mfgr
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3539,7 +3539,7 @@ having b.p_mfgr not in
 
   order by b.p_mfgr
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 POSTHOOK: query: explain select b.p_mfgr, min(p_retailprice)
 
@@ -3561,7 +3561,7 @@ having b.p_mfgr not in
 
   order by b.p_mfgr
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3794,13 +3794,13 @@ STAGE PLANS:
 
 PREHOOK: query: explain select f,a,e,b from (select count(*) as a, count(c_int) as b, sum(c_int) as c, avg(c_int) as d, max(c_int) as e, min(c_int) as f from `c/b/o_t1`) `c/b/o_t1`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select f,a,e,b from (select count(*) as a, count(c_int) as b, sum(c_int) as c, avg(c_int) as d, max(c_int) as e, min(c_int) as f from `c/b/o_t1`) `c/b/o_t1`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3864,17 +3864,17 @@ STAGE PLANS:
 
 PREHOOK: query: explain select * from (select * from `c/b/o_t1` order by key, c_boolean, value, dt)a union all select * from (select * from `//cbo_t2` order by key, c_boolean, value, dt)b
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select * from (select * from `c/b/o_t1` order by key, c_boolean, value, dt)a union all select * from (select * from `//cbo_t2` order by key, c_boolean, value, dt)b
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -3962,170 +3962,170 @@ STAGE PLANS:
 
 PREHOOK: query: create view v1_n7 as select c_int, value, c_boolean, dt from `c/b/o_t1`
 PREHOOK: type: CREATEVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 POSTHOOK: query: create view v1_n7 as select c_int, value, c_boolean, dt from `c/b/o_t1`
 POSTHOOK: type: CREATEVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 POSTHOOK: Lineage: v1_n7.c_boolean SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_boolean, type:boolean, comment:null), ]
 POSTHOOK: Lineage: v1_n7.c_int SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_int, type:int, comment:null), ]
 POSTHOOK: Lineage: v1_n7.dt SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:dt, type:string, comment:null), ]
 POSTHOOK: Lineage: v1_n7.value SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: create view v2_n2 as select c_int, value from `//cbo_t2`
 PREHOOK: type: CREATEVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@v2_n2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 POSTHOOK: query: create view v2_n2 as select c_int, value from `//cbo_t2`
 POSTHOOK: type: CREATEVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@v2_n2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 POSTHOOK: Lineage: v2_n2.c_int SIMPLE [(//cbo_t2)//cbo_t2.FieldSchema(name:c_int, type:int, comment:null), ]
 POSTHOOK: Lineage: v2_n2.value SIMPLE [(//cbo_t2)//cbo_t2.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: select value from v1_n7 where c_boolean=false
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: select value from v1_n7 where c_boolean=false
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 1
 1
 PREHOOK: query: select max(c_int) from v1_n7 group by (c_boolean)
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: select max(c_int) from v1_n7 group by (c_boolean)
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 1
 1
 NULL
 PREHOOK: query: select count(v1_n7.c_int)  from v1_n7 join `//cbo_t2` on v1_n7.c_int = `//cbo_t2`.c_int
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: select count(v1_n7.c_int)  from v1_n7 join `//cbo_t2` on v1_n7.c_int = `//cbo_t2`.c_int
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 234
 PREHOOK: query: select count(v1_n7.c_int)  from v1_n7 join v2_n2 on v1_n7.c_int = v2_n2.c_int
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-PREHOOK: Input: db~!@#$%^&*(),<>@v2_n2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 #### A masked pattern was here ####
 POSTHOOK: query: select count(v1_n7.c_int)  from v1_n7 join v2_n2 on v1_n7.c_int = v2_n2.c_int
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Input: db~!@#$%^&*(),<>@//cbo_t2@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-POSTHOOK: Input: db~!@#$%^&*(),<>@v2_n2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 #### A masked pattern was here ####
 234
 PREHOOK: query: select count(*) from v1_n7 a join v1_n7 b on a.value = b.value
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: select count(*) from v1_n7 a join v1_n7 b on a.value = b.value
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 156
 PREHOOK: query: create view v3_n0 as select v1_n7.value val from v1_n7 join `c/b/o_t1` on v1_n7.c_boolean = `c/b/o_t1`.c_boolean
 PREHOOK: type: CREATEVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@v3_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 POSTHOOK: query: create view v3_n0 as select v1_n7.value val from v1_n7 join `c/b/o_t1` on v1_n7.c_boolean = `c/b/o_t1`.c_boolean
 POSTHOOK: type: CREATEVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@v3_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 POSTHOOK: Lineage: v3_n0.val EXPRESSION [(c/b/o_t1)c/b/o_t1.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: select count(val) from v3_n0 where val != '1'
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-PREHOOK: Input: db~!@#$%^&*(),<>@v3_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 #### A masked pattern was here ####
 POSTHOOK: query: select count(val) from v3_n0 where val != '1'
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-POSTHOOK: Input: db~!@#$%^&*(),<>@v3_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 #### A masked pattern was here ####
 96
 PREHOOK: query: with q1 as ( select key from `c/b/o_t1` where key = '1')
 
 select count(*) from q1
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: with q1 as ( select key from `c/b/o_t1` where key = '1')
 
 select count(*) from q1
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 12
 PREHOOK: query: with q1 as ( select value from v1_n7 where c_boolean = false)
 
 select count(value) from q1
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: with q1 as ( select value from v1_n7 where c_boolean = false)
 
 select count(value) from q1
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 2
 PREHOOK: query: create view v4_n0 as
@@ -4134,20 +4134,20 @@ with q1 as ( select key,c_int from `c/b/o_t1`  where key = '1')
 
 select * from q1
 PREHOOK: type: CREATEVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@v4_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 POSTHOOK: query: create view v4_n0 as
 
 with q1 as ( select key,c_int from `c/b/o_t1`  where key = '1')
 
 select * from q1
 POSTHOOK: type: CREATEVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@v4_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 POSTHOOK: Lineage: v4_n0.c_int SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_int, type:int, comment:null), ]
 POSTHOOK: Lineage: v4_n0.key SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:key, type:string, comment:null), ]
 PREHOOK: query: with q1 as ( select c_int from q2 where c_boolean = false),
@@ -4156,9 +4156,9 @@ q2 as ( select c_int,c_boolean from v1_n7  where value = '1')
 
 select sum(c_int) from (select c_int from q1) a
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 POSTHOOK: query: with q1 as ( select c_int from q2 where c_boolean = false),
 
@@ -4166,9 +4166,9 @@ q2 as ( select c_int,c_boolean from v1_n7  where value = '1')
 
 select sum(c_int) from (select c_int from q1) a
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 #### A masked pattern was here ####
 2
 PREHOOK: query: with q1 as ( select `c/b/o_t1`.c_int c_int from q2 join `c/b/o_t1` where q2.c_int = `c/b/o_t1`.c_int  and `c/b/o_t1`.dt='2014'),
@@ -4177,10 +4177,10 @@ q2 as ( select c_int,c_boolean from v1_n7  where value = '1' or dt = '14')
 
 select count(*) from q1 join q2 join v4_n0 on q1.c_int = q2.c_int and v4_n0.c_int = q2.c_int
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-PREHOOK: Input: db~!@#$%^&*(),<>@v4_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 #### A masked pattern was here ####
 POSTHOOK: query: with q1 as ( select `c/b/o_t1`.c_int c_int from q2 join `c/b/o_t1` where q2.c_int = `c/b/o_t1`.c_int  and `c/b/o_t1`.dt='2014'),
 
@@ -4188,53 +4188,53 @@ q2 as ( select c_int,c_boolean from v1_n7  where value = '1' or dt = '14')
 
 select count(*) from q1 join q2 join v4_n0 on q1.c_int = q2.c_int and v4_n0.c_int = q2.c_int
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-POSTHOOK: Input: db~!@#$%^&*(),<>@v4_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 #### A masked pattern was here ####
 31104
 PREHOOK: query: drop view v1_n7
 PREHOOK: type: DROPVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-PREHOOK: Output: db~!@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 POSTHOOK: query: drop view v1_n7
 POSTHOOK: type: DROPVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@v1_n7
-POSTHOOK: Output: db~!@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v1_n7
 PREHOOK: query: drop view v2_n2
 PREHOOK: type: DROPVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@v2_n2
-PREHOOK: Output: db~!@#$%^&*(),<>@v2_n2
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 POSTHOOK: query: drop view v2_n2
 POSTHOOK: type: DROPVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@v2_n2
-POSTHOOK: Output: db~!@#$%^&*(),<>@v2_n2
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v2_n2
 PREHOOK: query: drop view v3_n0
 PREHOOK: type: DROPVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@v3_n0
-PREHOOK: Output: db~!@#$%^&*(),<>@v3_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 POSTHOOK: query: drop view v3_n0
 POSTHOOK: type: DROPVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@v3_n0
-POSTHOOK: Output: db~!@#$%^&*(),<>@v3_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v3_n0
 PREHOOK: query: drop view v4_n0
 PREHOOK: type: DROPVIEW
-PREHOOK: Input: db~!@#$%^&*(),<>@v4_n0
-PREHOOK: Output: db~!@#$%^&*(),<>@v4_n0
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 POSTHOOK: query: drop view v4_n0
 POSTHOOK: type: DROPVIEW
-POSTHOOK: Input: db~!@#$%^&*(),<>@v4_n0
-POSTHOOK: Output: db~!@#$%^&*(),<>@v4_n0
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@v4_n0
 PREHOOK: query: explain select count(c_int) over(partition by c_float order by key), sum(c_float) over(partition by c_float order by key), max(c_int) over(partition by c_float order by key), min(c_int) over(partition by c_float order by key), row_number() over(partition by c_float order by key) as rn, rank() over(partition by c_float order by key), dense_rank() over(partition by c_float order by key), round(percent_rank() over(partition by c_float order by key), 2), lead(c_int, 2, c_int) over(partition by c_float order by key), lag(c_float, 2, c_float) over(partition by c_float order by key) from `c/b/o_t1` order by rn
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 POSTHOOK: query: explain select count(c_int) over(partition by c_float order by key), sum(c_float) over(partition by c_float order by key), max(c_int) over(partition by c_float order by key), min(c_int) over(partition by c_float order by key), row_number() over(partition by c_float order by key) as rn, rank() over(partition by c_float order by key), dense_rank() over(partition by c_float order by key), round(percent_rank() over(partition by c_float order by key), 2), lead(c_int, 2, c_int) over(partition by c_float order by key), lag(c_float, 2, c_float) over(partition by c_float order by key) from `c/b/o_t1` order by rn
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Input: db~!@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1@dt=2014
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -4383,39 +4383,39 @@ STAGE PLANS:
 PREHOOK: query: insert into table `src/_/cbo` select * from default.src
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
-PREHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: query: insert into table `src/_/cbo` select * from default.src
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
-POSTHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
 PREHOOK: query: select * from `src/_/cbo` limit 1
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: select * from `src/_/cbo` limit 1
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 238	val_238
 PREHOOK: query: insert overwrite table `src/_/cbo` select * from default.src
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
-PREHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: query: insert overwrite table `src/_/cbo` select * from default.src
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
-POSTHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
 POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
 PREHOOK: query: select * from `src/_/cbo` limit 1
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: select * from `src/_/cbo` limit 1
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
 #### A masked pattern was here ####
 238	val_238
 PREHOOK: query: drop table `t//`
@@ -4424,45 +4424,45 @@ POSTHOOK: query: drop table `t//`
 POSTHOOK: type: DROPTABLE
 PREHOOK: query: create table `t//` (col string)
 PREHOOK: type: CREATETABLE
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@t//
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: query: create table `t//` (col string)
 POSTHOOK: type: CREATETABLE
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@t//
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 PREHOOK: query: insert into `t//` values(1)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: db~!@#$%^&*(),<>@t//
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: query: insert into `t//` values(1)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: db~!@#$%^&*(),<>@t//
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: Lineage: t//.col SCRIPT []
 PREHOOK: query: insert into `t//` values(null)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: db~!@#$%^&*(),<>@t//
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: query: insert into `t//` values(null)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: db~!@#$%^&*(),<>@t//
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: Lineage: t//.col SCRIPT []
 PREHOOK: query: analyze table `t//` compute statistics
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@t//
-PREHOOK: Output: db~!@#$%^&*(),<>@t//
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 POSTHOOK: query: analyze table `t//` compute statistics
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@t//
-POSTHOOK: Output: db~!@#$%^&*(),<>@t//
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 PREHOOK: query: explain select * from `t//`
 PREHOOK: type: QUERY
-PREHOOK: Input: db~!@#$%^&*(),<>@t//
+PREHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 #### A masked pattern was here ####
 POSTHOOK: query: explain select * from `t//`
 POSTHOOK: type: QUERY
-POSTHOOK: Input: db~!@#$%^&*(),<>@t//
+POSTHOOK: Input: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
 #### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -4479,27 +4479,27 @@ STAGE PLANS:
             outputColumnNames: _col0
             ListSink
 
-PREHOOK: query: drop database `db~!@#$%^&*(),<>` cascade
+PREHOOK: query: drop database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@` cascade
 PREHOOK: type: DROPDATABASE
-PREHOOK: Input: database:db~!@#$%^&*(),<>
-PREHOOK: Output: database:db~!@#$%^&*(),<>
-PREHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
-PREHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
-PREHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
-PREHOOK: Output: db~!@#$%^&*(),<>@cv1_n0
-PREHOOK: Output: db~!@#$%^&*(),<>@line/item
-PREHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
-PREHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
-PREHOOK: Output: db~!@#$%^&*(),<>@t//
-POSTHOOK: query: drop database `db~!@#$%^&*(),<>` cascade
+PREHOOK: Input: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+PREHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//
+POSTHOOK: query: drop database `db"% &()*+,-/:;<=>?[]_|{}$^!~#``@` cascade
 POSTHOOK: type: DROPDATABASE
-POSTHOOK: Input: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: database:db~!@#$%^&*(),<>
-POSTHOOK: Output: db~!@#$%^&*(),<>@//cbo_t2
-POSTHOOK: Output: db~!@#$%^&*(),<>@c/b/o_t1
-POSTHOOK: Output: db~!@#$%^&*(),<>@cbo_/t3////
-POSTHOOK: Output: db~!@#$%^&*(),<>@cv1_n0
-POSTHOOK: Output: db~!@#$%^&*(),<>@line/item
-POSTHOOK: Output: db~!@#$%^&*(),<>@p/a/r/t
-POSTHOOK: Output: db~!@#$%^&*(),<>@src/_/cbo
-POSTHOOK: Output: db~!@#$%^&*(),<>@t//
+POSTHOOK: Input: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: database:db"% &()*+,-/:;<=>?[]_|{}$^!~#`@
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@//cbo_t2
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@c/b/o_t1
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cbo_/t3////
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@cv1_n0
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@line/item
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@p/a/r/t
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@src/_/cbo
+POSTHOOK: Output: db"% &()*+,-/:;<=>?[]_|{}$^!~#`@@t//

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -240,15 +240,15 @@ public class Warehouse {
       if (db.getName().equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
         return getWhRootExternal();
       } else {
-        return new Path(getWhRootExternal(), dbDirFromDbName(db));
+        return new Path(getWhRootExternal(), dbDirFromDbName(db.getName()));
       }
     } else {
-      return new Path(getDnsPath(new Path(cat.getLocationUri())), dbDirFromDbName(db));
+      return new Path(getDnsPath(new Path(cat.getLocationUri())), dbDirFromDbName(db.getName()));
     }
   }
 
-  private String dbDirFromDbName(Database db) throws MetaException {
-    return db.getName().toLowerCase() + DATABASE_WAREHOUSE_SUFFIX;
+  private String dbDirFromDbName(final String dbName) {
+    return MetaStoreUtils.encodeTableName(dbName.toLowerCase()) + DATABASE_WAREHOUSE_SUFFIX;
   }
 
   /**
@@ -307,7 +307,7 @@ public class Warehouse {
       return getWhRoot();
     }
 
-    return new Path(getWhRoot(), db.getName().toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
+    return new Path(getWhRoot(), dbDirFromDbName(db.getName()));
   }
 
   public Path getDefaultDatabasePath(String dbName) throws MetaException {
@@ -329,12 +329,12 @@ public class Warehouse {
       if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
         return getWhRootExternal();
       }
-      return new Path(getWhRootExternal(), dbName.toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
+      return new Path(getWhRootExternal(), dbDirFromDbName(dbName);
     } else {
       if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
         return getWhRoot();
       }
-      return new Path(getWhRoot(), dbName.toLowerCase() + DATABASE_WAREHOUSE_SUFFIX);
+      return new Path(getWhRoot(), dbDirFromDbName(dbName));
     }
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -330,7 +330,7 @@ public class Warehouse {
       if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
         return getWhRootExternal();
       }
-      return new Path(getWhRootExternal(), dbDirFromDbName(dbName);
+      return new Path(getWhRootExternal(), dbDirFromDbName(dbName));
     } else {
       if (dbName.equalsIgnoreCase(DEFAULT_DATABASE_NAME)) {
         return getWhRoot();

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_TABLE_PATTERN;
 import static org.apache.hadoop.hive.common.AcidConstants.SOFT_DELETE_PATH_SUFFIX;
+import static org.apache.hadoop.hive.metastore.utils.StringUtils.normalizeIdentifier;
 
 /**
  * This class represents a warehouse where data of Hive tables is stored
@@ -248,7 +249,7 @@ public class Warehouse {
   }
 
   private String dbDirFromDbName(final String dbName) {
-    return MetaStoreUtils.encodeTableName(dbName.toLowerCase()) + DATABASE_WAREHOUSE_SUFFIX;
+    return MetaStoreUtils.encodeTableName(normalizeIdentifier(dbName)) + DATABASE_WAREHOUSE_SUFFIX;
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -107,6 +107,7 @@ import org.junit.Test;
 import com.google.common.collect.Lists;
 
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.convertToGetPartitionsByNamesRequest;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.encodeTableName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1348,7 +1349,6 @@ public abstract class TestHiveMetaStore {
     }
   }
 
-
   @Test
   public void testDatabaseLocationOnDrop() throws Throwable {
     try {
@@ -1393,6 +1393,23 @@ public abstract class TestHiveMetaStore {
       System.err.println("testDatabaseLocationOnDrop() failed.");
       throw e;
     }
+  }
+
+  @Test
+  public void testCreateDatabaseDefaultLocationSpecialChars() throws Exception {
+    final String dbName = "db\"% &()*+,-/:;<=>?[]_|{}$^!~#``@";
+    silentDropDatabase(dbName);
+
+    Database database = new DatabaseBuilder()
+        .setName(dbName)
+        .create(client, conf);
+
+    Database createdDatabase = client.getDatabase(database.getName());
+
+    Assert.assertEquals("Comparing database name", dbName, createdDatabase.getName());
+    Assert.assertEquals("Comparing location", 
+        warehouse.getWhRootExternal() + "/" + encodeTableName(createdDatabase.getName()) + ".db",
+        createdDatabase.getLocationUri());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.FunctionBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
 import org.apache.thrift.TException;
 import org.junit.After;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR encodes that database name when using it to generate the default database path. For this purpose, the method `MetaStoreUtils.encodeTableName` is used. This is analogous to how table names are encoded when used to generate the default path for a table.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If the database name is not encoded, special characters which are allowed in schema names are used as is in the path. This causes problems in cases where these special characters are not allowed. One example being URI generation from the database path.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The default location for a database change in case the database name contains special characters. For example, `my{schema}` resulted in "my{schema}.db", now it results in "my-123-schema-125-.db".


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I've extended the name of the schema created in test special_character_in_tabnames_1.q such that it contains additional, problematic characters. Without the fix, the modified test case fails, with the fix, the modified test case runs clean.