### PR TITLE
HIVE-27303: Set correct output name to ReduceSink when there is a SMB join after Union

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
@@ -423,7 +423,7 @@ public class GenTezWork implements SemanticNodeProcessor {
         rWork.getTagToInput().put(tag == -1 ? 0 : tag, work.getName());
 
         // remember the output name of the reduce sink
-        rs.getConf().setOutputName(rWork.getName());
+        rs.getConf().setOutputName(getActualOutputWorkName(context, rWork));
 
         // For dynamic partitioned hash join, run the ReduceSinkMapJoinProc logic for any
         // ReduceSink parents that we missed.
@@ -512,5 +512,23 @@ public class GenTezWork implements SemanticNodeProcessor {
     tezWork.connect(unionWork, work, edgeProp);
     unionWork.addUnionOperators(context.currentUnionOperators);
     context.workWithUnionOperators.add(work);
+  }
+
+  /**
+   * If the given reduceWork is the merged work of a MergeJoinWork, return the name of that MergeJoinWork.
+   * Otherwise, return the name of the given reduceWork.
+   */
+  private String getActualOutputWorkName(GenTezProcContext context, ReduceWork reduceWork) {
+    for (MergeJoinWork mergeJoinWork: context.opMergeJoinWorkMap.values()) {
+      if (mergeJoinWork.getBaseWorkList().contains(reduceWork)) {
+        // getMainWork() == null means that we have not visited the leaf Operator of MergeJoinWork.
+        // In this case, GenTezWork will adjust the output name of merged works
+        // by calling MergeJoinWork.addMergedWork() with non-null argument for parameter work.
+        if (mergeJoinWork.getMainWork() != null) {
+          return mergeJoinWork.getMainWork().getName();
+        }
+      }
+    }
+    return reduceWork.getName();
   }
 }

--- a/ql/src/test/queries/clientpositive/smb_join_after_union.q
+++ b/ql/src/test/queries/clientpositive/smb_join_after_union.q
@@ -31,7 +31,7 @@ on t.COLUMID = t1.COLUMID where t1.COLUMID is null;
 -- contained in MergeJoinWork(Root: GBY9, Name: Reduce3) for MERGEJOIN40.
 -- The output should be adjusted to MergeJoinWork as a merged work is not a regular tez vertex.
 -- But TezCompiler already visited RS21-GBY22 path during Path3 and cut the parent-child relationship between them.
--- Therefore, TezCompiler does not visit MERGEJOIN40 during Path4, and the output of RS21 is configured to non-existent Vertex.
+-- Therefore, TezCompiler does not visit MERGEJOIN40 during Path4, and the output name of RS21 is configured to non-existent vertex.
 
 -- Use SMB join
 set hive.auto.convert.join=false;

--- a/ql/src/test/queries/clientpositive/smb_join_after_union.q
+++ b/ql/src/test/queries/clientpositive/smb_join_after_union.q
@@ -1,0 +1,56 @@
+-- SORT_QUERY_RESULTS
+
+create external table hive1_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string);
+create external table hive2_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string);
+create external table hive3_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string);
+create external table hive4_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string);
+
+insert into table hive1_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000';
+insert into table hive1_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000';
+insert into table hive2_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001';
+insert into table hive2_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001';
+
+-- Reference, without SMB join
+set hive.auto.convert.sortmerge.join=false;
+
+select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null;
+
+-- HIVE-27303
+-- The following list is the expected OperatorGraph for the query.
+-- (Path1)                           TS0-SEL1-UNION4
+-- (Path2)                           TS2-SEL3-UNION4-GBY7-RS8-GBY9-MERGEJOIN40
+-- (Path3)  TS11-FIL32-SEL13-UNION17
+-- (Path4)  TS14-FIL33-SEL16-UNION17-GBY20-RS21-GBY22-DUMMYSTORE41-MERGEJOIN40-FIL27-SEL28-FS29
+-- With previous implementation, HIVE-27303 issue happens in the following steps.
+-- TezCompiler.generateTaskTree() traverses the OperatorGraph in the following order: Path1 -> Path2 -> Path3 -> Path4.
+-- During traversing Path4, TezCompiler changes the Output of RS21 to merged ReduceWork(Root: GBY22, Name: Reduce7)
+-- contained in MergeJoinWork(Root: GBY9, Name: Reduce3) for MERGEJOIN40.
+-- The output should be adjusted to MergeJoinWork as a merged work is not a regular tez vertex.
+-- But TezCompiler already visited RS21-GBY22 path during Path3 and cut the parent-child relationship between them.
+-- Therefore, TezCompiler does not visit MERGEJOIN40 during Path4, and the output of RS21 is configured to non-existent Vertex.
+
+-- Use SMB join
+set hive.auto.convert.join=false;
+set hive.auto.convert.sortmerge.join=true;
+set hive.optimize.dynamic.partition.hashjoin=false;
+set hive.disable.unsafe.external.table.operations=false;
+
+-- Prevent using AntiJoin
+set hive.auto.convert.anti.join=false;
+
+explain
+select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null;
+
+select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null;

--- a/ql/src/test/results/clientpositive/llap/smb_join_after_union.q.out
+++ b/ql/src/test/results/clientpositive/llap/smb_join_after_union.q.out
@@ -1,0 +1,320 @@
+PREHOOK: query: create external table hive1_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hive1_tbl_data
+POSTHOOK: query: create external table hive1_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hive1_tbl_data
+PREHOOK: query: create external table hive2_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hive2_tbl_data
+POSTHOOK: query: create external table hive2_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hive2_tbl_data
+PREHOOK: query: create external table hive3_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hive3_tbl_data
+POSTHOOK: query: create external table hive3_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hive3_tbl_data
+PREHOOK: query: create external table hive4_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hive4_tbl_data
+POSTHOOK: query: create external table hive4_tbl_data (COLUMID string,COLUMN_FN string,COLUMN_LN string,EMAIL string,COL_UPDATED_DATE timestamp, PK_COLUM string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hive4_tbl_data
+PREHOOK: query: insert into table hive1_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hive1_tbl_data
+POSTHOOK: query: insert into table hive1_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hive1_tbl_data
+POSTHOOK: Lineage: hive1_tbl_data.col_updated_date EXPRESSION []
+POSTHOOK: Lineage: hive1_tbl_data.columid SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.column_fn SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.column_ln SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.email SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.pk_colum SIMPLE []
+PREHOOK: query: insert into table hive1_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hive1_tbl_data
+POSTHOOK: query: insert into table hive1_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','4000-10000'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hive1_tbl_data
+POSTHOOK: Lineage: hive1_tbl_data.col_updated_date EXPRESSION []
+POSTHOOK: Lineage: hive1_tbl_data.columid SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.column_fn SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.column_ln SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.email SIMPLE []
+POSTHOOK: Lineage: hive1_tbl_data.pk_colum SIMPLE []
+PREHOOK: query: insert into table hive2_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hive2_tbl_data
+POSTHOOK: query: insert into table hive2_tbl_data select '00001','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hive2_tbl_data
+POSTHOOK: Lineage: hive2_tbl_data.col_updated_date EXPRESSION []
+POSTHOOK: Lineage: hive2_tbl_data.columid SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.column_fn SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.column_ln SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.email SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.pk_colum SIMPLE []
+PREHOOK: query: insert into table hive2_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hive2_tbl_data
+POSTHOOK: query: insert into table hive2_tbl_data select '00002','john','doe','john@hotmail.com','2014-01-01 12:01:02','00001'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hive2_tbl_data
+POSTHOOK: Lineage: hive2_tbl_data.col_updated_date EXPRESSION []
+POSTHOOK: Lineage: hive2_tbl_data.columid SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.column_fn SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.column_ln SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.email SIMPLE []
+POSTHOOK: Lineage: hive2_tbl_data.pk_colum SIMPLE []
+PREHOOK: query: select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hive1_tbl_data
+PREHOOK: Input: default@hive2_tbl_data
+PREHOOK: Input: default@hive3_tbl_data
+PREHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####
+POSTHOOK: query: select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hive1_tbl_data
+POSTHOOK: Input: default@hive2_tbl_data
+POSTHOOK: Input: default@hive3_tbl_data
+POSTHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####
+PREHOOK: query: explain
+select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hive1_tbl_data
+PREHOOK: Input: default@hive2_tbl_data
+PREHOOK: Input: default@hive3_tbl_data
+PREHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hive1_tbl_data
+POSTHOOK: Input: default@hive2_tbl_data
+POSTHOOK: Input: default@hive3_tbl_data
+POSTHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Union 2 (CONTAINS)
+        Map 4 <- Union 2 (CONTAINS)
+        Map 5 <- Union 6 (CONTAINS)
+        Map 8 <- Union 6 (CONTAINS)
+        Reducer 3 <- Union 2 (SIMPLE_EDGE), Union 6 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: hive3_tbl_data
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: columid (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Group By Operator
+                      keys: _col0 (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: hive1_tbl_data
+                  Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: columid (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: _col0 (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: hive4_tbl_data
+                  filterExpr: columid is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: columid is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: columid (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: hive2_tbl_data
+                  filterExpr: columid is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: columid is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: columid (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 3 
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                Dummy Store
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 2 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                Merge Join Operator
+                  condition map:
+                       Left Outer Join 0 to 1
+                  keys:
+                    0 _col0 (type: string)
+                    1 _col0 (type: string)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col1 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Union 2 
+            Vertex: Union 2
+        Union 6 
+            Vertex: Union 6
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hive1_tbl_data
+PREHOOK: Input: default@hive2_tbl_data
+PREHOOK: Input: default@hive3_tbl_data
+PREHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####
+POSTHOOK: query: select t.COLUMID from 
+(select distinct t.COLUMID as COLUMID from (SELECT COLUMID FROM hive3_tbl_data UNION ALL SELECT COLUMID FROM hive1_tbl_data) t) t
+left join
+(select distinct t.COLUMID from (SELECT COLUMID FROM hive4_tbl_data UNION ALL SELECT COLUMID FROM hive2_tbl_data) t) t1
+on t.COLUMID = t1.COLUMID where t1.COLUMID is null
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hive1_tbl_data
+POSTHOOK: Input: default@hive2_tbl_data
+POSTHOOK: Input: default@hive3_tbl_data
+POSTHOOK: Input: default@hive4_tbl_data
+#### A masked pattern was here ####


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When setting the output name of ReduceSinkOperator, check whether the output ReduceWork is contained in any MergeJoinWork's merged work list.
If so, set the output name to the name of the main work of that MergeJoinWork.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In short, ReduceSinkOperator may point a merged BaseWork of MergeJoinWork instead of its main BaseWork.
When this happens, ReduceSinkOperator does not send intermediate data to next Vertex in runtime.

For more details, let's assume the following partial OperatorGraph.
...
TS1--UNION1-RS1-GBY-DUMMYSTORE-MERGEJOIN
TS2-/
...
TezCompiler creates 5 BaseWorks for the above operators:
  - MapWork1(TS1-RS1)
  - MapWork2(TS2-(cloned)RS1)
  - ReduceWork1(GBY-DUMMYSTORE)
  - ReduceWork2(MERGEJOIN)
  - MergeJoinWork1(ReduceWork1, ReduceWork2).

The output name of RS1 should be the name of MergeJoinWork1 because ReduceWork1 will not be converted to a regular Tez Vertex. (cf. The name of MergeJoinWork is equal to the name of its main work.)

Suppose that TezCompiler visits the operators in the following order: TS1, UNION1, RS1, GBY, DUMMYSTORE, MERGEJOIN, TS2, UNION1, RS1.

TezCompiler creates ReduceWork1 when it visits DUMMYSTORE (after TS1, UNION1, and RS1). At this point, the output name of RS1 is set to ReduceWork1. TezCompiler cuts the parent-child relationship between RS1 and GBY and proceeds to next operator, MERGEJOIN.

TezCompiler visits MERGEJOIN and indicates that ReduceWork1 is a merged work of MergeJoinWork1. Therefore, TezCompiler changes the output name of RS1 to the name of MergeJoinWork1. At this point, RS1's output name is ReduceWork2.

TezCompiler visits RS1 again through TS2-UNION1. It creates MapWork2 for TS2-UNION1-RS1 and then it indicates that there is a following BaseWork for RS1. When there is a following BaseWork after a ReduceSink, TezCompiler sets the name of the following BaseWork to the ReduceSink's output name. At this point, RS1's output name is set to ReduceWork1 again.

The problem happens here. Since RS1 and GBY do not have parent-child relationship anymore, TezCompiler skips visiting MERGEJOIN again. So RS1's output name will not be corrected in the remaining traversal, which leads to HIVE-27303 issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a new qfile test that runs the query explained in HIVE-27303 JIRA page.