### PR TITLE
HIVE-27400:Upgrade jetty to 11.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <javax-servlet.version>3.1.0</javax-servlet.version>
     <javolution.version>5.5.1</javolution.version>
     <jettison.version>1.5.4</jettison.version>
-    <jetty.version>9.4.40.v20210413</jetty.version>
+    <jetty.version>11.0.15</jetty.version>
     <jersey.version>1.19</jersey.version>
     <jline.version>2.14.6</jline.version>
     <jms.version>2.0.2</jms.version>


### PR DESCRIPTION
What changes were proposed in this pull request?
[HIVE-27400](https://issues.apache.org/jira/browse/HIVE-27400)

Why are the changes needed?
Keeping dependencies upto date

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
Yes

How was this patch tested?
Existing UT