### PR TITLE
HIVE-27501: CVE-2022-45868 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <flatbuffers.version>1.12.0</flatbuffers.version>
     <guava.version>22.0</guava.version>
     <groovy.version>2.4.21</groovy.version>
-    <h2database.version>2.1.214</h2database.version>
+    <h2database.version>2.2.220</h2database.version>
     <hadoop.version>3.3.1</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
1. Changes : Upgrade h2database version to 2.2.220 for CVE-2022-45868 fix.

2.  The change is required because the web-based admin console in H2 Database Engine through 2.1.214 can be started via the CLI with the argument -webAdminPassword, which allows the user to specify the password in cleartext for the web admin console. Consequently, a local user (or an attacker that has obtained local access through some means) would be able to discover the password by listing processes and their arguments.


3. Dependency tree: 
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-storage-api ---
[INFO]
[INFO] ------------------------< org.apache.hive:hive >------------------------
[INFO] Building Hive 4.0.0-beta-1-SNAPSHOT                               [2/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive ---
[INFO]
[INFO] ----------------< org.apache.hive:hive-classification >-----------------
[INFO] Building Hive Classifications 4.0.0-beta-1-SNAPSHOT               [3/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-classification ---
[INFO]
[INFO] --------------< org.apache.hive.shims:hive-shims-common >---------------
[INFO] Building Hive Shims Common 4.0.0-beta-1-SNAPSHOT                  [4/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-shims-common ---
[INFO]
[INFO] ---------------< org.apache.hive.shims:hive-shims-0.23 >----------------
[INFO] Building Hive Shims 0.23 4.0.0-beta-1-SNAPSHOT                    [5/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-shims-0.23 ---
[INFO]
[INFO] ---------------------< org.apache.hive:hive-shims >---------------------
[INFO] Building Hive Shims 4.0.0-beta-1-SNAPSHOT                         [6/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-shims ---
[INFO]
[INFO] -------------< org.apache.hive:hive-standalone-metastore >--------------
[INFO] Building Hive Standalone Metastore 4.0.0-beta-1-SNAPSHOT          [7/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-standalone-metastore ---
[INFO]
[INFO] ----------< org.apache.hive:hive-standalone-metastore-common >----------
[INFO] Building Hive Standalone Metastore Common Code 4.0.0-beta-1-SNAPSHOT [8/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-standalone-metastore-common ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-common >---------------------
[INFO] Building Hive Common 4.0.0-beta-1-SNAPSHOT                        [9/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-common ---
[INFO]
[INFO] ------------------< org.apache.hive:hive-service-rpc >------------------
[INFO] Building Hive Service RPC 4.0.0-beta-1-SNAPSHOT                  [10/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-service-rpc ---
[INFO]
[INFO] ---------------------< org.apache.hive:hive-serde >---------------------
[INFO] Building Hive Serde 4.0.0-beta-1-SNAPSHOT                        [11/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-serde ---
[INFO]
[INFO] -------------------< org.apache.hive:hive-metastore >-------------------
[INFO] Building Hive Metastore 4.0.0-beta-1-SNAPSHOT                    [12/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-metastore ---
[INFO]
[INFO] ----------------< org.apache.hive:hive-vector-code-gen >----------------
[INFO] Building Hive Vector-Code-Gen Utilities 4.0.0-beta-1-SNAPSHOT    [13/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-vector-code-gen ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-parser >---------------------
[INFO] Building Hive Parser 4.0.0-beta-1-SNAPSHOT                       [14/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-parser ---
[INFO]
[INFO] ----------------------< org.apache.hive:hive-udf >----------------------
[INFO] Building Hive UDF 4.0.0-beta-1-SNAPSHOT                          [15/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-udf ---
[INFO]
[INFO] ------------------< org.apache.hive:hive-llap-common >------------------
[INFO] Building Hive Llap Common 4.0.0-beta-1-SNAPSHOT                  [16/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-llap-common ---
[INFO]
[INFO] ------------------< org.apache.hive:hive-llap-client >------------------
[INFO] Building Hive Llap Client 4.0.0-beta-1-SNAPSHOT                  [17/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-llap-client ---
[INFO]
[INFO] -------------------< org.apache.hive:hive-llap-tez >--------------------
[INFO] Building Hive Llap Tez 4.0.0-beta-1-SNAPSHOT                     [18/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-llap-tez ---
[INFO]
[INFO] ----------< org.apache.hive:hive-standalone-metastore-server >----------
[INFO] Building Hive Metastore Server 4.0.0-beta-1-SNAPSHOT             [19/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-standalone-metastore-server ---
[INFO]
[INFO] ---------------------< org.apache.hive:hive-exec >----------------------
[INFO] Building Hive Query Language 4.0.0-beta-1-SNAPSHOT               [20/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-exec ---
[INFO]
[INFO] -------------------< org.apache.hive:hive-testutils >-------------------
[INFO] Building Hive TestUtils 4.0.0-beta-1-SNAPSHOT                    [21/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-testutils ---
[INFO]
[INFO] ------------------< org.apache.hive:hive-llap-server >------------------
[INFO] Building Hive Llap Server 4.0.0-beta-1-SNAPSHOT                  [22/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-llap-server ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-hplsql >---------------------
[INFO] Building Hive HPL/SQL 4.0.0-beta-1-SNAPSHOT                      [23/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hplsql ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-service >--------------------
[INFO] Building Hive Service 4.0.0-beta-1-SNAPSHOT                      [24/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-service ---
[INFO]
[INFO] ---------------< org.apache.hive:hive-accumulo-handler >----------------
[INFO] Building Hive Accumulo Handler 4.0.0-beta-1-SNAPSHOT             [25/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-accumulo-handler ---
[INFO]
[INFO] ---------------------< org.apache.hive:hive-jdbc >----------------------
[INFO] Building Hive JDBC 4.0.0-beta-1-SNAPSHOT                         [26/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-jdbc ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-beeline >--------------------
[INFO] Building Hive Beeline 4.0.0-beta-1-SNAPSHOT                      [27/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-beeline ---
[INFO]
[INFO] ----------------------< org.apache.hive:hive-cli >----------------------
[INFO] Building Hive CLI 4.0.0-beta-1-SNAPSHOT                          [28/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-cli ---
[INFO]
[INFO] --------------------< org.apache.hive:hive-contrib >--------------------
[INFO] Building Hive Contrib 4.0.0-beta-1-SNAPSHOT                      [29/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-contrib ---
[INFO]
[INFO] -----------------< org.apache.hive:hive-druid-handler >-----------------
[INFO] Building Hive Druid Handler 4.0.0-beta-1-SNAPSHOT                [30/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-druid-handler ---
[INFO]
[INFO] -----------------< org.apache.hive:hive-hbase-handler >-----------------
[INFO] Building Hive HBase Handler 4.0.0-beta-1-SNAPSHOT                [31/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hbase-handler ---
[INFO]
[INFO] -----------------< org.apache.hive:hive-jdbc-handler >------------------
[INFO] Building Hive JDBC Handler 4.0.0-beta-1-SNAPSHOT                 [32/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-jdbc-handler ---
[INFO] org.apache.hive:hive-jdbc-handler:jar:4.0.0-beta-1-SNAPSHOT
[INFO] \- com.h2database:h2:jar:2.2.220:test
[INFO]
[INFO] ---------------< org.apache.hive.hcatalog:hive-hcatalog >---------------
[INFO] Building Hive HCatalog 4.0.0-beta-1-SNAPSHOT                     [33/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hcatalog ---
[INFO]
[INFO] ------------< org.apache.hive.hcatalog:hive-hcatalog-core >-------------
[INFO] Building Hive HCatalog Core 4.0.0-beta-1-SNAPSHOT                [34/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hcatalog-core ---
[INFO]
[INFO] ---------< org.apache.hive.hcatalog:hive-hcatalog-pig-adapter >---------
[INFO] Building Hive HCatalog Pig Adapter 4.0.0-beta-1-SNAPSHOT         [35/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hcatalog-pig-adapter ---
[INFO]
[INFO] ------< org.apache.hive.hcatalog:hive-hcatalog-server-extensions >------
[INFO] Building Hive HCatalog Server Extensions 4.0.0-beta-1-SNAPSHOT   [36/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-hcatalog-server-extensions ---
[INFO]
[INFO] ---------< org.apache.hive.hcatalog:hive-webhcat-java-client >----------
[INFO] Building Hive HCatalog Webhcat Java Client 4.0.0-beta-1-SNAPSHOT [37/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-webhcat-java-client ---
[INFO]
[INFO] ---------------< org.apache.hive.hcatalog:hive-webhcat >----------------
[INFO] Building Hive HCatalog Webhcat 4.0.0-beta-1-SNAPSHOT             [38/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-webhcat ---
[INFO]
[INFO] -------------------< org.apache.hive:hive-streaming >-------------------
[INFO] Building Hive Streaming 4.0.0-beta-1-SNAPSHOT                    [39/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-streaming ---
[INFO]
[INFO] ----------------< org.apache.hive:hive-llap-ext-client >----------------
[INFO] Building Hive Llap External Client 4.0.0-beta-1-SNAPSHOT         [40/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-llap-ext-client ---
[INFO]
[INFO] ---------------< org.apache.hive:hive-shims-aggregator >----------------
[INFO] Building Hive Shims Aggregator 4.0.0-beta-1-SNAPSHOT             [41/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-shims-aggregator ---
[INFO]
[INFO] -----------------< org.apache.hive:hive-kudu-handler >------------------
[INFO] Building Hive Kudu Handler 4.0.0-beta-1-SNAPSHOT                 [42/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-kudu-handler ---
[INFO]
[INFO] -------------------< org.apache.hive:kafka-handler >--------------------
[INFO] Building Hive Kafka Storage Handler 4.0.0-beta-1-SNAPSHOT        [43/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ kafka-handler ---
[INFO]
[INFO] -------------------< org.apache.hive:hive-packaging >-------------------
[INFO] Building Hive Packaging 4.0.0-beta-1-SNAPSHOT                    [44/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-packaging ---
[INFO]
[INFO] ----------------< org.apache.hive:hive-metastore-tools >----------------
[INFO] Building Hive Metastore Tools 4.0.0-beta-1-SNAPSHOT              [45/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-metastore-tools ---
[INFO]
[INFO] ---------------< org.apache.hive:metastore-tools-common >---------------
[INFO] Building Hive Metastore Tools common libraries 4.0.0-beta-1-SNAPSHOT [46/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ metastore-tools-common ---
[INFO]
[INFO] -------------< org.apache.hive:hive-metastore-benchmarks >--------------
[INFO] Building Hive metastore benchmarks 4.0.0-beta-1-SNAPSHOT         [47/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-metastore-benchmarks ---
[INFO]
[INFO] -----------------< org.apache.hive:hive-upgrade-acid >------------------
[INFO] Building Hive Upgrade Acid 4.0.0-beta-1-SNAPSHOT                 [48/49]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-upgrade-acid ---
[INFO]
[INFO] ------------------< org.apache.hive:hive-pre-upgrade >------------------
[INFO] Building Hive Pre Upgrade Acid 4.0.0-beta-1-SNAPSHOT             [49/49]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ hive-pre-upgrade ---
[INFO] ------------------------------------------------------------------------