### PR TITLE
HIVE-24485: Make the slow-start behavior tunable

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -475,7 +475,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE:
-      setupAutoReducerParallelism(edgeProp, w);
+      setupAutoReducerParallelism(edgeProp, w, vConf);
       // fall through
 
     default:
@@ -519,7 +519,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE: {
-      setupAutoReducerParallelism(edgeProp, w);
+      setupAutoReducerParallelism(edgeProp, w, vConf);
       break;
     }
     case CUSTOM_SIMPLE_EDGE: {
@@ -1648,7 +1648,7 @@ public class DagUtils {
     return instance;
   }
 
-  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v)
+  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v, Configuration conf)
     throws IOException {
     if (edgeProp.isAutoReduce()) {
       Configuration pluginConf = new Configuration(false);
@@ -1661,6 +1661,16 @@ public class DagUtils {
       pluginConf.setLong(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE,
           edgeProp.getInputSizePerReducer());
+      pluginConf.setFloat(
+          ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
+          conf.getFloat(
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT));
+      pluginConf.setFloat(
+          ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
+          conf.getFloat(
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT));
       UserPayload payload = TezUtils.createUserPayloadFromConf(pluginConf);
       desc.setUserPayload(payload);
       v.setVertexManagerPlugin(desc);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -475,7 +475,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE:
-      setupAutoReducerParallelism(edgeProp, w, vConf);
+      setupAutoReducerParallelism(edgeProp, w);
       // fall through
 
     default:
@@ -519,7 +519,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE: {
-      setupAutoReducerParallelism(edgeProp, w, vConf);
+      setupAutoReducerParallelism(edgeProp, w);
       break;
     }
     case CUSTOM_SIMPLE_EDGE: {
@@ -1648,7 +1648,7 @@ public class DagUtils {
     return instance;
   }
 
-  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v, Configuration conf)
+  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v)
     throws IOException {
     if (edgeProp.isAutoReduce()) {
       Configuration pluginConf = new Configuration(false);
@@ -1663,14 +1663,10 @@ public class DagUtils {
           edgeProp.getInputSizePerReducer());
       pluginConf.setFloat(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
-          conf.getFloat(
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT));
+          edgeProp.getMinSrcFraction());
       pluginConf.setFloat(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
-          conf.getFloat(
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT));
+          edgeProp.getMaxSrcFraction());
       UserPayload payload = TezUtils.createUserPayloadFromConf(pluginConf);
       desc.setUserPayload(payload);
       v.setVertexManagerPlugin(desc);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LlapDecider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/LlapDecider.java
@@ -190,12 +190,13 @@ public class LlapDecider implements PhysicalPlanResolver {
         if (newMin < reduceWork.getMaxReduceTasks()) {
           reduceWork.setMinReduceTasks(newMin);
           reduceWork.getEdgePropRef().setAutoReduce(conf, true, newMin,
-              reduceWork.getMaxReduceTasks(), conf.getLongVar(HiveConf.ConfVars.BYTESPERREDUCER));
+              reduceWork.getMaxReduceTasks(), conf.getLongVar(HiveConf.ConfVars.BYTESPERREDUCER),
+              reduceWork.getMinSrcFraction(), reduceWork.getMaxSrcFraction());
         } else {
           reduceWork.setAutoReduceParallelism(false);
           reduceWork.setNumReduceTasks(newMin);
           // TODO: is this correct? based on the same logic as HIVE-14200
-          reduceWork.getEdgePropRef().setAutoReduce(null, false, 0, 0, 0);
+          reduceWork.getEdgePropRef().setAutoReduce(null, false, 0, 0, 0, 0.0f, 0.0f);
         }
       } else {
         // UNIFORM || AUTOPARALLEL (maxed out)

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
@@ -460,7 +460,8 @@ public class GenTezWork implements SemanticNodeProcessor {
           if (rWork.isAutoReduceParallelism()) {
             edgeProp =
                 new TezEdgeProperty(context.conf, edgeType, true, rWork.isSlowStart(),
-                    rWork.getMinReduceTasks(), rWork.getMaxReduceTasks(), bytesPerReducer);
+                    rWork.getMinReduceTasks(), rWork.getMaxReduceTasks(), bytesPerReducer,
+                    rWork.getMinSrcFraction(), rWork.getMaxSrcFraction());
           } else {
             edgeProp = new TezEdgeProperty(edgeType);
             edgeProp.setSlowStart(rWork.isSlowStart());

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
@@ -27,13 +27,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
-import org.apache.hadoop.hive.ql.exec.OperatorUtils;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 import org.apache.hadoop.hive.ql.plan.Explain.Vectorization;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.mapred.JobConf;
 
 /**
  * ReduceWork represents all the information used to run a reduce task on the cluster.
@@ -89,6 +86,12 @@ public class ReduceWork extends BaseWork {
 
   // for auto reduce parallelism - max reducers requested
   private int maxReduceTasks;
+
+  // for auto reduce parallelism - the first task can be scheduled after this fraction of source tasks complete
+  private float minSrcFraction;
+
+  // for auto reduce parallelism - all tasks can be scheduled after this fraction of source tasks complete
+  private float maxSrcFraction;
 
   private ObjectInspector keyObjectInspector = null;
   private ObjectInspector valueObjectInspector = null;
@@ -219,6 +222,22 @@ public class ReduceWork extends BaseWork {
 
   public void setSlowStart(boolean isSlowStart) {
     this.isSlowStart = isSlowStart;
+  }
+
+  public void setMinSrcFraction(float minSrcFraction) {
+    this.minSrcFraction = minSrcFraction;
+  }
+
+  public float getMinSrcFraction() {
+    return minSrcFraction;
+  }
+
+  public void setMaxSrcFraction(float maxSrcFraction) {
+    this.maxSrcFraction = maxSrcFraction;
+  }
+
+  public float getMaxSrcFraction() {
+    return maxSrcFraction;
   }
 
   // ReducerTraits.UNIFORM

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TezEdgeProperty.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TezEdgeProperty.java
@@ -41,6 +41,8 @@ public class TezEdgeProperty {
   private int minReducer;
   private int maxReducer;
   private long inputSizePerReducer;
+  private float minSrcFraction;
+  private float maxSrcFraction;
   private Integer bufferSize;
 
   public TezEdgeProperty(HiveConf hiveConf, EdgeType edgeType,
@@ -51,19 +53,22 @@ public class TezEdgeProperty {
   }
 
   public TezEdgeProperty(HiveConf hiveConf, EdgeType edgeType, boolean isAutoReduce,
-      boolean isSlowStart, int minReducer, int maxReducer, long bytesPerReducer) {
+      boolean isSlowStart, int minReducer, int maxReducer, long bytesPerReducer,
+      float minSrcFraction, float maxSrcFraction) {
     this(hiveConf, edgeType, -1);
-    setAutoReduce(hiveConf, isAutoReduce, minReducer, maxReducer, bytesPerReducer);
+    setAutoReduce(hiveConf, isAutoReduce, minReducer, maxReducer, bytesPerReducer, minSrcFraction, maxSrcFraction);
     this.isSlowStart = isSlowStart;
   }
 
   public void setAutoReduce(HiveConf hiveConf, boolean isAutoReduce, int minReducer,
-      int maxReducer, long bytesPerReducer) {
+      int maxReducer, long bytesPerReducer, float minSrcFraction, float maxSrcFraction) {
     this.hiveConf = hiveConf;
     this.minReducer = minReducer;
     this.maxReducer = maxReducer;
     this.isAutoReduce = isAutoReduce;
     this.inputSizePerReducer = bytesPerReducer;
+    this.minSrcFraction = minSrcFraction;
+    this.maxSrcFraction = maxSrcFraction;
   }
 
   public TezEdgeProperty(EdgeType edgeType) {
@@ -100,6 +105,14 @@ public class TezEdgeProperty {
 
   public boolean isSlowStart() {
     return isSlowStart;
+  }
+
+  public float getMinSrcFraction() {
+    return minSrcFraction;
+  }
+
+  public float getMaxSrcFraction() {
+    return maxSrcFraction;
   }
 
   public void setSlowStart(boolean slowStart) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Let Hive respect `tez.shuffle-vertex-manager.min-src-fraction` and `tez.shuffle-vertex-manager.max-src-fraction` when auto reducer parallelism is enabled. Currently, we don't have any methods to configure the parameters.

https://issues.apache.org/jira/browse/HIVE-24485

### Why are the changes needed?

We sometimes want to tune the parameters so that Tez can finalize the number of reducers with a more accurate estimation. For example, in extreme cases where the previous stage is very skewed, we may want to configure both params at `1.0`.

### Does this PR introduce _any_ user-facing change?

The behavior will change if a user configures `tez.shuffle-vertex-manager.{min,max}-src-fraction`.

### How was this patch tested?

```
zookage@client-node-0:~$ beeline -e '
> SET hive.tez.auto.reducer.parallelism=true;
> SET hive.tez.min.partition.factor=1.0; -- enforce auto-parallelism
> SET tez.shuffle-vertex-manager.min-src-fraction=0.55;
> SET tez.shuffle-vertex-manager.max-src-fraction=0.95;
> CREATE TABLE mofu (name string);
> INSERT INTO mofu (name) VALUES ('12345');
> SELECT name, count(*) FROM mofu GROUP BY name;
> '
```

```
2023-06-11 15:50:57,287 [INFO] [Dispatcher thread {Central}] |vertexmanager.ShuffleVertexManagerBase|: Settings minFrac: 0.55 maxFrac: 0.95 auto: true desiredTaskIput: 256000000
```