### PR TITLE
HIVE-24286: Render date and time with progress of Hive on Tez

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.exec.tez.monitoring;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import org.apache.hadoop.hive.common.log.InPlaceUpdate;
 import org.apache.hadoop.hive.common.log.ProgressMonitor;
@@ -150,8 +151,10 @@ class RenderStrategy {
     private static final DateTimeFormatter REPORT_DATE_TIME_FORMATTER =
         DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
 
-    private boolean hiveServer2InPlaceProgressEnabled =
+    private final boolean hiveServer2InPlaceProgressEnabled =
         SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_INPLACE_PROGRESS);
+    private final ZoneId localTimeZone = SessionState.get().getConf().getLocalTimeZone();
+
     LogToFileFunction(TezJobMonitor monitor) {
       super(monitor);
     }
@@ -166,7 +169,7 @@ class RenderStrategy {
       if (hiveServer2InPlaceProgressEnabled) {
         LOGGER.info(report);
       } else {
-        String time = REPORT_DATE_TIME_FORMATTER.format(LocalDateTime.now());
+        final String time = REPORT_DATE_TIME_FORMATTER.format(LocalDateTime.now(localTimeZone));
         monitor.console.printInfo(time + "\t" + report);
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hive.ql.exec.tez.monitoring;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.apache.hadoop.hive.common.log.InPlaceUpdate;
 import org.apache.hadoop.hive.common.log.ProgressMonitor;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -145,6 +147,9 @@ class RenderStrategy {
    */
   static class LogToFileFunction extends BaseUpdateFunction {
     private static final Logger LOGGER = LoggerFactory.getLogger(LogToFileFunction.class);
+    private static final DateTimeFormatter REPORT_DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
+
     private boolean hiveServer2InPlaceProgressEnabled =
         SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SERVER2_INPLACE_PROGRESS);
     LogToFileFunction(TezJobMonitor monitor) {
@@ -161,7 +166,8 @@ class RenderStrategy {
       if (hiveServer2InPlaceProgressEnabled) {
         LOGGER.info(report);
       } else {
-        monitor.console.printInfo(report);
+        String time = REPORT_DATE_TIME_FORMATTER.format(LocalDateTime.now());
+        monitor.console.printInfo(time + "\t" + report);
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add date and time to the progress log when `hive.server2.in.place.progress` is disabled.
https://issues.apache.org/jira/browse/HIVE-24286

### Why are the changes needed?
With `hive.server2.in.place.progress` disabled, Hive prints progress periodically. We want to add date and time to each line so that we can review what phase took time or where the job got stuck easily. As I mentioned in [HIVE-24286](https://issues.apache.org/jira/browse/HIVE-24286), Hive on MR or Hive on Spark add date and time.

```
INFO  : Map 1: -/-	Reducer 2: 0/1	
INFO  : Map 1: 0/1	Reducer 2: 0/1	
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/1	
INFO  : Map 1: 1/1	Reducer 2: 0(+1)/1	
INFO  : Map 1: 1/1	Reducer 2: 1/1	
```

### Does this PR introduce _any_ user-facing change?
The log format can change if a user configures `hive.server2.in.place.progress=false`.

### Is the change a dependency upgrade?
No

### How was this patch tested?
I tested the patch on my local machine.

```
INFO  : 2023-06-15 14:07:44,590	Map 1: -/-	Reducer 2: 0/1	
INFO  : 2023-06-15 14:07:45,605	Map 1: 0/1	Reducer 2: 0/1	
INFO  : 2023-06-15 14:07:48,135	Map 1: 0(+1)/1	Reducer 2: 0/1	
INFO  : 2023-06-15 14:07:49,658	Map 1: 1/1	Reducer 2: 1/1	
```