### PR TITLE
HIVE-27466: Remove obsolete reference to category-X JSON license from NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Hive
 Copyright 2008-2023 The Apache Software Foundation
 
-This product includes software developed by The Apache Software
-Foundation (http://www.apache.org/).
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -3,5 +3,3 @@ Copyright 2008-2023 The Apache Software Foundation
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
-
-This project includes software licensed under the JSON license.

--- a/standalone-metastore/NOTICE
+++ b/standalone-metastore/NOTICE
@@ -1,6 +1,5 @@
 Apache Hive Metastore
-
 Copyright 2008-2023 The Apache Software Foundation
 
-This product includes software developed by The Apache Software
-Foundation (http://www.apache.org/).
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/storage-api/NOTICE
+++ b/storage-api/NOTICE
@@ -1,6 +1,5 @@
 Apache Hive Storage API
-
 Copyright 2008-2023 The Apache Software Foundation
 
-This product includes software developed by The Apache Software
-Foundation (http://www.apache.org/).
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### Why are the changes needed?
* Avoid propagating misleading information
* Comply with ASF policy and NOTICE guidelines

### Does this PR introduce _any_ user-facing change?
No but removes restrictions and ambiguity for consumers and people building products on top of Hive.

### Is the change a dependency upgrade?
No

### How was this patch tested?
Not necessary