### PR TITLE
HIVE-27245: Iceberg: Implement LOAD data for partitioned tables via Append API.

### DIFF
--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_load_data.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_load_data.q
@@ -58,3 +58,29 @@ LOAD DATA LOCAL INPATH '../../data/files/part.orc' INTO TABLE ice_orc;
 select * from ice_orc order by p_partkey;
 
 select count(*) from ice_orc;
+
+create external table ice_parquet_partitioned (
+  strcol string,
+  intcol integer
+) partitioned by (pcol int)
+stored by iceberg;
+
+insert into ice_parquet_partitioned values ('AA', 10, 100), ('BB', 20, 200), ('CC', 30, 300);
+
+select * from ice_parquet_partitioned order by intcol;
+
+explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE ice_parquet_partitioned
+PARTITION (pcol='300');
+
+LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='100');
+
+select * from ice_parquet_partitioned order by intcol;
+
+explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+        ice_parquet_partitioned PARTITION (pcol='200');
+
+LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='200');
+
+select * from ice_parquet_partitioned order by intcol;

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_load_data.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_load_data.q.out
@@ -406,3 +406,97 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ice_orc
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 52
+PREHOOK: query: create external table ice_parquet_partitioned (
+  strcol string,
+  intcol integer
+) partitioned by (pcol int)
+stored by iceberg
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_parquet_partitioned
+POSTHOOK: query: create external table ice_parquet_partitioned (
+  strcol string,
+  intcol integer
+) partitioned by (pcol int)
+stored by iceberg
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_parquet_partitioned
+PREHOOK: query: insert into ice_parquet_partitioned values ('AA', 10, 100), ('BB', 20, 200), ('CC', 30, 300)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_parquet_partitioned
+POSTHOOK: query: insert into ice_parquet_partitioned values ('AA', 10, 100), ('BB', 20, 200), ('CC', 30, 300)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_parquet_partitioned
+PREHOOK: query: select * from ice_parquet_partitioned order by intcol
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_parquet_partitioned
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_parquet_partitioned order by intcol
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_parquet_partitioned
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+AA	10	100
+BB	20	200
+CC	30	300
+PREHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE ice_parquet_partitioned
+PARTITION (pcol='300')
+PREHOOK: type: LOAD
+POSTHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE ice_parquet_partitioned
+PARTITION (pcol='300')
+POSTHOOK: type: LOAD
+Stage-0
+  Move Operator
+    table:{"name:":"default.ice_parquet_partitioned"}
+
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='100')
+PREHOOK: type: LOAD
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=100' INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='100')
+POSTHOOK: type: LOAD
+PREHOOK: query: select * from ice_parquet_partitioned order by intcol
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_parquet_partitioned
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_parquet_partitioned order by intcol
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_parquet_partitioned
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+a	1	100
+b	2	100
+AA	10	100
+BB	20	200
+CC	30	300
+PREHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+        ice_parquet_partitioned PARTITION (pcol='200')
+PREHOOK: type: LOAD
+POSTHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+        ice_parquet_partitioned PARTITION (pcol='200')
+POSTHOOK: type: LOAD
+Stage-0
+  Move Operator
+    table:{"name:":"default.ice_parquet_partitioned"}
+
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='200')
+PREHOOK: type: LOAD
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition/pcol=200' OVERWRITE INTO TABLE
+ice_parquet_partitioned PARTITION (pcol='200')
+POSTHOOK: type: LOAD
+PREHOOK: query: select * from ice_parquet_partitioned order by intcol
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_parquet_partitioned
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_parquet_partitioned order by intcol
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_parquet_partitioned
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+a	1	100
+b	2	100
+c	3	200
+d	4	200
+AA	10	100
+CC	30	300

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -1069,7 +1069,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
       if (loadTableWork.isUseAppendForLoad()) {
         loadTableWork.getMdTable().getStorageHandler()
             .appendFiles(loadTableWork.getMdTable().getTTable(), loadTableWork.getSourcePath().toUri(),
-                loadTableWork.getLoadFileType() == LoadFileType.REPLACE_ALL);
+                loadTableWork.getLoadFileType() == LoadFileType.REPLACE_ALL, loadTableWork.getPartitionSpec());
         return true;
       }
       // Get the info from the table data

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;
 import org.apache.hadoop.hive.common.type.SnapshotContext;
@@ -316,14 +315,23 @@ public interface HiveStorageHandler extends Configurable {
   /**
    * Checks whether the table supports appending data files to the table.
    * @param table the table
+   * @param withPartClause whether a partition is specified
    * @return true if the table can append files directly to the table
    * @throws SemanticException in case of any error.
    */
-  default boolean supportsAppendData(Table table) throws SemanticException {
+  default boolean supportsAppendData(Table table, boolean withPartClause) throws SemanticException {
     return false;
   }
 
-  default void appendFiles(Table tbl, URI fromURI, boolean isOverwrite)
+  /**
+   * Appends files to the table
+   * @param tbl the table object.
+   * @param fromURI the source of files.
+   * @param isOverwrite whether to overwrite the existing table data.
+   * @param partitionSpec the partition spec.
+   * @throws SemanticException in case of any error
+   */
+  default void appendFiles(Table tbl, URI fromURI, boolean isOverwrite, Map<String, String> partitionSpec)
       throws SemanticException {
     throw new SemanticException(ErrorMsg.LOAD_INTO_NON_NATIVE.getMsg());
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -300,9 +300,11 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     if (ts.tableHandle.isNonNative()) {
       HiveStorageHandler storageHandler = ts.tableHandle.getStorageHandler();
       boolean isUseNativeApi = conf.getBoolVar(HIVE_LOAD_DATA_USE_NATIVE_API);
-      if (isUseNativeApi && storageHandler.supportsAppendData(ts.tableHandle.getTTable())) {
+      boolean supportAppend = isUseNativeApi && storageHandler.supportsAppendData(ts.tableHandle.getTTable(),
+          ts.getPartSpec() != null && !ts.getPartSpec().isEmpty());
+      if (supportAppend) {
         LoadTableDesc loadTableWork =
-            new LoadTableDesc(new Path(fromURI), ts.tableHandle, isOverWrite, true, isOverWrite);
+            new LoadTableDesc(new Path(fromURI), ts.tableHandle, isOverWrite, true, ts.getPartSpec());
         Task<?> childTask =
             TaskFactory.get(new MoveWork(getInputs(), getOutputs(), loadTableWork, null, true, isLocal));
         rootTasks.add(childTask);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/LoadTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/LoadTableDesc.java
@@ -160,13 +160,13 @@ public class LoadTableDesc extends LoadDesc implements Serializable {
   }
 
   public LoadTableDesc(Path path, Table tableHandle, boolean isOverWrite, boolean useAppendForLoad,
-      boolean isInsertOverwrite) {
+      Map<String, String> partitionSpec) {
     super(path, AcidUtils.Operation.NOT_ACID);
     this.mdTable = tableHandle;
     this.useAppendForLoad = useAppendForLoad;
     this.loadFileType = isOverWrite ? LoadFileType.REPLACE_ALL : LoadFileType.KEEP_EXISTING;
     this.table = Utilities.getTableDesc(tableHandle);
-    this.isInsertOverwrite = isInsertOverwrite;
+    this.partitionSpec = partitionSpec;
   }
 
   public boolean isUseAppendForLoad() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add support to use Append API for partitioned tables for LOAD queries

### Why are the changes needed?

Better usability.

### Does this PR introduce _any_ user-facing change?

Yes, Load data queries for iceberg table with PARTITION clause works

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT