### PR TITLE
Hive-27479: Fix for the BETWEEN parameter issue and adjusted selectivity estimation in BETWEEN case for NULLs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -225,21 +225,21 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   }
 
   private Double computeBetweenPredicateSelectivity(RexCall call) {
-    final boolean hasInputRef = call.getOperands().get(0).getKind().equals(SqlKind.INPUT_REF);
-    final boolean hasLiteralLeft = call.getOperands().get(1).getKind().equals(SqlKind.LITERAL);
-    final boolean hasLiteralRight = call.getOperands().get(2).getKind().equals(SqlKind.LITERAL);
+    final boolean hasInputRef = call.getOperands().get(1).getKind().equals(SqlKind.INPUT_REF);
+    final boolean hasLiteralLeft = call.getOperands().get(2).getKind().equals(SqlKind.LITERAL);
+    final boolean hasLiteralRight = call.getOperands().get(3).getKind().equals(SqlKind.LITERAL);
 
     if (childRel instanceof HiveTableScan && hasInputRef && hasLiteralLeft && hasLiteralRight) {
       final HiveTableScan t = (HiveTableScan) childRel;
-      final int inputRefIndex = ((RexInputRef) call.getOperands().get(0)).getIndex();
+      final int inputRefIndex = ((RexInputRef) call.getOperands().get(1)).getIndex();
       final List<ColStatistics> colStats = t.getColStat(Collections.singletonList(inputRefIndex));
 
       if (!colStats.isEmpty() && isHistogramAvailable(colStats.get(0))) {
         final KllFloatsSketch kll = KllFloatsSketch.heapify(Memory.wrap(colStats.get(0).getHistogram()));
-        final SqlTypeName typeName = call.getOperands().get(0).getType().getSqlTypeName();
-        final Object leftBoundValueObject = ((RexLiteral) call.getOperands().get(1)).getValue();
+        final SqlTypeName typeName = call.getOperands().get(1).getType().getSqlTypeName();
+        final Object leftBoundValueObject = ((RexLiteral) call.getOperands().get(2)).getValue();
         float leftValue = extractLiteral(typeName, leftBoundValueObject);
-        final Object rightBoundValueObject = ((RexLiteral) call.getOperands().get(2)).getValue();
+        final Object rightBoundValueObject = ((RexLiteral) call.getOperands().get(3)).getValue();
         float rightValue = extractLiteral(typeName, rightBoundValueObject);
 
         if (NOT_BETWEEN.equals(call.getOperator())) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -245,7 +245,7 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
         final Object rightBoundValueObject = ((RexLiteral) call.getOperands().get(3)).getValue();
         float rightValue = extractLiteral(typeName, rightBoundValueObject);
         // when inverseBool == true, this is a NOT_BETWEEN and selectivity must be inverted
-        if (inverseBool == true) {
+        if (inverseBool) {
           if (rightValue == leftValue) {
             return computeNotEqualitySelectivity(call);
           } else if (rightValue < leftValue) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -250,7 +250,8 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
         }
         // when they are equal it's an equality predicate, we cannot handle it as "between"
         if (Double.compare(leftValue, rightValue) != 0) {
-          return betweenSelectivity(kll, leftValue, rightValue);
+          //return betweenSelectivity(kll, leftValue, rightValue);
+          return kll.getN() * betweenSelectivity(kll, leftValue, rightValue) / t.getTable().getRowCount();
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/FilterSelectivityEstimator.java
@@ -225,11 +225,12 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
   }
 
   private Double computeBetweenPredicateSelectivity(RexCall call) {
+    final boolean hasLiteralBool = call.getOperands().get(0).getKind().equals(SqlKind.LITERAL);
     final boolean hasInputRef = call.getOperands().get(1).getKind().equals(SqlKind.INPUT_REF);
     final boolean hasLiteralLeft = call.getOperands().get(2).getKind().equals(SqlKind.LITERAL);
     final boolean hasLiteralRight = call.getOperands().get(3).getKind().equals(SqlKind.LITERAL);
 
-    if (childRel instanceof HiveTableScan && hasInputRef && hasLiteralLeft && hasLiteralRight) {
+    if (childRel instanceof HiveTableScan && hasLiteralBool && hasInputRef && hasLiteralLeft && hasLiteralRight) {
       final HiveTableScan t = (HiveTableScan) childRel;
       final int inputRefIndex = ((RexInputRef) call.getOperands().get(1)).getIndex();
       final List<ColStatistics> colStats = t.getColStat(Collections.singletonList(inputRefIndex));
@@ -237,20 +238,23 @@ public class FilterSelectivityEstimator extends RexVisitorImpl<Double> {
       if (!colStats.isEmpty() && isHistogramAvailable(colStats.get(0))) {
         final KllFloatsSketch kll = KllFloatsSketch.heapify(Memory.wrap(colStats.get(0).getHistogram()));
         final SqlTypeName typeName = call.getOperands().get(1).getType().getSqlTypeName();
+        final Object inverseBoolValueObject = ((RexLiteral) call.getOperands().get(0)).getValue();
+        boolean inverseBool = Boolean.parseBoolean(inverseBoolValueObject.toString());
         final Object leftBoundValueObject = ((RexLiteral) call.getOperands().get(2)).getValue();
         float leftValue = extractLiteral(typeName, leftBoundValueObject);
         final Object rightBoundValueObject = ((RexLiteral) call.getOperands().get(3)).getValue();
         float rightValue = extractLiteral(typeName, rightBoundValueObject);
-
-        if (NOT_BETWEEN.equals(call.getOperator())) {
-          if (rightValue <= leftValue) {
+        // when inverseBool == true, this is a NOT_BETWEEN and selectivity must be inverted
+        if (inverseBool == true) {
+          if (rightValue == leftValue) {
+            return computeNotEqualitySelectivity(call);
+          } else if (rightValue < leftValue) {
             return 1.0;
           }
-          return lessThanSelectivity(kll, leftValue) + greaterThanSelectivity(kll, rightValue);
+          return 1.0 - (kll.getN() * betweenSelectivity(kll, leftValue, rightValue) / t.getTable().getRowCount());
         }
         // when they are equal it's an equality predicate, we cannot handle it as "between"
         if (Double.compare(leftValue, rightValue) != 0) {
-          //return betweenSelectivity(kll, leftValue, rightValue);
           return kll.getN() * betweenSelectivity(kll, leftValue, rightValue) / t.getTable().getRowCount();
         }
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -68,9 +68,7 @@ public class TestFilterSelectivityEstimator {
   private static final float DELTA = Float.MIN_VALUE;
   private static final RexBuilder REX_BUILDER = new RexBuilder(new JavaTypeFactoryImpl(new HiveTypeSystemImpl()));
   private static final RelDataTypeFactory TYPE_FACTORY = REX_BUILDER.getTypeFactory();
-
   private static RelOptCluster relOptCluster;
-
   private static RexNode intMinus1;
   private static RexNode int0;
   private static RexNode int1;
@@ -84,7 +82,8 @@ public class TestFilterSelectivityEstimator {
   private static RexNode int11;
   private static RelDataType tableType;
   private static RexNode inputRef0;
-  private static RexNode bool;
+  private static RexNode boolFalse;
+  private static RexNode boolTrue;
   private static ColStatistics stats;
 
   @Mock
@@ -111,7 +110,8 @@ public class TestFilterSelectivityEstimator {
     int8 = REX_BUILDER.makeLiteral(8, integerType, true);
     int10 = REX_BUILDER.makeLiteral(10, integerType, true);
     int11 = REX_BUILDER.makeLiteral(11, integerType, true);
-    bool = REX_BUILDER.makeLiteral(false, TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN), true);
+    boolFalse = REX_BUILDER.makeLiteral(false, TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN), true);
+    boolTrue = REX_BUILDER.makeLiteral(true, TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN), true);
     tableType = TYPE_FACTORY.createStructType(ImmutableList.of(integerType), ImmutableList.of("f1"));
 
     RelOptPlanner planner = CalcitePlanner.createPlanner(new HiveConf());
@@ -364,7 +364,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetween() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int1, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int1, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -372,7 +372,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenFromMinToMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int1, int7);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int1, int7);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -380,7 +380,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenFromLowerThanMinToHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int0, int8);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int0, int8);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -388,7 +388,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftLowerThanMin() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int0, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int0, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -396,7 +396,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenRightLowerThanMin() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, intMinus1, int0);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, intMinus1, int0);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -404,7 +404,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int10, int11);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int10, int11);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -412,7 +412,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftLowerThanRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int4, int2);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int4, int2);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -421,7 +421,7 @@ public class TestFilterSelectivityEstimator {
   public void testComputeRangePredicateSelectivityBetweenLeftEqualsRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     doReturn(10.0).when(mq).getDistinctRowCount(scan, ImmutableBitSet.of(0), REX_BUILDER.makeLiteral(true));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int3, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int3, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     // this is what FilterSelectivityEstimator returns for a generic "function" based on NDV values, in this case 1 / 10
     Assert.assertEquals(0.1, estimator.estimateSelectivity(filter), DELTA);
@@ -430,7 +430,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetween() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int3, int5);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolTrue, inputRef0, int3, int5);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.7692307692307693, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -438,7 +438,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenLowerThanMinHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int0, int10);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolTrue, inputRef0, int0, int10);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -446,7 +446,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenRightLowerThanLeft() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int5, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolTrue, inputRef0, int5, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -454,8 +454,62 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenLeftEqualsRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int3, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolTrue, inputRef0, int3, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityGreaterThanWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN, inputRef0, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.2, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityGreaterThanOrEqualWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, inputRef0, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.25, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityLessThanWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN, inputRef0, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.4, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityLessThanOrEqualWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, inputRef0, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.45, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityBetweenWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolFalse, inputRef0, int1, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.45, estimator.estimateSelectivity(filter), DELTA);
+  }
+
+  @Test
+  public void testComputeRangePredicateSelectivityNotBetweenWithNULLS() {
+    doReturn((double) 20).when(tableMock).getRowCount();
+    doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, boolTrue, inputRef0, int1, int3);
+    FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
+    Assert.assertEquals(0.55, estimator.estimateSelectivity(filter), DELTA);
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/stats/TestFilterSelectivityEstimator.java
@@ -84,6 +84,7 @@ public class TestFilterSelectivityEstimator {
   private static RexNode int11;
   private static RelDataType tableType;
   private static RexNode inputRef0;
+  private static RexNode bool;
   private static ColStatistics stats;
 
   @Mock
@@ -110,6 +111,7 @@ public class TestFilterSelectivityEstimator {
     int8 = REX_BUILDER.makeLiteral(8, integerType, true);
     int10 = REX_BUILDER.makeLiteral(10, integerType, true);
     int11 = REX_BUILDER.makeLiteral(11, integerType, true);
+    bool = REX_BUILDER.makeLiteral(false, TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN), true);
     tableType = TYPE_FACTORY.createStructType(ImmutableList.of(integerType), ImmutableList.of("f1"));
 
     RelOptPlanner planner = CalcitePlanner.createPlanner(new HiveConf());
@@ -362,7 +364,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetween() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int1, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int1, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -370,7 +372,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenFromMinToMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int1, int7);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int1, int7);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -378,7 +380,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenFromLowerThanMinToHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int0, int8);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int0, int8);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -386,7 +388,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftLowerThanMin() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int0, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int0, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.6923076923076923, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -394,7 +396,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenRightLowerThanMin() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, intMinus1, int0);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, intMinus1, int0);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -402,7 +404,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int10, int11);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int10, int11);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -410,7 +412,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityBetweenLeftLowerThanRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int4, int2);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int4, int2);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -419,7 +421,7 @@ public class TestFilterSelectivityEstimator {
   public void testComputeRangePredicateSelectivityBetweenLeftEqualsRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
     doReturn(10.0).when(mq).getDistinctRowCount(scan, ImmutableBitSet.of(0), REX_BUILDER.makeLiteral(true));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, inputRef0, int3, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.BETWEEN, bool, inputRef0, int3, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     // this is what FilterSelectivityEstimator returns for a generic "function" based on NDV values, in this case 1 / 10
     Assert.assertEquals(0.1, estimator.estimateSelectivity(filter), DELTA);
@@ -428,7 +430,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetween() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, inputRef0, int3, int5);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int3, int5);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0.7692307692307693, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -436,7 +438,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenLowerThanMinHigherThanMax() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, inputRef0, int0, int10);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int0, int10);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(0, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -444,7 +446,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenRightLowerThanLeft() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, inputRef0, int5, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int5, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }
@@ -452,7 +454,7 @@ public class TestFilterSelectivityEstimator {
   @Test
   public void testComputeRangePredicateSelectivityNotBetweenLeftEqualsRight() {
     doReturn(Collections.singletonList(stats)).when(tableMock).getColStat(Collections.singletonList(0));
-    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, inputRef0, int3, int3);
+    RexNode filter = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT_BETWEEN, bool, inputRef0, int3, int3);
     FilterSelectivityEstimator estimator = new FilterSelectivityEstimator(scan, mq);
     Assert.assertEquals(1, estimator.estimateSelectivity(filter), DELTA);
   }

--- a/ql/src/test/queries/clientpositive/stats_histogram_null.q
+++ b/ql/src/test/queries/clientpositive/stats_histogram_null.q
@@ -1,0 +1,80 @@
+set hive.stats.kll.enable=true;
+set metastore.stats.fetch.bitvector=true;
+set metastore.stats.fetch.kll=true;
+set hive.stats.autogather=true;
+set hive.stats.column.autogather=true;
+
+CREATE TABLE test_stats (a string, b int, c double, d float, e decimal(5,2), f timestamp, g date)
+STORED AS ORC;
+
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("a", 2, 1.1, 12.2, 1.3, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("b", 2, 2.1, NULL, 6.3, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("c", 2, 2.1, NULL, -8.3, "2020-11-2 00:00:00", "2020-11-02");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("d", 2, 3.1, 13.2, 10.2, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("e", 2, 3.1, 14.2, 10.2, "2020-11-02 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("f", 2, 4.1, NULL, 12.2, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("g", 2, 5.1, 15.2, -10.2, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("h", 2, 6.1, 16.2, 12.2, "2020-11-2 00:00:00", "2020-11-2");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("i", 3, 6.1, 17.2, 7.2, "2020-11-03 00:00:00", "2020-11-3");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("j", 4, NULL, 20.2, 1.2, "2020-11-4 00:00:00", "2020-11-4");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("k", 5, NULL, 50.2, -123.2, "2020-11-5 00:00:00", "2020-11-05");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("l", 6, NULL, 55.2, 1.2, "2020-11-6 00:00:00", "2020-11-6");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("m", 7, 9.1, 57.2, 1001.2, "2020-11-7 00:00:00", "2020-11-7");
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("n", NULL, 10.1, 11.2, 0.2, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("o", NULL, 56.1, 53.3, -12.3, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("p", NULL, 23.3, 67.2, 1.2, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("q", NULL, 31.1, 34.6, 2.4, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("r", NULL, 11.5, 29.4, 3.4, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("s", NULL, 101.2, 27.2, -6.1, NULL, NULL);
+INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("t", NULL, 33.9, 58.5, 4.3, NULL, NULL);
+
+DESCRIBE FORMATTED test_stats;
+DESCRIBE FORMATTED test_stats a;
+DESCRIBE FORMATTED test_stats b;
+DESCRIBE FORMATTED test_stats c;
+DESCRIBE FORMATTED test_stats d;
+DESCRIBE FORMATTED test_stats e;
+DESCRIBE FORMATTED test_stats f;
+DESCRIBE FORMATTED test_stats g;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2;
+
+EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5;
+SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5;

--- a/ql/src/test/results/clientpositive/llap/stats_histogram.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram.q.out
@@ -710,16 +710,16 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: test_stats
-                  filterExpr: (d NOT BETWEEN 3.0 AND 7.0 and (e > 0)) (type: boolean)
+                  filterExpr: ((e > 0) and d NOT BETWEEN 3.0 AND 7.0) (type: boolean)
                   Statistics: Num rows: 15 Data size: 1732 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (d NOT BETWEEN 3.0 AND 7.0 and (e > 0)) (type: boolean)
-                    Statistics: Num rows: 10 Data size: 1156 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((e > 0) and d NOT BETWEEN 3.0 AND 7.0) (type: boolean)
+                    Statistics: Num rows: 12 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
-                      Statistics: Num rows: 10 Data size: 1156 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 12 Data size: 1388 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: count()
-                        minReductionHashAggr: 0.9
+                        minReductionHashAggr: 0.9166667
                         mode: hash
                         outputColumnNames: _col0
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_null.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_null.q.out
@@ -1,0 +1,1228 @@
+PREHOOK: query: CREATE TABLE test_stats (a string, b int, c double, d float, e decimal(5,2), f timestamp, g date)
+STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: CREATE TABLE test_stats (a string, b int, c double, d float, e decimal(5,2), f timestamp, g date)
+STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_stats
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("a", 2, 1.1, 12.2, 1.3, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("a", 2, 1.1, 12.2, 1.3, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("b", 2, 2.1, NULL, 6.3, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("b", 2, 2.1, NULL, 6.3, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d EXPRESSION []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("c", 2, 2.1, NULL, -8.3, "2020-11-2 00:00:00", "2020-11-02")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("c", 2, 2.1, NULL, -8.3, "2020-11-2 00:00:00", "2020-11-02")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d EXPRESSION []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("d", 2, 3.1, 13.2, 10.2, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("d", 2, 3.1, 13.2, 10.2, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("e", 2, 3.1, 14.2, 10.2, "2020-11-02 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("e", 2, 3.1, 14.2, 10.2, "2020-11-02 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("f", 2, 4.1, NULL, 12.2, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("f", 2, 4.1, NULL, 12.2, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d EXPRESSION []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("g", 2, 5.1, 15.2, -10.2, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("g", 2, 5.1, 15.2, -10.2, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("h", 2, 6.1, 16.2, 12.2, "2020-11-2 00:00:00", "2020-11-2")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("h", 2, 6.1, 16.2, 12.2, "2020-11-2 00:00:00", "2020-11-2")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("i", 3, 6.1, 17.2, 7.2, "2020-11-03 00:00:00", "2020-11-3")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("i", 3, 6.1, 17.2, 7.2, "2020-11-03 00:00:00", "2020-11-3")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("j", 4, NULL, 20.2, 1.2, "2020-11-4 00:00:00", "2020-11-4")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("j", 4, NULL, 20.2, 1.2, "2020-11-4 00:00:00", "2020-11-4")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c EXPRESSION []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("k", 5, NULL, 50.2, -123.2, "2020-11-5 00:00:00", "2020-11-05")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("k", 5, NULL, 50.2, -123.2, "2020-11-5 00:00:00", "2020-11-05")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c EXPRESSION []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("l", 6, NULL, 55.2, 1.2, "2020-11-6 00:00:00", "2020-11-6")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("l", 6, NULL, 55.2, 1.2, "2020-11-6 00:00:00", "2020-11-6")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c EXPRESSION []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("m", 7, 9.1, 57.2, 1001.2, "2020-11-7 00:00:00", "2020-11-7")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("m", 7, 9.1, 57.2, 1001.2, "2020-11-7 00:00:00", "2020-11-7")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b SCRIPT []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f SCRIPT []
+POSTHOOK: Lineage: test_stats.g SCRIPT []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("n", NULL, 10.1, 11.2, 0.2, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("n", NULL, 10.1, 11.2, 0.2, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("o", NULL, 56.1, 53.3, -12.3, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("o", NULL, 56.1, 53.3, -12.3, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("p", NULL, 23.3, 67.2, 1.2, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("p", NULL, 23.3, 67.2, 1.2, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("q", NULL, 31.1, 34.6, 2.4, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("q", NULL, 31.1, 34.6, 2.4, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("r", NULL, 11.5, 29.4, 3.4, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("r", NULL, 11.5, 29.4, 3.4, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("s", NULL, 101.2, 27.2, -6.1, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("s", NULL, 101.2, 27.2, -6.1, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("t", NULL, 33.9, 58.5, 4.3, NULL, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats (a, b, c, d, e, f, g) VALUES ("t", NULL, 33.9, 58.5, 4.3, NULL, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.a SCRIPT []
+POSTHOOK: Lineage: test_stats.b EXPRESSION []
+POSTHOOK: Lineage: test_stats.c SCRIPT []
+POSTHOOK: Lineage: test_stats.d SCRIPT []
+POSTHOOK: Lineage: test_stats.e SCRIPT []
+POSTHOOK: Lineage: test_stats.f EXPRESSION []
+POSTHOOK: Lineage: test_stats.g EXPRESSION []
+PREHOOK: query: DESCRIBE FORMATTED test_stats
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+# col_name            	data_type           	comment             
+a                   	string              	                    
+b                   	int                 	                    
+c                   	double              	                    
+d                   	float               	                    
+e                   	decimal(5,2)        	                    
+f                   	timestamp           	                    
+g                   	date                	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+	bucketing_version   	2                   
+	numFiles            	20                  
+	numRows             	20                  
+	rawDataSize         	5332                
+	totalSize           	14529               
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: DESCRIBE FORMATTED test_stats a
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats a
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	a                   
+data_type           	string              
+min                 	                    
+max                 	                    
+num_nulls           	0                   
+distinct_count      	20                  
+avg_col_len         	1.0                 
+max_col_len         	1                   
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	                    
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats b
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats b
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	b                   
+data_type           	int                 
+min                 	2                   
+max                 	7                   
+num_nulls           	7                   
+distinct_count      	6                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 2, Q2: 2, Q3: 4 
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats c
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats c
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	c                   
+data_type           	double              
+min                 	1.1                 
+max                 	101.2               
+num_nulls           	3                   
+distinct_count      	14                  
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 3.1, Q2: 6.1, Q3: 23.3
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats d
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats d
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	d                   
+data_type           	float               
+min                 	11.199999809265137  
+max                 	67.19999694824219   
+num_nulls           	3                   
+distinct_count      	17                  
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 15.2, Q2: 27.2, Q3: 53.3
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats e
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats e
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	e                   
+data_type           	decimal(5,2)        
+min                 	-12.3               
+max                 	12.2                
+num_nulls           	1                   
+distinct_count      	15                  
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: -6.1, Q2: 1.3, Q3: 7.2
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats f
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats f
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	f                   
+data_type           	timestamp           
+min                 	2020-11-02 00:00:00 
+max                 	2020-11-07 00:00:00 
+num_nulls           	7                   
+distinct_count      	6                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 2020-11-02 00:00:00, Q2: 2020-11-02 00:00:00, Q3: 2020-11-04 00:00:00
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: DESCRIBE FORMATTED test_stats g
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_stats
+POSTHOOK: query: DESCRIBE FORMATTED test_stats g
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_stats
+col_name            	g                   
+data_type           	date                
+min                 	2020-11-02          
+max                 	2020-11-07          
+num_nulls           	7                   
+distinct_count      	6                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+histogram           	Q1: 2020-11-02, Q2: 2020-11-02, Q3: 2020-11-04
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\",\"c\":\"true\",\"d\":\"true\",\"e\":\"true\",\"f\":\"true\",\"g\":\"true\"}}
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (b BETWEEN 2 AND 6 and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (b BETWEEN 2 AND 6 and a is not null) (type: boolean)
+                    Statistics: Num rows: 12 Data size: 1056 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.9166667
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b BETWEEN 2 AND 6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+12
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (b NOT BETWEEN 2 AND 6 and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (b NOT BETWEEN 2 AND 6 and a is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 85 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 1 Data size: 85 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b NOT BETWEEN 2 AND 6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+1
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: ((b >= 3) and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((b >= 3) and a is not null) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 441 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 5 Data size: 425 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 425 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.8
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b >= 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+5
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: ((b > 3) and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((b > 3) and a is not null) (type: boolean)
+                    Statistics: Num rows: 4 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 4 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 4 Data size: 340 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.75
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b > 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+4
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: ((b <= 2) and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((b <= 2) and a is not null) (type: boolean)
+                    Statistics: Num rows: 8 Data size: 704 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 8 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 8 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 8 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.875
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b <= 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+8
+PREHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: ((b < 5) and a is not null) (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((b < 5) and a is not null) (type: boolean)
+                    Statistics: Num rows: 10 Data size: 878 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 10 Data size: 850 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 10 Data size: 850 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t2
+                  filterExpr: a is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: a is not null (type: boolean)
+                    Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 20 Data size: 1700 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                Statistics: Num rows: 10 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  minReductionHashAggr: 0.9
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT COUNT(*)
+FROM test_stats t1 JOIN test_stats t2 ON (t1.a = t2.a)
+WHERE t1.b < 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+10


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://issues.apache.org/jira/browse/HIVE-27479

1. Before this PR, the code for computing BETWEEN selectivity estimation assumed that the BETWEEN call consisted of 3 operands: InputRef, LiteralLeft, and LiteralRight. However there is a forth boolean operand (in position 0) that was not accounted for. Due to this, the conditions for entering the computeBetweenPredicateSelectivity function were incorrectly failing. This PR fixes this issue and accounts for the forth boolean operand in the conditions to enter the computeBetweenPredicateSelectivity function.

2. For the BETWEEN case, NULL values are not being accounted for in the selectivity estimation, this PR fixes the selectivity estimation to account for NULLs.

3. The forth boolean operand, which was initially not accounted for, represents whether the BETWEEN case is a traditional BETWEEN or a NOT BETWEEN. Code was added to invert the selectivity if the boolean operand suggests that the BETWEEN case was a NOT BETWEEN.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Since the forth boolean operand (in position 0) is not accounted for, the checks to enter the computeBetweenPredicateSelectivity function always fail and selectivity is never calculated for BETWEEN calls.

2. The BETWEEN selectivity estimation was partially incorrect as it did not consider NULL values in its calculation.

3. If the boolean operand suggests that the BETWEEN case was a NOT BETWEEN, then the selectivity should be inverted. Before this PR, this boolean operand was not considered in the BETWEEN selectivity estimation.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests are found in `TestFilterSelectivityEstimator.java` file.
`mvn test -Dtest.output.overwrite -Dtest=TestMiniLlapLocalCliDriver -Dqfile=stats_histogram_null.q  -pl itests/qtest -Pitests`