### PR TITLE
HIVE-27460: HiveMetastoreClient should not wrap TTransportException in MetaException

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -113,6 +113,8 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   public final static ClientCapabilities TEST_VERSION = new ClientCapabilities(
       Lists.newArrayList(ClientCapability.INSERT_ONLY_TABLES, ClientCapability.TEST_CAPABILITY));
 
+  private static final String CONNECT_METASTORE_FAILED = "Could not connect to metastore: ";
+
   ThriftHiveMetastore.Iface client = null;
   private TTransport transport = null;
   private boolean isConnected = false;
@@ -560,8 +562,7 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
             LOG.warn("Failed to connect to the MetaStore Server...");
           }
         } catch (MetaException e) {
-          throw new MetaException("Could not connect to meta store by MetaException: "
-              + StringUtils.stringifyException(e));
+          throw new MetaException(CONNECT_METASTORE_FAILED + StringUtils.stringifyException(e));
         }
         if (isConnected) {
           break;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -555,12 +555,7 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
           }
         } catch (TTransportException e) {
           tte = e;
-          if (LOG.isDebugEnabled()) {
-            LOG.warn("Failed to connect to the MetaStore Server...", e);
-          } else {
-            // Don't print full exception trace if DEBUG is not on.
-            LOG.warn("Failed to connect to the MetaStore Server...");
-          }
+          LOG.warn("Failed to connect to the MetaStore Server.");
         } catch (MetaException e) {
           throw new MetaException(CONNECT_METASTORE_FAILED + StringUtils.stringifyException(e));
         }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreClientConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreClientConnection.java
@@ -74,8 +74,7 @@ public class TestHiveMetastoreClientConnection {
       Assert.fail("Instantiate client should fail by MetaException for http mode.");
     } catch (MetaException e) {
       // expected
-      Assert.assertTrue(
-          e.getMessage().contains("Could not connect to meta store by MetaException:"));
+      Assert.assertTrue(e.getMessage().contains("Failed to connect to metastore:"));
     }
     Assert.assertEquals(HiveMetastoreClientWithException.connectCounts, 1);
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreClientConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreClientConnection.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MetastoreCheckinTest.class)
+public class TestHiveMetastoreClientConnection {
+  private Configuration conf;
+
+  /** Test class mock the connection exception for http and binary mode. */
+  static class HiveMetastoreClientWithException extends HiveMetaStoreClient {
+    private static int connectCounts = 0;
+
+    public HiveMetastoreClientWithException(Configuration conf) throws MetaException {
+      super(conf);
+    }
+
+    @Override
+    protected TTransport createAuthBinaryTransport(URI store, TTransport underlyingTransport)
+        throws MetaException, TTransportException {
+      connectCounts++;
+      throw new TTransportException();
+    }
+
+    @Override
+    protected HttpClientBuilder createHttpClientBuilder() throws MetaException {
+      connectCounts++;
+      throw new MetaException();
+    }
+  }
+
+  @Before
+  public void setup() {
+    HiveMetastoreClientWithException.connectCounts = 0;
+    conf = MetastoreConf.newMetastoreConf();
+    MetastoreConf.setVar(conf, ConfVars.THRIFT_URIS, "thrift://localhost:1,thrift://localhost:2");
+  }
+
+  @Test
+  public void testConnectionWithMetaException() {
+    MetastoreConf.setVar(conf, ConfVars.METASTORE_CLIENT_THRIFT_TRANSPORT_MODE, "http");
+    try {
+      new HiveMetastoreClientWithException(conf);
+      Assert.fail("Instantiate client should fail by MetaException for http mode.");
+    } catch (MetaException e) {
+      // expected
+      Assert.assertTrue(
+          e.getMessage().contains("Could not connect to meta store by MetaException:"));
+    }
+    Assert.assertEquals(HiveMetastoreClientWithException.connectCounts, 1);
+  }
+
+  @Test
+  public void testConnectionWithTTransportException() {
+    MetastoreConf.setVar(conf, ConfVars.METASTORE_CLIENT_THRIFT_TRANSPORT_MODE, "binary");
+    try {
+      new HiveMetastoreClientWithException(conf);
+      Assert.fail("Instantiate client should fail by TTransportException for binary mode.");
+    } catch (MetaException e) {
+      // expected
+      Assert.assertTrue(
+          e.getMessage().contains("Could not connect to meta store using any of the URIs provided."));
+    }
+    Assert.assertEquals(HiveMetastoreClientWithException.connectCounts, 6);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. throw `TTransportException` directly in `HiveMetastoreClient` rather than wrap it in `MetaException`
2. do not retry connect when encountered `MetaException` 

### Why are the changes needed?
As discussed in [HIVE-27097](https://issues.apache.org/jira/browse/HIVE-27097), client side only concerns about `TTransportException`, which should also apply to the connection building stage. So we can distinguish `TTransportException` from `MetaException` and stop connect immediately when encountered `MetaException`.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Add a new unit test.
