### PR TITLE
HIVE-27438: Audit leader election event failed in non-appendable file…

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -579,7 +579,7 @@ public class MetastoreConf {
     METASTORE_HOUSEKEEPING_LEADER_AUDIT_FILE_LIMIT("metastore.housekeeping.leader.auditFiles.limit",
         "metastore.housekeeping.leader.auditFiles.limit", 10,
         "Limit the number of small audit files when metastore.housekeeping.leader.newAuditFile is true.\n" +
-        "If the number of audit files exceeds the limit that greater than 0, then the oldest will be deleted."),
+        "If the number of audit files exceeds the limit, then the oldest will be deleted."),
     METASTORE_HOUSEKEEPING_THREADS_ON("metastore.housekeeping.threads.on",
         "hive.metastore.housekeeping.threads.on", false,
         "Whether to run the tasks under metastore.task.threads.remote on this metastore instance or not.\n" +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -566,11 +566,20 @@ public class MetastoreConf {
     METASTORE_HOUSEKEEPING_LEADER_ELECTION("metastore.housekeeping.leader.election",
         "metastore.housekeeping.leader.election",
         "host", new StringSetValidator("host", "lock"),
-        "If sets to host, HMS will choose the leader by the configured metastore.housekeeping.leader.hostname.\n" +
-        "When configured to lock, HMS will use hive locks to elect the leader."),
+        "Set to host, HMS will choose the leader by the configured metastore.housekeeping.leader.hostname.\n" +
+        "Set to lock, HMS will use the hive lock to elect the leader."),
     METASTORE_HOUSEKEEPING_LEADER_AUDITTABLE("metastore.housekeeping.leader.auditTable",
         "metastore.housekeeping.leader.auditTable", "",
-        "Audit the Metastore leader changes to the target table when configured."),
+        "Audit the leader election event to a plain json table when configured."),
+    METASTORE_HOUSEKEEPING_LEADER_NEW_AUDIT_FILE("metastore.housekeeping.leader.newAuditFile",
+        "metastore.housekeeping.leader.newAuditFile", false,
+        "Whether to create a new audit file in response to the new election event " +
+        "when the metastore.housekeeping.leader.auditTable is not empty.\n" +
+        "True for creating a new file, false otherwise."),
+    METASTORE_HOUSEKEEPING_LEADER_AUDIT_FILE_LIMIT("metastore.housekeeping.leader.auditFiles.limit",
+        "metastore.housekeeping.leader.auditFiles.limit", 10,
+        "Limit the number of small audit files when metastore.housekeeping.leader.newAuditFile is true.\n" +
+        "If the number of audit files exceeds the limit that greater than 0, then the oldest will be deleted."),
     METASTORE_HOUSEKEEPING_THREADS_ON("metastore.housekeeping.threads.on",
         "hive.metastore.housekeeping.threads.on", false,
         "Whether to run the tasks under metastore.task.threads.remote on this metastore instance or not.\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -852,7 +852,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           }
           context.start();
         } catch (Throwable e) {
-          LOG.error("Compaction or Housekeeping tasks may not happen", e);
+          LOG.error("Failure when starting the leader tasks, Compaction or Housekeeping tasks may not happen", e);
         } finally {
           startLock.unlock();
         }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -852,7 +852,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           }
           context.start();
         } catch (Throwable e) {
-          LOG.error("Compactions or housekeeping tasks may not happen", e);
+          LOG.error("Compaction or Housekeeping tasks may not happen", e);
         } finally {
           startLock.unlock();
         }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ShutdownHookManager;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.thrift.TProcessor;
@@ -836,28 +835,24 @@ public class HiveMetaStore extends ThriftHiveMetastore {
 
          LeaderElectionContext context = new LeaderElectionContext.ContextBuilder(conf)
              .setHMSHandler(thriftServer.getHandler()).servHost(getServerHostName())
-             // always tasks
-             .setTType(LeaderElectionContext.TTYPE.ALWAYS_TASKS)
+             .setTType(LeaderElectionContext.TTYPE.ALWAYS_TASKS) // always tasks
              .addListener(new HouseKeepingTasks(conf, false))
-             // housekeeping tasks
-             .setTType(LeaderElectionContext.TTYPE.HOUSEKEEPING)
+             .setTType(LeaderElectionContext.TTYPE.HOUSEKEEPING) // housekeeping tasks
              .addListener(new CMClearer(conf))
              .addListener(new StatsUpdaterTask(conf))
              .addListener(new CompactorTasks(conf, false))
              .addListener(new CompactorPMF())
              .addListener(new HouseKeepingTasks(conf, true))
-             // compactor worker
-             .setTType(LeaderElectionContext.TTYPE.WORKER)
-             .addListener(new CompactorTasks(conf, true), MetastoreConf.getVar(conf,
-                 MetastoreConf.ConfVars.HIVE_METASTORE_RUNWORKER_IN).equals("metastore"))
+             .setTType(LeaderElectionContext.TTYPE.WORKER) // compactor worker
+             .addListener(new CompactorTasks(conf, true),
+                 MetastoreConf.getVar(conf, MetastoreConf.ConfVars.HIVE_METASTORE_RUNWORKER_IN).equals("metastore"))
              .build();
           if (shutdownHookMgr != null) {
             shutdownHookMgr.addShutdownHook(() -> context.close(), 0);
           }
           context.start();
         } catch (Throwable e) {
-          LOG.error("Failure when starting the leader tasks, compactions or housekeeping tasks may not happen, " +
-              StringUtils.stringifyException(e));
+          LOG.error("Compactions or housekeeping tasks may not happen", e);
         } finally {
           startLock.unlock();
         }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/AuditLeaderListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/AuditLeaderListener.java
@@ -109,6 +109,7 @@ public class AuditLeaderListener implements LeaderElection.LeadershipStateListen
 
   @Override
   public void takeLeadership(LeaderElection election) throws Exception {
+    HiveMetaStore.LOG.info("Became the LEADER for {}", election.getName());
     String hostName = getHostname();
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     String message = "{\"leader_host\": \"" + hostName + "\", \"leader_type\": \""
@@ -166,7 +167,7 @@ public class AuditLeaderListener implements LeaderElection.LeadershipStateListen
 
   @Override
   public void lossLeadership(LeaderElection election) throws Exception {
-    // do nothing
+    HiveMetaStore.LOG.info("Lost leadership for {}", election.getName());
   }
 
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/AuditLeaderListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/AuditLeaderListener.java
@@ -94,7 +94,7 @@ public class AuditLeaderListener implements LeaderElection.LeadershipStateListen
     String output = table.getSd().getOutputFormat();
     if (!SERDE.equals(serde) || !INPUTFORMAT.equals(input)
         || !OUTPUTFORMAT.equals(output)) {
-      throw new RuntimeException(tableName + " should be in json + text format");
+      throw new RuntimeException(tableName + " should be a plain json table");
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/CompactorTasks.java
@@ -152,6 +152,7 @@ public class CompactorTasks implements LeaderElection.LeadershipStateListener {
         if (thread instanceof Thread) {
           ((Thread)thread).interrupt();
         }
+        HiveMetaStore.LOG.info("Stopped the Compaction task: {}.", thread.getClass().getName());
       });
       metastoreThreadsMap = null;
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/HouseKeepingTasks.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/HouseKeepingTasks.java
@@ -114,6 +114,9 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
       metastoreTaskThreadPool.shutdown();
       metastoreTaskThreadPool = null;
     }
+
+    HiveMetaStore.LOG.info("Stopped the {} Housekeeping tasks",
+        runOnlyRemoteTasks ? "remote" : "always");
   }
 
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/HouseKeepingTasks.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/HouseKeepingTasks.java
@@ -41,6 +41,8 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
 
   private boolean runOnlyRemoteTasks;
 
+  private List<MetastoreTaskThread> runningTasks;
+
   public HouseKeepingTasks(Configuration configuration, boolean runOnlyRemoteTasks) {
     this.configuration = new Configuration(requireNonNull(configuration,
         "configuration is null"));
@@ -84,6 +86,7 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
     if (metastoreTaskThreadPool != null) {
       throw new IllegalStateException("There should be no running tasks before taking the leadership!");
     }
+    runningTasks = new ArrayList<>();
     metastoreTaskThreadPool = ThreadPool.initialize(configuration);
     if (!runOnlyRemoteTasks) {
       List<MetastoreTaskThread> alwaysTasks = new ArrayList<>(getAlwaysTasks());
@@ -93,7 +96,7 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
         // For backwards compatibility, since some threads used to be hard coded but only run if
         // frequency was > 0
         if (freq > 0) {
-          HiveMetaStore.LOG.info("Scheduling for " + task.getClass().getCanonicalName() + " service.");
+          runningTasks.add(task);
           metastoreTaskThreadPool.getPool().scheduleAtFixedRate(task, freq, freq, TimeUnit.MILLISECONDS);
         }
       }
@@ -102,10 +105,14 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
       for (MetastoreTaskThread task : remoteOnlyTasks) {
         task.setConf(configuration);
         long freq = task.runFrequency(TimeUnit.MILLISECONDS);
-        HiveMetaStore.LOG.info("Scheduling for " + task.getClass().getCanonicalName() + " service.");
+        runningTasks.add(task);
         metastoreTaskThreadPool.getPool().scheduleAtFixedRate(task, freq, freq, TimeUnit.MILLISECONDS);
       }
     }
+
+    runningTasks.forEach(task -> {
+      HiveMetaStore.LOG.info("Scheduling for " + task.getClass().getCanonicalName() + " service.");
+    });
   }
 
   @Override
@@ -115,8 +122,12 @@ public class HouseKeepingTasks implements LeaderElection.LeadershipStateListener
       metastoreTaskThreadPool = null;
     }
 
-    HiveMetaStore.LOG.info("Stopped the {} Housekeeping tasks",
-        runOnlyRemoteTasks ? "remote" : "always");
+    if (runningTasks != null && !runningTasks.isEmpty()) {
+      runningTasks.forEach(task -> {
+        HiveMetaStore.LOG.info("Stopped the Housekeeping task: {}", task.getClass().getCanonicalName());
+      });
+      runningTasks.clear();
+    }
   }
 
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionContext.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionContext.java
@@ -156,12 +156,11 @@ public class LeaderElectionContext {
     case "lock":
       return ttype.getTableName();
     default:
-      throw new UnsupportedOperationException("Do not support " + method + " now");
+      throw new UnsupportedOperationException(method + " not supported for leader election");
     }
   }
 
   public static class ContextBuilder {
-
     private Configuration configuration;
     private boolean startAsDaemon;
     private String servHost;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/LeaderElectionFactory.java
@@ -31,7 +31,7 @@ public class LeaderElectionFactory {
         MetastoreConf.getVar(conf, MetastoreConf.ConfVars.METASTORE_HOUSEKEEPING_LEADER_ELECTION);
     switch (method.toLowerCase()) {
       case "host":
-        return new HostLeaderElection();
+        return new StaticLeaderElection();
       case "lock":
         return new LeaseLeaderElection();
       default:

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/StaticLeaderElection.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/StaticLeaderElection.java
@@ -33,9 +33,9 @@ import static java.util.Objects.requireNonNull;
  * If the value is empty, means no election happening and all instances are leaders,
  * otherwise the instance matching the configured hostname will be selected as a leader.
  */
-public class HostLeaderElection implements LeaderElection<String> {
+public class StaticLeaderElection implements LeaderElection<String> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HostLeaderElection.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StaticLeaderElection.class);
   private volatile boolean isLeader;
   private String name;
   private List<LeadershipStateListener> listeners = new ArrayList<>();
@@ -62,8 +62,7 @@ public class HostLeaderElection implements LeaderElection<String> {
         try {
           listener.takeLeadership(this);
         } catch (Exception e) {
-          LOG.warn("Error while notifying the listener: " +
-              listener + ", isLeader: " + isLeader, e);
+          LOG.warn("Error while notifying the listener: " + listener, e);
         }
       });
     }
@@ -98,8 +97,7 @@ public class HostLeaderElection implements LeaderElection<String> {
         try {
           listener.lossLeadership(this);
         } catch (Exception e) {
-          LOG.warn("Error while notifying the listener: " +
-              listener + ", isLeader: " + isLeader, e);
+          LOG.warn("Error while notifying the listener: " + listener, e);
         }
       });
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/StatsUpdaterTask.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/leader/StatsUpdaterTask.java
@@ -90,6 +90,7 @@ public class StatsUpdaterTask implements LeaderElection.LeadershipStateListener 
       statsUpdater.ifPresent(statsUpdater -> {
         stop.set(true);
         ((Thread) statsUpdater).interrupt();
+        HiveMetaStore.LOG.info("Stopped the stats updater tasks.");
       });
       statsUpdater = null;
       stop = null;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderElection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderElection.java
@@ -37,7 +37,7 @@ public class TestLeaderElection {
 
   @Test
   public void testConfigLeaderElection() throws Exception {
-    LeaderElection election = new HostLeaderElection();
+    LeaderElection election = new StaticLeaderElection();
     String leaderHost = "host1.work";
     Configuration configuration = MetastoreConf.newMetastoreConf();
     election.tryBeLeader(configuration, leaderHost);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderListener.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.leader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.utils.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLeaderListener {
+
+  @Test
+  public void testAuditLeaderListener() throws Exception {
+    Path location = new Path(".", "test_audit_leader_listener_" + System.currentTimeMillis());
+    Configuration conf = MetastoreConf.newMetastoreConf();
+    FileSystem fileSystem = FileSystem.get(conf);
+    try {
+      conf.set(AuditLeaderListener.CREATE_NEW_FILE_ON_ELECTION, "true");
+      conf.set(AuditLeaderListener.AUDIT_FILE_LIMIT, "3");
+      // create a new file on the election event
+      AuditLeaderListener listener = new AuditLeaderListener(location, conf);
+      StaticLeaderElection election = new StaticLeaderElection();
+      election.setName("testAuditLeaderListener");
+      listener.takeLeadership(election);
+      List<FileStatus> fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Pattern pattern = Pattern.compile("leader_testAuditLeaderListener_[0-9]+\\.json");
+      fileStatuses.forEach(fileStatus -> Assert.assertTrue(pattern.matcher(fileStatus.getPath().getName()).matches()));
+
+      FileStatus oldestFile = fileStatuses.get(0);
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.remove(oldestFile));
+      Assert.assertTrue(fileStatuses.size() == 1);
+      FileStatus tmpFileStatus = fileStatuses.get(0);
+
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.size() == 3);
+      List<FileStatus> tempFileStatuses = new ArrayList<>(fileStatuses);
+      fileStatuses.forEach(fileStatus -> Assert.assertTrue(pattern.matcher(fileStatus.getPath().getName()).matches()));
+
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.size() == 3);
+      Assert.assertTrue(tempFileStatuses.remove(oldestFile));
+      Assert.assertTrue(tempFileStatuses.contains(tmpFileStatus));
+      Assert.assertFalse(fileStatuses.contains(oldestFile));
+      tempFileStatuses.removeAll(fileStatuses);
+      Assert.assertTrue(tempFileStatuses.isEmpty());
+
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.size() == 3);
+      Assert.assertFalse(fileStatuses.contains(tmpFileStatus));
+
+      // only one file
+      fileSystem.delete(location, true);
+      Assert.assertTrue(FileUtils.isDirEmpty(fileSystem, location));
+      conf.set(AuditLeaderListener.CREATE_NEW_FILE_ON_ELECTION, "false");
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.size() == 1);
+      Assert.assertTrue(fileStatuses.get(0).getPath().getName().equals("leader_testAuditLeaderListener.json"));
+      listener.takeLeadership(election);
+      listener.takeLeadership(election);
+      fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
+      Assert.assertTrue(fileStatuses.size() == 1);
+      Assert.assertTrue(fileStatuses.get(0).getPath().getName().equals("leader_testAuditLeaderListener.json"));
+    } finally {
+      FileUtils.moveToTrash(fileSystem, location, conf, true);
+    }
+  }
+
+}

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/leader/TestLeaderListener.java
@@ -39,8 +39,8 @@ public class TestLeaderListener {
     Configuration conf = MetastoreConf.newMetastoreConf();
     FileSystem fileSystem = FileSystem.get(conf);
     try {
-      conf.set(AuditLeaderListener.CREATE_NEW_FILE_ON_ELECTION, "true");
-      conf.set(AuditLeaderListener.AUDIT_FILE_LIMIT, "3");
+      MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.METASTORE_HOUSEKEEPING_LEADER_NEW_AUDIT_FILE, true);
+      MetastoreConf.setLongVar(conf, MetastoreConf.ConfVars.METASTORE_HOUSEKEEPING_LEADER_AUDIT_FILE_LIMIT, 3);
       // create a new file on the election event
       AuditLeaderListener listener = new AuditLeaderListener(location, conf);
       StaticLeaderElection election = new StaticLeaderElection();
@@ -80,7 +80,7 @@ public class TestLeaderListener {
       // only one file
       fileSystem.delete(location, true);
       Assert.assertTrue(FileUtils.isDirEmpty(fileSystem, location));
-      conf.set(AuditLeaderListener.CREATE_NEW_FILE_ON_ELECTION, "false");
+      MetastoreConf.setBoolVar(conf, MetastoreConf.ConfVars.METASTORE_HOUSEKEEPING_LEADER_NEW_AUDIT_FILE, false);
       listener.takeLeadership(election);
       fileStatuses = FileUtils.getFileStatusRecurse(location, fileSystem);
       Assert.assertTrue(fileStatuses.size() == 1);


### PR DESCRIPTION
…systems

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Two new properties:
  metastore.housekeeping.leader.auditFiles.limit: Max number of audit files for a leader, if exceeds the limit, then the oldest audit file will be removed, default is 10.
  metastore.housekeeping.leader.newAuditFile:   Boolean flag to tell the audit listener how to response to the election event, true means write this event into a new file, false otherwise. Default is false.


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
- UT
- Tested on the warehouse based on S3
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
