### PR TITLE
HIVE-12679: Allow users to be able to specify an implementation of IMetaStoreClient via HiveConf

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -889,9 +889,6 @@ public class HiveConf extends Configuration {
     HADOOPNUMREDUCERS("mapreduce.job.reduces", -1, "", true),
 
     // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
-    METASTORE_CLIENT_FACTORY_CLASS("hive.metastore.client.factory.class",
-        "org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClientFactory",
-        "The name of the factory class that produces objects implementing the IMetaStoreClient interface."),
     METASTOREDBTYPE("hive.metastore.db.type", "DERBY", new StringSet("DERBY", "ORACLE", "MYSQL", "MSSQL", "POSTGRES"),
         "Type of database used by the metastore. Information schema & JDBCStorageHandler depend on it."),
     /**

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -889,6 +889,9 @@ public class HiveConf extends Configuration {
     HADOOPNUMREDUCERS("mapreduce.job.reduces", -1, "", true),
 
     // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
+    METASTORE_CLIENT_FACTORY_CLASS("hive.metastore.client.factory.class",
+        "org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClientFactory",
+        "The name of the factory class that produces objects implementing the IMetaStoreClient interface."),
     METASTOREDBTYPE("hive.metastore.db.type", "DERBY", new StringSet("DERBY", "ORACLE", "MYSQL", "MSSQL", "POSTGRES"),
         "Type of database used by the metastore. Information schema & JDBCStorageHandler depend on it."),
     /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -236,6 +236,7 @@ import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hive.common.util.HiveVersionInfo;
 import org.apache.thrift.TException;
 import org.apache.thrift.TApplicationException;
@@ -5700,11 +5701,25 @@ private void constructOneLBLocationMap(FileStatus fSta,
       }
     };
 
-    if (conf.getBoolVar(ConfVars.METASTORE_FASTPATH)) {
-      return new SessionHiveMetaStoreClient(conf, hookLoader, allowEmbedded);
-    } else {
-      return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
-          SessionHiveMetaStoreClient.class.getName(), allowEmbedded);
+    return createMetaStoreClientFactory(conf)
+        .createMetaStoreClient(conf, hookLoader, allowEmbedded, metaCallTimeMap);
+  }
+
+  private static HiveMetaStoreClientFactory createMetaStoreClientFactory(HiveConf conf) throws
+          MetaException {
+    String metaStoreClientFactoryClassName = conf.getVar(HiveConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS);
+
+    try {
+      Class<? extends HiveMetaStoreClientFactory> factoryClass =
+              conf.getClassByName(metaStoreClientFactoryClassName)
+                      .asSubclass(HiveMetaStoreClientFactory.class);
+      return ReflectionUtils.newInstance(factoryClass, conf);
+    } catch (Exception e) {
+      String errorMessage = String.format(
+              "Unable to instantiate a metastore client factory %s due to: %s",
+              metaStoreClientFactoryClassName, e);
+      LOG.error(errorMessage, e);
+      throw new MetaException(errorMessage);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.UpdateTransactionalStatsRequest;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
 import org.apache.hadoop.hive.ql.io.HdfsUtils;
 import org.apache.hadoop.hive.metastore.HiveMetaException;
@@ -123,7 +124,6 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.SynchronizedMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -5707,7 +5707,8 @@ private void constructOneLBLocationMap(FileStatus fSta,
 
   private static HiveMetaStoreClientFactory createMetaStoreClientFactory(HiveConf conf) throws
           MetaException {
-    String metaStoreClientFactoryClassName = conf.getVar(HiveConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS);
+    String metaStoreClientFactoryClassName = MetastoreConf.getVar(conf,
+        MetastoreConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS);
 
     try {
       Class<? extends HiveMetaStoreClientFactory> factoryClass =

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.metadata;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+/**
+ * Abstract factory that defines an interface for other factories that produce concrete
+ * MetaStoreClient objects.
+ *
+ */
+public interface HiveMetaStoreClientFactory {
+
+  /**
+   * A method for producing IMetaStoreClient objects.
+   *
+   * The implementation returned by this method must throw a MetaException if allowEmbedded = true
+   * and it does not support embedded mode.
+   *
+   * @param conf
+   *          Hive Configuration.
+   * @param hookLoader
+   *          Hook for handling events related to tables.
+   * @param allowEmbedded
+   *          Flag indicating the implementation must run in-process, e.g. for unit testing or
+   *          "fast path".
+   * @param metaCallTimeMap
+   *          A container for storing entry and exit timestamps of IMetaStoreClient method
+   *          invocations.
+   * @return IMetaStoreClient An implementation of IMetaStoreClient.
+   * @throws MetaException
+   */
+  IMetaStoreClient createMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader,
+      boolean allowEmbedded, ConcurrentHashMap<String, Long> metaCallTimeMap) throws MetaException;
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
@@ -48,7 +48,7 @@ public interface HiveMetaStoreClientFactory {
    *          A container for storing entry and exit timestamps of IMetaStoreClient method
    *          invocations.
    * @return IMetaStoreClient An implementation of IMetaStoreClient.
-   * @throws MetaException
+   * @throws MetaException if this method fails to create IMetaStoreClient
    */
   IMetaStoreClient createMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader,
       boolean allowEmbedded, ConcurrentHashMap<String, Long> metaCallTimeMap) throws MetaException;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClientFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.metadata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+/**
+ * Default MetaStoreClientFactory for Hive which produces SessionHiveMetaStoreClient objects.
+ *
+ */
+public final class SessionHiveMetaStoreClientFactory implements HiveMetaStoreClientFactory {
+
+  @Override
+  public IMetaStoreClient createMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader,
+      boolean allowEmbedded,
+      ConcurrentHashMap<String, Long> metaCallTimeMap) throws MetaException {
+
+    checkNotNull(conf, "conf cannot be null!");
+    checkNotNull(hookLoader, "hookLoader cannot be null!");
+    checkNotNull(metaCallTimeMap, "metaCallTimeMap cannot be null!");
+
+    if (conf.getBoolVar(ConfVars.METASTORE_FASTPATH)) {
+      return new SessionHiveMetaStoreClient(conf, hookLoader, allowEmbedded);
+    } else {
+      return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
+          SessionHiveMetaStoreClient.class.getName(), allowEmbedded);
+    }
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.hive.ql.metadata;
 
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -38,7 +40,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+<<<<<<< HEAD
 import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
+=======
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+>>>>>>> 1558b1ad12 (HIVE-12679: Allow users to be able to specify an implementation of IMetaStoreClient via HiveConf)
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -890,6 +896,7 @@ public class TestHive {
     assertTrue(prevHiveObj != newHiveObj);
   }
 
+<<<<<<< HEAD
   public void testFireInsertEvent() throws Throwable {
     Hive hiveDb = Hive.getWithFastCheck(hiveConf, false);
     String tableName = "test_fire_insert_event";
@@ -953,6 +960,44 @@ public class TestHive {
     return "";
   }
 
+=======
+  @Test
+  public void testLoadingHiveMetaStoreClientFactory() throws Throwable {
+    String factoryClassName = SessionHiveMetaStoreClientFactory.class.getName();
+    HiveConf conf = new HiveConf();
+    conf.setVar(ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
+    // Make sure we instantiate the embedded version
+    // so the implementation chosen is SessionHiveMetaStoreClient, not a retryable version of it.
+    conf.setBoolVar(ConfVars.METASTORE_FASTPATH, true);
+    // The current object was constructed in setUp() before we got here
+    // so clean that up so we can inject our own dummy implementation of IMetaStoreClient
+    Hive.closeCurrent();
+    Hive hive = Hive.get(conf);
+    IMetaStoreClient tmp = hive.getMSC();
+    assertNotNull("getMSC() failed.", tmp);
+    assertThat("Invalid default client implementation created.", tmp,
+        instanceOf(SessionHiveMetaStoreClient.class));
+  }
+
+  @Test
+  public void testLoadingInvalidHiveMetaStoreClientFactory() throws Throwable {
+    // Intentionally invalid class
+    String factoryClassName = String.class.getName();
+    HiveConf conf = new HiveConf();
+    conf.setVar(HiveConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
+    // The current object was constructed in setUp() before we got here
+    // so clean that up so we can inject our own dummy implementation of IMetaStoreClient
+    Hive.closeCurrent();
+    Hive hive = Hive.get(conf);
+    try {
+      hive.getMSC();
+      fail("getMSC() was expected to throw MetaException.");
+    } catch (Exception e) {
+      assertTrue("getMSC() failed, which IS expected.", true);
+    }
+  }
+
+>>>>>>> 1558b1ad12 (HIVE-12679: Allow users to be able to specify an implementation of IMetaStoreClient via HiveConf)
   // shamelessly copied from Path in hadoop-2
   private static final String SEPARATOR = "/";
   private static final char SEPARATOR_CHAR = '/';

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -960,7 +960,7 @@ public class TestHive {
   public void testLoadingHiveMetaStoreClientFactory() throws Throwable {
     String factoryClassName = SessionHiveMetaStoreClientFactory.class.getName();
     HiveConf conf = new HiveConf();
-    conf.setVar(ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
     // Make sure we instantiate the embedded version
     // so the implementation chosen is SessionHiveMetaStoreClient, not a retryable version of it.
     conf.setBoolVar(ConfVars.METASTORE_FASTPATH, true);
@@ -979,7 +979,7 @@ public class TestHive {
     // Intentionally invalid class
     String factoryClassName = String.class.getName();
     HiveConf conf = new HiveConf();
-    conf.setVar(HiveConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
+    MetastoreConf.setVar(conf, MetastoreConf.ConfVars.METASTORE_CLIENT_FACTORY_CLASS, factoryClassName);
     // The current object was constructed in setUp() before we got here
     // so clean that up so we can inject our own dummy implementation of IMetaStoreClient
     Hive.closeCurrent();

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -40,11 +40,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-<<<<<<< HEAD
-import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
-=======
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
->>>>>>> 1558b1ad12 (HIVE-12679: Allow users to be able to specify an implementation of IMetaStoreClient via HiveConf)
+import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -896,7 +893,6 @@ public class TestHive {
     assertTrue(prevHiveObj != newHiveObj);
   }
 
-<<<<<<< HEAD
   public void testFireInsertEvent() throws Throwable {
     Hive hiveDb = Hive.getWithFastCheck(hiveConf, false);
     String tableName = "test_fire_insert_event";
@@ -960,7 +956,6 @@ public class TestHive {
     return "";
   }
 
-=======
   @Test
   public void testLoadingHiveMetaStoreClientFactory() throws Throwable {
     String factoryClassName = SessionHiveMetaStoreClientFactory.class.getName();
@@ -997,7 +992,6 @@ public class TestHive {
     }
   }
 
->>>>>>> 1558b1ad12 (HIVE-12679: Allow users to be able to specify an implementation of IMetaStoreClient via HiveConf)
   // shamelessly copied from Path in hadoop-2
   private static final String SEPARATOR = "/";
   private static final char SEPARATOR_CHAR = '/';

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -185,6 +185,7 @@ public class MetastoreConf {
       ConfVars.KERBEROS_PRINCIPAL,
       ConfVars.USE_THRIFT_SASL,
       ConfVars.METASTORE_CLIENT_AUTH_MODE,
+      ConfVars.METASTORE_CLIENT_FACTORY_CLASS,
       ConfVars.METASTORE_CLIENT_PLAIN_USERNAME,
       ConfVars.CACHE_PINOBJTYPES,
       ConfVars.CONNECTION_POOLING_TYPE,
@@ -1609,6 +1610,10 @@ public class MetastoreConf {
                     " and password. Any other value is ignored right now but may be used later."
                 + "If JWT- Supported only in HTTP transport mode. If set, HMS Client will pick the value of JWT from "
                 + "environment variable HMS_JWT and set it in Authorization header in http request"),
+    METASTORE_CLIENT_FACTORY_CLASS("metastore.client.factory.class",
+        "hive.metastore.client.factory.class",
+        "org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClientFactory",
+        "The name of the factory class that produces objects implementing the IMetaStoreClient interface."),
     METASTORE_CLIENT_ADDITIONAL_HEADERS("metastore.client.http.additional.headers",
         "hive.metastore.client.http.additional.headers", "",
         "Comma separated list of headers which are passed to the metastore service in the http headers"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make it possible to replace the default IMetaStoreClient with a custom one.

It is the third time to try to send this patch. Austin originally opened [HIVE-12679](https://issues.apache.org/jira/browse/HIVE-12679) in 2016, and @moomindani tried to send his patch in #1402, and then I took over it again.

### Why are the changes needed?

In some environments, we want to connect to another data catalog rather than the native Hive Metastore. Looks like, [AWS Glue Data Catalog](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/branch-3.4.0/aws-glue-datacatalog-hive3-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java) is one of the cases. We also have a similar case for some historical reasons.

As we can see, more than 40 people are watching [HIVE-12679](https://issues.apache.org/jira/browse/HIVE-12679), and some of them have asked us about the progress of this ticket. I'm sure it is worth maintaining this feature.

### Does this PR introduce _any_ user-facing change?

This doesn't change the original behavior at all.

### Is the change a dependency upgrade?
No

### How was this patch tested?
I tested HiveServer2 still works with this patch.