### PR TITLE
HIVE-27368: Vectorization: ArrayIndexOutOfBoundsException when map key vector has repeating values

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorUDFMapIndexStringScalar.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorUDFMapIndexStringScalar.java
@@ -69,10 +69,11 @@ public class VectorUDFMapIndexStringScalar extends VectorUDFMapIndexBaseScalar {
     final boolean isRepeating = keyColVector.isRepeating;
     for (int i = 0; i < count; i++) {
       final int keyOffset = offset + i;
+      final int start = isRepeating? keyStart[0]: keyStart[keyOffset];
       final int len = isRepeating? keyLength[0]: keyLength[keyOffset];
       byte[] rowKey = isRepeating? keyVector[0]: keyVector[keyOffset];
       if (StringExpr.equal(key, 0, key.length,
-          rowKey, keyStart[keyOffset], len)) {
+          rowKey, start, len)) {
         return offset + i;
       }
     }


### PR DESCRIPTION
Addendum to this PR: https://github.com/apache/hive/pull/3492
