### PR TITLE
HIVE-27450: Fix for CVE-2023-34455 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <tez.version>0.10.2</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>
-    <snappy.version>1.1.8.4</snappy.version>
+    <snappy.version>1.1.10.1</snappy.version>
     <wadl-resourcedoc-doclet.version>1.4</wadl-resourcedoc-doclet.version>
     <velocity.version>2.3</velocity.version>
     <xerces.version>2.12.2</xerces.version>


### PR DESCRIPTION
1. Updated snappy-java version to 1.1.10.1 to fix CVE-2023-34455
JIRA: [https://issues.apache.org/jira/browse/HIVE-27450](url)