### PR TITLE
HIVE-27363: Typo in the description of hive.tez.bucket.pruning

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4779,7 +4779,7 @@ public class HiveConf extends Configuration {
         "hive.tez.bucket.pruning", true,
          "When pruning is enabled, filters on bucket columns will be processed by \n" +
          "filtering the splits against a bitset of included buckets. This needs predicates \n"+
-            "produced by hive.optimize.ppd and hive.optimize.index.filters."),
+            "produced by hive.optimize.ppd and hive.optimize.index.filter."),
     TEZ_OPTIMIZE_BUCKET_PRUNING_COMPAT(
         "hive.tez.bucket.pruning.compat", true,
         "When pruning is enabled, handle possibly broken inserts due to negative hashcodes.\n" +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix typo.

https://issues.apache.org/jira/browse/HIVE-27363

### Why are the changes needed?

Users will be unlikely to get confused.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This change doesn't change any behaviors.