### PR TITLE
HIVE-27402: Refactor Kafka credential handling into kafka-handler module

### DIFF
--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -207,24 +207,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-reload4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.reload4j</groupId>
-          <artifactId>reload4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -87,6 +87,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
@@ -58,14 +58,14 @@ public class KafkaDagCredentialSupplier implements DagCredentialSupplier {
     PartitionDesc partition = partitions.values().stream().findFirst().orElse(null);
     if (partition != null) {
       TableDesc tableDesc = partition.getTableDesc();
-      if (collectKafkaDelegationTokenForTableDesc(tableDesc)) {
+      if (isTokenRequired(tableDesc)) {
         // don't collect delegation token again, if it was already successful
         return getKafkaDelegationTokenForBrokers(conf, tableDesc);
       }
     }
 
     for (TableDesc tableDesc : fileSinkTableDescs) {
-      if (collectKafkaDelegationTokenForTableDesc(tableDesc)) {
+      if (isTokenRequired(tableDesc)) {
         // don't collect delegation token again, if it was already successful
         return getKafkaDelegationTokenForBrokers(conf, tableDesc);
       }
@@ -79,12 +79,12 @@ public class KafkaDagCredentialSupplier implements DagCredentialSupplier {
   }
 
   /**
-   * Returns whether we should collect delegation tokens for kafka in the scope of a TableDesc.
+   * Returns whether a Kafka token is required for performing operations on the specified table.
    * If "security.protocol" is set to "PLAINTEXT", we don't need to collect delegation token at all.
-   * @param tableDesc
-   * @return true if we should collect a token for the specified table and false otherwise.
+   * 
+   * @return true if a Kafka token is required for performing operations on the specified table and false otherwise.
    */
-  private boolean collectKafkaDelegationTokenForTableDesc(TableDesc tableDesc) {
+  private boolean isTokenRequired(TableDesc tableDesc) {
     String kafkaBrokers = (String) tableDesc.getProperties().get("kafka.bootstrap.servers"); //FIXME: KafkaTableProperties
     String consumerSecurityProtocol = (String) tableDesc.getProperties().get(
         "kafka.consumer." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.kafka;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.tez.DagCredentialSupplier;
+import org.apache.hadoop.hive.ql.plan.BaseWork;
+import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.hive.ql.plan.PartitionDesc;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.token.Token;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateDelegationTokenOptions;
+import org.apache.kafka.clients.admin.CreateDelegationTokenResult;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.token.delegation.DelegationToken;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+public class KafkaDagCredentialSupplier implements DagCredentialSupplier {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaDagCredentialSupplier.class);
+  private static final Text KAFKA_DELEGATION_TOKEN_KEY = new Text("KAFKA_DELEGATION_TOKEN");
+
+  @Override
+  public Token<?> obtainToken(BaseWork work, Set<TableDesc> fileSinkTableDescs, Configuration conf) {
+    if(!(work instanceof MapWork)){
+      return null;
+    }
+    Map<String, PartitionDesc> partitions = ((MapWork) work).getAliasToPartnInfo();
+
+    // We don't need to iterate on all partitions, and check the same TableDesc.
+    PartitionDesc partition = partitions.values().stream().findFirst().orElse(null);
+    if (partition != null) {
+      TableDesc tableDesc = partition.getTableDesc();
+      if (collectKafkaDelegationTokenForTableDesc(tableDesc)) {
+        // don't collect delegation token again, if it was already successful
+        return getKafkaDelegationTokenForBrokers(conf, tableDesc);
+      }
+    }
+
+    for (TableDesc tableDesc : fileSinkTableDescs) {
+      if (collectKafkaDelegationTokenForTableDesc(tableDesc)) {
+        // don't collect delegation token again, if it was already successful
+        return getKafkaDelegationTokenForBrokers(conf, tableDesc);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Text getTokenAlias() {
+    return KAFKA_DELEGATION_TOKEN_KEY;
+  }
+
+  /**
+   * Returns whether we should collect delegation tokens for kafka in the scope of a TableDesc.
+   * If "security.protocol" is set to "PLAINTEXT", we don't need to collect delegation token at all.
+   * @param tableDesc
+   * @return true if we should collect a token for the specified table and false otherwise.
+   */
+  private boolean collectKafkaDelegationTokenForTableDesc(TableDesc tableDesc) {
+    String kafkaBrokers = (String) tableDesc.getProperties().get("kafka.bootstrap.servers"); //FIXME: KafkaTableProperties
+    String consumerSecurityProtocol = (String) tableDesc.getProperties().get(
+        "kafka.consumer." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
+    String producerSecurityProtocol = (String) tableDesc.getProperties().get(
+        "kafka.producer." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
+    return kafkaBrokers != null && !kafkaBrokers.isEmpty()
+        && !CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL.equalsIgnoreCase(consumerSecurityProtocol)
+        && !CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL.equalsIgnoreCase(producerSecurityProtocol);
+  }
+
+  private Token<?> getKafkaDelegationTokenForBrokers(Configuration conf, TableDesc tableDesc) {
+    String kafkaBrokers = (String) tableDesc.getProperties().get("kafka.bootstrap.servers");
+    LOG.info("Getting kafka credentials for brokers: {}", kafkaBrokers);
+
+    String keytab = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_KEYTAB);
+    String principal = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_PRINCIPAL);
+    try {
+      principal = SecurityUtil.getServerPrincipal(principal, "0.0.0.0");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    Properties config = new Properties();
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBrokers);
+    config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+
+    String jaasConfig =
+        String.format("%s %s %s %s serviceName=\"%s\" keyTab=\"%s\" principal=\"%s\";",
+            "com.sun.security.auth.module.Krb5LoginModule required", "debug=true", "useKeyTab=true",
+            "storeKey=true", "kafka", keytab, principal);
+    config.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
+
+    LOG.debug("Jaas config for requesting kafka credentials: {}", jaasConfig);
+    AdminClient admin = AdminClient.create(config);
+
+    CreateDelegationTokenOptions createDelegationTokenOptions = new CreateDelegationTokenOptions();
+    CreateDelegationTokenResult createResult =
+        admin.createDelegationToken(createDelegationTokenOptions);
+    DelegationToken token;
+    try {
+      token = createResult.delegationToken().get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException("Exception while getting kafka delegation tokens", e);
+    }
+    LOG.info("Got kafka delegation token: {}", token);
+    return new Token<>(token.tokenInfo().tokenId().getBytes(), token.hmac(), null, new Text("kafka"));
+  }
+
+}

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplier.java
@@ -43,9 +43,10 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.hadoop.hive.kafka.KafkaUtils.KAFKA_DELEGATION_TOKEN_KEY;
+
 public class KafkaDagCredentialSupplier implements DagCredentialSupplier {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaDagCredentialSupplier.class);
-  private static final Text KAFKA_DELEGATION_TOKEN_KEY = new Text("KAFKA_DELEGATION_TOKEN");
 
   @Override
   public Token<?> obtainToken(BaseWork work, Set<TableDesc> fileSinkTableDescs, Configuration conf) {

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaUtils.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaUtils.java
@@ -75,6 +75,7 @@ final class KafkaUtils {
   private static final String JAAS_TEMPLATE_SCRAM =
       "org.apache.kafka.common.security.scram.ScramLoginModule required "
           + "username=\"%s\" password=\"%s\" serviceName=\"%s\" tokenauth=true;";
+  static final Text KAFKA_DELEGATION_TOKEN_KEY = new Text("KAFKA_DELEGATION_TOKEN");
 
   private KafkaUtils() {
   }
@@ -383,7 +384,7 @@ final class KafkaUtils {
 
     if (configuration instanceof JobConf) {
       Credentials creds = ((JobConf) configuration).getCredentials();
-      Token<?> token = creds.getToken(new Text("KAFKA_DELEGATION_TOKEN"));
+      Token<?> token = creds.getToken(KAFKA_DELEGATION_TOKEN_KEY);
 
       if (token != null) {
         log.info("Kafka delegation token has been found: {}", token);

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaBrokerResource.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaBrokerResource.java
@@ -34,7 +34,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Test Helper Class to start and stop a kafka broker.
@@ -43,10 +46,24 @@ class KafkaBrokerResource extends ExternalResource {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaBrokerResource.class);
   private static final String TOPIC = "TEST-CREATE_TOPIC";
   static final String BROKER_IP_PORT = "127.0.0.1:9092";
+  static final String BROKER_SASL_PORT = "127.0.0.1:9093";
   private EmbeddedZookeeper zkServer;
   private KafkaServer kafkaServer;
   private AdminZkClient adminZkClient;
   private Path tmpLogDir;
+  private String principal;
+  private String keytab;
+
+  /**
+   * Enables SASL for broker using the principal and keytab provided.
+   * <p>The method must be called before starting the KafkaServer (see {@link #before()}).</p>
+   * @return the same broker resource with SASL setup enabled.
+   */
+  KafkaBrokerResource enableSASL(String principal, String keytab) {
+    this.principal = principal;
+    this.keytab = keytab;
+    return this;
+  }
 
   /**
    * Override to set up your specific external resource.
@@ -64,7 +81,25 @@ class KafkaBrokerResource extends ExternalResource {
     brokerProps.setProperty("zookeeper.connect", zkConnect);
     brokerProps.setProperty("broker.id", "0");
     brokerProps.setProperty("log.dir", tmpLogDir.toString());
-    brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_IP_PORT);
+    Map<String, BrokerListener> listeners = new HashMap<>();
+    listeners.put("L1", new BrokerListener(BROKER_IP_PORT, "PLAINTEXT"));
+    if (principal != null) {
+      listeners.put("L2", new BrokerListener(BROKER_SASL_PORT, "SASL_PLAINTEXT"));
+    }
+    String listenersURLs = listeners.entrySet().stream().map((e) -> e.getKey() + "://" + e.getValue().url)
+        .collect(Collectors.joining(","));
+    brokerProps.setProperty("listeners", listenersURLs);
+    String listenersProtocols = listeners.entrySet().stream().map((e) -> e.getKey() + ":" + e.getValue().protocol)
+        .collect(Collectors.joining(","));
+    brokerProps.setProperty("listener.security.protocol.map", listenersProtocols);
+    brokerProps.setProperty("inter.broker.listener.name", "L1");
+    if (principal != null) {
+      String jaasConfig = String.format("%s %s %s %s serviceName=\"%s\" keyTab=\"%s\" principal=\"%s\";",
+          "com.sun.security.auth.module.Krb5LoginModule required", "debug=true", "useKeyTab=true", "storeKey=true",
+          principal, keytab, principal + "/localhost");
+      brokerProps.setProperty("listener.name.l2.gssapi.sasl.jaas.config", jaasConfig);
+      brokerProps.setProperty("delegation.token.secret.key", "abcd");
+    }
     brokerProps.setProperty("offsets.topic.replication.factor", "1");
     brokerProps.setProperty("transaction.state.log.replication.factor", "1");
     brokerProps.setProperty("transaction.state.log.min.isr", "1");
@@ -98,5 +133,15 @@ class KafkaBrokerResource extends ExternalResource {
 
   void deleteTopic(@SuppressWarnings("SameParameterValue") String topic) {
     adminZkClient.deleteTopic(topic);
+  }
+
+  private static class BrokerListener {
+    String url;
+    String protocol;
+
+    public BrokerListener(final String url, final String protocol) {
+      this.url = url;
+      this.protocol = protocol;
+    }
   }
 }

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplierTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/KafkaDagCredentialSupplierTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 
-public class TestKafkaDagCredentialSupplier {
+public class KafkaDagCredentialSupplierTest {
   private static final java.nio.file.Path KEYSTORE_DIR =
       Paths.get(System.getProperty("test.tmp.dir"), "kdc_root_dir" + UUID.randomUUID());
   private static final String HIVE_USER_NAME = "hive";

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TestKafkaDagCredentialSupplier.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TestKafkaDagCredentialSupplier.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.kafka;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.OperatorFactory;
+import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
+import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.token.Token;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.UUID;
+
+public class TestKafkaDagCredentialSupplier {
+  private static final java.nio.file.Path KEYSTORE_DIR =
+      Paths.get(System.getProperty("test.tmp.dir"), "kdc_root_dir" + UUID.randomUUID());
+  private static final String HIVE_USER_NAME = "hive";
+  private static final java.nio.file.Path HIVE_USER_KEYTAB = KEYSTORE_DIR.resolve(HIVE_USER_NAME + ".keytab");
+  private static final String KAFKA_USER_NAME = "kafka";
+  private static final java.nio.file.Path KAFKA_USER_KEYTAB = KEYSTORE_DIR.resolve(KAFKA_USER_NAME + ".keytab");
+  private static final KafkaBrokerResource KAFKA_BROKER_RESOURCE =
+      new KafkaBrokerResource().enableSASL(KAFKA_USER_NAME, KAFKA_USER_KEYTAB.toString());
+  private static MiniKdc kdc = null;
+
+  private static MiniKdc initKDC() {
+    try {
+      Properties conf = MiniKdc.createConf();
+      MiniKdc kdc = new MiniKdc(conf, KEYSTORE_DIR.toFile());
+      kdc.start();
+      kdc.createPrincipal(HIVE_USER_KEYTAB.toFile(), HIVE_USER_NAME + "/localhost");
+      kdc.createPrincipal(KAFKA_USER_KEYTAB.toFile(), KAFKA_USER_NAME + "/localhost");
+      return kdc;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @BeforeClass
+  public static void startCluster() throws Throwable {
+    kdc = initKDC();
+    KAFKA_BROKER_RESOURCE.before();
+  }
+
+  @AfterClass
+  public static void stopCluster() {
+    KAFKA_BROKER_RESOURCE.after();
+    kdc.stop();
+  }
+
+  @Test
+  public void testObtainTokenNotNull() {
+    HiveConf conf = new HiveConf();
+    conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_AUTHENTICATION, "KERBEROS");
+    conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_PRINCIPAL, HIVE_USER_NAME + "/localhost");
+    conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_KEYTAB, HIVE_USER_KEYTAB.toString());
+
+    TableDesc fileSinkDesc = createKafkaDesc();
+    MapWork work = createFileSinkWork(fileSinkDesc);
+    KafkaDagCredentialSupplier supplier = new KafkaDagCredentialSupplier();
+    Token<?> t = supplier.obtainToken(work, Collections.singleton(fileSinkDesc), conf);
+    Assert.assertNotNull(t);
+    Assert.assertEquals(new Text("kafka"), t.getService());
+  }
+
+  private static MapWork createFileSinkWork(TableDesc tableDesc) {
+    MapWork work = new MapWork();
+    Path fakePath = new Path("fake", "path");
+    Operator<FileSinkDesc> op =
+        OperatorFactory.get(new CompilationOpContext(), new FileSinkDesc(fakePath, tableDesc, true));
+    work.addMapWork(fakePath, "fakeAlias", op, null);
+    return work;
+  }
+
+  private static TableDesc createKafkaDesc() {
+    Properties props = new Properties();
+    props.setProperty("name", "kafka_table_fake");
+    props.setProperty("kafka.bootstrap.servers", KafkaBrokerResource.BROKER_SASL_PORT);
+    return new TableDesc(KafkaInputFormat.class, KafkaOutputFormat.class, props);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1116,6 +1116,22 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -858,17 +858,6 @@
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafka.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.shiro</groupId>
-          <artifactId>shiro-crypto-cipher</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.esri.geometry</groupId>
       <artifactId>esri-geometry-api</artifactId>
       <scope>compile</scope>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagCredentialSupplier.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagCredentialSupplier.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.classification.InterfaceAudience.Private;
+import org.apache.hadoop.hive.ql.plan.BaseWork;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.token.Token;
+
+import java.util.Set;
+
+/**
+ * A supplier of credentials for Tez dags.
+ */
+@Private
+public interface DagCredentialSupplier {
+  /**
+   * Obtains a token for the specified unit of work, tables, and configuration.
+   * @return a valid token or null if such token cannot be supplied.
+   */
+  Token<?> obtainToken(BaseWork work, Set<TableDesc> tables, Configuration conf);
+
+  /**
+   * Returns the alias for tokens obtained by this supplier.
+   * <p>It returns always the same value and never null.</p>
+   * @return the alias for tokens obtained by this supplier.
+   */
+  Text getTokenAlias();
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -309,8 +309,8 @@ public class DagUtils {
     for (String s : supplierClassNames) {
       try {
         Class<? extends DagCredentialSupplier> c = Class.forName(s).asSubclass(DagCredentialSupplier.class);
-        dagSuppliers.add(c.newInstance());
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        dagSuppliers.add(c.getConstructor().newInstance());
+      } catch (ReflectiveOperationException e) {
         LOG.error("Failed to add credential supplier", e);
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hive.ql.exec.tez;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -34,7 +34,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +42,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.TimeUnit;
@@ -55,13 +53,6 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hive.common.util.HiveStringUtils;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.CreateDelegationTokenOptions;
-import org.apache.kafka.clients.admin.CreateDelegationTokenResult;
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.tez.dag.api.OutputCommitterDescriptor;
 import org.apache.tez.mapreduce.common.MRInputSplitDistributor;
 import org.apache.tez.mapreduce.hadoop.InputSplitInfo;
@@ -114,7 +105,6 @@ import org.apache.hadoop.hive.ql.plan.FileSinkDesc;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MergeJoinWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
-import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceWork;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.TezEdgeProperty;
@@ -134,7 +124,6 @@ import org.apache.hadoop.mapred.FileOutputFormat;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
-import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.records.LocalResource;
@@ -190,13 +179,13 @@ public class DagUtils {
   public static final String TEZ_TMP_DIR_KEY = "_hive_tez_tmp_dir";
   private static final Logger LOG = LoggerFactory.getLogger(DagUtils.class.getName());
   private static final String TEZ_DIR = "_tez_scratch_dir";
-  private static final DagUtils instance = new DagUtils();
+  private static final DagUtils instance = new DagUtils(defaultCredentialSuppliers());
   // The merge file being currently processed.
   public static final String TEZ_MERGE_CURRENT_MERGE_FILE_PREFIX =
       "hive.tez.current.merge.file.prefix";
   // A comma separated list of work names used as prefix.
   public static final String TEZ_MERGE_WORK_FILE_PREFIXES = "hive.tez.merge.file.prefixes";
-  private static final Text KAFKA_DELEGATION_TOKEN_KEY = new Text("KAFKA_DELEGATION_TOKEN");
+  private final List<DagCredentialSupplier> credentialSuppliers;
   /**
    * Notifiers to synchronize resource localization across threads. If one thread is localizing
    * a file, other threads can wait on the corresponding notifier object instead of just sleeping
@@ -288,108 +277,50 @@ public class DagUtils {
         }
         dag.addURIsForCredentials(uris);
       }
-      getKafkaCredentials((MapWork)work, fileSinkTableDescs, dag, conf);
+      getCredentialsFromSuppliers(work, fileSinkTableDescs, dag, conf);
     }
     getCredentialsForFileSinks(work, fileSinkUris, dag);
+  }
+
+  private void getCredentialsFromSuppliers(BaseWork work, Set<TableDesc> tables, DAG dag, JobConf conf) {
+    if (!UserGroupInformation.isSecurityEnabled()){
+      return;
+    }
+    for (DagCredentialSupplier supplier : credentialSuppliers) {
+      Text alias = supplier.getTokenAlias();
+      Token<?> t = dag.getCredentials().getToken(alias);
+      if (t != null) {
+        continue;
+      }
+      LOG.debug("Attempt to get token {} for work {}", alias, work.getName());
+      t = supplier.obtainToken(work, tables, conf);
+      if (t != null) {
+        dag.getCredentials().addToken(alias, t);
+      }
+    }
+  }
+
+  private static List<DagCredentialSupplier> defaultCredentialSuppliers() {
+    // Class names of credential providers that should be used when adding credentials to the dag.
+    // Use plain strings instead of {@link Class#getName()} to avoid compile scope dependencies to other modules.
+    List<String> supplierClassNames =
+        Collections.singletonList("org.apache.hadoop.hive.kafka.KafkaDagCredentialSupplier");
+    List<DagCredentialSupplier> dagSuppliers = new ArrayList<>();
+    for (String s : supplierClassNames) {
+      try {
+        Class<? extends DagCredentialSupplier> c = Class.forName(s).asSubclass(DagCredentialSupplier.class);
+        dagSuppliers.add(c.newInstance());
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        LOG.error("Failed to add credential supplier", e);
+      }
+    }
+    return dagSuppliers;
   }
 
   private void collectNeededFileSinkData(BaseWork work, Set<URI> fileSinkUris, Set<TableDesc> fileSinkTableDescs) {
     List<Node> topNodes = getTopNodes(work);
     LOG.debug("Collecting file sink uris for {} topnodes: {}", work.getClass(), topNodes);
     collectFileSinkUris(topNodes, fileSinkUris, fileSinkTableDescs);
-  }
-
-  private void getKafkaCredentials(MapWork work, Set<TableDesc> fileSinkTableDescs, DAG dag, JobConf conf) {
-    if (!UserGroupInformation.isSecurityEnabled()){
-      return;
-    }
-    Token<?> tokenCheck = dag.getCredentials().getToken(KAFKA_DELEGATION_TOKEN_KEY);
-    if (tokenCheck != null) {
-      LOG.debug("Kafka credentials already added, skipping...");
-      return;
-    }
-    LOG.debug("Getting kafka credentials for mapwork (if needed): " + work.getName());
-
-    Map<String, PartitionDesc> partitions = work.getAliasToPartnInfo();
-
-    // We don't need to iterate on all partitions, and check the same TableDesc.
-    PartitionDesc partition = partitions.values().stream().findFirst().orElse(null);
-    if (partition != null) {
-      TableDesc tableDesc = partition.getTableDesc();
-      if (collectKafkaDelegationTokenForTableDesc(dag, conf, tableDesc)) {
-        // don't collect delegation token again, if it was already successful
-        return;
-      }
-    }
-
-    for (TableDesc tableDesc : fileSinkTableDescs) {
-      if (collectKafkaDelegationTokenForTableDesc(dag, conf, tableDesc)) {
-        // don't collect delegation token again, if it was already successful
-        return;
-      }
-    }
-  }
-
-  /**
-   * Tries to collect delegation tokens for kafka in the scope of a TableDesc.
-   * If "security.protocol" is set to "PLAINTEXT", we don't need to collect delegation token at all.
-   * @param dag
-   * @param conf
-   * @param tableDesc
-   * @return a boolean, telling whether the token collection was successful
-   */
-  private boolean collectKafkaDelegationTokenForTableDesc(DAG dag, JobConf conf, TableDesc tableDesc) {
-    String kafkaBrokers = (String) tableDesc.getProperties().get("kafka.bootstrap.servers"); //FIXME: KafkaTableProperties
-    String consumerSecurityProtocol = (String) tableDesc.getProperties().get(
-        "kafka.consumer." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
-    String producerSecurityProtocol = (String) tableDesc.getProperties().get(
-        "kafka.producer." + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
-    if (kafkaBrokers != null && !kafkaBrokers.isEmpty() &&
-        !CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL.equalsIgnoreCase(consumerSecurityProtocol) &&
-        !CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL.equalsIgnoreCase(producerSecurityProtocol)) {
-      getKafkaDelegationTokenForBrokers(dag, conf, kafkaBrokers);
-      return true;
-    }
-    return false;
-  }
-
-  private void getKafkaDelegationTokenForBrokers(DAG dag, JobConf conf, String kafkaBrokers) {
-    LOG.info("Getting kafka credentials for brokers: {}", kafkaBrokers);
-
-    String keytab = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_KEYTAB);
-    String principal = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_PRINCIPAL);
-    try {
-      principal = SecurityUtil.getServerPrincipal(principal, "0.0.0.0");
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-
-    Properties config = new Properties();
-    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBrokers);
-    config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
-
-    String jaasConfig =
-        String.format("%s %s %s %s serviceName=\"%s\" keyTab=\"%s\" principal=\"%s\";",
-            "com.sun.security.auth.module.Krb5LoginModule required", "debug=true", "useKeyTab=true",
-            "storeKey=true", "kafka", keytab, principal);
-    config.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
-
-    LOG.debug("Jaas config for requesting kafka credentials: {}", jaasConfig);
-    AdminClient admin = AdminClient.create(config);
-
-    CreateDelegationTokenOptions createDelegationTokenOptions = new CreateDelegationTokenOptions();
-    CreateDelegationTokenResult createResult =
-        admin.createDelegationToken(createDelegationTokenOptions);
-    DelegationToken token;
-    try {
-      token = createResult.delegationToken().get();
-    } catch (InterruptedException | ExecutionException e) {
-      throw new RuntimeException("Exception while getting kafka delegation tokens", e);
-    }
-    LOG.info("Got kafka delegation token: {}", token);
-
-    dag.getCredentials().addToken(KAFKA_DELEGATION_TOKEN_KEY,
-        new Token<>(token.tokenInfo().tokenId().getBytes(), token.hmac(), null, new Text("kafka")));
   }
 
   private void getCredentialsForFileSinks(BaseWork baseWork, Set<URI> fileSinkUris, DAG dag) {
@@ -1765,8 +1696,9 @@ public class DagUtils {
     return (name != null) ? name : conf.get("mapred.job.name");
   }
 
-  private DagUtils() {
-    // don't instantiate
+  @VisibleForTesting
+  DagUtils(List<DagCredentialSupplier> suppliers) {
+    this.credentialSuppliers = suppliers;
   }
 
   /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/IncrementalIntDagCredentialSupplier.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/IncrementalIntDagCredentialSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.plan.BaseWork;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.token.Token;
+
+import java.util.Set;
+
+/**
+ * A credential supplier that creates and returns a new token based on an incrementing integer on every call.
+ */
+public class IncrementalIntDagCredentialSupplier implements DagCredentialSupplier {
+  private static final Text ALIAS = new Text("test_token");
+  private static final Text SERVICE = new Text("test_service");
+  int tokenCalls = 0;
+
+  @Override
+  public Token<?> obtainToken(final BaseWork work, final Set<TableDesc> tables, final Configuration conf) {
+    tokenCalls++;
+    byte[] idpass = String.valueOf(tokenCalls).getBytes();
+    return new Token<>(idpass, idpass, null, SERVICE);
+  }
+
+  @Override
+  public Text getTokenAlias() {
+    return ALIAS;
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtilsSecurityEnabled.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtilsSecurityEnabled.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.tez.dag.api.DAG;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DagUtils} where {@link UserGroupInformation#isSecurityEnabled()} is true.
+ */
+public class TestDagUtilsSecurityEnabled {
+
+  @BeforeClass
+  public static void setup() {
+    System.setProperty("java.security.krb5.kdc", "");
+    System.setProperty("java.security.krb5.realm", "FAKE.REALM");
+    Configuration conf = new Configuration();
+    SecurityUtil.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
+    UserGroupInformation.setConfiguration(conf);
+  }
+
+  @AfterClass
+  public static void clear() {
+    System.clearProperty("java.security.krb5.kdc");
+    System.clearProperty("java.security.krb5.realm");
+    Configuration conf = new Configuration();
+    SecurityUtil.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.SIMPLE, conf);
+    UserGroupInformation.setConfiguration(conf);
+  }
+
+  @Test
+  public void testAddCredentialsWithCredentialSupplierNewTokenAdded() {
+    IncrementalIntDagCredentialSupplier supplier = new IncrementalIntDagCredentialSupplier();
+    DagUtils dagUtils = new DagUtils(Collections.singletonList(supplier));
+    DAG dag = DAG.create("test_credentials_dag");
+
+    dagUtils.addCredentials(mock(MapWork.class), dag, null);
+    Token<?> newToken = dag.getCredentials().getToken(supplier.getTokenAlias());
+    assertEquals(String.valueOf(1), new String(newToken.getIdentifier()));
+  }
+
+  @Test
+  public void testAddCredentialsWithCredentialSupplierTokenExistsNothingAdded() {
+    IncrementalIntDagCredentialSupplier supplier = new IncrementalIntDagCredentialSupplier();
+    DagUtils dagUtils = new DagUtils(Collections.singletonList(supplier));
+    DAG dag = DAG.create("test_credentials_dag");
+    Token<TokenIdentifier> oldToken = new Token<>();
+    // Add explicitly the token in the DAG before calling addCredentials simulating the use-case where the DAG has already the token
+    dag.getCredentials().addToken(supplier.getTokenAlias(), oldToken);
+    
+    dagUtils.addCredentials(mock(MapWork.class), dag, null);
+    Token<?> newToken = dag.getCredentials().getToken(supplier.getTokenAlias());
+    assertEquals(oldToken, newToken);
+    assertEquals(0, supplier.tokenCalls);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
#### Production changes:
1. Add new internal interface DagCredentialSupplier in hive-exec module encapsulating and abstracting the token retrieval process.
2. Move Kafka token retrieval code from DagUtils (hive-exec) to KafkaDagCredentialSupplier (kafka-handler).
3. Remove now redundant dependency to kafka-client from hive-exec module.

#### Test changes:
4. Expose constructor in DagUtils to allow unit testing with custom credential suppliers.
5. Add hadoop-minikdc dependency in kafka-handler to allow Kerberized tests and centralize exclusions in the main pom.xml file.
6. Enhance KafkaBrokerResource to support SAML connections with Kerberos to enable testing the Kafka token retrieval logic.
7. Add tests for affected code to ensure it is functional (and will remain as such in the future).


### Why are the changes needed?
Currently the code for handling credentials and authentication for the Kafka storage handler is spread across hive-exec and kafka-handler modules. This leads to unexpected dependencies to kafka (e.g., kafka-client) in hive-exec module and limits sharing opportunities of credential utilities present in KafkaUtil class.

The goal of this refactoring is threefold:
* Centralize Kafka credential handling (in one module) opening the road to more code reuse and better encapsulation;
* Remove kafka dependencies (e.g., kafka-client) from hive-exec module.
* Facilitate unit testing and product stability.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn -pl ql test -Dtest=TestDagUtils*
mvn -pl kafka-handler test
```