### PR TITLE
HIVE-27439: Support Decimal(precision, scale) format

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
@@ -334,7 +334,7 @@ public final class TypeInfoUtils {
             || !isTypeChar(typeInfoString.charAt(end))) {
           Token t = new Token();
           t.position = begin;
-          t.text = typeInfoString.substring(begin, end);
+          t.text = typeInfoString.substring(begin, end).trim();
           t.isType = isTypeChar(typeInfoString.charAt(begin));
           tokens.add(t);
           begin = end;

--- a/serde/src/test/org/apache/hadoop/hive/serde2/typeinfo/TestTypeInfoUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/typeinfo/TestTypeInfoUtils.java
@@ -47,7 +47,12 @@ public class TestTypeInfoUtils {
         "string",
         "varchar(10)",
         "char(15)",
-        "array<int>"
+        "array<int>",
+        "decimal(10,2)",
+        "decimal(10, 2)",
+        "decimal(10, 2 )",
+        "decimal( 10, 2 )",
+        "struct<user id:int,user group: int>"
     };
 
     String[] invalidTypeStrings = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now, TypeInfoUtils#parseType only support Decimal(precision,scale) instead of Decimal(precision, scale), for example, support decimal(10,2) instead of decimal(10, 2) with a blank before 2, however, users may create decimal in this format decimal(10, 2) and it will throw exception in 

```

Integer.parseInt(params[1]);

```

we need fix this issue.


### Why are the changes needed?
Fix the Decimal(precision, scale) parsing error.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
