### PR TITLE
Hive 27427 rerunning tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
     <orc.version>1.8.3</orc.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <powermock.version>2.0.2</powermock.version>
+    <rerun.failing.tests.count>1</rerun.failing.tests.count>
     <mina.version>2.0.0-M5</mina.version>
     <netty.version>4.1.77.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
@@ -1673,6 +1674,7 @@
           <reuseForks>false</reuseForks>
           <failIfNoTests>false</failIfNoTests>
           <argLine>${maven.test.jvm.args}</argLine>
+          <rerunFailingTestsCount>${rerun.failing.tests.count}</rerunFailingTestsCount>
           <trimStackTrace>false</trimStackTrace>
           <additionalClasspathElements>
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -116,6 +116,7 @@
     <thrift.args>-I ${thrift.home} --gen java:beans,generated_annotations=undated --gen cpp --gen php --gen py --gen rb
     </thrift.args>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+    <rerun.failing.tests.count>1</rerun.failing.tests.count>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -502,6 +503,7 @@
           <version>${maven.surefire.plugin.version}</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
+            <rerunFailingTestsCount>${rerun.failing.tests.count}</rerunFailingTestsCount>
           </configuration>
         </plugin>
         <plugin>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -38,6 +38,7 @@
     <checkstyle.conf.dir>${basedir}/checkstyle/</checkstyle.conf.dir>
     <maven.versions.plugin.version>2.13.0</maven.versions.plugin.version>
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+    <rerun.failing.tests.count>1</rerun.failing.tests.count>
   </properties>
   <dependencies>
     <!-- compile inter-project -->
@@ -195,6 +196,7 @@
           <reuseForks>false</reuseForks>
           <argLine>-Xmx3g</argLine>
           <failIfNoTests>false</failIfNoTests>
+          <rerunFailingTestsCount>${rerun.failing.tests.count}</rerunFailingTestsCount>
           <systemPropertyVariables>
             <test.tmp.dir>${project.build.directory}/tmp</test.tmp.dir>
           </systemPropertyVariables>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adding ability to automatically rerun failed tests.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It often happens that Hive unit tests fail during pre-commit which requires rerunning the whole pre-commit job and creates hours of delays.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Passing hive pre-commit pipeline. 
Manual testing: changed existing unit test to fail, rerun and observed that it was retried.
A part of the log is pasted below.
Did the same manual testing with a q-test too.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.217 s <<< FAILURE! - in org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils
[ERROR] org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testcolumnsIncludedByNameType  Time elapsed: 1.201 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testcolumnsIncludedByNameType(TestMetaStoreServerUtils.java:130)

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.251 s <<< FAILURE! - in org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils
[ERROR] org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testcolumnsIncludedByNameType  Time elapsed: 0 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testcolumnsIncludedByNameType(TestMetaStoreServerUtils.java:130)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testcolumnsIncludedByNameType
[ERROR]   Run 1: TestMetaStoreServerUtils.testcolumnsIncludedByNameType:130
[ERROR]   Run 2: TestMetaStoreServerUtils.testcolumnsIncludedByNameType:130
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
