### PR TITLE
HIVE-23831: Introduce a threshold to turn on or off auto-parallelism …

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4764,9 +4764,10 @@ public class HiveConf extends Configuration {
         "Turn on Tez' auto reducer parallelism feature. When enabled, Hive will still estimate data sizes\n" +
         "and set parallelism estimates. Tez will sample source vertices' output sizes and adjust the estimates at runtime as\n" +
         "necessary."),
-    TEZ_AUTO_REDUCER_PARALLELISM_THRESHOLD("hive.tez.auto.reducer.parallelism.threshold", 8,
-        "Hive on Tez enables auto reducer parallelism when the maximum parallelism is greater than or equal to this\n" +
-        "value. This is effective only when hive.tez.auto.reducer.parallelism is true."),
+    TEZ_AUTO_REDUCER_PARALLELISM_MIN_THRESHOLD("hive.tez.auto.reducer.parallelism.min.threshold", 1.0f,
+        "Hive on Tez disables auto reducer parallelism if # of reducers * hive.tez.min.partition.factor is smaller\n" +
+        "than this value. This helps to avoid overhead when the potential impact of auto reducer parallelism is not\n" +
+        "significant. This is effective only when hive.tez.auto.reducer.parallelism is true."),
     TEZ_LLAP_MIN_REDUCER_PER_EXECUTOR("hive.tez.llap.min.reducer.per.executor", 0.33f,
         "If above 0, the min number of reducers for auto-parallelism for LLAP scheduling will\n" +
         "be set to this fraction of the number of executors."),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4764,6 +4764,9 @@ public class HiveConf extends Configuration {
         "Turn on Tez' auto reducer parallelism feature. When enabled, Hive will still estimate data sizes\n" +
         "and set parallelism estimates. Tez will sample source vertices' output sizes and adjust the estimates at runtime as\n" +
         "necessary."),
+    TEZ_AUTO_REDUCER_PARALLELISM_THRESHOLD("hive.tez.auto.reducer.parallelism.threshold", 8,
+        "Hive on Tez enables auto reducer parallelism when the maximum parallelism is greater than or equal to this\n" +
+        "value. This is effective only when hive.tez.auto.reducer.parallelism is true."),
     TEZ_LLAP_MIN_REDUCER_PER_EXECUTOR("hive.tez.llap.min.reducer.per.executor", 0.33f,
         "If above 0, the min number of reducers for auto-parallelism for LLAP scheduling will\n" +
         "be set to this fraction of the number of executors."),

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -130,8 +130,8 @@ public class GenTezUtils {
       maxPartition = (maxPartition > maxReducers) ? maxReducers : maxPartition;
 
       // reduce only if the parameters are significant
-      final int parallelismThreshold = context.conf.getIntVar(HiveConf.ConfVars.TEZ_AUTO_REDUCER_PARALLELISM_THRESHOLD);
-      if (minPartition < maxPartition && maxPartition >= parallelismThreshold) {
+      final float minThreshold = context.conf.getFloatVar(HiveConf.ConfVars.TEZ_AUTO_REDUCER_PARALLELISM_MIN_THRESHOLD);
+      if (minPartition < maxPartition && nReducers * minPartitionFactor >= minThreshold) {
         reduceWork.setAutoReduceParallelism(true);
 
         reduceWork.setMinReduceTasks(minPartition);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -130,8 +130,8 @@ public class GenTezUtils {
       maxPartition = (maxPartition > maxReducers) ? maxReducers : maxPartition;
 
       // reduce only if the parameters are significant
-      if (minPartition < maxPartition &&
-          nReducers * minPartitionFactor >= 1.0) {
+      final int parallelismThreshold = context.conf.getIntVar(HiveConf.ConfVars.TEZ_AUTO_REDUCER_PARALLELISM_THRESHOLD);
+      if (minPartition < maxPartition && maxPartition >= parallelismThreshold) {
         reduceWork.setAutoReduceParallelism(true);
 
         reduceWork.setMinReduceTasks(minPartition);


### PR DESCRIPTION
…of Tez

### What changes were proposed in this pull request?

This PR adds a new threshold to enable/disable auto reducer parallelism based on the potential reduction.
https://issues.apache.org/jira/browse/HIVE-23831

### Why are the changes needed?

We introduced a heuristics to disable auto reducer parallelism in [HIVE-14200](https://issues.apache.org/jira/browse/HIVE-14200) when `{# of tasks} * {hive.tez.min.partition.factor}` is smaller than 1.0. It takes effect when the estimated number is smaller than 4 by default because the default `hive.tez.min.partition.factor` is 0.25.

For example, if the estimated number is equal to 4, Tez tunes the final number between 1 and 8 because the minimum number can be 4 * 0.25 = 1.0, and the maximum number can be 4 * 2.0 = 8 as the default `hive.tez.max.partition.factor` is 2.0.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=150
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/8	
INFO  : Map 1: 1/1	Reducer 2: 2/2
```

If the estimated number is 3, Tez doesn't apply auto-reducer parallelism because `{# of tasks} * {hive.tez.min.partition.factor}` = `3 * 0.25` is smaller than 1.0.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=200
...
INFO  : Map 1: 1/1	Reducer 2: 0(+1)/6	
INFO  : Map 1: 1/1	Reducer 2: 6/6
```

I understand we introduced [HIVE-14200](https://issues.apache.org/jira/browse/HIVE-14200) so that Hive on Tez can avoid overhead when the possible reduction is small. However, I know `{# of tasks} * {hive.tez.min.partition.factor} < 1.0` is a little overfitting the default values of `hive.tez.min.partition.factor` and `hive.tez.max.partition.factor`. For example, when we configure `hive.tez.min.partition.factor=0.05`, auto reducer parallelism is disabled when # of tasks is 19 or less. It means Hive on Tez misses a chance to tune parallelism between 1 and 38 in the worst case. I expect the case is worth trying auto reducer parallelism.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=30 --hiveconf hive.tez.min.partition.factor=0.05
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/34	
INFO  : Map 1: 1/1	Reducer 2: 1(+1)/34	
INFO  : Map 1: 1/1	Reducer 2: 13(+0)/34
```

I guess a similar issue can happen when we give big `hive.tez.max.partition.factor`.

### Does this PR introduce _any_ user-facing change?

Yes if a user already configures `hive.tez.min.partition.factor` or `hive.tez.max.partition.factor`. If not, the behavior doesn't change.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

I tested it on my local machine.

No behaviors change with default parameters.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=150
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/8	
INFO  : Map 1: 1/1	Reducer 2: 0(+1)/2	
...
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=200
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/6	
INFO  : Map 1: 1/1	Reducer 2: 1(+1)/6
```

We can tune the new threshold to trigger auto reducer parallelism.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=200 --hiveconf hive.tez.auto.reducer.parallelism.min.threshold=0.5
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/6	
INFO  : Map 1: 1/1	Reducer 2: 2/2
```

Auto reducer parallelism can be enabled even when `hive.tez.min.partition.factor` is very small.

```
$ beeline -e 'SELECT item_id, sum(price) FROM orders GROUP BY item_id' --hiveconf hive.server2.in.place.progress=false --hiveconf hive.tez.auto.reducer.parallelism=true --hiveconf hive.exec.reducers.bytes.per.reducer=30 --hiveconf hive.tez.min.partition.factor=0.05 --hiveconf hive.tez.auto.reducer.parallelism.min.threshold=0.5
...
INFO  : Map 1: 0(+1)/1	Reducer 2: 0/34	
INFO  : Map 1: 1/1	Reducer 2: 1(+1)/12
```