### PR TITLE
HIVE-27393: Upgrade ant to 1.10.13 to fix CVE's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <maven.cyclonedx.plugin.version>2.7.6</maven.cyclonedx.plugin.version>
     <!-- Library Dependency Versions -->
     <accumulo.version>1.10.1</accumulo.version>
-    <ant.version>1.10.12</ant.version>
+    <ant.version>1.10.13</ant.version>
     <antlr.version>3.5.2</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HIVE-27393](https://issues.apache.org/jira/browse/HIVE-27393)


### Why are the changes needed?
Ant 1.10.12 has 2 CVE:

1. [CVE-2022-23437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23437)
2. [CVE-2020-14338](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14338)

As mention here: https://mvnrepository.com/artifact/org.apache.ant/ant/1.10.12


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running build on local machine
