### PR TITLE
HIVE-27437: Vectorization: VectorizedOrcRecordReader does not reset VectorizedRowBatch after processing

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedBatchUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedBatchUtil.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -69,6 +70,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
 
 public class VectorizedBatchUtil {
   private static final Logger LOG = LoggerFactory.getLogger(VectorizedBatchUtil.class);
@@ -998,5 +1001,17 @@ public class VectorizedBatchUtil {
       int index = (batch.selectedInUse ? batch.selected[i] : i);
       debugDisplayOneRow(batch, index, prefix);
     }
+  }
+
+  /**
+   * Reset all columns other than Partition columns
+   * @param rowBatch VectorizedRowBatch to reset
+   */
+  public static void resetNonPartitionColumns(VectorizedRowBatch rowBatch) {
+    List<Integer> columnsToReset = IntStream.concat(
+            IntStream.range(0, rowBatch.getDataColumnCount()),
+            IntStream.range(rowBatch.getDataColumnCount() + rowBatch.getPartitionColumnCount(), rowBatch.cols.length)
+    ).boxed().collect(toList());
+    rowBatch.reset(columnsToReset);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
@@ -122,6 +123,7 @@ public class VectorizedOrcInputFormat extends FileInputFormat<NullWritable, Vect
     public boolean next(NullWritable key, VectorizedRowBatch value) throws IOException {
 
       try {
+        VectorizedBatchUtil.resetNonPartitionColumns(value);
         // Check and update partition cols if necessary. Ideally, this should be done
         // in CreateValue as the partition is constant per split. But since Hive uses
         // CombineHiveRecordReader and

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedParquetRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedParquetRecordReader.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.llap.LlapCacheAwareFs;
 import org.apache.hadoop.hive.llap.LlapHiveUtils;
 import org.apache.hadoop.hive.llap.io.api.LlapProxy;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
 import org.apache.hadoop.hive.ql.io.BucketIdentifier;
@@ -104,6 +105,7 @@ public class VectorizedParquetRecordReader extends ParquetRecordReaderBase
   private List<TypeInfo> columnTypesList;
   private VectorizedRowBatchCtx rbCtx;
   private Object[] partitionValues;
+  private boolean addPartitionCols = true;
   private Path cacheFsPath;
   private static final int MAP_DEFINITION_LEVEL_MAX = 3;
 
@@ -397,14 +399,17 @@ public class VectorizedParquetRecordReader extends ParquetRecordReaderBase
   private boolean nextBatch(VectorizedRowBatch columnarBatch) throws IOException {
     currentRowNumInRowGroup += lastReturnedRowCount;
 
-    columnarBatch.reset();
+    VectorizedBatchUtil.resetNonPartitionColumns(columnarBatch);
     if (rowsReturned >= totalRowCount) {
       return false;
     }
 
     // Add partition cols if necessary (see VectorizedOrcInputFormat for details).
-    if (partitionValues != null) {
-      rbCtx.addPartitionColsToBatch(columnarBatch, partitionValues);
+    if (addPartitionCols) {
+      if (partitionValues != null) {
+        rbCtx.addPartitionColsToBatch(columnarBatch, partitionValues);
+      }
+      addPartitionCols = false;
     }
     checkEndOfRowGroup();
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedRowBatch.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizedRowBatch.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hive.ql.exec.vector;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.IntStream;
 
 import org.apache.hadoop.hive.ql.io.filter.MutableFilterContext;
 import org.apache.hadoop.io.NullWritable;
@@ -342,10 +345,22 @@ public class VectorizedRowBatch implements Writable, MutableFilterContext {
    */
   @Override
   public void reset() {
+    reset(cols);
+  }
+
+  public void reset(Collection<Integer> columnIndices) {
+    ColumnVector[] columnsToReset = columnIndices.stream()
+            .filter(index -> index < cols.length)
+            .map(x -> cols[x])
+            .toArray(ColumnVector[]::new);
+    reset(columnsToReset);
+  }
+
+  private void reset(ColumnVector[] columns) {
     selectedInUse = false;
     size = 0;
     endOfFile = false;
-    for (ColumnVector vc : cols) {
+    for (ColumnVector vc : columns) {
       if (vc != null) {
         vc.reset();
         vc.init();


### PR DESCRIPTION
A reset similar to what is done in VectorizedParquetRecordReader - https://github.com/apache/hive/blob/f78ca5df80c0bcb566f0915cda65112268df492c/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedParquetRecordReader.java#L400

