### PR TITLE
HIVE-27440: Improve data connector cache

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1963,6 +1963,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
       ms.openTransaction();
       ms.alterDataConnector(dcName, newDC);
+      DataConnectorProviderFactory.updateDataConnectorCache(dcName);
 
         /*
         if (!transactionalListeners.isEmpty()) {
@@ -2021,6 +2022,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     RawStore ms = getMS();
     try {
       connector = getMS().getDataConnector(dcName);
+      DataConnectorProviderFactory.updateDataConnectorCache(dcName);
     } catch (NoSuchObjectException e) {
       if (!ifNotExists) {
         throw new NoSuchObjectException("DataConnector " + dcName + " doesn't exist");

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1963,7 +1963,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
       ms.openTransaction();
       ms.alterDataConnector(dcName, newDC);
-      DataConnectorProviderFactory.updateDataConnectorCache(dcName);
+      DataConnectorProviderFactory.invalidateDataConnectorFromCache(dcName);
 
         /*
         if (!transactionalListeners.isEmpty()) {
@@ -2022,7 +2022,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     RawStore ms = getMS();
     try {
       connector = getMS().getDataConnector(dcName);
-      DataConnectorProviderFactory.updateDataConnectorCache(dcName);
+      DataConnectorProviderFactory.invalidateDataConnectorFromCache(dcName);
     } catch (NoSuchObjectException e) {
       if (!ifNotExists) {
         throw new NoSuchObjectException("DataConnector " + dcName + " doesn't exist");

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
@@ -52,9 +52,10 @@ public class DataConnectorProviderFactory {
     public void onRemoval(@Nullable String dcName, @Nullable IDataConnectorProvider dataConnectorProvider,
                           @NonNull RemovalCause cause) {
       try {
+        LOG.info("Closing dataConnectorProvider :{}", dcName);
         dataConnectorProvider.close();
       } catch (Exception e) {
-        LOG.warn("Exception when closing dataconnectorprovider: {} due to: {}" + dcName, e.getMessage());
+        LOG.warn("Exception when closing dataConnectorProvider: {} due to: {}" + dcName, e.getMessage());
       }
     }
   }
@@ -119,14 +120,14 @@ public class DataConnectorProviderFactory {
    * to avoid using the invalid dataConnector next time.
    * @param dcName dataConnector to be cleaned
    */
-  public static synchronized void updateDataConnectorCache(String dcName) {
+  public static synchronized void invalidateDataConnectorFromCache(String dcName) {
     try {
       IDataConnectorProvider dataConnectorProvider = dataConnectorCache.getIfPresent(dcName);
       if (dataConnectorProvider != null) {
         dataConnectorCache.invalidate(dcName);
       }
     } catch (Exception e) {
-      LOG.warn("Exception when removing dataconnectorprovider: {} from cache due to: {}" + dcName, e.getMessage());
+      LOG.warn("Exception when removing dataConnectorProvider: {} from cache due to: {}" + dcName, e.getMessage());
     }
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
@@ -18,29 +18,52 @@
 
 package org.apache.hadoop.hive.metastore.dataconnector;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DatabaseType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.*;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.DERBY_TYPE;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.MSSQL_TYPE;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.MYSQL_TYPE;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.ORACLE_TYPE;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.POSTGRES_TYPE;
 
 public class DataConnectorProviderFactory {
-  Logger LOG = LoggerFactory.getLogger(DataConnectorProviderFactory.class);
+  static final Logger LOG = LoggerFactory.getLogger(DataConnectorProviderFactory.class);
 
-  private static Map<String, IDataConnectorProvider> cache = null;
+  private static Cache<String, IDataConnectorProvider> dataConnectorCache = null;
   private static DataConnectorProviderFactory singleton = null;
   private static IHMSHandler hmsHandler = null;
 
+  private static class CacheRemoveListener implements RemovalListener<String, IDataConnectorProvider> {
+    @Override
+    public void onRemoval(@Nullable String dcName, @Nullable IDataConnectorProvider dataConnectorProvider,
+                          @NonNull RemovalCause cause) {
+      try {
+        dataConnectorProvider.close();
+      } catch (Exception e) {
+        LOG.warn("Exception when closing dataconnectorprovider: {} due to: {}" + dcName, e.getMessage());
+      }
+    }
+  }
+
   private DataConnectorProviderFactory(IHMSHandler hmsHandler) {
-    cache = new HashMap<String, IDataConnectorProvider>();
+    dataConnectorCache = Caffeine.newBuilder()
+        .removalListener(new CacheRemoveListener())
+        .maximumSize(100)
+        .expireAfterAccess(1, TimeUnit.HOURS).build();
     this.hmsHandler = hmsHandler;
   }
 
@@ -59,11 +82,9 @@ public class DataConnectorProviderFactory {
     }
 
     String scopedDb = (db.getRemote_dbname() != null) ? db.getRemote_dbname() : db.getName();
-    if (cache.containsKey(db.getConnector_name().toLowerCase())) {
-      provider = cache.get(db.getConnector_name().toLowerCase());
-      if (provider != null) {
-        provider.setScope(scopedDb);
-      }
+    provider = dataConnectorCache.getIfPresent(db.getConnector_name().toLowerCase());
+    if (provider != null) {
+      provider.setScope(scopedDb);
       return provider;
     }
 
@@ -89,19 +110,23 @@ public class DataConnectorProviderFactory {
     default:
       throw new MetaException("Data connector of type " + connector.getType() + " not implemented yet");
     }
-    cache.put(connector.getName().toLowerCase(), provider);
+    dataConnectorCache.put(connector.getName().toLowerCase(), provider);
     return provider;
   }
 
-  public void shutdown() {
-    for (IDataConnectorProvider provider: cache.values()) {
-      try {
-        provider.close();
-      } catch(Exception e) {
-        LOG.warn("Exception invoking close on dataconnectorprovider:" + provider, e);
-      } finally {
-        cache.clear();
+  /**
+   * After executing Drop or Alter DDL on a dataConnector, we should update cache to clean the dataConnector
+   * to avoid using the invalid dataConnector next time.
+   * @param dcName dataConnector to be cleaned
+   */
+  public static synchronized void updateDataConnectorCache(String dcName) {
+    try {
+      IDataConnectorProvider dataConnectorProvider = dataConnectorCache.getIfPresent(dcName);
+      if (dataConnectorProvider != null) {
+        dataConnectorCache.invalidate(dcName);
       }
+    } catch (Exception e) {
+      LOG.warn("Exception when removing dataconnectorprovider: {} from cache due to: {}" + dcName, e.getMessage());
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`DataConnectorProviderFactory `uses HashMap to cache data connector instances, and there is no way to invalidate the cache unless you restart the MetaStore.  
What is more serious is that if you drop or alter the dataconnector, the cache will not change, and you maybe use a invalid dataconnector next time.

 

I think we can improve the dataconnector cache from the two aspects:

1. Use Caffeine with a maxmumsize e.g. 100  to cache data connector instead of HashMap, and set a expire time after the last accessing. And we also should close the underlying  datasource connection using Caffeine RemovalListener.

2. After executing Drop or Alter DDL on a dataConnector, we should update cache to clean the dataConnector to avoid using the invalid dataConnector next time.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing Qtest and Local Hive cluster env.