### PR TITLE
HIVE-27461: HiveMetaStoreAuthorizer lost the root cause of checkPrivileges

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
 import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.security.HiveMetastoreAuthenticationProvider;
@@ -110,10 +111,7 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
       }
     } catch (Exception e) {
       LOG.error("HiveMetaStoreAuthorizer.onEvent(): failed", e);
-      MetaException me = new MetaException(e.getMessage());
-      // Init cause for testing check.
-      me.initCause(e);
-      throw me;
+      throw MetaStoreUtils.newMetaException(e);
     }
 
     LOG.debug("<== HiveMetaStoreAuthorizer.onEvent(): EventType=" + preEventContext.getEventType());
@@ -598,7 +596,7 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
   }
 
   private void checkPrivileges(final HiveMetaStoreAuthzInfo authzContext, HiveAuthorizer authorizer)
-      throws HiveAccessControlException, HiveAuthzPluginException, MetaException {
+      throws HiveAccessControlException, HiveAuthzPluginException {
     LOG.debug("==> HiveMetaStoreAuthorizer.checkPrivileges(): authzContext=" + authzContext + ", authorizer=" + authorizer);
 
     HiveOperationType         hiveOpType       = authzContext.getOperationType();

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.security.authorization.plugin.metastore;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.FileUtils;
@@ -36,9 +37,10 @@ import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
 import org.junit.Before;
 import org.junit.Test;
-import java.util.Map;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -409,6 +411,21 @@ public class TestHiveMetaStoreAuthorizer {
       hmsHandler.drop_dataconnector(dcName, true, true);
     } catch (Exception e) {
       fail("testU_DropDataConnector_authorizedUser() failed with " + e);
+    }
+  }
+
+  @Test
+  public void testUnAuthorizedCause() {
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(unAuthorizedUser));
+    try {
+      Database db = new DatabaseBuilder()
+              .setName(dbName)
+              .build(conf);
+      hmsHandler.create_database(db);
+    } catch (Exception e) {
+      String[] rootCauseStackTrace = ExceptionUtils.getRootCauseStackTrace(e);
+      assertTrue(Arrays.stream(rootCauseStackTrace)
+              .anyMatch(stack -> stack.contains(DummyHiveAuthorizer.class.getName())));
     }
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hive.ql.security.authorization.plugin.metastore;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.ColumnType;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Retain all stack traces within the authorization exception.


### Why are the changes needed?
To facilitate better troubleshooting of authorization failures via logging.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Add a new UT.
