### PR TITLE
HIVE-27101: Support incremental materialized view rebuild when Iceberg source tables have insert operation only. (Krisztian Kasa, reviewed by Denys Kuzmenko, Aman Sinha) - ADDENDUM

### DIFF
--- a/iceberg/patched-iceberg-core/pom.xml
+++ b/iceberg/patched-iceberg-core/pom.xml
@@ -76,6 +76,7 @@
                   <outputDirectory>${project.build.directory}/classes</outputDirectory>
                   <excludes>
                       **/HadoopInputFile.class
+                      **/SerializableTable.class
                   </excludes>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
add missing exclusion