### PR TITLE
HIVE-27353: Show saved snapshot of materialized view source tables

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc.q
@@ -2,6 +2,7 @@
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 -- Mask random snapshot id
 --! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
+--! qt:replace:/(.*snapshotId=)\S+(\}.*)/$1#SnapshotId#$2/
 -- Mask added file size
 --! qt:replace:/(\S\"added-files-size\\\":\\\")(\d+)(\\\")/$1#Masked#$3/
 -- Mask total file size

--- a/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/mv_iceberg_partitioned_orc2.q
@@ -1,6 +1,7 @@
 -- MV data is stored by partitioned iceberg with partition spec
 --! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
 --! qt:replace:/(\s+current-snapshot-id\s+)\d+(\s*)/$1#SnapshotId#/
+--! qt:replace:/(.*snapshotId=)\S+(\}.*)/$1#SnapshotId#$2/
 -- Mask added file size
 --! qt:replace:/(\S\"added-files-size\\\":\\\")(\d+)(\\\")/$1#Masked#$3/
 -- Mask total file size

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -96,7 +96,7 @@ Outdated for Rewriting:	Unknown
 	 	 
 # Materialized View Source table information	 	 
 Table name          	Snapshot            	 
-default.tbl_ice     	SnapshotContext{snapshotId=6604871607751762574}	 
+default.tbl_ice     	SnapshotContext{snapshotId=#SnapshotId#}	 
 PREHOOK: query: select * from mat1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -184,4 +184,4 @@ Outdated for Rewriting:	Unknown
 	 	 
 # Materialized View Source table information	 	 
 Table name          	Snapshot            	 
-default.tbl_ice     	SnapshotContext{snapshotId=6604871607751762574}	 
+default.tbl_ice     	SnapshotContext{snapshotId=#SnapshotId#}	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc.q.out
@@ -95,8 +95,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.tbl_ice	0/0/0               	 
+Table name          	Snapshot            	 
+default.tbl_ice     	SnapshotContext{snapshotId=6604871607751762574}	 
 PREHOOK: query: select * from mat1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -183,5 +183,5 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.tbl_ice	0/0/0               	 
+Table name          	Snapshot            	 
+default.tbl_ice     	SnapshotContext{snapshotId=6604871607751762574}	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -97,7 +97,7 @@ Outdated for Rewriting:	Unknown
 	 	 
 # Materialized View Source table information	 	 
 Table name          	Snapshot            	 
-default.tbl_ice     	SnapshotContext{snapshotId=2865399148907497103}	 
+default.tbl_ice     	SnapshotContext{snapshotId=#SnapshotId#}	 
 PREHOOK: query: select * from mat1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -186,4 +186,4 @@ Outdated for Rewriting:	Unknown
 	 	 
 # Materialized View Source table information	 	 
 Table name          	Snapshot            	 
-default.tbl_ice     	SnapshotContext{snapshotId=2865399148907497103}	 
+default.tbl_ice     	SnapshotContext{snapshotId=#SnapshotId#}	 

--- a/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/mv_iceberg_partitioned_orc2.q.out
@@ -96,8 +96,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.tbl_ice	0/0/0               	 
+Table name          	Snapshot            	 
+default.tbl_ice     	SnapshotContext{snapshotId=2865399148907497103}	 
 PREHOOK: query: select * from mat1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -185,5 +185,5 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.tbl_ice	0/0/0               	 
+Table name          	Snapshot            	 
+default.tbl_ice     	SnapshotContext{snapshotId=2865399148907497103}	 

--- a/iceberg/iceberg-handler/src/test/results/positive/show_iceberg_materialized_views.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_iceberg_materialized_views.q.out
@@ -394,8 +394,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	Unknown             	 
 PREHOOK: query: DESCRIBE FORMATTED test1.shtb_test1_view1
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: test1@shtb_test1_view1
@@ -445,8 +445,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	Unknown             	 
 PREHOOK: query: DESCRIBE FORMATTED test1.shtb_test1_view2
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: test1@shtb_test1_view2
@@ -497,8 +497,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	Unknown             	 
 PREHOOK: query: SHOW MATERIALIZED VIEWS IN test2 LIKE "nomatch"
 PREHOOK: type: SHOWMATERIALIZEDVIEWS
 POSTHOOK: query: SHOW MATERIALIZED VIEWS IN test2 LIKE "nomatch"
@@ -602,8 +602,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.database.foo_n0	0/0/0               	 
+Table name          	Snapshot            	 
+database.foo_n0     	Unknown             	 
 PREHOOK: query: DROP MATERIALIZED VIEW fooview
 PREHOOK: type: DROP_MATERIALIZED_VIEW
 POSTHOOK: query: DROP MATERIALIZED VIEW fooview

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/formatter/TextDescTableFormatter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/formatter/TextDescTableFormatter.java
@@ -66,6 +66,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.Map.Entry;
@@ -283,7 +284,7 @@ class TextDescTableFormatter extends DescTableFormatter {
   private static MaterializationSnapshotFormatter createMaterializationSnapshotFormatter(
           MaterializationSnapshot snapshot) {
     if (snapshot != null && snapshot.getTableSnapshots() != null && !snapshot.getTableSnapshots().isEmpty()) {
-      return qualifiedTableName -> snapshot.getTableSnapshots().get(qualifiedTableName).toString();
+      return qualifiedTableName -> Objects.toString(snapshot.getTableSnapshots().get(qualifiedTableName), "Unknown");
     } else if (snapshot != null && snapshot.getValidTxnList() != null) {
       ValidTxnWriteIdList validReaderWriteIdList = new ValidTxnWriteIdList(snapshot.getValidTxnList());
       return qualifiedTableName -> {

--- a/ql/src/test/results/clientpositive/llap/masking_mv.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_mv.q.out
@@ -179,8 +179,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.masking_test_n_mv	0/0/0               	 
+Table name          	Snapshot            	 
+default.masking_test_n_mv	:1:9223372036854775807::	 
 PREHOOK: query: explain
 select key from `masking_test_n_mv`
 PREHOOK: type: QUERY
@@ -881,8 +881,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.srctnx 	0/0/0               	 
+Table name          	Snapshot            	 
+default.srctnx      	:1:9223372036854775807::	 
 PREHOOK: query: explain
 select key from `masking_test_view_n_mv_2` order by key
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/masking_mv_by_text.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_mv_by_text.q.out
@@ -179,8 +179,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.masking_test_n_mv	0/0/0               	 
+Table name          	Snapshot            	 
+default.masking_test_n_mv	:1:9223372036854775807::	 
 PREHOOK: query: explain cbo
 select key from `masking_test_n_mv`
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/materialized_view_cluster.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_cluster.q.out
@@ -204,8 +204,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:1:9223372036854775807::	 
 Found 2 items
 #### A masked pattern was here ####
 val_201201
@@ -1005,8 +1005,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:3:9223372036854775807::	 
 PREHOOK: query: INSERT INTO src_txn VALUES (238, 'val_238_n2')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1411,5 +1411,5 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:4:9223372036854775807::	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create.q.out
@@ -72,8 +72,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n4	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n4	N/A                 	 
 PREHOOK: query: select * from cmv_mat_view_n4
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cmv_mat_view_n4
@@ -140,8 +140,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n4	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n4	N/A                 	 
 PREHOOK: query: select * from cmv_mat_view2_n1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cmv_mat_view2_n1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
@@ -77,4 +77,4 @@ Outdated for Rewriting:	No
 	 	 
 # Materialized View Source table information	 	 
 Table name          	Snapshot            	 
-default.cmv_basetable_n4	default.cmv_basetable_n4:1:9223372036854775807::	 
+default.cmv_basetable_n4	:1:9223372036854775807::	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_acid.q.out
@@ -76,5 +76,5 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n4	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n4	default.cmv_basetable_n4:1:9223372036854775807::	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
@@ -323,9 +323,9 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	0/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:1:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)
@@ -567,9 +567,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Yes                 	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	1/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:1:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)
@@ -1126,9 +1126,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	0/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:2:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)
@@ -1442,9 +1442,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	0/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:3:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)
@@ -1752,9 +1752,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	0/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:4:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)
@@ -2238,9 +2238,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n2	0/0/0               	 
-hive.default.cmv_basetable_n5	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n2	:5:9223372036854775807::	 
+default.cmv_basetable_n5	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n5.a, sum(cmv_basetable_2_n2.d)
 FROM cmv_basetable_n5 join cmv_basetable_2_n2 ON (cmv_basetable_n5.a = cmv_basetable_2_n2.a)

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_5.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_5.q.out
@@ -418,9 +418,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n3	0/0/0               	 
-hive.default.cmv_basetable_n6	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n3	:2:9223372036854775807::	 
+default.cmv_basetable_n6	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n6.a
 FROM cmv_basetable_n6 join cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window.q.out
@@ -315,9 +315,9 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n1	0/0/0               	 
-hive.default.cmv_basetable_n3	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n1	:1:9223372036854775807::	 
+default.cmv_basetable_n3	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n3.a
 FROM cmv_basetable_n3 join cmv_basetable_2_n1 ON (cmv_basetable_n3.a = cmv_basetable_2_n1.a)
@@ -554,9 +554,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n1	1/0/0               	 
-hive.default.cmv_basetable_n3	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n1	:1:9223372036854775807::	 
+default.cmv_basetable_n3	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n3.a
 FROM cmv_basetable_n3 join cmv_basetable_2_n1 ON (cmv_basetable_n3.a = cmv_basetable_2_n1.a)
@@ -898,9 +898,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n1	0/0/0               	 
-hive.default.cmv_basetable_n3	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n1	:2:9223372036854775807::	 
+default.cmv_basetable_n3	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT cmv_basetable_n3.a
 FROM cmv_basetable_n3 join cmv_basetable_2_n1 ON (cmv_basetable_n3.a = cmv_basetable_2_n1.a)

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window_2.q.out
@@ -121,9 +121,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n100	0/0/0               	 
-hive.default.cmv_basetable_n100	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n100	:1:9223372036854775807::	 
+default.cmv_basetable_n100	:1:9223372036854775807::	 
 PREHOOK: query: insert into cmv_basetable_2_n100 values
  (3, 'charlie', 15.8, 1)
 PREHOOK: type: QUERY
@@ -185,9 +185,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	Yes                 	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n100	1/0/0               	 
-hive.default.cmv_basetable_n100	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n100	:1:9223372036854775807::	 
+default.cmv_basetable_n100	:1:9223372036854775807::	 
 PREHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n300 REBUILD
 PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 PREHOOK: Input: default@cmv_basetable_2_n100
@@ -249,9 +249,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_2_n100	0/0/0               	 
-hive.default.cmv_basetable_n100	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_2_n100	:2:9223372036854775807::	 
+default.cmv_basetable_n100	:1:9223372036854775807::	 
 PREHOOK: query: drop materialized view cmv_mat_view_n300
 PREHOOK: type: DROP_MATERIALIZED_VIEW
 PREHOOK: Input: default@cmv_mat_view_n300

--- a/ql/src/test/results/clientpositive/llap/materialized_view_describe.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_describe.q.out
@@ -94,8 +94,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n8	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n8	N/A                 	 
 PREHOOK: query: show tblproperties cmv_mat_view_n8
 PREHOOK: type: SHOW_TBLPROPERTIES
 POSTHOOK: query: show tblproperties cmv_mat_view_n8
@@ -191,8 +191,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n8	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n8	N/A                 	 
 PREHOOK: query: select a from cmv_mat_view2_n3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cmv_mat_view2_n3
@@ -278,8 +278,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n8	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n8	N/A                 	 
 PREHOOK: query: select a, b, c from cmv_mat_view3_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cmv_mat_view3_n0
@@ -374,8 +374,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	Unknown             	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.cmv_basetable_n8	0/0/0               	 
+Table name          	Snapshot            	 
+default.cmv_basetable_n8	N/A                 	 
 PREHOOK: query: select a from cmv_mat_view4_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cmv_mat_view4_n0

--- a/ql/src/test/results/clientpositive/llap/materialized_view_distribute_sort.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_distribute_sort.q.out
@@ -204,8 +204,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:1:9223372036854775807::	 
 Found 1 items
 #### A masked pattern was here ####
 val_201201
@@ -492,8 +492,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:1:9223372036854775807::	 
 Found 1 items
 #### A masked pattern was here ####
 201val_201
@@ -1046,9 +1046,9 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
-hive.default.src_txn_2	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:2:9223372036854775807::	 
+default.src_txn_2   	:1:9223372036854775807::	 
 Found 1 items
 #### A masked pattern was here ####
 val_201201

--- a/ql/src/test/results/clientpositive/llap/materialized_view_parquet.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_parquet.q.out
@@ -221,8 +221,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.emps_parquet_n3	0/0/0               	 
+Table name          	Snapshot            	 
+default.emps_parquet_n3	:3:9223372036854775807::	 
 PREHOOK: query: explain cbo
 select *
 from (select * from emps_parquet_n3 where empid < 120) t

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partition_cluster.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partition_cluster.q.out
@@ -320,8 +320,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:1:9223372036854775807::	 
 Found 32 items
 #### A masked pattern was here ####
 PREHOOK: query: EXPLAIN
@@ -1847,8 +1847,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:3:9223372036854775807::	 
 PREHOOK: query: INSERT INTO src_txn VALUES (238, 'val_238_n2')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -2648,5 +2648,5 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:4:9223372036854775807::	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned.q.out
@@ -282,8 +282,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.default.src_txn	0/0/0               	 
+Table name          	Snapshot            	 
+default.src_txn     	:1:9223372036854775807::	 
 PREHOOK: query: EXPLAIN
 SELECT * FROM partition_mv_1 where key = 238
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/show_materialized_views.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_materialized_views.q.out
@@ -388,8 +388,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	:0:9223372036854775807::	 
 PREHOOK: query: DESCRIBE FORMATTED test1.shtb_test1_view1
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: test1@shtb_test1_view1
@@ -432,8 +432,8 @@ Rewrite Enabled:    	No
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	:0:9223372036854775807::	 
 PREHOOK: query: DESCRIBE FORMATTED test1.shtb_test1_view2
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: test1@shtb_test1_view2
@@ -477,8 +477,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.test1.shtb_test1	0/0/0               	 
+Table name          	Snapshot            	 
+test1.shtb_test1    	:0:9223372036854775807::	 
 PREHOOK: query: SHOW MATERIALIZED VIEWS IN test2 LIKE "nomatch"
 PREHOOK: type: SHOWMATERIALIZEDVIEWS
 POSTHOOK: query: SHOW MATERIALIZED VIEWS IN test2 LIKE "nomatch"
@@ -573,8 +573,8 @@ Rewrite Enabled:    	Yes
 Outdated for Rewriting:	No                  	 
 	 	 
 # Materialized View Source table information	 	 
-Table name          	I/U/D since last rebuild	 
-hive.database.foo_n0	0/0/0               	 
+Table name          	Snapshot            	 
+database.foo_n0     	:0:9223372036854775807::	 
 PREHOOK: query: DROP MATERIALIZED VIEW fooview
 PREHOOK: type: DROP_MATERIALIZED_VIEW
 POSTHOOK: query: DROP MATERIALIZED VIEW fooview


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
See [HIVE-27353](https://issues.apache.org/jira/browse/HIVE-27353)

### Why are the changes needed?
See [HIVE-27353](https://issues.apache.org/jira/browse/HIVE-27353)

### Does this PR introduce _any_ user-facing change?
Yes. Output of describe formatted of materialized view is changed
from
```
# Materialized View Source table information	 	 
Table name          	I/U/D since last rebuild	 
hive.default.cmv_basetable_2_n2	0/0/0               	 
hive.default.cmv_basetable_n5	0/0/0               	 
```
to
```
Table name          	Snapshot            	 
default.cmv_basetable_2_n2	:1:9223372036854775807::	 
default.cmv_basetable_n5	:1:9223372036854775807::
```

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_acid.q,materialized_view_describe.q -pl itests/qtest -Pitests
```