### PR TITLE
HIVE-27443: Remove duplicate dependency from pom to avoid maven warnings

### DIFF
--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -92,10 +92,6 @@
       <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
-    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In **_itests/hive-jmh/pom.xml_**, the dependency of hive-exec is defined 2 times which is causing unnecessary maven warnings while building hive. Hence removing the duplicate dependency.

### Why are the changes needed?
To prevent maven warnings while build 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing test should be enough