### PR TITLE
HIVE-27392: Use String instead of Long for file length in HadoopInputFile.

### DIFF
--- a/iceberg/patched-iceberg-core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/iceberg/patched-iceberg-core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -190,7 +190,7 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
       FutureDataInputStreamBuilder fsBuilder = fs.openFile(path);
       if (length != null) {
         LOG.debug("Using fs.option.openfile.length as {} for {}", length, location);
-        fsBuilder.opt("fs.option.openfile.length", length);
+        fsBuilder.opt("fs.option.openfile.length", Long.toString(length));
       }
       LOG.debug("Explicitly using fs.s3a.experimental.input.fadvise as normal for {}", location);
       return HadoopStreams.wrap(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pass String instead of Long for file length, due to [HADOOP-18724](https://issues.apache.org/jira/browse/HADOOP-18724)

### Why are the changes needed?

Reasons mentioned over here:

https://github.com/apache/hive/pull/3862#discussion_r1205601741

### Does this PR introduce _any_ user-facing change?

No