### PR TITLE
Upgrade jetty-server to 11.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -759,7 +759,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>11.0.15</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
What changes were proposed in this pull request?
Upgrade jetty-server to 11.0.15

Why are the changes needed?
Keeping dependencies upto date

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
Yes

How was this patch tested?
Existing UT