### PR TITLE
HIVE-27415: Publish blogs for Apache Hive.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,3 +40,6 @@ notifications:
   issues:       gitbox@hive.apache.org
   pullrequests: gitbox@hive.apache.org
   jira_options: link label
+publish:
+  whoami: asf-blog
+  type: blog  


### PR DESCRIPTION
### What changes were proposed in this pull request?

Deploy a page for Hive Blogs.

### Why are the changes needed?

To publish blogs/design/proposals for Hive

### Does this PR introduce _any_ user-facing change?

Code Level: No, In general: Yes, (They can read blogs)

### How was this patch tested?

Trusting doc shared by Infra:
https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-BlogdeploymentserviceforGitrepositories 🤞
