### PR TITLE
HIVE-27474 Remove unused function resources method param for registerUDF method in Registry

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -146,16 +146,30 @@ public class Registry {
 
   }
 
+  @Deprecated
   public FunctionInfo registerUDF(String functionName,
       Class<? extends UDF> UDFClass, boolean isOperator) {
     FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
     return registerUDF(functionName, functionType, UDFClass, isOperator, functionName.toLowerCase());
   }
 
+  @Deprecated
   public FunctionInfo registerUDF(String functionName,
                                   Class<? extends UDF> UDFClass, boolean isOperator, String displayName) {
     FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
     return registerUDF(functionName, functionType, UDFClass, isOperator, displayName);
+  }
+
+  //TODO Remove the above two deprecated methods in next release
+  public FunctionInfo registerUDF(String functionName,
+                                  Class<? extends UDF> UDFClass, boolean isOperator) {
+    return registerUDF(functionName, UDFClass, isOperator, functionName.toLowerCase());
+  }
+
+  public FunctionInfo registerUDF(String functionName,
+                                  Class<? extends UDF> UDFClass, boolean isOperator, String displayName) {
+      FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
+      return registerUDF(functionName, functionType, UDFClass, isOperator, displayName);
   }
 
   private FunctionInfo registerUDF(String functionName, FunctionType functionType,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -147,13 +147,13 @@ public class Registry {
   }
 
   public FunctionInfo registerUDF(String functionName,
-      Class<? extends UDF> UDFClass, boolean isOperator, FunctionResource... resources) {
-    return registerUDF(functionName, UDFClass, isOperator, functionName.toLowerCase(), resources);
+      Class<? extends UDF> UDFClass, boolean isOperator) {
+    FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
+    return registerUDF(functionName, functionType, UDFClass, isOperator, functionName.toLowerCase());
   }
 
   public FunctionInfo registerUDF(String functionName,
-      Class<? extends UDF> UDFClass, boolean isOperator, String displayName,
-      FunctionResource... resources) {
+                                  Class<? extends UDF> UDFClass, boolean isOperator, String displayName) {
     FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
     return registerUDF(functionName, functionType, UDFClass, isOperator, displayName);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -146,21 +146,28 @@ public class Registry {
 
   }
 
+  /**
+   * @deprecated From next release, replaced by {@link #registerUDF(String, Class, boolean)}
+   * Deprecated because method unnecessarily accepts and passes FunctionResource vararg param
+   */
   @Deprecated
   public FunctionInfo registerUDF(String functionName,
-      Class<? extends UDF> UDFClass, boolean isOperator) {
-    FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
-    return registerUDF(functionName, functionType, UDFClass, isOperator, functionName.toLowerCase());
+      Class<? extends UDF> UDFClass, boolean isOperator, FunctionResource... resources) {
+    return registerUDF(functionName, UDFClass, isOperator, functionName.toLowerCase(), resources);
   }
 
+  /**
+   * @deprecated From next release, replaced by {@link #registerUDF(String, Class, boolean, String)}
+   * Deprecated because method unnecessarily accepts FunctionResource vararg param
+   */
   @Deprecated
   public FunctionInfo registerUDF(String functionName,
-                                  Class<? extends UDF> UDFClass, boolean isOperator, String displayName) {
+      Class<? extends UDF> UDFClass, boolean isOperator, String displayName,
+      FunctionResource... resources) {
     FunctionType functionType = isNative ? FunctionType.BUILTIN : FunctionType.TEMPORARY;
     return registerUDF(functionName, functionType, UDFClass, isOperator, displayName);
   }
 
-  //TODO Remove the above two deprecated methods in next release
   public FunctionInfo registerUDF(String functionName,
                                   Class<? extends UDF> UDFClass, boolean isOperator) {
     return registerUDF(functionName, UDFClass, isOperator, functionName.toLowerCase());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Remove unused function resources method param for registerUDF method in Registry for cleanup/better readability.  

https://github.com/apache/hive/blob/25892ea409b3351acbd409d1f66f399a43614798/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java#L154-L159

Not used by calling code here, likewise there are more places in the same file https://github.com/suprithIUB/hive/blob/14a1f70607db5ae6cf71b6d4343f308a5167581c/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java#L496-L514








### Why are the changes needed?
Cleanup


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Existing tests
