### PR TITLE
HIVE-27447: Iceberg: Queries failing due to FileSystem close errors due to column statistics.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -439,7 +439,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     Table table = IcebergTableUtil.getTable(conf, hmsTable.getTTable());
     if (canSetColStatistics(hmsTable)) {
       Path statsPath = getStatsPath(table);
-      try (FileSystem fs = statsPath.getFileSystem(conf)) {
+      try {
+        FileSystem fs = statsPath.getFileSystem(conf);
         if (fs.exists(statsPath)) {
           return true;
         }
@@ -496,12 +497,13 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   }
 
   private void invalidateStats(Path statsPath) {
-    try (FileSystem fs = statsPath.getFileSystem(conf)) {
+    try {
+      FileSystem fs = statsPath.getFileSystem(conf);
       if (fs.exists(statsPath)) {
         fs.delete(statsPath, true);
       }
     } catch (IOException e) {
-      LOG.error("Failed to invalidate stale column stats: {}", e);
+      LOG.error("Failed to invalidate stale column stats: {}", e.getMessage());
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid closing FIleSystem during column statistics stage. FileSystem instance is cached across the service, If we close one and some other thread tries to use that cached FS, it will fail with FS Closed Errors.

Second,
Closing & Recreating a new FS every time is costly, as the FS needs to be initialised every time & hence it shouldn't be closed mid way.

### Why are the changes needed?

Avoid FS Close Errors

### Does this PR introduce _any_ user-facing change?

Queries doesn't fail with FS close error when using column stats source as Iceberg

### Is the change a dependency upgrade?

No