### PR TITLE
HIVE-27428: CTAS fails with SemanticException when join subquery has complex type column and false filter predicate

### DIFF
--- a/ql/src/test/queries/clientpositive/empty_result_ctas.q
+++ b/ql/src/test/queries/clientpositive/empty_result_ctas.q
@@ -3,3 +3,10 @@ SET hive.cli.print.header=true;
 CREATE TABLE T1 (c_primitive int, c_array array<int>, c_nested array<struct<f1:int, f2:map<int, double>, f3:array<char(10)>>>);
 CREATE TABLE T2 AS SELECT * FROM T1 LIMIT 0;
 DESCRIBE FORMATTED t2;
+
+create table t3 (a string, b string);
+
+-- ctas with subquery and complex type
+create table t_dest as
+with cte1 as (select * from t3), cte2 as (select * from t1 where 1=0) select cte1.*, cte2.* from cte1 left join cte2;
+DESCRIBE FORMATTED t_dest;

--- a/ql/src/test/results/clientpositive/llap/analyze_npe.q.out
+++ b/ql/src/test/results/clientpositive/llap/analyze_npe.q.out
@@ -133,7 +133,7 @@ STAGE PLANS:
           Filter Operator
             predicate: c1 is null (type: boolean)
             Select Operator
-              expressions: null (type: void)
+              expressions: map(null:null) (type: map<string,string>)
               outputColumnNames: _col0
               ListSink
 
@@ -159,7 +159,7 @@ STAGE PLANS:
           Filter Operator
             predicate: c1 is null (type: boolean)
             Select Operator
-              expressions: null (type: void)
+              expressions: array(null) (type: array<string>)
               outputColumnNames: _col0
               ListSink
 
@@ -185,7 +185,7 @@ STAGE PLANS:
           Filter Operator
             predicate: c1 is null (type: boolean)
             Select Operator
-              expressions: null (type: void)
+              expressions: named_struct('name',null,'age',null) (type: struct<name:string,age:int>)
               outputColumnNames: _col0
               ListSink
 

--- a/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
+++ b/ql/src/test/results/clientpositive/llap/empty_result_ctas.q.out
@@ -59,3 +59,70 @@ Bucket Columns:     	[]
 Sort Columns:       	[]                  	 
 Storage Desc Params:	 	 
 	serialization.format	1                   
+PREHOOK: query: create table t3 (a string, b string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t3
+POSTHOOK: query: create table t3 (a string, b string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t3
+PREHOOK: query: create table t_dest as
+with cte1 as (select * from t3), cte2 as (select * from t1 where 1=0) select cte1.*, cte2.* from cte1 left join cte2
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t3
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t_dest
+POSTHOOK: query: create table t_dest as
+with cte1 as (select * from t3), cte2 as (select * from t1 where 1=0) select cte1.*, cte2.* from cte1 left join cte2
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t_dest
+POSTHOOK: Lineage: t_dest.a SIMPLE [(t3)t3.FieldSchema(name:a, type:string, comment:null), ]
+POSTHOOK: Lineage: t_dest.b SIMPLE [(t3)t3.FieldSchema(name:b, type:string, comment:null), ]
+POSTHOOK: Lineage: t_dest.c_array EXPRESSION []
+POSTHOOK: Lineage: t_dest.c_nested EXPRESSION []
+POSTHOOK: Lineage: t_dest.c_primitive SIMPLE []
+cte1.a	cte1.b	cte2.c_primitive	cte2.c_array	cte2.c_nested
+PREHOOK: query: DESCRIBE FORMATTED t_dest
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@t_dest
+POSTHOOK: query: DESCRIBE FORMATTED t_dest
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@t_dest
+col_name	data_type	comment
+# col_name            	data_type           	comment             
+a                   	string              	                    
+b                   	string              	                    
+c_primitive         	int                 	                    
+c_array             	array<int>          	                    
+c_nested            	array<struct<f1:int,f2:map<int,double>,f3:array<char(10)>>>	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Create AST representation of `NULL` literals of RexLiterals with complex types in `ASTConverter`

### Why are the changes needed?
Such literals was converted to `NULL` without type information however CTAS statements require the exact type of all columns in the resulting schema of the query.

### Does this PR introduce _any_ user-facing change?
Yes. Such CTAS statements will be executed without error. See jira for example.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=vector_groupby_grouping_sets_grouping.q,vector_ptf_part_simple.q,min_structvalue.q,vector_coalesce.q,analyze_npe.q,empty_result_ctas.q -pl itests/qtest -Pitests
```