### PR TITLE
HIVE-27494: Deduplicate the task result that generated by more branch…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -1435,6 +1435,9 @@ public final class Utilities {
     FileSystem fs = specPath.getFileSystem(hconf);
     Path tmpPath = Utilities.toTempPath(specPath);
     Path taskTmpPath = Utilities.toTaskTempPath(specPath);
+    if (!StringUtils.isEmpty(unionSuffix)) {
+      specPath = specPath.getParent();
+    }
     PerfLogger perfLogger = SessionState.getPerfLogger();
     boolean isBlobStorage = BlobStorageUtils.isBlobStorageFileSystem(hconf, fs);
     boolean avoidRename = false;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFileSinkOperator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFileSinkOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec;
 
+import org.junit.After;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -78,7 +79,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,8 +172,9 @@ public class TestFileSinkOperator {
     setupData(DataFormat.WITH_PARTITION_VALUE);
 
     FileSinkDesc desc = (FileSinkDesc) getFileSink(AcidUtils.Operation.NOT_ACID, true, 0).getConf().clone();
+    Path linkedDir = desc.getDirName();
     desc.setLinkedFileSink(true);
-    desc.setDirName(new Path(desc.getDirName(), AbstractFileMergeOperator.UNION_SUDBIR_PREFIX + "0"));
+    desc.setDirName(new Path(linkedDir, AbstractFileMergeOperator.UNION_SUDBIR_PREFIX + "0"));
     JobConf jobConf = new JobConf(jc);
     jobConf.set("hive.execution.engine", "tez");
     jobConf.set("mapred.task.id", "000000_0");
@@ -188,41 +189,85 @@ public class TestFileSinkOperator {
     op2.setConf(desc);
     op2.initialize(jobConf2, new ObjectInspector[]{inspector});
 
+    // Another sub-query in union
+    JobConf jobConf3 = new JobConf(jobConf);
+    jobConf3.set("mapred.task.id", "000001_0");
+    FileSinkOperator op3 = (FileSinkOperator)OperatorFactory.get(
+        new CompilationOpContext(), FileSinkDesc.class);
+    FileSinkDesc sinkDesc = (FileSinkDesc) desc.clone();
+    sinkDesc.setDirName(new Path(linkedDir, AbstractFileMergeOperator.UNION_SUDBIR_PREFIX + "1"));
+    op3.setConf(sinkDesc);
+    op3.initialize(jobConf3, new ObjectInspector[]{inspector});
+
+    JobConf jobConf4 = new JobConf(jobConf);
+    jobConf4.set("mapred.task.id", "000001_1");
+    FileSinkOperator op4 = (FileSinkOperator)OperatorFactory.get(
+        new CompilationOpContext(), FileSinkDesc.class);
+    op4.setConf(sinkDesc);
+    op4.initialize(jobConf4, new ObjectInspector[]{inspector});
+
     for (Object r : rows) {
       op1.process(r, 0);
       op2.process(r, 0);
+      op3.process(r, 0);
+      op4.process(r, 0);
     }
 
     op1.close(false);
     // Assume op2 also ends successfully, this happens in different containers
     op2.close(false);
-    Path[] paths = findFilesInBasePath();
-    List<Path> mondays = Arrays.stream(paths)
-        .filter(path -> path.getParent().toString().endsWith("partval=Monday/HIVE_UNION_SUBDIR_0"))
-        .collect(Collectors.toList());
-    Assert.assertEquals("Two result files are expected", 2, mondays.size());
-    Set<String> fileNames = new HashSet<>();
-    fileNames.add(mondays.get(0).getName());
-    fileNames.add(mondays.get(1).getName());
+    op3.close(false);
+    op4.close(false);
 
+    Path[] paths = findFilesInPath(linkedDir);
+              // = findFilesInBasePath() # use findFilesInBasePath before the fix
+    Set<String> fileNames = Arrays.stream(paths)
+        .filter(path -> path.getParent().toString().endsWith("partval=Monday/HIVE_UNION_SUBDIR_0"))
+        .map(path -> path.getName())
+        .collect(Collectors.toSet());
+    Assert.assertEquals("Two result files are expected", 2, fileNames.size());
     Assert.assertTrue("000000_1 file is expected", fileNames.contains("000000_1"));
     Assert.assertTrue("000000_0 file is expected", fileNames.contains("000000_0"));
 
+    fileNames = Arrays.stream(paths)
+        .filter(path -> path.getParent().toString().endsWith("partval=Monday/HIVE_UNION_SUBDIR_1"))
+        .map(path -> path.getName())
+        .collect(Collectors.toSet());
+    Assert.assertEquals("Two result files are expected", 2, fileNames.size());
+    Assert.assertTrue("000001_0 file is expected", fileNames.contains("000001_0"));
+    Assert.assertTrue("000001_1 file is expected", fileNames.contains("000001_1"));
+
+    // Close op3 first to see if it can deduplicate the result under HIVE_UNION_SUBDIR_0
+    op3.jobCloseOp(jobConf, true);
     // This happens in HiveServer2 when the job is finished, the job will call
     // jobCloseOp to end his operators. For the FileSinkOperator, a deduplication on the
     // output files may happen so that only one output file is left for each yarn task.
     op1.jobCloseOp(jobConf, true);
     List<Path> resultFiles = new ArrayList<Path>();
-    recurseOnPath(basePath, basePath.getFileSystem(jc), resultFiles);
-    mondays = resultFiles.stream()
-        .filter(path -> path.getParent().toString().endsWith("partval=Monday/HIVE_UNION_SUBDIR_0"))
+    String linkedDirPath = linkedDir.toUri().getPath();
+    recurseOnPath(linkedDir, linkedDir.getFileSystem(jc), resultFiles);
+    List<Path> mondays = resultFiles.stream()
+        .filter(path -> path.getParent().toUri().getPath()
+            .equals(linkedDirPath + "/partval=Monday/HIVE_UNION_SUBDIR_0"))
         .collect(Collectors.toList());
     Assert.assertEquals("Only 1 file should be here after cleaning", 1, mondays.size());
     Assert.assertEquals("000000_1 file is expected", "000000_1", mondays.get(0).getName());
 
-    confirmOutput(DataFormat.WITH_PARTITION_VALUE, resultFiles.toArray(new Path[0]));
-    // Clean out directory after testing
-    basePath.getFileSystem(jc).delete(basePath, true);
+    List<Path> subdir1 = resultFiles.stream()
+        .filter(path -> path.getParent().getName().equals("HIVE_UNION_SUBDIR_1")).sorted()
+        .collect(Collectors.toList());
+    Assert.assertEquals("Two partitions expected", 2, subdir1.size());
+    Path monday = subdir1.get(0), tuesday = subdir1.get(1);
+    Assert.assertEquals("Only 1 file left under the partition after deduplication", monday.toUri().getPath(),
+        linkedDirPath + "/partval=Monday/HIVE_UNION_SUBDIR_1/000001_1");
+    Assert.assertEquals("Only 1 file left under the partition after deduplication", tuesday.toUri().getPath(),
+        linkedDirPath + "/partval=Tuesday/HIVE_UNION_SUBDIR_1/000001_1");
+
+    // Confirm the output
+    confirmOutput(DataFormat.WITH_PARTITION_VALUE, resultFiles.stream()
+        .filter(p -> p.getParent().getName().equals("HIVE_UNION_SUBDIR_0")).sorted()
+        .collect(Collectors.toList()).toArray(new Path[0]));
+    confirmOutput(DataFormat.WITH_PARTITION_VALUE, subdir1.toArray(new Path[0]));
   }
 
   @Test
@@ -268,6 +313,16 @@ public class TestFileSinkOperator {
     jc.set(HiveConf.ConfVars.HIVE_STATS_DEFAULT_AGGREGATOR.varname,
         TFSOStatsAggregator.class.getName());
     jc.set(HiveConf.ConfVars.HIVESTATSDBCLASS.varname, "custom");
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    Path parent = basePath.getParent();
+    String last = basePath.getName();
+    FileSystem fs = basePath.getFileSystem(jc);
+    fs.delete(basePath, true);
+    fs.delete(new Path(parent, "_tmp." + last), true);
+    fs.delete(new Path(parent, "_task_tmp." + last), true);
   }
 
   private void setBasePath(String testName) {
@@ -411,6 +466,13 @@ public class TestFileSinkOperator {
     FileSystem fs = basePath.getFileSystem(jc);
     List<Path> paths = new ArrayList<Path>();
     recurseOnPath(tmpPath, fs, paths);
+    return paths.toArray(new Path[paths.size()]);
+  }
+
+  private Path[] findFilesInPath(Path path) throws IOException {
+    FileSystem fs = path.getFileSystem(jc);
+    List<Path> paths = new ArrayList<Path>();
+    recurseOnPath(path, fs, paths);
     return paths.toArray(new Path[paths.size()]);
   }
 


### PR DESCRIPTION
…es in union all

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Think of an union all case inserting data to an external table(dynamic partition):
FS[1] specPath: <staging_dir>/-ext-10000/HIVE_UNION_SUBDIR_1
FS[2] specPath: <staging_dir>/-ext-10000/HIVE_UNION_SUBDIR_2

Finally, the output of FS will locate under the directory:
FS[1]: <staging_dir>/_tmp.-ext-10000/<dynamic_partition>/HIVE_UNION_SUBDIR_1
FS[2]: <staging_dir>/_tmp.-ext-10000/<dynamic_partition>/HIVE_UNION_SUBDIR_2

When the task finishes, FS[1] and FS[2] will call jobClose to move their output to <staging_dir>/-ext-10000, the MoveTask is responsible for moving it to the destination table.

https://github.com/apache/hive/blob/81759a105e50b9fd8c66ffbf2920f425a1d7a64c/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java#L679-L689

Before the FS[1] moves the data, it will rename <staging_dir>/_tmp.-ext-10000 to <staging_dir>/_tmp.-ext-10000.moved, 
https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java#L1453-L1456

FS[1] will only deduplicate the result under the _tmp.-ext-10000.moved/<dynamic_partition>/HIVE_UNION_SUBDIR_1, and add the valid output file to `filesKept`, ignore the result under HIVE_UNION_SUBDIR_2 or more...
When it turns to FS[2] to close the operator, as the temp output directory has already been renamed to `_tmp.-ext-10000.moved`, so the FS[2] will do nothing.

So this will cause task result duplication, and in some cases, the result will lose as the `filesKept` only keeps the result of only one branch.

To solve this, one idea is making every FS have his own private temp output directory. For example:
FS[1]: <staging_dir>/-ext-10000/_tmp.HIVE_UNION_SUBDIR_1/<dynamic_partition>/HIVE_UNION_SUBDIR_1
FS[2]: <staging_dir>/-ext-10000/_tmp.HIVE_UNION_SUBDIR_2/<dynamic_partition>/HIVE_UNION_SUBDIR_2

When FS closes, each FS operator only takes care of his own output, and moves the temp output to <staging_dir>/-ext-10000 as it does before, and this method will bring some performance gain in case renaming to `_tmp.-ext-10000.moved` is not allowed:
https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java#L1461-L1462

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
Added UT
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
