### PR TITLE
HIVE-27501: Upgrade h2database version to 2.2.220 to fix CVE-2022-45868

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <flatbuffers.version>1.2.0-3f79e055</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <h2database.version>1.3.166</h2database.version>
+    <h2database.version>2.2.220</h2database.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
1. Changes : Upgrade h2database version to 2.2.220 for https://github.com/advisories/GHSA-22wj-vf5f-wrvj fix.

2. The change is required because the web-based admin console in H2 Database Engine through 2.1.214 can be started via the CLI with the argument -webAdminPassword, which allows the user to specify the password in cleartext for the web admin console. Consequently, a local user (or an attacker that has obtained local access through some means) would be able to discover the password by listing processes and their arguments.
3. JIRA link : [https://issues.apache.org/jira/browse/HIVE-27501](url)