### PR TITLE
HIVE-27394: Upgrade commons dependency to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,16 +115,16 @@
     <datanucleus-core.version>5.2.10</datanucleus-core.version>
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>5.2.10</datanucleus-rdbms.version>
-    <commons-cli.version>1.4</commons-cli.version>
+    <commons-cli.version>1.5.0</commons-cli.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-collections4.version>4.1</commons-collections4.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.23.0</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-exec.version>1.1</commons-exec.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.12.0</commons-io.version>
     <commons-pool2.version>2.11.1</commons-pool2.version>
-    <commons-lang3.version>3.9</commons-lang3.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <commons-text.version>1.10.0</commons-text.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -59,7 +59,7 @@
     <!-- Dependency versions -->
     <antlr.version>3.5.2</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
-    <commons-lang3.version>3.9</commons-lang3.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <datasketches.version>1.1.0-incubating</datasketches.version>


### PR DESCRIPTION
  1. Upgrade commons-cli to 1.5.0 to fix CVE-2020-15250
  2. Upgrade commons-compress to 1.23.0
  3. Upgrade commons-lang3 to 3.12.0
  4. Upgrade commons-io to 2.12.0

### What changes were proposed in this pull request?
[HIVE-27394](https://issues.apache.org/jira/browse/HIVE-27394)


### Why are the changes needed?
To fix CVE and use the latest versions


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running build on local machine
