### PR TITLE
HIVE-27431: Clean invalid properties in test moduel

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4899,7 +4899,7 @@ public class HiveConf extends Configuration {
         "(size/arena_count) bytes. This size must be <= 1Gb and >= max allocation; if it is\n" +
         "not the case, an adjusted size will be used. Using powers of 2 is recommended."),
     LLAP_IO_MEMORY_MAX_SIZE("hive.llap.io.memory.size", "1Gb", new SizeValidator(),
-        "Maximum size for IO allocator or ORC low-level cache."),
+        "Maximum size for IO allocator or ORC low-level cache.", "hive.llap.io.cache.orc.size"),
     LLAP_ALLOCATOR_DIRECT("hive.llap.io.allocator.direct", true,
         "Whether ORC low-level cache should use direct allocation."),
     LLAP_ALLOCATOR_PREALLOCATE("hive.llap.io.allocator.preallocate", true,

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4899,7 +4899,7 @@ public class HiveConf extends Configuration {
         "(size/arena_count) bytes. This size must be <= 1Gb and >= max allocation; if it is\n" +
         "not the case, an adjusted size will be used. Using powers of 2 is recommended."),
     LLAP_IO_MEMORY_MAX_SIZE("hive.llap.io.memory.size", "1Gb", new SizeValidator(),
-        "Maximum size for IO allocator or ORC low-level cache.", "hive.llap.io.cache.orc.size"),
+        "Maximum size for IO allocator or ORC low-level cache."),
     LLAP_ALLOCATOR_DIRECT("hive.llap.io.allocator.direct", true,
         "Whether ORC low-level cache should use direct allocation."),
     LLAP_ALLOCATOR_PREALLOCATE("hive.llap.io.allocator.preallocate", true,

--- a/data/conf/hive-site-old.xml
+++ b/data/conf/hive-site-old.xml
@@ -81,14 +81,6 @@
 </property>
 
 <property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${build.dir}/test/data/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
-</property>
-
-<property>
   <name>test.log.dir</name>
   <value>${build.dir}/test/logs</value>
   <description></description>

--- a/data/conf/hive-site.xml
+++ b/data/conf/hive-site.xml
@@ -20,21 +20,9 @@
 <configuration>
 
   <property>
-    <name>hive.metastore.client.cache.maxSize</name>
-    <value>10Mb</value>
-    <description>Max size for hive metastore client local cache</description>
-  </property>
-
-  <property>
     <name>hive.metastore.client.cache.enabled</name>
     <value>true</value>
     <description>This property enables a Caffeiene Cache for Metastore client</description>
-  </property>
-
-  <property>
-    <name>hive.metastore.client.cache.recordStats</name>
-    <value>true</value>
-    <description>This property enables recording metastore client cache stats in DEBUG logs</description>
   </property>
 
 <property>
@@ -122,14 +110,6 @@
   <name>hive.metastore.warehouse.dir</name>
   <value>${test.warehouse.dir}</value>
   <description></description>
-</property>
-
-<property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${test.tmp.dir}/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
 </property>
 
 <property>
@@ -227,16 +207,6 @@
 </property>
 
 <property>
-  <name>hive.mapjoin.max.gc.time.percentage</name>
-  <value>0.99</value>
-  <description>
-  Maximum percentage of wallclock time that the JVM can spend in GC.
-  If this limit is exceeded, the local task will abort by itself.
-  Tests may run in very stressed environment, so this number is set very high to avoid false negatives.
-  </description>
-</property>
-
-<property>
   <name>hive.input.format</name>
   <value>org.apache.hadoop.hive.ql.io.CombineHiveInputFormat</value>
   <description>The default input format, if it is not specified, the system assigns it. It is set to HiveInputFormat for hadoop versions 17, 18 and 19, whereas it is set to CombineHiveInputFormat for hadoop 20. The user can always overwrite it - if there is a bug in CombineHiveInputFormat, it can always be manually set to HiveInputFormat. </description>
@@ -246,11 +216,6 @@
   <name>hive.default.rcfile.serde</name>
   <value>org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe</value>
   <description>The default SerDe hive will use for the rcfile format</description>
-</property>
-
-<property>
-  <name>hive.stats.key.prefix.reserve.length</name>
-  <value>0</value>
 </property>
 
 <property>
@@ -308,27 +273,6 @@
   <name>hive.security.authorization.manager</name>
   <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactoryForTest</value>
   <description>The Hive client authorization manager class name.</description>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.size</name>
-  <value>8388608</value>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.arena.size</name>
-  <value>8388608</value>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.alloc.max</name>
-  <value>2097152</value>
-</property>
-
-
-<property>
-  <name>hive.llap.io.cache.orc.alloc.min</name>
-  <value>32768</value>
 </property>
 
 <property>

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -111,14 +111,6 @@
     </property>
 
     <property>
-        <name>hive.metastore.metadb.dir</name>
-        <value>file://${test.tmp.dir}/metadb/</value>
-        <description>
-            Required by metastore server or if the uris argument below is not supplied
-        </description>
-    </property>
-
-    <property>
         <name>test.log.dir</name>
         <value>${test.tmp.dir}/log/</value>
         <description></description>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -111,14 +111,6 @@
 </property>
 
 <property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${test.tmp.dir}/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
-</property>
-
-<property>
   <name>test.log.dir</name>
   <value>${test.tmp.dir}/log/</value>
   <description></description>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -20,21 +20,9 @@
 <configuration>
 
   <property>
-    <name>hive.metastore.client.cache.maxSize</name>
-    <value>10Mb</value>
-    <description>Max size for hive metastore client local cache</description>
-  </property>
-
-  <property>
     <name>hive.metastore.client.cache.enabled</name>
     <value>true</value>
     <description>This property enables a Caffeiene Cache for Metastore client</description>
-  </property>
-
-  <property>
-    <name>hive.metastore.client.cache.recordStats</name>
-    <value>true</value>
-    <description>This property enables recording metastore client cache stats in DEBUG logs</description>
   </property>
 
 <property>
@@ -132,14 +120,6 @@
   <name>hive.metastore.warehouse.dir</name>
   <value>${test.warehouse.dir}</value>
   <description></description>
-</property>
-
-<property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${test.tmp.dir}/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
 </property>
 
 <property>

--- a/data/conf/rlist/hive-site.xml
+++ b/data/conf/rlist/hive-site.xml
@@ -18,23 +18,10 @@
 -->
 
 <configuration>
-
-  <property>
-    <name>hive.metastore.client.cache.maxSize</name>
-    <value>10Mb</value>
-    <description>Max size for hive metastore client local cache</description>
-  </property>
-
   <property>
     <name>hive.metastore.client.cache.enabled</name>
     <value>true</value>
     <description>This property enables a Caffeiene Cache for Metastore client</description>
-  </property>
-
-  <property>
-    <name>hive.metastore.client.cache.recordStats</name>
-    <value>true</value>
-    <description>This property enables recording metastore client cache stats in DEBUG logs</description>
   </property>
 
 <property>
@@ -116,14 +103,6 @@
   <name>hive.metastore.warehouse.dir</name>
   <value>${test.warehouse.dir}</value>
   <description></description>
-</property>
-
-<property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${test.tmp.dir}/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
 </property>
 
 <property>
@@ -233,15 +212,9 @@
 </property>
 
 <property>
-  <name>hive.stats.key.prefix.reserve.length</name>
-  <value>0</value>
-</property>
-
-<property>
   <name>hive.exec.submit.local.task.via.child</name>
   <value>false</value>
 </property>
-
 
 <property>
   <name>hive.dummyparam.test.server.specific.config.override</name>
@@ -286,27 +259,6 @@
   <name>hive.security.authorization.manager</name>
   <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactoryForTest</value>
   <description>The Hive client authorization manager class name.</description>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.size</name>
-  <value>8388608</value>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.arena.size</name>
-  <value>8388608</value>
-</property>
-
-<property>
-  <name>hive.llap.io.cache.orc.alloc.max</name>
-  <value>2097152</value>
-</property>
-
-
-<property>
-  <name>hive.llap.io.cache.orc.alloc.min</name>
-  <value>32768</value>
 </property>
 
 <property>

--- a/data/conf/tez/hive-site.xml
+++ b/data/conf/tez/hive-site.xml
@@ -111,14 +111,6 @@
 </property>
 
 <property>
-  <name>hive.metastore.metadb.dir</name>
-  <value>file://${test.tmp.dir}/metadb/</value>
-  <description>
-  Required by metastore server or if the uris argument below is not supplied
-  </description>
-</property>
-
-<property>
   <name>test.log.dir</name>
   <value>${test.tmp.dir}/log/</value>
   <description></description>

--- a/itests/hive-blobstore/src/test/resources/hive-site.xml
+++ b/itests/hive-blobstore/src/test/resources/hive-site.xml
@@ -111,14 +111,6 @@
   </property>
 
   <property>
-    <name>hive.metastore.metadb.dir</name>
-    <value>file://${test.tmp.dir}/metadb/</value>
-    <description>
-      Required by metastore server or if the uris argument below is not supplied
-    </description>
-  </property>
-
-  <property>
     <name>test.log.dir</name>
     <value>${test.tmp.dir}/log/</value>
     <description></description>
@@ -221,11 +213,6 @@
     <name>hive.default.rcfile.serde</name>
     <value>org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe</value>
     <description>The default SerDe hive will use for the rcfile format</description>
-  </property>
-
-  <property>
-    <name>hive.stats.key.prefix.reserve.length</name>
-    <value>0</value>
   </property>
 
   <property>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In `data/conf` module,  `hive-site.xml` is used to qtest&test. It keeps many invalid properties, and if you run test in IDE, you will see lots lof `WARN`: 

```
2023-06-12T01:28:18,074  WARN [main] conf.HiveConf: HiveConf of name hive.mapjoin.max.gc.time.percentage does not exist
2023-06-12T01:28:18,074  WARN [main] conf.HiveConf: HiveConf of name hive.llap.io.cache.orc.size does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.dummyparam.test.server.specific.config.override does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.metastore.metadb.dir does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.llap.io.cache.orc.alloc.min does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.dummyparam.test.server.specific.config.hivesite does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.llap.io.cache.orc.alloc.max does not exist
2023-06-12T01:28:18,075  WARN [main] conf.HiveConf: HiveConf of name hive.metastore.client.cache.maxSize does not exist
2023-06-12T01:28:18,076  WARN [main] conf.HiveConf: HiveConf of name hive.dummyparam.test.server.specific.config.metastoresite does not exist
2023-06-12T01:28:18,076  WARN [main] conf.HiveConf: HiveConf of name hive.metastore.client.cache.recordStats does not exist
2023-06-12T01:28:18,076  WARN [main] conf.HiveConf: HiveConf of name hive.llap.io.cache.orc.arena.size does not exist
2023-06-12T01:28:18,076  WARN [main] conf.HiveConf: HiveConf of name hive.stats.key.prefix.reserve.length does not exist
```


**I have traced the  life cycle of these invalid properties:**

 `hive.mapjoin.max.gc.time.percentage`
Introduced by HIVE-17684, and removed by HIVE-26134.

```
hive.llap.io.cache.orc.size
hive.llap.io.cache.orc.alloc.min
hive.llap.io.cache.orc.alloc.max
```
Introduced by HIVE-11908, and removed by HIVE-12597.


```
hive.dummyparam.test.server.specific.config.override
hive.dummyparam.test.server.specific.config.hivesite
hive.dummyparam.test.server.specific.config.metastoresite
```
Introduced by HIVE-7342, although the three properties do not exist in `HiveConf`, they are used by `org.apache.hadoop.hive.metastore.TestServerSpecificConfig`. So Let's keep it as it is.


`hive.metastore.metadb.dir`
Introduced by HADOOP-3601, and removed by HIVE-143 & HIVE-1897.


```
hive.metastore.client.cache.maxSize
hive.metastore.client.cache.recordStats
```
Introduced by HIVE-23949, and removed by HIVE-24202.

`hive.llap.io.cache.orc.arena.size`
Introduced by HIVE-11908, and removed by HIVE-12171.

`hive.stats.key.prefix.reserve.length`
Introduced by HIVE-6229, and removed by HIVE-12411.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I have searched all `hive-site.xml` to ensure these invalid properties were cleaned.