### PR TITLE
HIVE-27407: INSERT INTO external Kafka table fails with NoSuchFieldException

### DIFF
--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/HiveKafkaProducer.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/HiveKafkaProducer.java
@@ -138,11 +138,11 @@ class HiveKafkaProducer<K, V> implements Producer<K, V> {
 
     Object transactionManager = getValue(kafkaProducer, "transactionManager");
 
-    Object topicPartitionBookkeeper = getValue(transactionManager, "topicPartitionBookkeeper");
+    Object txnPartitionMap = getValue(transactionManager, "txnPartitionMap");
     invoke(transactionManager,
         "transitionTo",
         getEnum("org.apache.kafka.clients.producer.internals.TransactionManager$State.INITIALIZING"));
-    invoke(topicPartitionBookkeeper, "reset");
+    invoke(txnPartitionMap, "reset");
     Object producerIdAndEpoch = getValue(transactionManager, "producerIdAndEpoch");
     setValue(producerIdAndEpoch, "producerId", producerId);
     setValue(producerIdAndEpoch, "epoch", epoch);

--- a/ql/src/test/queries/clientpositive/kafka_storage_handler.q
+++ b/ql/src/test/queries/clientpositive/kafka_storage_handler.q
@@ -1,5 +1,3 @@
---! qt:disabled:HIVE-23985
-
 SET hive.vectorized.execution.enabled=true;
 
 CREATE EXTERNAL TABLE kafka_table

--- a/ql/src/test/results/clientpositive/kafka/kafka_storage_handler.q.out
+++ b/ql/src/test/results/clientpositive/kafka/kafka_storage_handler.q.out
@@ -1569,72 +1569,12 @@ STAGE PLANS:
                     output format: org.apache.hadoop.hive.kafka.KafkaOutputFormat
                     properties:
                       EXTERNAL TRUE
-                      avro.schema.literal {
-  "type" : "record",
-  "name" : "Wikipedia",
-  "namespace" : "org.apache.hive.kafka",
-  "version": "1",
-  "fields" : [ {
-    "name" : "isrobot",
-    "type" : "boolean"
-  }, {
-    "name" : "channel",
-    "type" : "string"
-  }, {
-    "name" : "timestamp",
-    "type" : "string"
-  }, {
-    "name" : "flags",
-    "type" : "string"
-  }, {
-    "name" : "isunpatrolled",
-    "type" : "boolean"
-  }, {
-    "name" : "page",
-    "type" : "string"
-  }, {
-    "name" : "diffurl",
-    "type" : "string"
-  }, {
-    "name" : "added",
-    "type" : "long"
-  }, {
-    "name" : "comment",
-    "type" : "string"
-  }, {
-    "name" : "commentlength",
-    "type" : "long"
-  }, {
-    "name" : "isnew",
-    "type" : "boolean"
-  }, {
-    "name" : "isminor",
-    "type" : "boolean"
-  }, {
-    "name" : "delta",
-    "type" : "long"
-  }, {
-    "name" : "isanonymous",
-    "type" : "boolean"
-  }, {
-    "name" : "user",
-    "type" : "string"
-  }, {
-    "name" : "deltabucket",
-    "type" : "double"
-  }, {
-    "name" : "deleted",
-    "type" : "long"
-  }, {
-    "name" : "namespace",
-    "type" : "string"
-  } ]
-}
+                      avro.schema.literal {"type":"record","name":"Wikipedia","namespace":"org.apache.hive.kafka","fields":[{"name":"isrobot","type":"boolean"},{"name":"channel","type":"string"},{"name":"timestamp","type":"string"},{"name":"flags","type":"string"},{"name":"isunpatrolled","type":"boolean"},{"name":"page","type":"string"},{"name":"diffurl","type":"string"},{"name":"added","type":"long"},{"name":"comment","type":"string"},{"name":"commentlength","type":"long"},{"name":"isnew","type":"boolean"},{"name":"isminor","type":"boolean"},{"name":"delta","type":"long"},{"name":"isanonymous","type":"boolean"},{"name":"user","type":"string"},{"name":"deltabucket","type":"double"},{"name":"deleted","type":"long"},{"name":"namespace","type":"string"}],"version":"1"}
                       bucketing_version 2
                       column.name.delimiter ,
-                      columns isrobot,channel,timestamp,flags,isunpatrolled,page,diffurl,added,comment,commentlength,isnew,isminor,delta,isanonymous,user,deltabucket,deleted,namespace,__key,__partition,__offset,__timestamp
+                      columns isrobot,channel,timestamp,flags,isunpatrolled,page,diffurl,added,comment,commentlength,isnew,isminor,delta,isanonymous,user,deltabucket,deleted,namespace
                       columns.comments 'from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer','from deserializer'
-                      columns.types boolean:string:string:string:boolean:string:string:bigint:string:bigint:boolean:boolean:bigint:boolean:string:double:bigint:string:binary:int:bigint:bigint
+                      columns.types boolean,string,string,string,boolean,string,string,bigint,string,bigint,boolean,boolean,bigint,boolean,string,double,bigint,string
 #### A masked pattern was here ####
                       hive.kafka.max.retries 6
                       hive.kafka.metadata.poll.timeout.ms 30000


### PR DESCRIPTION
### What changes were proposed in this pull request?
The topicPartitionBookkeeper field was removed from TransactionManager in the latest Kafka version and was replaced by txnPartitionMap.

Below the commit which applied the respective refactoring in Kafka: https://github.com/apache/kafka/commit/3ea7b418fb3d7e9fc74c27751c1b02b04877f197

Renable the kafka_storage_handler.q test since it has now passed sucessfully from the flaky-checker:
http://ci.hive.apache.org/job/hive-flaky-check/694/

### Why are the changes needed?
Resolve `NoSuchFieldException` when running INSERT queries in Kafka tables

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
mvn -pl itests/qtest -Pitests test -Dtest=TestMiniHiveKafkaCliDriver -Dqfile=kafka_storage_handler.q
```