### PR TITLE
HIVE-22618: Fix checkstyle violations for ParseUtils

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -224,8 +224,8 @@ public final class ParseUtils {
       int i = filterCondn.getType() == HiveParser.TOK_FUNCTION ? 1 : 0;
       for (; i < filterCondn.getChildCount(); i++) {
         int cIdx = checkJoinFilterRefersOneAlias(tabAliases, (ASTNode) filterCondn.getChild(i));
-        if ( cIdx != idx ) {
-          if ( idx != -1 && cIdx != -1 ) {
+        if (cIdx != idx) {
+          if (idx != -1 && cIdx != -1) {
             return -1;
           }
           idx = idx == -1 ? cIdx : idx;
@@ -238,23 +238,23 @@ public final class ParseUtils {
   public static DecimalTypeInfo getDecimalTypeTypeInfo(ASTNode node)
       throws SemanticException {
     if (node.getChildCount() > 2) {
-        throw new SemanticException("Bad params for type decimal");
-      }
+      throw new SemanticException("Bad params for type decimal");
+    }
 
-      int precision = HiveDecimal.USER_DEFAULT_PRECISION;
-      int scale = HiveDecimal.USER_DEFAULT_SCALE;
+    int precision = HiveDecimal.USER_DEFAULT_PRECISION;
+    int scale = HiveDecimal.USER_DEFAULT_SCALE;
 
-      if (node.getChildCount() >= 1) {
-        String precStr = node.getChild(0).getText();
-        precision = Integer.parseInt(precStr);
-      }
+    if (node.getChildCount() >= 1) {
+      String precStr = node.getChild(0).getText();
+      precision = Integer.parseInt(precStr);
+    }
 
-      if (node.getChildCount() == 2) {
-        String scaleStr = node.getChild(1).getText();
-        scale = Integer.parseInt(scaleStr);
-      }
+    if (node.getChildCount() == 2) {
+      String scaleStr = node.getChild(1).getText();
+      scale = Integer.parseInt(scaleStr);
+    }
 
-      return TypeInfoFactory.getDecimalTypeInfo(precision, scale);
+    return TypeInfoFactory.getDecimalTypeInfo(precision, scale);
   }
 
   public static String ensureClassExists(String className)
@@ -271,249 +271,249 @@ public final class ParseUtils {
   }
 
   public static boolean containsTokenOfType(ASTNode root, Integer ... tokens) {
-      final Set<Integer> tokensToMatch = new HashSet<Integer>();
-      for (Integer tokenTypeToMatch : tokens) {
-          tokensToMatch.add(tokenTypeToMatch);
-        }
-
-        return ParseUtils.containsTokenOfType(root, new PTFUtils.Predicate<ASTNode>() {
-          @Override
-          public boolean apply(ASTNode node) {
-              return tokensToMatch.contains(node.getType());
-            }
-        });
+    final Set<Integer> tokensToMatch = new HashSet<Integer>();
+    for (Integer tokenTypeToMatch : tokens) {
+      tokensToMatch.add(tokenTypeToMatch);
     }
 
-    public static boolean containsTokenOfType(ASTNode root, PTFUtils.Predicate<ASTNode> predicate) {
-      Queue<ASTNode> queue = new ArrayDeque<ASTNode>();
+    return ParseUtils.containsTokenOfType(root, new PTFUtils.Predicate<ASTNode>() {
+      @Override
+      public boolean apply(ASTNode node) {
+        return tokensToMatch.contains(node.getType());
+      }
+    });
+  }
 
-      // BFS
-      queue.add(root);
-      while (!queue.isEmpty())  {
-        ASTNode current = queue.remove();
-        // If the predicate matches, then return true.
-        // Otherwise visit the next set of nodes that haven't been seen.
-        if (predicate.apply(current)) {
-          return true;
-        } else {
-          // Guard because ASTNode.getChildren.iterator returns null if no children available (bug).
-          if (current.getChildCount() > 0) {
-            for (Node child : current.getChildren()) {
-              queue.add((ASTNode) child);
-            }
+  public static boolean containsTokenOfType(ASTNode root, PTFUtils.Predicate<ASTNode> predicate) {
+    Queue<ASTNode> queue = new ArrayDeque<ASTNode>();
+
+    // BFS
+    queue.add(root);
+    while (!queue.isEmpty())  {
+      ASTNode current = queue.remove();
+      // If the predicate matches, then return true.
+      // Otherwise visit the next set of nodes that haven't been seen.
+      if (predicate.apply(current)) {
+        return true;
+      } else {
+        // Guard because ASTNode.getChildren.iterator returns null if no children available (bug).
+        if (current.getChildCount() > 0) {
+          for (Node child : current.getChildren()) {
+            queue.add((ASTNode) child);
           }
         }
       }
-
-      return false;
     }
 
-    private static void handleSetColRefs(ASTNode tree, Context ctx) {
-      CalcitePlanner.ASTSearcher astSearcher = new CalcitePlanner.ASTSearcher();
-      while (true) {
-        astSearcher.reset();
-        ASTNode setCols = astSearcher.depthFirstSearch(tree, HiveParser.TOK_SETCOLREF);
-        if (setCols == null) break;
-        processSetColsNode(setCols, astSearcher, ctx);
+    return false;
+  }
+
+  private static void handleSetColRefs(ASTNode tree, Context ctx) {
+    CalcitePlanner.ASTSearcher astSearcher = new CalcitePlanner.ASTSearcher();
+    while (true) {
+      astSearcher.reset();
+      ASTNode setCols = astSearcher.depthFirstSearch(tree, HiveParser.TOK_SETCOLREF);
+      if (setCols == null) break;
+      processSetColsNode(setCols, astSearcher, ctx);
+    }
+  }
+
+  /**
+   * Replaces a spurious TOK_SETCOLREF added by parser with column names referring to the query
+   * in e.g. a union. This is to maintain the expectations that some code, like order by position
+   * alias, might have about not having ALLCOLREF. If it cannot find the columns with confidence
+   * it will just replace SETCOLREF with ALLCOLREF. Most of the cases where that happens are
+   * easy to work around in the query (e.g. by adding column aliases in the union).
+   * @param setCols TOK_SETCOLREF ASTNode.
+   * @param searcher AST searcher to reuse.
+   */
+  private static void processSetColsNode(ASTNode setCols, ASTSearcher searcher, Context ctx) {
+    searcher.reset();
+    CommonTree rootNode = setCols;
+    while (rootNode != null && rootNode.getType() != HiveParser.TOK_INSERT) {
+      rootNode = rootNode.parent;
+    }
+    if (rootNode == null || rootNode.parent == null) {
+      // Couldn't find the parent insert; replace with ALLCOLREF.
+      LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the root INSERT");
+      setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+      return;
+    }
+    rootNode = rootNode.parent; // TOK_QUERY above insert
+    Tree fromNode = null;
+    for (int j = 0; j < rootNode.getChildCount(); ++j) {
+      Tree child = rootNode.getChild(j);
+      if (child.getType() == HiveParser.TOK_FROM) {
+        fromNode = child;
+        break;
       }
     }
-
-    /**
-     * Replaces a spurious TOK_SETCOLREF added by parser with column names referring to the query
-     * in e.g. a union. This is to maintain the expectations that some code, like order by position
-     * alias, might have about not having ALLCOLREF. If it cannot find the columns with confidence
-     * it will just replace SETCOLREF with ALLCOLREF. Most of the cases where that happens are
-     * easy to work around in the query (e.g. by adding column aliases in the union).
-     * @param setCols TOK_SETCOLREF ASTNode.
-     * @param searcher AST searcher to reuse.
-     */
-    private static void processSetColsNode(ASTNode setCols, ASTSearcher searcher, Context ctx) {
-      searcher.reset();
-      CommonTree rootNode = setCols;
-      while (rootNode != null && rootNode.getType() != HiveParser.TOK_INSERT) {
-        rootNode = rootNode.parent;
+    if (!(fromNode instanceof ASTNode)) {
+      // Couldn't find the from that contains subquery; replace with ALLCOLREF.
+      LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the FROM");
+      setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+      return;
+    }
+    // We are making what we are trying to do more explicit if there's a union alias; so
+    // that if we do something we didn't expect to do, it'd be more likely to fail.
+    String alias = null;
+    if (fromNode.getChildCount() > 0) {
+      Tree fromWhat = fromNode.getChild(0);
+      if (fromWhat.getType() == HiveParser.TOK_SUBQUERY && fromWhat.getChildCount() > 1) {
+        Tree child = fromWhat.getChild(fromWhat.getChildCount() - 1);
+        if (child.getType() == HiveParser.Identifier) {
+          alias = child.getText();
+        }
       }
-      if (rootNode == null || rootNode.parent == null) {
-        // Couldn't find the parent insert; replace with ALLCOLREF.
-        LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the root INSERT");
+    }
+    // Note: we assume that this isn't an already malformed query;
+    //       we don't check for that here - it will fail later anyway.
+    // First, we find the SELECT closest to the top.
+    ASTNode select = searcher.simpleBreadthFirstSearchAny((ASTNode)fromNode,
+        HiveParser.TOK_SELECT, HiveParser.TOK_SELECTDI);
+    if (select == null) {
+      // Couldn't find the from that contains subquery; replace with ALLCOLREF.
+      LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the SELECT");
+      setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+      return;
+    }
+
+    // Then, find the leftmost logical sibling select, because that's what Hive uses for aliases.
+    while (true) {
+      CommonTree queryOfSelect = select.parent;
+      while (queryOfSelect != null && queryOfSelect.getType() != HiveParser.TOK_QUERY) {
+        queryOfSelect = queryOfSelect.parent;
+      }
+      // We should have some QUERY; and also its parent because by supposition we are in subq.
+      if (queryOfSelect == null || queryOfSelect.parent == null) {
+        LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the QUERY");
         setCols.token.setType(HiveParser.TOK_ALLCOLREF);
         return;
       }
-      rootNode = rootNode.parent; // TOK_QUERY above insert
-      Tree fromNode = null;
-      for (int j = 0; j < rootNode.getChildCount(); ++j) {
-        Tree child = rootNode.getChild(j);
-        if (child.getType() == HiveParser.TOK_FROM) {
-          fromNode = child;
+      if (queryOfSelect.childIndex == 0) break; // We are the left-most child.
+      Tree moreToTheLeft = queryOfSelect.parent.getChild(0);
+      Preconditions.checkState(moreToTheLeft != queryOfSelect);
+      ASTNode newSelect = searcher.simpleBreadthFirstSearchAny((ASTNode)moreToTheLeft,
+          HiveParser.TOK_SELECT, HiveParser.TOK_SELECTDI);
+      Preconditions.checkState(newSelect != select);
+      select = newSelect;
+      // Repeat the procedure for the new select.
+    }
+
+    // Find the proper columns.
+    List<ASTNode> newChildren = new ArrayList<>(select.getChildCount());
+    HashSet<String> aliases = new HashSet<>();
+    for (int i = 0; i < select.getChildCount(); ++i) {
+      Tree selExpr = select.getChild(i);
+      if (selExpr.getType() == HiveParser.QUERY_HINT) continue;
+      assert selExpr.getType() == HiveParser.TOK_SELEXPR;
+      assert selExpr.getChildCount() > 0;
+      // we can have functions which generate multiple aliases (e.g. explode(map(x, y)) as (key, val))
+      boolean isFunctionWithMultipleParameters =
+          selExpr.getChild(0).getType() == HiveParser.TOK_FUNCTION && selExpr.getChildCount() > 2;
+      // if so let's skip the function token buth then examine all its parameters - otherwise check only the last item
+      int start = isFunctionWithMultipleParameters ? 1 : selExpr.getChildCount() - 1;
+      for (int j = start; j < selExpr.getChildCount(); ++j) {
+        Tree child = selExpr.getChild(j);
+        switch (child.getType()) {
+        case HiveParser.TOK_SETCOLREF:
+          // We have a nested setcolref. Process that and start from scratch TODO: use stack?
+          processSetColsNode((ASTNode) child, searcher, ctx);
+          processSetColsNode(setCols, searcher, ctx);
+          return;
+        case HiveParser.TOK_ALLCOLREF:
+          // We should find an alias of this insert and do (alias).*. This however won't fix e.g.
+          // positional order by alias case, cause we'd still have a star on the top level. Bail.
+          LOG.debug("Replacing SETCOLREF with ALLCOLREF because of nested ALLCOLREF");
+          setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+          return;
+        case HiveParser.TOK_TABLE_OR_COL:
+          Tree idChild = child.getChild(0);
+          assert idChild.getType() == HiveParser.Identifier : idChild;
+          if (!createChildColumnRef(idChild, alias, newChildren, aliases, ctx)) {
+            setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+            return;
+          }
+          break;
+        case HiveParser.Identifier:
+          if (!createChildColumnRef(child, alias, newChildren, aliases, ctx)) {
+            setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+            return;
+          }
+          break;
+        case HiveParser.DOT: {
+          Tree colChild = child.getChild(child.getChildCount() - 1);
+          assert colChild.getType() == HiveParser.Identifier : colChild;
+          if (!createChildColumnRef(colChild, alias, newChildren, aliases, ctx)) {
+            setCols.token.setType(HiveParser.TOK_ALLCOLREF);
+            return;
+          }
           break;
         }
-      }
-      if (!(fromNode instanceof ASTNode)) {
-        // Couldn't find the from that contains subquery; replace with ALLCOLREF.
-        LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the FROM");
-        setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-        return;
-      }
-      // We are making what we are trying to do more explicit if there's a union alias; so
-      // that if we do something we didn't expect to do, it'd be more likely to fail.
-      String alias = null;
-      if (fromNode.getChildCount() > 0) {
-        Tree fromWhat = fromNode.getChild(0);
-        if (fromWhat.getType() == HiveParser.TOK_SUBQUERY && fromWhat.getChildCount() > 1) {
-          Tree child = fromWhat.getChild(fromWhat.getChildCount() - 1);
-          if (child.getType() == HiveParser.Identifier) {
-            alias = child.getText();
-          }
-        }
-      }
-      // Note: we assume that this isn't an already malformed query;
-      //       we don't check for that here - it will fail later anyway.
-      // First, we find the SELECT closest to the top.
-      ASTNode select = searcher.simpleBreadthFirstSearchAny((ASTNode)fromNode,
-          HiveParser.TOK_SELECT, HiveParser.TOK_SELECTDI);
-      if (select == null) {
-        // Couldn't find the from that contains subquery; replace with ALLCOLREF.
-        LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the SELECT");
-        setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-        return;
-      }
-
-      // Then, find the leftmost logical sibling select, because that's what Hive uses for aliases.
-      while (true) {
-        CommonTree queryOfSelect = select.parent;
-        while (queryOfSelect != null && queryOfSelect.getType() != HiveParser.TOK_QUERY) {
-          queryOfSelect = queryOfSelect.parent;
-        }
-        // We should have some QUERY; and also its parent because by supposition we are in subq.
-        if (queryOfSelect == null || queryOfSelect.parent == null) {
-          LOG.debug("Replacing SETCOLREF with ALLCOLREF because we couldn't find the QUERY");
+        default:
+          // Not really sure how to refer to this (or if we can).
+          // TODO: We could find a different from branch for the union, that might have an alias?
+          //       Or we could add an alias here to refer to, but that might break other branches.
+          LOG.debug("Replacing SETCOLREF with ALLCOLREF because of the nested node "
+              + child.getType() + " " + child.getText());
           setCols.token.setType(HiveParser.TOK_ALLCOLREF);
           return;
         }
-        if (queryOfSelect.childIndex == 0) break; // We are the left-most child.
-        Tree moreToTheLeft = queryOfSelect.parent.getChild(0);
-        Preconditions.checkState(moreToTheLeft != queryOfSelect);
-        ASTNode newSelect = searcher.simpleBreadthFirstSearchAny((ASTNode)moreToTheLeft,
-          HiveParser.TOK_SELECT, HiveParser.TOK_SELECTDI);
-        Preconditions.checkState(newSelect != select);
-        select = newSelect;
-        // Repeat the procedure for the new select.
-      }
-
-      // Find the proper columns.
-      List<ASTNode> newChildren = new ArrayList<>(select.getChildCount());
-      HashSet<String> aliases = new HashSet<>();
-      for (int i = 0; i < select.getChildCount(); ++i) {
-        Tree selExpr = select.getChild(i);
-        if (selExpr.getType() == HiveParser.QUERY_HINT) continue;
-        assert selExpr.getType() == HiveParser.TOK_SELEXPR;
-        assert selExpr.getChildCount() > 0;
-        // we can have functions which generate multiple aliases (e.g. explode(map(x, y)) as (key, val))
-        boolean isFunctionWithMultipleParameters =
-            selExpr.getChild(0).getType() == HiveParser.TOK_FUNCTION && selExpr.getChildCount() > 2;
-        // if so let's skip the function token buth then examine all its parameters - otherwise check only the last item
-        int start = isFunctionWithMultipleParameters ? 1 : selExpr.getChildCount() - 1;
-        for (int j = start; j < selExpr.getChildCount(); ++j) {
-          Tree child = selExpr.getChild(j);
-          switch (child.getType()) {
-            case HiveParser.TOK_SETCOLREF:
-              // We have a nested setcolref. Process that and start from scratch TODO: use stack?
-              processSetColsNode((ASTNode) child, searcher, ctx);
-              processSetColsNode(setCols, searcher, ctx);
-              return;
-            case HiveParser.TOK_ALLCOLREF:
-              // We should find an alias of this insert and do (alias).*. This however won't fix e.g.
-              // positional order by alias case, cause we'd still have a star on the top level. Bail.
-              LOG.debug("Replacing SETCOLREF with ALLCOLREF because of nested ALLCOLREF");
-              setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-              return;
-            case HiveParser.TOK_TABLE_OR_COL:
-              Tree idChild = child.getChild(0);
-              assert idChild.getType() == HiveParser.Identifier : idChild;
-              if (!createChildColumnRef(idChild, alias, newChildren, aliases, ctx)) {
-                setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-                return;
-              }
-              break;
-            case HiveParser.Identifier:
-              if (!createChildColumnRef(child, alias, newChildren, aliases, ctx)) {
-                setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-                return;
-              }
-              break;
-            case HiveParser.DOT: {
-              Tree colChild = child.getChild(child.getChildCount() - 1);
-              assert colChild.getType() == HiveParser.Identifier : colChild;
-              if (!createChildColumnRef(colChild, alias, newChildren, aliases, ctx)) {
-                setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-                return;
-              }
-              break;
-            }
-            default:
-              // Not really sure how to refer to this (or if we can).
-              // TODO: We could find a different from branch for the union, that might have an alias?
-              //       Or we could add an alias here to refer to, but that might break other branches.
-              LOG.debug("Replacing SETCOLREF with ALLCOLREF because of the nested node "
-                  + child.getType() + " " + child.getText());
-              setCols.token.setType(HiveParser.TOK_ALLCOLREF);
-              return;
-          }
-        }
-      }
-      // Insert search in the beginning would have failed if these parents didn't exist.
-      ASTNode parent = (ASTNode)setCols.parent.parent;
-      int t = parent.getType();
-      assert t == HiveParser.TOK_SELECT || t == HiveParser.TOK_SELECTDI : t;
-      int ix = setCols.parent.childIndex;
-      parent.deleteChild(ix);
-      for (ASTNode node : newChildren) {
-        parent.insertChild(ix++, node);
       }
     }
-
-    private static boolean createChildColumnRef(Tree child, String alias,
-        List<ASTNode> newChildren, HashSet<String> aliases, Context ctx) {
-      String colAlias = child.getText();
-      if (SemanticAnalyzer.isRegex(colAlias, (HiveConf)ctx.getConf())) {
-        LOG.debug("Skip creating child column reference because of regexp used as alias: " + colAlias);
-        return false;
-      }
-      if (!aliases.add(colAlias)) {
-        // TODO: if a side of the union has 2 columns with the same name, none on the higher
-        //       level can refer to them. We could change the alias in the original node.
-        LOG.debug("Replacing SETCOLREF with ALLCOLREF because of duplicate alias " + colAlias);
-        return false;
-      }
-      ASTBuilder selExpr = ASTBuilder.construct(HiveParser.TOK_SELEXPR, "TOK_SELEXPR");
-      ASTBuilder toc = ASTBuilder.construct(HiveParser.TOK_TABLE_OR_COL, "TOK_TABLE_OR_COL");
-      ASTBuilder id = ASTBuilder.construct(HiveParser.Identifier, colAlias);
-      if (alias == null) {
-        selExpr = selExpr.add(toc.add(id));
-      } else {
-        ASTBuilder dot = ASTBuilder.construct(HiveParser.DOT, ".");
-        ASTBuilder aliasNode = ASTBuilder.construct(HiveParser.Identifier, alias);
-        selExpr = selExpr.add(dot.add(toc.add(aliasNode)).add(id));
-      }
-      newChildren.add(selExpr.node());
-      return true;
+    // Insert search in the beginning would have failed if these parents didn't exist.
+    ASTNode parent = (ASTNode)setCols.parent.parent;
+    int t = parent.getType();
+    assert t == HiveParser.TOK_SELECT || t == HiveParser.TOK_SELECTDI : t;
+    int ix = setCols.parent.childIndex;
+    parent.deleteChild(ix);
+    for (ASTNode node : newChildren) {
+      parent.insertChild(ix++, node);
     }
+  }
 
-    public static String getKeywords(Set<String> excludes) {
-      StringBuilder sb = new StringBuilder();
-      for (Field f : HiveLexer.class.getDeclaredFields()) {
-        if (!Modifier.isStatic(f.getModifiers())) continue;
-        String name = f.getName();
-        if (!name.startsWith("KW_")) continue;
-        name = name.substring(3);
-        if (excludes != null && excludes.contains(name)) continue;
-        if (sb.length() > 0) {
-          sb.append(",");
-        }
-        sb.append(name);
-      }
-      return sb.toString();
+  private static boolean createChildColumnRef(Tree child, String alias,
+      List<ASTNode> newChildren, HashSet<String> aliases, Context ctx) {
+    String colAlias = child.getText();
+    if (SemanticAnalyzer.isRegex(colAlias, (HiveConf)ctx.getConf())) {
+      LOG.debug("Skip creating child column reference because of regexp used as alias: " + colAlias);
+      return false;
     }
+    if (!aliases.add(colAlias)) {
+      // TODO: if a side of the union has 2 columns with the same name, none on the higher
+      //       level can refer to them. We could change the alias in the original node.
+      LOG.debug("Replacing SETCOLREF with ALLCOLREF because of duplicate alias " + colAlias);
+      return false;
+    }
+    ASTBuilder selExpr = ASTBuilder.construct(HiveParser.TOK_SELEXPR, "TOK_SELEXPR");
+    ASTBuilder toc = ASTBuilder.construct(HiveParser.TOK_TABLE_OR_COL, "TOK_TABLE_OR_COL");
+    ASTBuilder id = ASTBuilder.construct(HiveParser.Identifier, colAlias);
+    if (alias == null) {
+      selExpr = selExpr.add(toc.add(id));
+    } else {
+      ASTBuilder dot = ASTBuilder.construct(HiveParser.DOT, ".");
+      ASTBuilder aliasNode = ASTBuilder.construct(HiveParser.Identifier, alias);
+      selExpr = selExpr.add(dot.add(toc.add(aliasNode)).add(id));
+    }
+    newChildren.add(selExpr.node());
+    return true;
+  }
+
+  public static String getKeywords(Set<String> excludes) {
+    StringBuilder sb = new StringBuilder();
+    for (Field f : HiveLexer.class.getDeclaredFields()) {
+      if (!Modifier.isStatic(f.getModifiers())) continue;
+      String name = f.getName();
+      if (!name.startsWith("KW_")) continue;
+      name = name.substring(3);
+      if (excludes != null && excludes.contains(name)) continue;
+      if (sb.length() > 0) {
+        sb.append(",");
+      }
+      sb.append(name);
+    }
+    return sb.toString();
+  }
 
   public static CBOPlan parseQuery(HiveConf conf, String viewQuery)
       throws SemanticException, ParseException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -406,7 +406,7 @@ public final class ParseUtils {
 
     // Find the proper columns.
     List<ASTNode> newChildren = new ArrayList<>(select.getChildCount());
-    HashSet<String> aliases = new HashSet<>();
+    Set<String> aliases = new HashSet<>();
     for (int i = 0; i < select.getChildCount(); ++i) {
       Tree selExpr = select.getChild(i);
       if (selExpr.getType() == HiveParser.QUERY_HINT) {
@@ -447,7 +447,7 @@ public final class ParseUtils {
             return;
           }
           break;
-        case HiveParser.DOT: {
+        case HiveParser.DOT:
           Tree colChild = child.getChild(child.getChildCount() - 1);
           assert colChild.getType() == HiveParser.Identifier : colChild;
           if (!createChildColumnRef(colChild, alias, newChildren, aliases, ctx)) {
@@ -455,7 +455,6 @@ public final class ParseUtils {
             return;
           }
           break;
-        }
         default:
           // Not really sure how to refer to this (or if we can).
           // TODO: We could find a different from branch for the union, that might have an alias?
@@ -479,7 +478,7 @@ public final class ParseUtils {
   }
 
   private static boolean createChildColumnRef(Tree child, String alias,
-      List<ASTNode> newChildren, HashSet<String> aliases, Context ctx) {
+      List<ASTNode> newChildren, Set<String> aliases, Context ctx) {
     String colAlias = child.getText();
     if (SemanticAnalyzer.isRegex(colAlias, (HiveConf)ctx.getConf())) {
       LOG.debug("Skip creating child column reference because of regexp used as alias: " + colAlias);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -313,7 +313,9 @@ public final class ParseUtils {
     while (true) {
       astSearcher.reset();
       ASTNode setCols = astSearcher.depthFirstSearch(tree, HiveParser.TOK_SETCOLREF);
-      if (setCols == null) break;
+      if (setCols == null) {
+        break;
+      }
       processSetColsNode(setCols, astSearcher, ctx);
     }
   }
@@ -390,7 +392,9 @@ public final class ParseUtils {
         setCols.token.setType(HiveParser.TOK_ALLCOLREF);
         return;
       }
-      if (queryOfSelect.childIndex == 0) break; // We are the left-most child.
+      if (queryOfSelect.childIndex == 0) {
+        break; // We are the left-most child.
+      }
       Tree moreToTheLeft = queryOfSelect.parent.getChild(0);
       Preconditions.checkState(moreToTheLeft != queryOfSelect);
       ASTNode newSelect = searcher.simpleBreadthFirstSearchAny((ASTNode)moreToTheLeft,
@@ -405,7 +409,9 @@ public final class ParseUtils {
     HashSet<String> aliases = new HashSet<>();
     for (int i = 0; i < select.getChildCount(); ++i) {
       Tree selExpr = select.getChild(i);
-      if (selExpr.getType() == HiveParser.QUERY_HINT) continue;
+      if (selExpr.getType() == HiveParser.QUERY_HINT) {
+        continue;
+      }
       assert selExpr.getType() == HiveParser.TOK_SELEXPR;
       assert selExpr.getChildCount() > 0;
       // we can have functions which generate multiple aliases (e.g. explode(map(x, y)) as (key, val))
@@ -502,11 +508,17 @@ public final class ParseUtils {
   public static String getKeywords(Set<String> excludes) {
     StringBuilder sb = new StringBuilder();
     for (Field f : HiveLexer.class.getDeclaredFields()) {
-      if (!Modifier.isStatic(f.getModifiers())) continue;
+      if (!Modifier.isStatic(f.getModifiers())) {
+        continue;
+      }
       String name = f.getName();
-      if (!name.startsWith("KW_")) continue;
+      if (!name.startsWith("KW_")) {
+        continue;
+      }
       name = name.substring(3);
-      if (excludes != null && excludes.contains(name)) continue;
+      if (excludes != null && excludes.contains(name)) {
+        continue;
+      }
       if (sb.length() > 0) {
         sb.append(",");
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java
@@ -120,26 +120,26 @@ public class TestParseUtils {
   @Test
   public void testTxnTypeWithEnabledReadOnlyFeature() throws Exception {
     enableReadOnlyTxnFeature(true);
-    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query,new Context(conf))), txnType);
+    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query, new Context(conf))), txnType);
   }
 
   @Test
   public void testTxnTypeWithDisabledReadOnlyFeature() throws Exception {
     enableReadOnlyTxnFeature(false);
-    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query,new Context(conf))),
+    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query, new Context(conf))),
         txnType == TxnType.READ_ONLY ? TxnType.DEFAULT : txnType);
   }
 
   @Test
   public void testTxnTypeWithLocklessReadsEnabled() throws Exception {
     enableLocklessReadsFeature(true);
-    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query,new Context(conf))), txnType);
+    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query, new Context(conf))), txnType);
   }
 
   @Test
   public void testTxnTypeWithLocklessReadsDisabled() throws Exception {
     enableLocklessReadsFeature(false);
-    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query,new Context(conf))), TxnType.DEFAULT);
+    Assert.assertEquals(AcidUtils.getTxnType(conf, ParseUtils.parse(query, new Context(conf))), TxnType.DEFAULT);
   }
   
   private void enableReadOnlyTxnFeature(boolean featureFlag) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR would just format `ParseUtils.java`.

https://issues.apache.org/jira/browse/HIVE-22618

I recommend reviewers take a look at the diff of this PR via the following URL.
https://github.com/apache/hive/compare/master...okumin:HIVE-22618-checkstyle?w=1

### Why are the changes needed?
Indentations of this file are totally broken and I felt it is hard to modify the file while working on another issue.

I'd say we have no strong reasons to merge this one. I just created it because I hope other PRs are unlikely to conflict with this change now since it is not often updated recently.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?

These are the original checkstyle report.

```
root@fcc249b8c79d:~/hive# mvn -pl ql checkstyle:check -Dcheckstyle.consoleOutput=true | grep 'parse/ParseUtils.java'
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:227:13: warning: '(' is followed by whitespace.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:227:25: warning: ')' is preceded with whitespace.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:228:15: warning: '(' is followed by whitespace.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:228:39: warning: ')' is preceded with whitespace.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:241: warning: 'if' child have incorrect indentation level 8, expected level should be 6.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:242: warning: 'if rcurly' have incorrect indentation level 6, expected level should be 4.
...
(too many violations)
root@fcc249b8c79d:~/hive#
root@fcc249b8c79d:~/hive# mvn -pl ql checkstyle:check -Dcheckstyle.consoleOutput=true | grep 'parse/TestParseUtils.java'
/root/hive/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java:123:75: warning: ',' is not followed by whitespace.
/root/hive/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java:129:75: warning: ',' is not followed by whitespace.
/root/hive/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java:136:75: warning: ',' is not followed by whitespace.
/root/hive/ql/src/test/org/apache/hadoop/hive/ql/parse/TestParseUtils.java:142:75: warning: ',' is not followed by whitespace.
root@fcc249b8c79d:~/hive# 
```

This is the result after applying this change. I'm keeping the `TODO` ones since it looks intentional.

```
root@fcc249b8c79d:~/hive# mvn -pl ql checkstyle:check -Dcheckstyle.consoleOutput=true | grep 'parse/ParseUtils.java'
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:426: warning: Comment matches to-do format 'TODO:'.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:460: warning: Comment matches to-do format 'TODO:'.
/root/hive/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java:488: warning: Comment matches to-do format 'TODO:'.
root@fcc249b8c79d:~/hive#
root@fcc249b8c79d:~/hive# mvn -pl ql checkstyle:check -Dcheckstyle.consoleOutput=true | grep 'parse/TestParseUtils.java'
root@fcc249b8c79d:~/hive#
```

