### PR TITLE
HIVE-27332: Addendum: Add retry backoff mechanism for abort cleanup

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
@@ -45,8 +45,8 @@ import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.ql.txn.compactor.handler.TaskHandler;
 import org.apache.hadoop.hive.ql.txn.compactor.handler.TaskHandlerFactory;
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.reflection.FieldSetter;
 
 import java.util.ArrayList;

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -986,7 +985,6 @@ public class TestCompactionMetrics  extends CompactorTest {
   }
 
   @Test
-  @Ignore("HIVE-27442")
   public void testCleanerFailuresCountedCorrectly() throws Exception {
     final String DEFAULT_DB = "default";
     final String SUCCESS_TABLE_NAME = "success_table";

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
@@ -607,4 +607,14 @@ public class TxnUtils {
         throw new MetaException("Unexpected compaction type " + ct);
     }
   }
+
+  /**
+   * A helper method to return SQL's 'IS NULL'
+   * clause whenever input is NULL.
+   * @param input A string to be compared to null.
+   * @return String
+   */
+  public static String nvl(String input) {
+    return input != null ? " = ? " : " IS NULL ";
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Addendum for add retry backoff mechanism for abort cleanup

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To resolve a possible deadlock contention. The deadlock was seen while executing TestCompactionMetrics#testCleanerFailuresCountedCorrectly multiple times.
````
ERROR [Cleaner-executor-thread-5] txn.CompactionTxnHandler: Unable to delete abort retry entries from COMPACTION_QUEUE due to A lock could not be obtained due to a deadlock, cycle of locks and waiters is:
Lock : ROW, COMPACTION_QUEUE, (1,21)
  Waiting XID : {5453, U} , APP, DELETE FROM "COMPACTION_QUEUE" WHERE "CQ_DATABASE" = ?  AND "CQ_TABLE" = ? AND ("CQ_PARTITION" = ? OR "CQ_PARTITION" IS NULL) AND "CQ_TYPE" = 'c'
  Granted XID : {5449, X} 
  
Lock : ROW, COMPACTION_QUEUE, (1,22)
  Waiting XID : {5449, U} , APP, DELETE FROM "COMPACTION_QUEUE" WHERE "CQ_DATABASE" = ?  AND "CQ_TABLE" = ? AND ("CQ_PARTITION" = ? OR "CQ_PARTITION" IS NULL) AND "CQ_TYPE" = 'c'
  Granted XID : {5450, X} 
  
Lock : ROW, COMPACTION_QUEUE, (1,21)
  Waiting XID : {5450, U} , APP, DELETE FROM "COMPACTION_QUEUE" WHERE "CQ_DATABASE" = ?  AND "CQ_TABLE" = ? AND ("CQ_PARTITION" = ? OR "CQ_PARTITION" IS NULL) AND "CQ_TYPE" = 'c'

The selected victim is XID : 5453.
````

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests and specifically solves the flakiness/deadlock contention of `TestCompactionMetrics#testCleanerFailuresCountedCorrectly`

`for i in {1..10}; do mvn test -Dtest=TestCompactionMetrics#testCleanerFailuresCountedCorrectly; done;`

Flaky test - `TestCleanerWithMinHistoryWriteId#testReadyForCleaningPileup` is also resolved.