### PR TITLE
HIVE-27456: Updated spring.framework version for CVE-2016-1000027

### DIFF
--- a/testutils/ptest2/pom.xml
+++ b/testutils/ptest2/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4j2.version>2.17.1</log4j2.version>
-    <spring.framework.version>3.2.16.RELEASE</spring.framework.version>
+    <spring.framework.version>6.0.0</spring.framework.version>
     <jclouds.version>2.0.0</jclouds.version>
     <checkstyle.conf.dir>${basedir}/../../checkstyle/</checkstyle.conf.dir>
     <maven.checkstyle.plugin.version>2.12.1</maven.checkstyle.plugin.version>


### PR DESCRIPTION
Upgraded spring framework version to 6.0.0 
This change is required for CVE-2016-1000027 fix [https://nvd.nist.gov/vuln/detail/CVE-2016-1000027](url)
JIRA: [https://issues.apache.org/jira/browse/HIVE-27456](url)