### PR TITLE
HIVE-26832: Implement SHOW PARTITIONS for Iceberg Tables

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -108,5 +108,6 @@ public class Constants {
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
 
   public static final String ICEBERG = "iceberg";
-  public static final String METADATA_LOCATION = "metadata_location";
+  public static final String ICEBERG_PARTITION_TABLE_SCHEMA = "partition,record_count,file_count,spec_id";
+  public static final String DELIMITED_JSON_SERDE = "org.apache.hadoop.hive.serde2.DelimitedJSONSerDe";
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -106,4 +106,6 @@ public class Constants {
 
   public static final String HTTP_HEADER_REQUEST_TRACK = "X-Request-ID";
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
+
+  public static final String ICEBERG = "iceberg";
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/Constants.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/Constants.java
@@ -108,4 +108,5 @@ public class Constants {
   public static final String TIME_POSTFIX_REQUEST_TRACK = "_TIME";
 
   public static final String ICEBERG = "iceberg";
+  public static final String METADATA_LOCATION = "metadata_location";
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3701,7 +3701,6 @@ public class HiveConf extends Configuration {
         "A list of io exception handler class names. This is used\n" +
         "to construct a list exception handlers to handle exceptions thrown\n" +
         "by record readers"),
-    HIVE_MAPRED_INPUT_DIR("mapred.input.dir", "", "Path to input dir."),
     // logging configuration
     HIVE_LOG4J_FILE("hive.log4j.file", "",
         "Hive log4j configuration file.\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2211,9 +2211,6 @@ public class HiveConf extends Configuration {
         "Whether to use codec pool in ORC. Disable if there are bugs with codec reuse."),
     HIVE_ICEBERG_STATS_SOURCE("hive.iceberg.stats.source", "iceberg",
         "Use stats from iceberg table snapshot for query planning. This has two values metastore and iceberg"),
-    HIVE_ICEBERG_MR_TABLE_LOC("iceberg.mr.table.location", "", "Iceberg table location"),
-    HIVE_ICEBERG_MR_TABLE_ID("iceberg.mr.table.identifier", "", "Iceberg table Identifier"),
-
     HIVE_ICEBERG_EXPIRE_SNAPSHOT_NUMTHREADS("hive.iceberg.expire.snapshot.numthreads", 4,
         "The number of threads to be used for deleting files during expire snapshot. If set to 0 or below it uses the" +
             " defult DirectExecutorService"),
@@ -3705,8 +3702,6 @@ public class HiveConf extends Configuration {
         "to construct a list exception handlers to handle exceptions thrown\n" +
         "by record readers"),
     HIVE_MAPRED_INPUT_DIR("mapred.input.dir", "", "Path to input dir."),
-    HIVE_READ_COLUMN_NAMES_CONF_STR("hive.io.file.readcolumn.names", "",
-        "Read column names" + " from the config string"),
     // logging configuration
     HIVE_LOG4J_FILE("hive.log4j.file", "",
         "Hive log4j configuration file.\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3701,6 +3701,7 @@ public class HiveConf extends Configuration {
         "A list of io exception handler class names. This is used\n" +
         "to construct a list exception handlers to handle exceptions thrown\n" +
         "by record readers"),
+
     // logging configuration
     HIVE_LOG4J_FILE("hive.log4j.file", "",
         "Hive log4j configuration file.\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2211,6 +2211,9 @@ public class HiveConf extends Configuration {
         "Whether to use codec pool in ORC. Disable if there are bugs with codec reuse."),
     HIVE_ICEBERG_STATS_SOURCE("hive.iceberg.stats.source", "iceberg",
         "Use stats from iceberg table snapshot for query planning. This has two values metastore and iceberg"),
+    HIVE_ICEBERG_MR_TABLE_LOC("iceberg.mr.table.location", "", "Iceberg table location"),
+    HIVE_ICEBERG_MR_TABLE_ID("iceberg.mr.table.identifier", "", "Iceberg table Identifier"),
+
     HIVE_ICEBERG_EXPIRE_SNAPSHOT_NUMTHREADS("hive.iceberg.expire.snapshot.numthreads", 4,
         "The number of threads to be used for deleting files during expire snapshot. If set to 0 or below it uses the" +
             " defult DirectExecutorService"),
@@ -3701,7 +3704,9 @@ public class HiveConf extends Configuration {
         "A list of io exception handler class names. This is used\n" +
         "to construct a list exception handlers to handle exceptions thrown\n" +
         "by record readers"),
-
+    HIVE_MAPRED_INPUT_DIR("mapred.input.dir", "", "Path to input dir."),
+    HIVE_READ_COLUMN_NAMES_CONF_STR("hive.io.file.readcolumn.names", "",
+        "Read column names" + " from the config string"),
     // logging configuration
     HIVE_LOG4J_FILE("hive.log4j.file", "",
         "Hive log4j configuration file.\n" +

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -168,7 +168,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   private static final Splitter TABLE_NAME_SPLITTER = Splitter.on("..");
   private static final String TABLE_NAME_SEPARATOR = "..";
   private static final String ICEBERG = "iceberg";
-  private static final String PUFFIN = "puffin";
   private static final int SPEC_IDX = 3;
   private static final int PART_IDX = 0;
   public static final String COPY_ON_WRITE = "copy-on-write";

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -1477,14 +1477,14 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       }
       return parts;
     } catch (Exception e) {
-      LOG.warn("Warn:", e);
+      LOG.warn("Warn: Unable to show partitions for iceberg table - ", e);
     }
     return parts;
   }
 
   @Override
-  public String tableType() {
-    return ICEBERG;
+  public boolean supportsPartitions() {
+    return true;
   }
 
   private List<String> getParts(DDLOperationContext context, Configuration job,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
@@ -279,8 +279,8 @@ public class HiveTableUtil {
             .filter(entry -> entry.getValue() != null)
             .map(java.lang.Object::toString)
             .collect(Collectors.joining("/"));
-    String currentSpecMarker = currentSpecId.toString().equals(specId) ? "*" : "";
-    return String.format("{Spec-id=%s}%s:%s", specId, currentSpecMarker, partString);
+    String currentSpecMarker = currentSpecId.toString().equals(specId) ? "current-" : "";
+    return String.format("%sspec-id=%s/%s", currentSpecMarker, specId, partString);
   }
 
   static JobConf getPartJobConf(Configuration confs, org.apache.hadoop.hive.ql.metadata.Table tbl) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
@@ -272,18 +272,18 @@ public class HiveTableUtil {
     return props;
   }
 
-  static String getParseData(String parseData, String specId, ObjectMapper mapper)
+  static String getParseData(String parseData, String specId, ObjectMapper mapper, Integer currentSpecId)
       throws JsonProcessingException {
     Map<String, String> map = mapper.readValue(parseData, Map.class);
     String partString =
         map.entrySet().stream().filter(entry -> entry.getValue() != null).map(java.lang.Object::toString)
             .collect(Collectors.joining("/"));
-    return String.format("Spec-id=%s/%s", specId, partString);
+    String currentSpecMarker = currentSpecId.toString().equals(specId) ? "*" : "";
+    return String.format("Spec-id=%s%s/%s", specId, currentSpecMarker, partString);
   }
 
   static JobConf getPartJobConf(Configuration confs, Path path, org.apache.hadoop.hive.ql.metadata.Table tbl) {
     JobConf job = new JobConf(confs);
-    job.set(MAPRED_INPUT_DIR, path.toString());
     job.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "partition,record_count,file_count,spec_id");
     job.set(InputFormatConfig.TABLE_LOCATION, tbl.getPath().toString());
     job.set(InputFormatConfig.TABLE_IDENTIFIER, tbl.getFullyQualifiedName() + ".partitions");

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveTableUtil.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
+import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
@@ -288,6 +289,7 @@ public class HiveTableUtil {
     job.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "partition,record_count,file_count,spec_id");
     job.set("iceberg.mr.table.location", tbl.getPath().toString());
     job.set("iceberg.mr.table.identifier", tbl.getFullyQualifiedName() + ".partitions");
+    job.set(HiveConf.ConfVars.HIVEFETCHOUTPUTSERDE.varname, "org.apache.hadoop.hive.serde2.DelimitedJSONSerDe");
     HiveConf.setBoolVar(job, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED, false);
     return job;
   }

--- a/iceberg/iceberg-handler/src/test/queries/negative/show_partitions_negative_test.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/show_partitions_negative_test.q
@@ -1,0 +1,11 @@
+-- Mask the totalSize value as it can have slight variability, causing test flakiness
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
+-- Mask random uuid
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+
+--Null case -> if partitions spec is altered. Null partitions need to be ignored.
+create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2') ;
+select * from default.ice2.partitions order by `partition`;
+show partitions ice2;
+
+

--- a/iceberg/iceberg-handler/src/test/queries/positive/show_partitions_test.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/show_partitions_test.q
@@ -1,0 +1,41 @@
+-- Mask the totalSize value as it can have slight variability, causing test flakiness
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#$2/
+-- Mask random uuid
+--! qt:replace:/(\s+uuid\s+)\S+(\s*)/$1#Masked#$2/
+-- SORT_QUERY_RESULTS
+
+set hive.vectorized.execution.enabled=false;
+create table hiveT1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored as orc ;
+insert into hiveT1 values ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5);
+create table ice1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2') ;
+insert into ice1 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5);
+
+--compare hive table  with iceberg table
+show partitions hiveT1;
+show partitions ice1 ;
+select * from default.ice1.partitions order by `partition`;
+
+explain show partitions hiveT1;
+explain show partitions ice1;
+explain select * from default.ice1.partitions;
+
+
+--Null case -> if partitions spec is altered. Null partitions need to be ignored.
+create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2') ;
+select * from default.ice2.partitions order by `partition`;
+show partitions ice2;
+insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5);
+
+select * from default.ice2.partitions order by `partition`;
+show partitions ice2;
+
+ALTER TABLE ice2 SET PARTITION SPEC (c) ;
+select * from default.ice2.partitions order by `partition`;
+--no output as new partition c is empty.
+show partitions ice2;
+
+insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5);
+select * from default.ice2.partitions order by `partition`;
+show partitions ice2;
+
+

--- a/iceberg/iceberg-handler/src/test/queries/positive/show_partitions_test.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/show_partitions_test.q
@@ -5,6 +5,8 @@
 -- SORT_QUERY_RESULTS
 
 set hive.vectorized.execution.enabled=false;
+
+-- Create a hive and iceberg table to compare.
 create table hiveT1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored as orc ;
 insert into hiveT1 values ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5);
 create table ice1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2') ;
@@ -19,11 +21,8 @@ explain show partitions hiveT1;
 explain show partitions ice1;
 explain select * from default.ice1.partitions;
 
-
---Null case -> if partitions spec is altered. Null partitions need to be ignored.
+-- Partition evolution
 create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2') ;
-select * from default.ice2.partitions order by `partition`;
-show partitions ice2;
 insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5);
 
 select * from default.ice2.partitions order by `partition`;
@@ -31,7 +30,6 @@ show partitions ice2;
 
 ALTER TABLE ice2 SET PARTITION SPEC (c) ;
 select * from default.ice2.partitions order by `partition`;
---no output as new partition c is empty.
 show partitions ice2;
 
 insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5);

--- a/iceberg/iceberg-handler/src/test/results/negative/show_partitions_negative_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/show_partitions_negative_test.q.out
@@ -1,0 +1,20 @@
+PREHOOK: query: create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice2
+POSTHOOK: query: create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice2
+PREHOOK: query: select * from default.ice2.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice2.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: show partitions ice2
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice2
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. Exception while processing show partitions for table ice2. TABLE_NOT_PARTITIONED or the table is empty 

--- a/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
@@ -57,9 +57,9 @@ PREHOOK: Input: default@ice1
 POSTHOOK: query: show partitions ice1
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice1
-Spec-id=0/d_part=10/e_part=5
-Spec-id=0/d_part=2/e_part=5
-Spec-id=0/d_part=3/e_part=4
+Spec-id=0*/d_part=10/e_part=5
+Spec-id=0*/d_part=2/e_part=5
+Spec-id=0*/d_part=3/e_part=4
 PREHOOK: query: select * from default.ice1.partitions order by `partition`
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice1
@@ -146,9 +146,9 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-Spec-id=0/d_part=10/e_part=5
-Spec-id=0/d_part=2/e_part=5
-Spec-id=0/d_part=3/e_part=4
+Spec-id=0*/d_part=10/e_part=5
+Spec-id=0*/d_part=2/e_part=5
+Spec-id=0*/d_part=3/e_part=4
 PREHOOK: query: ALTER TABLE ice2 SET PARTITION SPEC (c)
 PREHOOK: type: ALTERTABLE_SETPARTSPEC
 PREHOOK: Input: default@ice2
@@ -208,7 +208,7 @@ POSTHOOK: Input: default@ice2
 Spec-id=0/d_part=10/e_part=5
 Spec-id=0/d_part=2/e_part=5
 Spec-id=0/d_part=3/e_part=4
-Spec-id=1/c=2
-Spec-id=1/c=3
-Spec-id=1/c=4
-Spec-id=1/c=5
+Spec-id=1*/c=2
+Spec-id=1*/c=3
+Spec-id=1*/c=4
+Spec-id=1*/c=5

--- a/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
@@ -1,0 +1,228 @@
+PREHOOK: query: create table hiveT1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hiveT1
+POSTHOOK: query: create table hiveT1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hiveT1
+PREHOOK: query: insert into hiveT1 values ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hivet1
+POSTHOOK: query: insert into hiveT1 values ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hivet1
+POSTHOOK: Output: default@hivet1@d_part=10/e_part=5
+POSTHOOK: Output: default@hivet1@d_part=2/e_part=5
+POSTHOOK: Output: default@hivet1@d_part=3/e_part=4
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=10,e_part=5).a SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=10,e_part=5).b SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=10,e_part=5).c SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=2,e_part=5).a SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=2,e_part=5).b SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=2,e_part=5).c SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=3,e_part=4).a SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=3,e_part=4).b SCRIPT []
+POSTHOOK: Lineage: hivet1 PARTITION(d_part=3,e_part=4).c SCRIPT []
+PREHOOK: query: create table ice1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice1
+POSTHOOK: query: create table ice1 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice1
+PREHOOK: query: insert into ice1 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice1
+POSTHOOK: query: insert into ice1 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice1
+PREHOOK: query: show partitions hiveT1
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@hivet1
+POSTHOOK: query: show partitions hiveT1
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@hivet1
+d_part=10/e_part=5
+d_part=2/e_part=5
+d_part=3/e_part=4
+PREHOOK: query: show partitions ice1
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice1
+POSTHOOK: query: show partitions ice1
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice1
+Spec-id=0/d_part=10/e_part=5
+Spec-id=0/d_part=2/e_part=5
+Spec-id=0/d_part=3/e_part=4
+PREHOOK: query: select * from default.ice1.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice1.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"d_part":10,"e_part":5}	2	1	0
+{"d_part":2,"e_part":5}	1	1	0
+{"d_part":3,"e_part":4}	2	1	0
+PREHOOK: query: explain show partitions hiveT1
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@hivet1
+POSTHOOK: query: explain show partitions hiveT1
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@hivet1
+Stage-1
+  Fetch Operator
+    limit:-1
+    Stage-0
+      Show Partitions{"limit:":"-1","table:":"hiveT1"}
+
+PREHOOK: query: explain show partitions ice1
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice1
+POSTHOOK: query: explain show partitions ice1
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice1
+Stage-1
+  Fetch Operator
+    limit:-1
+    Stage-0
+      Show Partitions{"limit:":"-1","table:":"ice1"}
+
+PREHOOK: query: explain select * from default.ice1.partitions
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from default.ice1.partitions
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+Plan optimized by CBO.
+
+Stage-0
+  Fetch Operator
+    limit:-1
+    Select Operator [SEL_1]
+      Output:["_col0","_col1","_col2","_col3"]
+      TableScan [TS_0]
+        Output:["partition","record_count","file_count","spec_id"]
+
+PREHOOK: query: create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice2
+POSTHOOK: query: create table ice2 (a string, b int, c int) PARTITIONED BY (d_part int, e_part int) stored by iceberg stored as orc TBLPROPERTIES("format-version"='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice2
+PREHOOK: query: select * from default.ice2.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice2.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: show partitions ice2
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice2
+POSTHOOK: query: show partitions ice2
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice2
+PREHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice2
+POSTHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice2
+PREHOOK: query: select * from default.ice2.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice2.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"d_part":10,"e_part":5}	2	1	0
+{"d_part":2,"e_part":5}	1	1	0
+{"d_part":3,"e_part":4}	2	1	0
+PREHOOK: query: show partitions ice2
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice2
+POSTHOOK: query: show partitions ice2
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice2
+Spec-id=0/d_part=10/e_part=5
+Spec-id=0/d_part=2/e_part=5
+Spec-id=0/d_part=3/e_part=4
+PREHOOK: query: ALTER TABLE ice2 SET PARTITION SPEC (c)
+PREHOOK: type: ALTERTABLE_SETPARTSPEC
+PREHOOK: Input: default@ice2
+POSTHOOK: query: ALTER TABLE ice2 SET PARTITION SPEC (c)
+POSTHOOK: type: ALTERTABLE_SETPARTSPEC
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: default@ice2
+PREHOOK: query: select * from default.ice2.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice2.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"d_part":10,"e_part":5,"c":null}	2	1	0
+{"d_part":2,"e_part":5,"c":null}	1	1	0
+{"d_part":3,"e_part":4,"c":null}	2	1	0
+PREHOOK: query: show partitions ice2
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice2
+POSTHOOK: query: show partitions ice2
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice2
+Spec-id=0/d_part=10/e_part=5
+Spec-id=0/d_part=2/e_part=5
+Spec-id=0/d_part=3/e_part=4
+PREHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice2
+POSTHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice2
+PREHOOK: query: select * from default.ice2.partitions order by `partition`
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from default.ice2.partitions order by `partition`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+{"d_part":10,"e_part":5,"c":null}	2	1	0
+{"d_part":2,"e_part":5,"c":null}	1	1	0
+{"d_part":3,"e_part":4,"c":null}	2	1	0
+{"d_part":null,"e_part":null,"c":2}	2	1	1
+{"d_part":null,"e_part":null,"c":3}	1	1	1
+{"d_part":null,"e_part":null,"c":4}	1	1	1
+{"d_part":null,"e_part":null,"c":5}	1	1	1
+PREHOOK: query: show partitions ice2
+PREHOOK: type: SHOWPARTITIONS
+PREHOOK: Input: default@ice2
+POSTHOOK: query: show partitions ice2
+POSTHOOK: type: SHOWPARTITIONS
+POSTHOOK: Input: default@ice2
+Spec-id=0/d_part=10/e_part=5
+Spec-id=0/d_part=2/e_part=5
+Spec-id=0/d_part=3/e_part=4
+Spec-id=1/c=2
+Spec-id=1/c=3
+Spec-id=1/c=4
+Spec-id=1/c=5

--- a/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
@@ -57,9 +57,9 @@ PREHOOK: Input: default@ice1
 POSTHOOK: query: show partitions ice1
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice1
-Spec-id=0*/d_part=10/e_part=5
-Spec-id=0*/d_part=2/e_part=5
-Spec-id=0*/d_part=3/e_part=4
+{Spec-id=0}*:d_part=10/e_part=5
+{Spec-id=0}*:d_part=2/e_part=5
+{Spec-id=0}*:d_part=3/e_part=4
 PREHOOK: query: select * from default.ice1.partitions order by `partition`
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice1
@@ -146,9 +146,9 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-Spec-id=0*/d_part=10/e_part=5
-Spec-id=0*/d_part=2/e_part=5
-Spec-id=0*/d_part=3/e_part=4
+{Spec-id=0}*:d_part=10/e_part=5
+{Spec-id=0}*:d_part=2/e_part=5
+{Spec-id=0}*:d_part=3/e_part=4
 PREHOOK: query: ALTER TABLE ice2 SET PARTITION SPEC (c)
 PREHOOK: type: ALTERTABLE_SETPARTSPEC
 PREHOOK: Input: default@ice2
@@ -173,9 +173,9 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-Spec-id=0/d_part=10/e_part=5
-Spec-id=0/d_part=2/e_part=5
-Spec-id=0/d_part=3/e_part=4
+{Spec-id=0}:d_part=10/e_part=5
+{Spec-id=0}:d_part=2/e_part=5
+{Spec-id=0}:d_part=3/e_part=4
 PREHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -205,10 +205,10 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-Spec-id=0/d_part=10/e_part=5
-Spec-id=0/d_part=2/e_part=5
-Spec-id=0/d_part=3/e_part=4
-Spec-id=1*/c=2
-Spec-id=1*/c=3
-Spec-id=1*/c=4
-Spec-id=1*/c=5
+{Spec-id=0}:d_part=10/e_part=5
+{Spec-id=0}:d_part=2/e_part=5
+{Spec-id=0}:d_part=3/e_part=4
+{Spec-id=1}*:c=2
+{Spec-id=1}*:c=3
+{Spec-id=1}*:c=4
+{Spec-id=1}*:c=5

--- a/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
@@ -121,20 +121,6 @@ POSTHOOK: query: create table ice2 (a string, b int, c int) PARTITIONED BY (d_pa
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice2
-PREHOOK: query: select * from default.ice2.partitions order by `partition`
-PREHOOK: type: QUERY
-PREHOOK: Input: default@ice2
-PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from default.ice2.partitions order by `partition`
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@ice2
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-PREHOOK: query: show partitions ice2
-PREHOOK: type: SHOWPARTITIONS
-PREHOOK: Input: default@ice2
-POSTHOOK: query: show partitions ice2
-POSTHOOK: type: SHOWPARTITIONS
-POSTHOOK: Input: default@ice2
 PREHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 2, 2, 5), ('aa', 1, 2, 10, 5), ('aa', 1, 2, 10, 5)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table

--- a/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_partitions_test.q.out
@@ -57,9 +57,9 @@ PREHOOK: Input: default@ice1
 POSTHOOK: query: show partitions ice1
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice1
-{Spec-id=0}*:d_part=10/e_part=5
-{Spec-id=0}*:d_part=2/e_part=5
-{Spec-id=0}*:d_part=3/e_part=4
+current-spec-id=0/d_part=10/e_part=5
+current-spec-id=0/d_part=2/e_part=5
+current-spec-id=0/d_part=3/e_part=4
 PREHOOK: query: select * from default.ice1.partitions order by `partition`
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice1
@@ -146,9 +146,9 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-{Spec-id=0}*:d_part=10/e_part=5
-{Spec-id=0}*:d_part=2/e_part=5
-{Spec-id=0}*:d_part=3/e_part=4
+current-spec-id=0/d_part=10/e_part=5
+current-spec-id=0/d_part=2/e_part=5
+current-spec-id=0/d_part=3/e_part=4
 PREHOOK: query: ALTER TABLE ice2 SET PARTITION SPEC (c)
 PREHOOK: type: ALTERTABLE_SETPARTSPEC
 PREHOOK: Input: default@ice2
@@ -173,9 +173,9 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-{Spec-id=0}:d_part=10/e_part=5
-{Spec-id=0}:d_part=2/e_part=5
-{Spec-id=0}:d_part=3/e_part=4
+spec-id=0/d_part=10/e_part=5
+spec-id=0/d_part=2/e_part=5
+spec-id=0/d_part=3/e_part=4
 PREHOOK: query: insert into ice2 values  ('aa', 1, 2, 3, 4), ('aa', 1, 2, 3, 4), ('aa', 1, 3, 2, 5), ('aa', 1, 4, 10, 5), ('aa', 1, 5, 10, 5)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -205,10 +205,10 @@ PREHOOK: Input: default@ice2
 POSTHOOK: query: show partitions ice2
 POSTHOOK: type: SHOWPARTITIONS
 POSTHOOK: Input: default@ice2
-{Spec-id=0}:d_part=10/e_part=5
-{Spec-id=0}:d_part=2/e_part=5
-{Spec-id=0}:d_part=3/e_part=4
-{Spec-id=1}*:c=2
-{Spec-id=1}*:c=3
-{Spec-id=1}*:c=4
-{Spec-id=1}*:c=5
+current-spec-id=1/c=2
+current-spec-id=1/c=3
+current-spec-id=1/c=4
+current-spec-id=1/c=5
+spec-id=0/d_part=10/e_part=5
+spec-id=0/d_part=2/e_part=5
+spec-id=0/d_part=3/e_part=4

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
@@ -55,7 +55,7 @@ public class ShowPartitionsOperation extends DDLOperation<ShowPartitionsDesc> {
   public int execute() throws HiveException {
     Table tbl = context.getDb().getTable(desc.getTabName());
     List<String> parts;
-    if (tbl != null && tbl.isNonNative() && tbl.getStorageHandler().supportsPartitionTransform()) {
+    if (tbl.isNonNative() && tbl.getStorageHandler().supportsPartitionTransform()) {
       parts = tbl.getStorageHandler().showPartitions(context, tbl);
     } else if (!tbl.isPartitioned()) {
       throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, desc.getTabName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionsOperation.java
@@ -55,10 +55,10 @@ public class ShowPartitionsOperation extends DDLOperation<ShowPartitionsDesc> {
   public int execute() throws HiveException {
     Table tbl = context.getDb().getTable(desc.getTabName());
     List<String> parts;
-    if(tbl!=null && tbl.isNonNative() && tbl.getStorageHandler().supportsPartitionTransform()){
+    if (tbl != null && tbl.isNonNative() && tbl.getStorageHandler().supportsPartitionTransform()) {
       parts = tbl.getStorageHandler().showPartitions(context, tbl);
     } else if (!tbl.isPartitioned()) {
-        throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, desc.getTabName());
+      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, desc.getTabName());
     } else if (desc.getCond() != null || desc.getOrder() != null) {
       parts = getPartitionNames(tbl);
     } else if (desc.getPartSpec() != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import org.apache.hadoop.hive.common.type.SnapshotContext;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.Context.Operation;
+import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
@@ -655,4 +657,14 @@ public interface HiveStorageHandler extends Configurable {
   default Boolean hasAppendsOnly(org.apache.hadoop.hive.ql.metadata.Table hmsTable, SnapshotContext since) {
     return null;
   }
+
+  default List<String> showPartitions(DDLOperationContext context,
+      org.apache.hadoop.hive.ql.metadata.Table tbl) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Storage handler does not support show partitions command");
+  }
+
+  default String tableType(){
+    return "";
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -660,8 +660,6 @@ public interface HiveStorageHandler extends Configurable {
 
   /**
    * Checks if storage handler supports Show Partitions and returns a list of partitions
-   * @param context
-   * @param tbl
    * @return List of partitions
    * @throws UnsupportedOperationException
    * @throws HiveException

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -659,12 +659,8 @@ public interface HiveStorageHandler extends Configurable {
   }
 
   default List<String> showPartitions(DDLOperationContext context,
-      org.apache.hadoop.hive.ql.metadata.Table tbl) throws UnsupportedOperationException {
+      org.apache.hadoop.hive.ql.metadata.Table tbl) throws UnsupportedOperationException, HiveException {
     throw new UnsupportedOperationException("Storage handler does not support show partitions command");
-  }
-
-  default boolean supportsPartitions(){
-    return false;
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -663,8 +663,8 @@ public interface HiveStorageHandler extends Configurable {
     throw new UnsupportedOperationException("Storage handler does not support show partitions command");
   }
 
-  default String tableType(){
-    return "";
+  default boolean supportsPartitions(){
+    return false;
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -658,6 +658,14 @@ public interface HiveStorageHandler extends Configurable {
     return null;
   }
 
+  /**
+   * Checks if storage handler supports Show Partitions and returns a list of partitions
+   * @param context
+   * @param tbl
+   * @return List of partitions
+   * @throws UnsupportedOperationException
+   * @throws HiveException
+   */
   default List<String> showPartitions(DDLOperationContext context,
       org.apache.hadoop.hive.ql.metadata.Table tbl) throws UnsupportedOperationException, HiveException {
     throw new UnsupportedOperationException("Storage handler does not support show partitions command");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->


### What changes were proposed in this pull request?

SHOW PARTITIONS support for iceberg tables.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For Hive partition table , the show partition command outputs the following:

```
+---------------------+
|      partition      |
+---------------------+
| d_part=10/e_part=5  |
| d_part=2/e_part=5   |
| d_part=3/e_part=4   |
+---------------------+
```


In this PR, we are implementing the same feature for hive iceberg tables:

```
+--------------------------------+
|      partition                 |
+--------------------------------+
| Spec-id=0/d_part=10/e_part=5   |
| Spec-id=0/d_part=2/e_part=5    |
| Spec-id=0/d_part=3/e_part=4    |
+--------------------------------+
```

With partition evolution, the output will be per spec id:

```
+--------------------------------+
|      partition                 |
+--------------------------------+
| Spec-id=0/d_part=10/e_part=5   |
| Spec-id=0/d_part=2/e_part=5.   |
| Spec-id=0/d_part=3/e_part=4    |
| Spec-id=1/c=2                  |
| Spec-id=1/c=3                  |
| Spec-id=1/c=4                  |
| Spec-id=1/c=5                  |
+--------------------------------+
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Q test