### PR TITLE
HIVE-27458: Support HCatStorer and HCatLoader for Iceberg tables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
           java-version: 8
       - name: 'Build project'
         run: |
-          mvn clean install -DskipTests -Pitests
+          mvn clean install -DskipTests -Pitests,iceberg

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -75,6 +75,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-handler</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- inter-project -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
+import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
@@ -79,6 +80,8 @@ import org.apache.hive.hcatalog.mapreduce.StorerInfo;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils.setWriteOperation;
 
 public class HCatUtil {
 
@@ -526,9 +529,16 @@ public class HCatUtil {
           }
         }
       }
+      // Commit Iceberg job in Tez AM
+      String outputCommitter = jobProperties.get("mapred.output.committer.class");
+      if (outputCommitter != null && outputCommitter.contains("HiveIcebergNoJobCommitter")) {
+        jobProperties.put("mapred.output.committer.class", "org.apache.iceberg.mr.hive.HiveIcebergOutputCommitter");
+      }
       for (Map.Entry<String, String> el : jobProperties.entrySet()) {
         conf.set(el.getKey(), el.getValue());
       }
+      setWriteOperation(conf, tableDesc.getFullTableName(), Context.Operation.OTHER);
+      conf.set(HiveConf.ConfVars.HIVEQUERYID.varname, "PIG-QUERY");
     } catch (IOException e) {
       throw new IllegalStateException(
         "Failed to configure StorageHandler", e);

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
@@ -117,7 +117,8 @@ public class HCatOutputFormat extends HCatBaseOutputFormat {
       if ((idHash = conf.get(HCatConstants.HCAT_OUTPUT_ID_HASH)) == null) {
         idHash = String.valueOf(df.format(Math.random()));
       }
-      conf.set(HCatConstants.HCAT_OUTPUT_ID_HASH,idHash);
+      conf.set(HCatConstants.HCAT_OUTPUT_ID_HASH, idHash);
+      conf.set("iceberg.output.id", idHash);
 
       if (table.getTTable().getPartitionKeysSize() == 0) {
         if ((outputJobInfo.getPartitionValues() != null) && (!outputJobInfo.getPartitionValues().isEmpty())) {

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatBaseTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatBaseTest.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hive.hcatalog.common.HCatUtil;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.pig.ExecType;
 import org.apache.pig.PigServer;
 import org.apache.pig.backend.executionengine.ExecException;
@@ -74,6 +75,15 @@ public abstract class HCatBaseTest {
     }
   }
 
+  // Iceberg tables store table and partition information in SessionState and uses it as a Cache.
+  // Driver needs to be refreshed to clear the cache and obtain changes made by Pig server.
+  public void refreshDriver() throws Exception {
+    if (driver != null) {
+      driver.close();
+    }
+    driver = DriverFactory.newDriver(hiveConf);
+  }
+
   /**
    * Create a new HiveConf and set properties necessary for unit tests.
    */
@@ -98,6 +108,7 @@ public abstract class HCatBaseTest {
     hiveConf
     .setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
         "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+    hiveConf.setBoolean(InputFormatConfig.SCHEMA_AUTO_CONVERSION, true);
   }
 
   protected void logAndRegister(PigServer server, String query) throws IOException {

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -135,6 +135,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-iceberg-handler</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- test inter-project -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestE2EScenarios.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestE2EScenarios.java
@@ -113,8 +113,7 @@ public class TestE2EScenarios {
 
   private void createTable(String tablename, String schema, String partitionedBy, String storageFormat)
       throws Exception {
-    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver,
-            storageFormat);
+    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver, storageFormat, false);
   }
 
   private void driverRun(String cmd) throws Exception {

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderComplexSchema.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderComplexSchema.java
@@ -96,7 +96,7 @@ public class TestHCatLoaderComplexSchema {
   }
 
   private void createTable(String tablename, String schema, String partitionedBy) throws Exception {
-    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver, storageFormat);
+    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver, storageFormat, false);
   }
 
   private void createTable(String tablename, String schema) throws Exception {

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderStorer.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatLoaderStorer.java
@@ -66,7 +66,7 @@ public class TestHCatLoaderStorer extends HCatBaseTest {
       dataDir.toURI().getPath() + "'", driver);
     AbstractHCatLoaderTest.dropTable(tblName2, driver);
     AbstractHCatLoaderTest.createTableDefaultDB(tblName2, "my_small_int smallint, " +
-            "my_tiny_int " + "tinyint", null, driver, "textfile");
+            "my_tiny_int " + "tinyint", null, driver, "textfile", false);
 
     LOG.debug("File=" + INPUT_FILE_NAME);
     TestHCatStorer.dumpFile(INPUT_FILE_NAME);

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatStorerMulti.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestHCatStorerMulti.java
@@ -82,7 +82,7 @@ public class TestHCatStorerMulti {
   }
 
   private void createTable(String tablename, String schema, String partitionedBy) throws Exception {
-    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver, storageFormat);
+    AbstractHCatLoaderTest.createTableDefaultDB(tablename, schema, partitionedBy, driver, storageFormat, false);
   }
 
   private void createTable(String tablename, String schema) throws Exception {

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestIcebergHCatLoader.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestIcebergHCatLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hive.hcatalog.pig;
+
+import org.apache.hadoop.hive.ql.io.IOConstants;
+import org.junit.After;
+import org.junit.Ignore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestIcebergHCatLoader extends AbstractHCatLoaderTest {
+    static Logger LOG = LoggerFactory.getLogger(TestIcebergHCatLoader.class);
+    @Override
+    String getStorageFormat() {
+        return IOConstants.ORC;
+    }
+
+    @Override
+    public boolean isIcebergTable() {
+        return true;
+    }
+
+    @Override
+    @Ignore("Invalid for Iceberg table. Table size includes metadata file size")
+    public void testGetInputBytesMultipleTables() throws Exception { }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        refreshDriver();
+    }
+}

--- a/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestIcebergHCatStorer.java
+++ b/hcatalog/hcatalog-pig-adapter/src/test/java/org/apache/hive/hcatalog/pig/TestIcebergHCatStorer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hive.hcatalog.pig;
+
+import org.apache.hadoop.hive.ql.io.IOConstants;
+import org.junit.After;
+import org.junit.Ignore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestIcebergHCatStorer extends AbstractHCatStorerTest {
+    static Logger LOG = LoggerFactory.getLogger(TestIcebergHCatStorer.class);
+
+    @Override
+    String getStorageFormat() {
+        return IOConstants.ORCFILE;
+    }
+
+    @Override
+    public boolean isIcebergTable() {
+        return true;
+    }
+
+    @Override
+    @Ignore("TODO: PIG-5442 bug needs to be fixed to support multi table write")
+    public void testStoreMultiTables() throws Exception { }
+
+    @Override
+    @Ignore("TODO: A single vertex cannot write to same table multiple times")
+    public void testMultiPartColsInData() throws Exception { }
+
+    @Override
+    @Ignore("Show partitions does not work on Iceberg tables")
+    public void testPartitionPublish() throws Exception { }
+
+    @Override
+    @Ignore("Data type not supported by Iceberg")
+    public void testWriteTinyint() throws Exception { }
+
+    @Override
+    @Ignore("Data type not supported by Iceberg")
+    public void testWriteSmallint() throws Exception { }
+
+    @Override
+    @Ignore("Data type not supported by Iceberg")
+    public void testWriteVarchar() throws Exception { }
+
+    @Override
+    @Ignore("Data type not supported by Iceberg")
+    public void testWriteChar() throws Exception { }
+
+    @After
+    public void tearDown() throws Exception {
+        refreshDriver();
+    }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -116,8 +116,9 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
     TaskAttemptID attemptID = context.getTaskAttemptID();
     JobConf jobConf = context.getJobConf();
+    String outputId = jobConf.get(HiveIcebergOutputFormat.ICEBERG_OUTPUT_ID);
     Set<String> outputs = HiveIcebergStorageHandler.outputTables(context.getJobConf());
-    Map<String, List<HiveIcebergWriter>> writers = Optional.ofNullable(WriterRegistry.writers(attemptID))
+    Map<String, List<HiveIcebergWriter>> writers = Optional.ofNullable(WriterRegistry.writers(attemptID, outputId))
         .orElseGet(() -> {
           LOG.info("CommitTask found no writers for output tables: {}, attemptID: {}", outputs, attemptID);
           return ImmutableMap.of();
@@ -162,7 +163,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
     }
 
     // remove the writer to release the object
-    WriterRegistry.removeWriters(attemptID);
+    WriterRegistry.removeWriters(attemptID, outputId);
   }
 
   /**
@@ -175,7 +176,8 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
     TaskAttemptContext context = TezUtil.enrichContextWithAttemptWrapper(originalContext);
 
     // Clean up writer data from the local store
-    Map<String, List<HiveIcebergWriter>> writerMap = WriterRegistry.removeWriters(context.getTaskAttemptID());
+    Map<String, List<HiveIcebergWriter>> writerMap = WriterRegistry.removeWriters(context.getTaskAttemptID(),
+            originalContext.getJobConf().get(HiveIcebergOutputFormat.ICEBERG_OUTPUT_ID));
 
     // Remove files if it was not done already
     if (writerMap != null) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -45,6 +45,8 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     HiveOutputFormat<NullWritable, Container<Record>> {
   private static final String DELETE_FILE_THREAD_POOL_SIZE = "iceberg.delete.file.thread.pool.size";
   private static final int DELETE_FILE_THREAD_POOL_SIZE_DEFAULT = 10;
+  // There can be multiple MROutput present for a single operator
+  public static final String ICEBERG_OUTPUT_ID = "iceberg.output.id";
 
   @Override
   public FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jc, Path finalOutPath, Class valueClass,
@@ -75,6 +77,7 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
         .queryId(jc.get(HiveConf.ConfVars.HIVEQUERYID.varname))
         .tableName(tableName)
         .attemptID(taskAttemptID)
+        .outputId(jc.get(ICEBERG_OUTPUT_ID))
         .poolSize(poolSize)
         .operation(HiveCustomStorageHandlerUtils.getWriteOperation(jc, tableName))
         .build();

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -166,8 +166,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergStorageHandler.class);
 
   private static final String ICEBERG_URI_PREFIX = "iceberg://";
-  private static final Splitter TABLE_NAME_SPLITTER = Splitter.on("..");
   private static final String TABLE_NAME_SEPARATOR = "..";
+  private static final Splitter TABLE_NAME_SPLITTER = Splitter.on(TABLE_NAME_SEPARATOR);
   // Column index for partition metadata table
   private static final int SPEC_IDX = 1;
   private static final int PART_IDX = 0;
@@ -247,11 +247,14 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     map.put("mapred.output.committer.class", HiveIcebergNoJobCommitter.class.getName());
     // For MR, the jobConf is set only in configureJobConf, so we're setting the write key here to detect it over there
     String opType = getOperationType();
-    map.put(InputFormatConfig.OPERATION_TYPE_PREFIX + tableDesc.getTableName(), opType);
+    String tableName = tableDesc.getTableName();
+    map.put(InputFormatConfig.OPERATION_TYPE_PREFIX + tableName, opType);
+    String existingOutputTables = map.get(InputFormatConfig.OUTPUT_TABLES);
+    map.put(InputFormatConfig.OUTPUT_TABLES, getOutputTables(tableName, existingOutputTables));
     // Putting the key into the table props as well, so that projection pushdown can be determined on a
     // table-level and skipped only for output tables in HiveIcebergSerde. Properties from the map will be present in
     // the serde config for all tables in the query, not just the output tables, so we can't rely on that in the serde.
-    tableDesc.getProperties().put(InputFormatConfig.OPERATION_TYPE_PREFIX + tableDesc.getTableName(), opType);
+    tableDesc.getProperties().put(InputFormatConfig.OPERATION_TYPE_PREFIX + tableName, opType);
   }
 
   /**
@@ -288,9 +291,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       jobConf.set(opKey, tableDesc.getProperties().getProperty(opKey));
       Preconditions.checkArgument(!tableName.contains(TABLE_NAME_SEPARATOR),
           "Can not handle table " + tableName + ". Its name contains '" + TABLE_NAME_SEPARATOR + "'");
-      String tables = jobConf.get(InputFormatConfig.OUTPUT_TABLES);
-      tables = tables == null ? tableName : tables + TABLE_NAME_SEPARATOR + tableName;
-      jobConf.set(InputFormatConfig.OUTPUT_TABLES, tables);
+      String existingOutputTables = jobConf.get(InputFormatConfig.OUTPUT_TABLES);
+      jobConf.set(InputFormatConfig.OUTPUT_TABLES, getOutputTables(tableName, existingOutputTables));
 
       String catalogName = tableDesc.getProperties().getProperty(InputFormatConfig.CATALOG_NAME);
       if (catalogName != null) {
@@ -305,6 +307,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       }
     } catch (IOException e) {
       Throwables.propagate(e);
+    }
+  }
+
+  private static String getOutputTables(String outputTable, String existingOutputTables) {
+    if (existingOutputTables == null) {
+      return outputTable;
+    } else {
+      return TABLE_NAME_SPLITTER.splitToStream(existingOutputTables).anyMatch(x -> x.equals(outputTable)) ?
+              existingOutputTables : existingOutputTables + TABLE_NAME_SEPARATOR + outputTable;
     }
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterBuilder.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterBuilder.java
@@ -41,6 +41,7 @@ public class WriterBuilder {
   private final Table table;
   private String tableName;
   private TaskAttemptID attemptID;
+  private String outputId;
   private String queryId;
   private int poolSize;
   private Operation operation;
@@ -66,6 +67,11 @@ public class WriterBuilder {
 
   public WriterBuilder attemptID(TaskAttemptID newAttemptID) {
     this.attemptID = newAttemptID;
+    return this;
+  }
+
+  public WriterBuilder outputId(String identifier) {
+    this.outputId = identifier;
     return this;
   }
 
@@ -136,7 +142,7 @@ public class WriterBuilder {
                 operation.name());
     }
 
-    WriterRegistry.registerWriter(attemptID, tableName, writer);
+    WriterRegistry.registerWriter(attemptID, outputId, tableName, writer);
     return writer;
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java
@@ -21,31 +21,63 @@ package org.apache.iceberg.mr.hive.writer;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class WriterRegistry {
-  private static final Map<TaskAttemptID, Map<String, List<HiveIcebergWriter>>> writers = Maps.newConcurrentMap();
+  private static final Map<WriterKey, Map<String, List<HiveIcebergWriter>>> writers = Maps.newConcurrentMap();
 
   private WriterRegistry() {
   }
 
-  public static Map<String, List<HiveIcebergWriter>> removeWriters(TaskAttemptID taskAttemptID) {
-    return writers.remove(taskAttemptID);
+  public static Map<String, List<HiveIcebergWriter>> removeWriters(TaskAttemptID taskAttemptID, String outputId) {
+    return writers.remove(new WriterKey(taskAttemptID, outputId));
   }
 
-  public static void registerWriter(TaskAttemptID taskAttemptID, String tableName, HiveIcebergWriter writer) {
-    writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());
+  public static void registerWriter(TaskAttemptID taskAttemptID,
+                                    String outputId,
+                                    String tableName,
+                                    HiveIcebergWriter writer) {
+    WriterKey key = new WriterKey(taskAttemptID, outputId);
+    writers.putIfAbsent(key, Maps.newConcurrentMap());
 
-    Map<String, List<HiveIcebergWriter>> writersOfTableMap = writers.get(taskAttemptID);
+    Map<String, List<HiveIcebergWriter>> writersOfTableMap = writers.get(key);
     writersOfTableMap.putIfAbsent(tableName, Lists.newArrayList());
 
     List<HiveIcebergWriter> writerList = writersOfTableMap.get(tableName);
     writerList.add(writer);
   }
 
-  public static Map<String, List<HiveIcebergWriter>> writers(TaskAttemptID taskAttemptID) {
-    return writers.get(taskAttemptID);
+  public static Map<String, List<HiveIcebergWriter>> writers(TaskAttemptID taskAttemptID, String outputId) {
+    return writers.get(new WriterKey(taskAttemptID, outputId));
+  }
+
+  static class WriterKey {
+    private final TaskAttemptID taskAttemptID;
+    private final String outputId;
+
+    WriterKey(TaskAttemptID taskAttemptID, String outputId) {
+      this.taskAttemptID = taskAttemptID;
+      this.outputId = outputId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      WriterKey writerKey = (WriterKey) o;
+      return taskAttemptID.equals(writerKey.taskAttemptID) && Objects.equals(outputId, writerKey.outputId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(taskAttemptID, outputId);
+    }
   }
 }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -207,10 +207,10 @@ public class TestHiveIcebergOutputCommitter {
     Assert.assertEquals(1, argumentCaptor.getAllValues().size());
     TaskAttemptID capturedId = TezUtil.taskAttemptWrapper(argumentCaptor.getValue().getTaskAttemptID());
     // writer is still in the map after commitTask failure
-    Assert.assertNotNull(WriterRegistry.writers(capturedId));
+    Assert.assertNotNull(WriterRegistry.writers(capturedId, null));
     failingCommitter.abortTask(new TaskAttemptContextImpl(conf, capturedId));
     // abortTask succeeds and removes writer
-    Assert.assertNull(WriterRegistry.writers(capturedId));
+    Assert.assertNull(WriterRegistry.writers(capturedId, null));
   }
 
   private Table table(String location, boolean partitioned) {


### PR DESCRIPTION
Changes Made:
[HIVE-27458: Support multiple OutputCommitter in a single Vertex](https://github.com/apache/hive/pull/4446/commits/c5ae473d84cc7d1ab332c6c056681aef1d72216d) : 
Reason: There can be more than one OutputCommitter per vertex. If a job writes to 2 Iceberg tables in the same vertex, there can be 2 commit tasks happening in same vertex. In that case the first committer after finishing the commitTask will remove all the writers from the WritersRegistry that belongs to this task. WritersRegistry holds all writers in a concurrentMap with taskAttempt id as key - https://github.com/apache/hive/blob/9da7488179e7c69d986dbc8a6654a5c3dc6c0210/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/writer/WriterRegistry.java#L29
To fix this:

- Added a new setting "iceberg.output.id" to differentiate between different output committers so the commitTask will only remove writer belonging to this OutputCommitter.
- For existing Hive jobs it won't cause any issue as the id will be null and still the key will use (taskId, null) as key which is similar to existing flow.

[HIVE-27458: Support HCatStorer and HCatLoader for Iceberg tables](https://github.com/apache/hive/pull/4446/commits/af8b44889152194639511a48bf6e9ea5cd32c9fd) : 

Reason: The [Pig Reader](https://github.com/apache/iceberg/tree/master/pig/src/main/java/org/apache/iceberg/pig) available in Iceberg can only read Parquet tables using Hadoop catalog. There is no way to read tables in Glue or Hive catalog via Pig. Also there is no way to write data via Pig.

- There is not much change required apart from setting the write operation which right now will always be OTHER as delete/update or not supported in Pig.
- "iceberg.mr.output.tables" setting was missing as it is set in configureJob. This can be set in the configureOutputProperties along with the "iceberg.mr.operation.type" property. 
- configureOutputProperties can be called multiple times. The implementation should take care of [populating similar properties](https://github.com/apache/hive/blob/9da7488179e7c69d986dbc8a6654a5c3dc6c0210/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java#L161). So to avoid adding the same table name again and again, added a check to see if the outputTable name is already present in the config. 