### PR TITLE
HIVE-27446: Exception when rebuild materialized view incrementally in presence of delete operations

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -808,19 +808,20 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
     // We bypass the OR clause and select the first disjunct
     int indexDelete;
     int indexInsert;
-    if (whereClauseInInsert.getChild(0).getChild(0).getType() == HiveParser.DOT) {
+    if (whereClauseInInsert.getChild(0).getChild(0).getType() == HiveParser.KW_AND) {
       indexDelete = 0;
       indexInsert = 1;
-    } else if (whereClauseInInsert.getChild(0).getChild(1).getType() == HiveParser.DOT) {
+    } else if (whereClauseInInsert.getChild(0).getChild(1).getType() == HiveParser.KW_AND) {
       indexDelete = 1;
       indexInsert = 0;
     } else {
       throw new SemanticException("Unexpected condition in incremental rewriting");
     }
+    ASTNode deletePredicate =
+        (ASTNode) ParseDriver.adaptor.dupTree(whereClauseInInsert.getChild(0).getChild(indexDelete));
     ASTNode newCondInInsert = (ASTNode) whereClauseInInsert.getChild(0).getChild(indexInsert);
     ParseDriver.adaptor.setChild(whereClauseInInsert, 0, newCondInInsert);
 
-    ASTNode deletePredicate = (ASTNode) whereClauseInInsert.getChild(0).getChild(indexDelete);
     addDeleteBranch(insertNode, subqueryNodeInputROJ, deletePredicate, astBuilder);
 
     // 3) Add sort node to delete branch

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveJoinInsertDeleteIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveJoinInsertDeleteIncrementalRewritingRule.java
@@ -31,7 +31,6 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveJoin;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
-import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
 
 import java.util.ArrayList;
@@ -81,7 +80,7 @@ public class HiveJoinInsertDeleteIncrementalRewritingRule extends RelOptRule {
     // expressions for project operator
     List<RexNode> projExprs = new ArrayList<>();
     List<RexNode> joinConjs = new ArrayList<>();
-    for (int leftPos = 0; leftPos < joinLeftInput.getRowType().getFieldCount() - 1; leftPos++) {
+    for (int leftPos = 0; leftPos < joinLeftInput.getRowType().getFieldCount(); leftPos++) {
       RexNode leftRef = rexBuilder.makeInputRef(
               joinLeftInput.getRowType().getFieldList().get(leftPos).getType(), leftPos);
       RexNode rightRef = rexBuilder.makeInputRef(
@@ -94,12 +93,6 @@ public class HiveJoinInsertDeleteIncrementalRewritingRule extends RelOptRule {
     }
 
     RexNode joinCond = RexUtil.composeConjunction(rexBuilder, joinConjs);
-
-    int rowIsDeletedIdx = joinRightInput.getRowType().getFieldCount() - 1;
-    RexNode rowIsDeleted = rexBuilder.makeInputRef(
-            joinRightInput.getRowType().getFieldList().get(rowIsDeletedIdx).getType(),
-            joinLeftInput.getRowType().getFieldCount() + rowIsDeletedIdx);
-    projExprs.add(rowIsDeleted);
 
     // 3) Build plan
     RelNode newNode = call.builder()
@@ -152,6 +145,7 @@ public class HiveJoinInsertDeleteIncrementalRewritingRule extends RelOptRule {
     }
 
     private RelNode createFilter(HiveJoin join) {
+      RexBuilder rexBuilder = relBuilder.getRexBuilder();
       // This should be a Scan on the MV
       RelNode leftInput = join.getLeft();
 
@@ -161,34 +155,56 @@ public class HiveJoinInsertDeleteIncrementalRewritingRule extends RelOptRule {
       RelNode tmpJoin = visitChild(join, 1, rightInput);
       RelNode newRightInput = tmpJoin.getInput(1);
 
+      List<RexNode> leftProjects = new ArrayList<>(leftInput.getRowType().getFieldCount() + 1);
+      List<String> leftProjectNames = new ArrayList<>(leftInput.getRowType().getFieldCount() + 1);
+      for (int i = 0; i < leftInput.getRowType().getFieldCount(); ++i) {
+        RelDataTypeField relDataTypeField = leftInput.getRowType().getFieldList().get(i);
+        leftProjects.add(rexBuilder.makeInputRef(relDataTypeField.getType(), i));
+        leftProjectNames.add(relDataTypeField.getName());
+      }
+      List<RexNode> projects = new ArrayList<>(leftProjects.size() + newRightInput.getRowType().getFieldCount());
+      projects.addAll(leftProjects);
+      List<String> projectNames = new ArrayList<>(leftProjects.size() + newRightInput.getRowType().getFieldCount());
+      projectNames.addAll(leftProjectNames);
+
+      leftProjects.add(rexBuilder.makeLiteral(true));
+      leftProjectNames.add("flag");
+
+      leftInput = relBuilder
+          .push(leftInput)
+          .project(leftProjects, leftProjectNames)
+          .build();
+
+      // Create input ref to flag. It is used in filter condition later.
+      int flagIndex = leftProjects.size() - 1;
+      RexNode flagNode = rexBuilder.makeInputRef(
+          leftInput.getRowType().getFieldList().get(flagIndex).getType(), flagIndex);
+
       // Create input ref to rowIsDeleteColumn. It is used in filter condition later.
       RelDataType newRowType = newRightInput.getRowType();
       int rowIsDeletedIdx = newRowType.getFieldCount() - 1;
-      RexBuilder rexBuilder = relBuilder.getRexBuilder();
       RexNode rowIsDeleted = rexBuilder.makeInputRef(
-              newRowType.getFieldList().get(rowIsDeletedIdx).getType(),
-              leftInput.getRowType().getFieldCount() + rowIsDeletedIdx);
+          newRowType.getFieldList().get(rowIsDeletedIdx).getType(),
+          leftInput.getRowType().getFieldCount() + rowIsDeletedIdx);
 
-      List<RexNode> projects = new ArrayList<>(newRowType.getFieldCount());
-      List<String> projectNames = new ArrayList<>(newRowType.getFieldCount());
-      for (int i = 0; i < leftInput.getRowType().getFieldCount(); ++i) {
-        RelDataTypeField relDataTypeField = leftInput.getRowType().getFieldList().get(i);
-        projects.add(rexBuilder.makeInputRef(relDataTypeField.getType(), i));
-        projectNames.add(relDataTypeField.getName());
-      }
+      RexNode deleteBranchFilter = rexBuilder.makeCall(SqlStdOperatorTable.AND, flagNode, rowIsDeleted);
+      RexNode insertBranchFilter = rexBuilder.makeCall(SqlStdOperatorTable.NOT, rowIsDeleted);
+
       for (int i = 0; i < newRowType.getFieldCount() - 1; ++i) {
         RelDataTypeField relDataTypeField = newRowType.getFieldList().get(i);
         projects.add(rexBuilder.makeInputRef(relDataTypeField.getType(), leftInput.getRowType().getFieldCount() + i));
         projectNames.add(relDataTypeField.getName());
       }
 
+      RexNode newJoinCondition = new InputRefShifter(leftInput.getRowType().getFieldCount() - 1, relBuilder)
+          .apply(join.getCondition());
+
       // Create new Top Right Join and a Filter. The filter condition is used in CalcitePlanner.fixUpASTJoinIncrementalRebuild().
       return relBuilder
               .push(leftInput)
               .push(newRightInput)
-              .join(join.getJoinType(), join.getCondition())
-              .filter(rexBuilder.makeCall(SqlStdOperatorTable.OR,
-                      rowIsDeleted, rexBuilder.makeCall(SqlStdOperatorTable.NOT, rowIsDeleted)))
+              .join(join.getJoinType(), newJoinCondition)
+              .filter(rexBuilder.makeCall(SqlStdOperatorTable.OR, deleteBranchFilter, insertBranchFilter))
               .project(projects, projectNames)
               .build();
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveJoinInsertDeleteIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveJoinInsertDeleteIncrementalRewritingRule.java
@@ -45,12 +45,12 @@ import java.util.List;
  * Since CBO plan does not contain the INSERT branches we focus on the SELECT part of the plan in this rule.
  * See also {@link CalcitePlanner}
  *
- * FROM (select mv.ROW__ID, mv.a, mv.b from mv) mv
+ * FROM (select mv.ROW__ID, mv.a, mv.b, true as flag from mv) mv
  * RIGHT OUTER JOIN (SELECT _source_.ROW__IS_DELETED,_source_.a, _source_.b FROM _source_) source
  * ON (mv.a &lt;=&gt; source.a AND mv.b &lt;=&gt; source.b)
  * INSERT INTO TABLE mv_delete_delta
  *   SELECT mv.ROW__ID
- *   WHERE source.ROW__IS__DELETED
+ *   WHERE source.ROW__IS__DELETED AND flag
  * INSERT INTO TABLE mv
  *   SELECT source.a, source.b
  *   WHERE NOT source.ROW__IS__DELETED

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveRowIsDeletedPropagator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveRowIsDeletedPropagator.java
@@ -174,31 +174,6 @@ public class HiveRowIsDeletedPropagator extends HiveRelShuttleImpl {
             .build();
   }
 
-  protected static class InputRefShifter extends RexShuttle {
-    private final int startIndex;
-    private final RelBuilder relBuilder;
-
-    InputRefShifter(int startIndex, RelBuilder relBuilder) {
-      this.startIndex = startIndex;
-      this.relBuilder = relBuilder;
-    }
-
-    /**
-     * Shift input reference index by one if the referenced column index is higher or equals with the startIndex.
-     * @param inputRef - {@link RexInputRef} to transform
-     * @return new {@link RexInputRef} if the referenced column index is higher or equals with the startIndex,
-     * original otherwise
-     */
-    @Override
-    public RexNode visitInputRef(RexInputRef inputRef) {
-      if (inputRef.getIndex() >= startIndex) {
-        RexBuilder rexBuilder = relBuilder.getRexBuilder();
-        return rexBuilder.makeInputRef(inputRef.getType(), inputRef.getIndex() + 1);
-      }
-      return inputRef;
-    }
-  }
-
   private void populateProjects(RexBuilder rexBuilder, RelDataType inputRowType,
                                 List<RexNode> projects, List<String> projectNames) {
     populateProjects(rexBuilder, inputRowType, 0, inputRowType.getFieldCount(), projects, projectNames);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveRowIsDeletedPropagator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveRowIsDeletedPropagator.java
@@ -174,11 +174,11 @@ public class HiveRowIsDeletedPropagator extends HiveRelShuttleImpl {
             .build();
   }
 
-  private static class InputRefShifter extends RexShuttle {
+  protected static class InputRefShifter extends RexShuttle {
     private final int startIndex;
     private final RelBuilder relBuilder;
 
-    private InputRefShifter(int startIndex, RelBuilder relBuilder) {
+    InputRefShifter(int startIndex, RelBuilder relBuilder) {
       this.startIndex = startIndex;
       this.relBuilder = relBuilder;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/InputRefShifter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/InputRefShifter.java
@@ -1,0 +1,32 @@
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.tools.RelBuilder;
+
+public class InputRefShifter extends RexShuttle {
+  private final int startIndex;
+  private final RelBuilder relBuilder;
+
+  InputRefShifter(int startIndex, RelBuilder relBuilder) {
+    this.startIndex = startIndex;
+    this.relBuilder = relBuilder;
+  }
+
+  /**
+   * Shift input reference index by one if the referenced column index is higher or equals with the startIndex.
+   * @param inputRef - {@link RexInputRef} to transform
+   * @return new {@link RexInputRef} if the referenced column index is higher or equals with the startIndex,
+   * original otherwise
+   */
+  @Override
+  public RexNode visitInputRef(RexInputRef inputRef) {
+    if (inputRef.getIndex() >= startIndex) {
+      RexBuilder rexBuilder = relBuilder.getRexBuilder();
+      return rexBuilder.makeInputRef(inputRef.getType(), inputRef.getIndex() + 1);
+    }
+    return inputRef;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/InputRefShifter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/InputRefShifter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
 
 import org.apache.calcite.rex.RexBuilder;

--- a/ql/src/test/queries/clientpositive/materialized_view_join_rebuild.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_join_rebuild.q
@@ -1,0 +1,33 @@
+-- Test Incremental rebuild of materialized view without aggregate when source tables have
+-- delete operations since last rebuild.
+-- The view projects only one column.
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1);
+
+create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3);
+
+CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0;
+
+DELETE from cmv_basetable_2_n3 WHERE a=1;
+
+ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD;
+
+SELECT * FROM cmv_mat_view_n6;

--- a/ql/src/test/queries/clientpositive/materialized_view_repeated_rebuild.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_repeated_rebuild.q
@@ -1,0 +1,37 @@
+-- Test Incremental rebuild of materialized view without aggregate when source tables have
+-- 1) delete operations since last rebuild.
+-- 2) delete records with the same join key from the other joined table
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1);
+
+create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true');
+
+insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3);
+
+CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a, cmv_basetable_2_n3.c
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0;
+
+DELETE from cmv_basetable_2_n3 WHERE a=1;
+
+ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD;
+
+DELETE FROM cmv_basetable_n6 WHERE a=1;
+
+ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD;
+
+SELECT * FROM cmv_mat_view_n6;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_5.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_5.q.out
@@ -532,18 +532,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n6
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: a (type: int), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: a (type: int), c (type: decimal(10,2)), true (type: boolean), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 5 Data size: 980 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
+                      Statistics: Num rows: 5 Data size: 980 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: boolean), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -601,16 +601,16 @@ STAGE PLANS:
                 condition map:
                      Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col1, _col2, _col3, _col4
-                Statistics: Num rows: 6 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col0 (type: int), _col1 (type: decimal(10,2))
+                  1 _col0 (type: int), _col1 (type: decimal(10,2))
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 5 Data size: 920 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (_col2 and _col6) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -620,10 +620,10 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (not _col4) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (not _col6) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col2 (type: int), _col3 (type: decimal(10,2))
+                    expressions: _col4 (type: int), _col5 (type: decimal(10,2))
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -701,12 +701,12 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 2 Data size: 240 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
-                    key expressions: _col0 (type: int)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: int)
+                    key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
                     Statistics: Num rows: 2 Data size: 240 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: decimal(10,2)), _col2 (type: boolean)
+                    value expressions: _col2 (type: boolean)
 
   Stage: Stage-3
     Dependency Collection
@@ -872,18 +872,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n6
-                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: a (type: int), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 6 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: a (type: int), c (type: decimal(10,2)), true (type: boolean), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 6 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 6 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
+                      Statistics: Num rows: 6 Data size: 1176 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: boolean), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -941,29 +941,29 @@ STAGE PLANS:
                 condition map:
                      Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col1, _col2, _col3, _col4
-                Statistics: Num rows: 10 Data size: 1960 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col0 (type: int), _col1 (type: decimal(10,2))
+                  1 _col0 (type: int), _col1 (type: decimal(10,2))
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 9 Data size: 1640 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (_col2 and _col6) (type: boolean)
+                  Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (not _col4) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (not _col6) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col2 (type: int), _col3 (type: decimal(10,2))
+                    expressions: _col4 (type: int), _col5 (type: decimal(10,2))
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -996,10 +996,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -1041,12 +1041,12 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 3 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
-                    key expressions: _col0 (type: int)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: int)
+                    key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
                     Statistics: Num rows: 3 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: decimal(10,2)), _col2 (type: boolean)
+                    value expressions: _col2 (type: boolean)
 
   Stage: Stage-3
     Dependency Collection

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_8.q.out
@@ -402,18 +402,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n6
-                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 580 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: a (type: int), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 5 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                    expressions: a (type: int), c (type: decimal(10,2)), true (type: boolean), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 5 Data size: 980 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 5 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
+                      Statistics: Num rows: 5 Data size: 980 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: boolean), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -471,16 +471,16 @@ STAGE PLANS:
                 condition map:
                      Right Outer Join 0 to 1
                 keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                nullSafes: [true]
-                outputColumnNames: _col1, _col2, _col3, _col4
-                Statistics: Num rows: 2 Data size: 392 Basic stats: COMPLETE Column stats: COMPLETE
+                  0 _col0 (type: int), _col1 (type: decimal(10,2))
+                  1 _col0 (type: int), _col1 (type: decimal(10,2))
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col4 (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (_col2 and _col6) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col1 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -490,10 +490,10 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                       Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (not _col4) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (not _col6) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col2 (type: int), _col3 (type: decimal(10,2))
+                    expressions: _col4 (type: int), _col5 (type: decimal(10,2))
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -571,12 +571,12 @@ STAGE PLANS:
                   outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
-                    key expressions: _col0 (type: int)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: int)
+                    key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
                     Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: decimal(10,2)), _col2 (type: boolean)
+                    value expressions: _col2 (type: boolean)
 
   Stage: Stage-3
     Dependency Collection

--- a/ql/src/test/results/clientpositive/llap/materialized_view_join_rebuild.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_join_rebuild.q.out
@@ -1,0 +1,108 @@
+PREHOOK: query: create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: query: create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_basetable_n6
+PREHOOK: query: insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: query: insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: Lineage: cmv_basetable_n6.a SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.b SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.c SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.d SCRIPT []
+PREHOOK: query: create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_basetable_2_n3
+PREHOOK: query: insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: Lineage: cmv_basetable_2_n3.a SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.b SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.c SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.d SCRIPT []
+PREHOOK: query: CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: query: CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Lineage: cmv_mat_view_n6.a SIMPLE [(cmv_basetable_n6)cmv_basetable_n6.FieldSchema(name:a, type:int, comment:null), ]
+PREHOOK: query: DELETE from cmv_basetable_2_n3 WHERE a=1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: DELETE from cmv_basetable_2_n3 WHERE a=1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Output: default@cmv_basetable_2_n3
+PREHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Input: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Input: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Lineage: cmv_mat_view_n6.a SIMPLE [(cmv_basetable_n6)cmv_basetable_n6.FieldSchema(name:a, type:int, comment:null), ]
+PREHOOK: query: SELECT * FROM cmv_mat_view_n6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cmv_mat_view_n6
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM cmv_mat_view_n6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cmv_mat_view_n6
+#### A masked pattern was here ####
+3
+3

--- a/ql/src/test/results/clientpositive/llap/materialized_view_repeated_rebuild.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_repeated_rebuild.q.out
@@ -1,0 +1,134 @@
+PREHOOK: query: create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: query: create table cmv_basetable_n6 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_basetable_n6
+PREHOOK: query: insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: query: insert into cmv_basetable_n6 values
+ (1, 'alfred', 10.30, 2),
+ (2, 'bob', 3.14, 3),
+ (2, 'bonnie', 172342.2, 3),
+ (3, 'calvin', 978.76, 3),
+ (3, 'charlie', 9.8, 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: Lineage: cmv_basetable_n6.a SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.b SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.c SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_n6.d SCRIPT []
+PREHOOK: query: create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: create table cmv_basetable_2_n3 (a int, b varchar(256), c decimal(10,2), d int) stored as orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_basetable_2_n3
+PREHOOK: query: insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: insert into cmv_basetable_2_n3 values
+ (1, 'alfred', 10.30, 2),
+ (3, 'calvin', 978.76, 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: Lineage: cmv_basetable_2_n3.a SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.b SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.c SCRIPT []
+POSTHOOK: Lineage: cmv_basetable_2_n3.d SCRIPT []
+PREHOOK: query: CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a, cmv_basetable_2_n3.c
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: query: CREATE MATERIALIZED VIEW cmv_mat_view_n6
+  TBLPROPERTIES ('transactional'='true') AS
+  SELECT cmv_basetable_n6.a, cmv_basetable_2_n3.c
+  FROM cmv_basetable_n6 JOIN cmv_basetable_2_n3 ON (cmv_basetable_n6.a = cmv_basetable_2_n3.a)
+  WHERE cmv_basetable_2_n3.c > 10.0
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Lineage: cmv_mat_view_n6.a SIMPLE [(cmv_basetable_n6)cmv_basetable_n6.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: cmv_mat_view_n6.c SIMPLE [(cmv_basetable_2_n3)cmv_basetable_2_n3.FieldSchema(name:c, type:decimal(10,2), comment:null), ]
+PREHOOK: query: DELETE from cmv_basetable_2_n3 WHERE a=1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Output: default@cmv_basetable_2_n3
+POSTHOOK: query: DELETE from cmv_basetable_2_n3 WHERE a=1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Output: default@cmv_basetable_2_n3
+PREHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Input: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Input: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Lineage: cmv_mat_view_n6.a SIMPLE [(cmv_basetable_n6)cmv_basetable_n6.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: cmv_mat_view_n6.c SIMPLE [(cmv_basetable_2_n3)cmv_basetable_2_n3.FieldSchema(name:c, type:decimal(10,2), comment:null), ]
+PREHOOK: query: DELETE FROM cmv_basetable_n6 WHERE a=1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Output: default@cmv_basetable_n6
+POSTHOOK: query: DELETE FROM cmv_basetable_n6 WHERE a=1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Output: default@cmv_basetable_n6
+PREHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@cmv_basetable_2_n3
+PREHOOK: Input: default@cmv_basetable_n6
+PREHOOK: Input: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+PREHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: query: ALTER MATERIALIZED VIEW cmv_mat_view_n6 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@cmv_basetable_2_n3
+POSTHOOK: Input: default@cmv_basetable_n6
+POSTHOOK: Input: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Output: default@cmv_mat_view_n6
+POSTHOOK: Lineage: cmv_mat_view_n6.a SIMPLE [(cmv_basetable_n6)cmv_basetable_n6.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: cmv_mat_view_n6.c SIMPLE [(cmv_basetable_2_n3)cmv_basetable_2_n3.FieldSchema(name:c, type:decimal(10,2), comment:null), ]
+PREHOOK: query: SELECT * FROM cmv_mat_view_n6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@cmv_mat_view_n6
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM cmv_mat_view_n6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@cmv_mat_view_n6
+#### A masked pattern was here ####
+3	978.76
+3	978.76


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
The incremental MV rebuild plan in presence of delete operations is based on right outer joining the delta result set produced by the MV definition query to the MV.
https://github.com/apache/hive/blob/02851615a2f4ae3fced4edec76c7c4a06f6f63c1/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveJoinInsertDeleteIncrementalRewritingRule.java#L49-L51
Alter this CBO plan generation by projecting a flag on the MV side and use it in the filter of the delete branch when transforming the plan into a multi insert at the optimized AST level.

### Why are the changes needed?
1. Let assume that the MV definition has a join. When records with `join_key = x` is deleted the from only one of the joined tables the result records are also deleted from the MV at rebuild time. Then the records with the same key are deleted the next MV rebuild tries to delete the result records again from the MV but the `ROW_ID` of these records in the MV are no longer available and we end up with `NULL` as `ROW_ID` which leads to NPE.
The reason why these deleted records are appear in the delta is that MV rebuild fetches deleted rows too.

2. The MV rebuild plan have to contain a `Project` on top of the MV scan in order to project the `ROW_ID`. The `ROW_ID` can not be projected this way in the Calcite plan because it is not referenced in parent operators and further optimizations would remove the project. So adding the flag in this project and reference it in the filter condition prevents removal.

### Does this PR introduce _any_ user-facing change?
No exception is thrown in such cases.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_repeated_rebuild.q,materialized_view_join_rebuild.q,materialized_view_create_rewrite_5.q -pl itests/qtest -Pitests
```