### PR TITLE
HIVE-27365: Fix test acid_bloom_filter_orc_file_dump

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
@@ -82,13 +82,13 @@ public class PostExecOrcFileDump implements ExecuteWithHookContext {
       List<Path> directories;
       if (partitionedTable) {
         LOG.info("Printing orc file dump for files from partitioned directory..");
-        directories = fetchWork.getPartDir();
+        directories = Lists.newArrayList(fetchWork.getPartDir());
       } else {
         LOG.info("Printing orc file dump for files from table directory..");
-        directories = Lists.newArrayList();
-        directories.add(fetchWork.getTblDir());
+        directories = Lists.newArrayList(fetchWork.getTblDir());
       }
 
+      Collections.sort(directories);
       for (Path dir : directories) {
         printFileStatus(console, dir.getFileSystem(conf), dir);
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Sort directories the in `PostExecOrcFileDump`

### Why are the changes needed?
Tests dumps orc files of a table may get flaky due to order of directories contain the orc files is not deterministic.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=acid_bloom_filter_orc_file_dump.q,orc_file_dump.q -pl itests/qtest -Pitests
```