### PR TITLE
HIVE-27483: HMS add_partitions audit log adds table name and metrics

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -4055,7 +4055,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   private List<Partition> add_partitions_core(final RawStore ms, String catName,
                                               String dbName, String tblName, List<Partition> parts, final boolean ifNotExists)
       throws TException {
-    startTableFunction("add_partitions", catName, dbName, tblName);
+    logAndAudit("add_partitions" + " : tbl=" + TableName.getQualified(catName, dbName, tblName));
     boolean success = false;
     // Ensures that the list doesn't have dups, and keeps track of directories we have created.
     final Map<PartValEqWrapperLite, Boolean> addedPartitions = new ConcurrentHashMap<>();

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -4055,7 +4055,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   private List<Partition> add_partitions_core(final RawStore ms, String catName,
                                               String dbName, String tblName, List<Partition> parts, final boolean ifNotExists)
       throws TException {
-    logAndAudit("add_partitions" + " : tbl=" + TableName.getQualified(catName, dbName, tblName));
     boolean success = false;
     // Ensures that the list doesn't have dups, and keeps track of directories we have created.
     final Map<PartValEqWrapperLite, Boolean> addedPartitions = new ConcurrentHashMap<>();
@@ -4371,6 +4370,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       return result;
     }
 
+    List<Partition> ret = null;
+    Exception ex = null;
     if (!request.isSetCatName()) {
       request.setCatName(getDefaultCatalog(conf));
     }
@@ -4380,13 +4381,10 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         p.setCatName(getDefaultCatalog(conf));
       }
     });
-
     String catName = request.getCatName();
     String dbName = request.getDbName();
     String tableName = request.getTblName();
     startTableFunction(functionName, catName, dbName, tableName);
-    List<Partition> ret = null;
-    Exception ex = null;
     try {
       ret = add_partitions_core(getMS(), catName, dbName,
               tableName, request.getParts(), request.isIfNotExists());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -4446,8 +4446,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     Integer ret = null;
     Exception ex = null;
+    startTableFunction("add_partitions_pspec", catName, dbName, tableName);
     try {
-      startTableFunction("add_partitions_pspec", catName, dbName, tableName);
       ret = add_partitions_pspec_core(getMS(), catName, dbName, tableName, partSpecs, false);
     } catch (Exception e) {
       ex = e;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add table name to audit log and metrics.

### Why are the changes needed?
We are missing the table name and metrics related to `add_partitions` RPC.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
