### PR TITLE
HIVE-27441: Iceberg: CTLT with source table as Hive managed table fails with "The table must be stored using an ACID compliant format"

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -1381,6 +1381,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC, spec);
       tbl.getSd().getCols().addAll(tbl.getPartitionKeys());
       tbl.getTTable().setPartitionKeysIsSet(false);
+
+      // Remove any transactional properties as they aren't relevant in case of iceberg tables.
+      tbl.getParameters().keySet().removeIf(
+          key -> hive_metastoreConstants.TABLE_IS_TRANSACTIONAL.equalsIgnoreCase(key) ||
+              hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES.equalsIgnoreCase(key));
     }
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -1381,11 +1381,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       SessionStateUtil.addResourceOrThrow(conf, hive_metastoreConstants.PARTITION_TRANSFORM_SPEC, spec);
       tbl.getSd().getCols().addAll(tbl.getPartitionKeys());
       tbl.getTTable().setPartitionKeysIsSet(false);
-
-      // Remove any transactional properties as they aren't relevant in case of iceberg tables.
-      tbl.getParameters().keySet().removeIf(
-          key -> hive_metastoreConstants.TABLE_IS_TRANSACTIONAL.equalsIgnoreCase(key) ||
-              hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES.equalsIgnoreCase(key));
     }
   }
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/ctlt_iceberg.q
@@ -3,6 +3,8 @@
 -- Mask random uuid
 --! qt:replace:/(\s+'uuid'=')\S+('\s*)/$1#Masked#$2/
 
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 set hive.explain.user=false;
 
 create table source(a int) stored by iceberg tblproperties ('format-version'='2') ;
@@ -45,3 +47,12 @@ create table emp_like2 like emp stored by iceberg;
 -- Partition column should be there
 show create table emp_like2;
 
+-- create a managed table
+create managed table man_table (id int) Stored as orc TBLPROPERTIES ('transactional'='true');
+
+create table like_man_table like man_table stored by iceberg;
+
+-- insert some data into the table and see if things work
+insert into like_man_table values (1), (2), (3), (4);
+
+select * from like_man_table order by id;

--- a/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
@@ -38,7 +38,6 @@ STORED BY
 LOCATION
   'hdfs://### HDFS PATH ###'
 TBLPROPERTIES (
-  'TRANSLATED_TO_EXTERNAL'='TRUE', 
   'bucketing_version'='2', 
   'created_with_ctlt'='true', 
   'current-schema'='{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"}]}', 
@@ -162,7 +161,6 @@ STORED BY
 LOCATION
   'hdfs://### HDFS PATH ###'
 TBLPROPERTIES (
-  'TRANSLATED_TO_EXTERNAL'='TRUE', 
   'bucketing_version'='2', 
   'created_with_ctlt'='true', 
   'current-schema'='{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"id","required":false,"type":"int"},{"id":2,"name":"company","required":false,"type":"string"}]}', 
@@ -230,7 +228,6 @@ STORED BY
 LOCATION
   'hdfs://### HDFS PATH ###'
 TBLPROPERTIES (
-  'TRANSLATED_TO_EXTERNAL'='TRUE', 
   'bucketing_version'='2', 
   'created_with_ctlt'='true', 
   'current-schema'='{"type":"struct","schema-id":0,"fields":[{"id":1,"name":"id","required":false,"type":"int"},{"id":2,"name":"company","required":false,"type":"string"}]}', 

--- a/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
@@ -242,3 +242,39 @@ TBLPROPERTIES (
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
   'uuid'='#Masked#')
+PREHOOK: query: create managed table man_table (id int) Stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@man_table
+POSTHOOK: query: create managed table man_table (id int) Stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@man_table
+PREHOOK: query: create table like_man_table like man_table stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@like_man_table
+POSTHOOK: query: create table like_man_table like man_table stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@like_man_table
+PREHOOK: query: insert into like_man_table values (1), (2), (3), (4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@like_man_table
+POSTHOOK: query: insert into like_man_table values (1), (2), (3), (4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@like_man_table
+PREHOOK: query: select * from like_man_table order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@like_man_table
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from like_man_table order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@like_man_table
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1
+2
+3
+4

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/convert/AlterTableConvertOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/convert/AlterTableConvertOperation.java
@@ -38,7 +38,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE
  */
 public class AlterTableConvertOperation extends AbstractAlterTableOperation<AlterTableConvertDesc> {
 
-  private enum ConversionFormats {
+  public enum ConversionFormats {
     ICEBERG(ImmutableMap.of(META_TABLE_STORAGE, "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler")),
     ACID(ImmutableMap.of(TABLE_IS_TRANSACTIONAL, "true", TABLE_TRANSACTIONAL_PROPERTIES,
         DEFAULT_TRANSACTIONAL_PROPERTY));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove any transactional property from the iceberg table in case of CTLT, as they aren't relevant to it.

### Why are the changes needed?

CTLT with iceberg table as target and source as managed table fails, due to additional checks that happen due to transactional properties set in the iceberg tables

### Does this PR introduce _any_ user-facing change?

Yes, CTLT from managed to iceberg table will be successful 

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT