### PR TITLE
HIVE-24240: Implement missing features in UDTFStatsRule

### DIFF
--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -772,7 +772,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col6, _col7
@@ -823,7 +823,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col6, _col7
@@ -913,7 +913,7 @@ STAGE PLANS:
                                   outputColumnNames: _col0
                                   Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -934,7 +934,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col6, _col7
@@ -964,7 +964,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -1024,7 +1024,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -1045,7 +1045,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col6, _col7
@@ -1075,7 +1075,7 @@ STAGE PLANS:
                                       outputColumnNames: _col0
                                       Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -2356,7 +2356,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col6, _col7
@@ -2407,7 +2407,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col6, _col7
@@ -2497,7 +2497,7 @@ STAGE PLANS:
                                   outputColumnNames: _col0
                                   Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -2518,7 +2518,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col6, _col7
@@ -2548,7 +2548,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -2608,7 +2608,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col6, _col7, _col8
@@ -2629,7 +2629,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col6, _col7
@@ -2659,7 +2659,7 @@ STAGE PLANS:
                                       outputColumnNames: _col0
                                       Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col6, _col7, _col8


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24240

### What changes were proposed in this pull request?
Fix incorrect computations to estimate UDTF size.

- Put 1 when numRows becomes zero because Hive assumes zero is a number for missing stats
- Use `StatsUtils .scaleColStatistics` to update col stats so as to update # of distinct values
- Wrap the final stats with `applyRuntimeStats`

This is a follow-up of https://github.com/apache/hive/pull/1531.

[This change has been approved once](https://github.com/apache/hive/pull/1984) but it was closed without being merged. So, I opened this PR again.

### Why are the changes needed?
This PR would help Hive to compute more precise stats for UDTF.

### Does this PR introduce _any_ user-facing change?
Compatible from the point of view of users.

### How was this patch tested?
Revised one unit test.