### PR TITLE
HIVE-27507: ConvertJoinMapJoin#hasOuterJoin produce incorrect result

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -961,7 +961,8 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     return false;
   }
 
-  private boolean hasOuterJoin(JoinOperator joinOp) throws SemanticException {
+  @VisibleForTesting
+  protected static boolean hasOuterJoin(JoinOperator joinOp) throws SemanticException {
     boolean hasOuter = false;
     for (JoinCondDesc joinCondDesc : joinOp.getConf().getConds()) {
       switch (joinCondDesc.getType()) {
@@ -969,7 +970,6 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
         case JoinDesc.LEFT_SEMI_JOIN:
         case JoinDesc.ANTI_JOIN:
         case JoinDesc.UNIQUE_JOIN:
-          hasOuter = false;
           break;
 
         case JoinDesc.FULL_OUTER_JOIN:

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -1068,7 +1068,8 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     return false;
   }
 
-  private boolean hasOuterJoin(JoinOperator joinOp) throws SemanticException {
+  @VisibleForTesting
+  static boolean hasOuterJoin(JoinOperator joinOp) throws SemanticException {
     boolean hasOuter = false;
     for (JoinCondDesc joinCondDesc : joinOp.getConf().getConds()) {
       switch (joinCondDesc.getType()) {
@@ -1076,7 +1077,6 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
         case JoinDesc.LEFT_SEMI_JOIN:
         case JoinDesc.ANTI_JOIN:
         case JoinDesc.UNIQUE_JOIN:
-          hasOuter = false;
           break;
 
         case JoinDesc.FULL_OUTER_JOIN:

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.optimizer;
 
 import static org.junit.Assert.assertFalse;

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -1,0 +1,52 @@
+package org.apache.hadoop.hive.ql.optimizer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.JoinOperator;
+import org.apache.hadoop.hive.ql.exec.OperatorFactory;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.JoinCondDesc;
+import org.apache.hadoop.hive.ql.plan.JoinDesc;
+
+import org.junit.Test;
+
+public class TestConvertJoinMapJoin {
+
+  @Test
+  public void testHasOuterJoin1() throws SemanticException {
+    JoinCondDesc[] condDesc = new JoinCondDesc[2];
+    condDesc[0] = new JoinCondDesc(0, 1, JoinDesc.INNER_JOIN);
+    condDesc[1] = new JoinCondDesc(1, 2, JoinDesc.LEFT_OUTER_JOIN);
+    JoinDesc joinDesc = new JoinDesc();
+    joinDesc.setConds(condDesc);
+    CompilationOpContext cCtx = new CompilationOpContext();
+    JoinOperator joinOperator = (JoinOperator) OperatorFactory.get(cCtx, joinDesc);
+    assertTrue(ConvertJoinMapJoin.hasOuterJoin(joinOperator));
+  }
+
+  @Test
+  public void testHasOuterJoin2() throws SemanticException {
+    JoinCondDesc[] condDesc = new JoinCondDesc[2];
+    condDesc[0] = new JoinCondDesc(0, 1, JoinDesc.LEFT_OUTER_JOIN);
+    condDesc[1] = new JoinCondDesc(1, 2, JoinDesc.INNER_JOIN);
+    JoinDesc joinDesc = new JoinDesc();
+    joinDesc.setConds(condDesc);
+    CompilationOpContext cCtx = new CompilationOpContext();
+    JoinOperator joinOperator = (JoinOperator) OperatorFactory.get(cCtx, joinDesc);
+    assertTrue(ConvertJoinMapJoin.hasOuterJoin(joinOperator));
+  }
+
+  @Test
+  public void testHasOuterJoin3() throws SemanticException {
+    JoinCondDesc[] condDesc = new JoinCondDesc[2];
+    condDesc[0] = new JoinCondDesc(0, 1, JoinDesc.INNER_JOIN);
+    condDesc[1] = new JoinCondDesc(1, 2, JoinDesc.INNER_JOIN);
+    JoinDesc joinDesc = new JoinDesc();
+    joinDesc.setConds(condDesc);
+    CompilationOpContext cCtx = new CompilationOpContext();
+    JoinOperator joinOperator = (JoinOperator) OperatorFactory.get(cCtx, joinDesc);
+    assertFalse(ConvertJoinMapJoin.hasOuterJoin(joinOperator));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -30,11 +30,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.OperatorFactory;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.ColStatistics;
+import org.apache.hadoop.hive.ql.plan.JoinCondDesc;
+import org.apache.hadoop.hive.ql.plan.JoinDesc;
 import org.apache.hadoop.hive.ql.plan.Statistics;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestConvertJoinMapJoin {
 
@@ -161,5 +171,28 @@ class TestConvertJoinMapJoin {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static Stream<Arguments> joinConditions() {
+    return Stream.of(
+        Arguments.of(new int[] {JoinDesc.INNER_JOIN, JoinDesc.LEFT_OUTER_JOIN}, true),
+        Arguments.of(new int[] {JoinDesc.LEFT_OUTER_JOIN, JoinDesc.INNER_JOIN}, true),
+        Arguments.of(new int[] {JoinDesc.INNER_JOIN, JoinDesc.INNER_JOIN}, false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("joinConditions")
+  void testHasOuterJoin(int[] condTypes, boolean expected) throws SemanticException {
+    assertEquals(expected, ConvertJoinMapJoin.hasOuterJoin(createJoin(condTypes)));
+  }
+
+  private static JoinOperator createJoin(int... condTypes) {
+    JoinCondDesc[] conds = new JoinCondDesc[condTypes.length];
+    for (int i = 0; i < condTypes.length; i++) {
+      conds[i] = new JoinCondDesc(i, i + 1, condTypes[i]);
+    }
+    JoinDesc joinDesc = new JoinDesc();
+    joinDesc.setConds(conds);
+    return (JoinOperator) OperatorFactory.get(new CompilationOpContext(), joinDesc);
   }
 }

--- a/ql/src/test/results/clientpositive/llap/mapjoin_filter_on_outerjoin_tez.q.out
+++ b/ql/src/test/results/clientpositive/llap/mapjoin_filter_on_outerjoin_tez.q.out
@@ -242,31 +242,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 3 <- Map 1 (BROADCAST_EDGE), Reducer 2 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src2
-                  filterExpr: ((UDFToDouble(key) < 300.0D) or (UDFToDouble(key) < 10.0D)) (type: boolean)
+                  alias: src1
+                  filterExpr: (UDFToDouble(key) < 10.0D) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) < 300.0D) (type: boolean)
-                    Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
                   Filter Operator
                     predicate: (UDFToDouble(key) < 10.0D) (type: boolean)
                     Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -283,7 +268,29 @@ STAGE PLANS:
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 3 
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: src2
+                  filterExpr: (UDFToDouble(key) < 300.0D) (type: boolean)
+                  Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (UDFToDouble(key) < 300.0D) (type: boolean)
+                    Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src3
@@ -296,45 +303,39 @@ STAGE PLANS:
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Right Outer Join 0 to 1
-                             Inner Join 1 to 2
-                        filter predicates:
-                          0 
-                          1 {(UDFToDouble(_col0) > 10.0D)}
-                          2 
-                        keys:
-                          0 _col0 (type: string)
-                          1 _col0 (type: string)
-                          2 _col0 (type: string)
-                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                        input vertices:
-                          0 Map 1
-                          1 Reducer 2
-                        Statistics: Num rows: 8 Data size: 4224 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string), _col2 (type: string), _col4 (type: string)
-                          null sort order: zzz
-                          sort order: +++
-                          Statistics: Num rows: 8 Data size: 4224 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: string), _col3 (type: string), _col5 (type: string)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: vectorized, llap
+            Execution mode: llap
             Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string)
-                outputColumnNames: _col0, _col1
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                     Inner Join 1 to 2
+                filter predicates:
+                  0 
+                  1 {(UDFToDouble(KEY.reducesinkkey0) > 10.0D)}
+                  2 
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                  2 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 8 Data size: 4224 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 8 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: string), (UDFToShort((not (UDFToDouble(_col0) > 10.0D))) * 1S) (type: smallint)
-        Reducer 4 
+                  key expressions: _col0 (type: string), _col2 (type: string), _col4 (type: string)
+                  null sort order: zzz
+                  sort order: +++
+                  Statistics: Num rows: 8 Data size: 4224 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string), _col3 (type: string), _col5 (type: string)
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/vector_leftsemi_mapjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_leftsemi_mapjoin.q.out
@@ -2420,8 +2420,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 1 (BROADCAST_EDGE), Map 4 (BROADCAST_EDGE)
-        Reducer 3 <- Map 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2445,7 +2445,7 @@ STAGE PLANS:
                         Statistics: Num rows: 11 Data size: 44 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: all inputs
-        Map 2 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: b
@@ -2458,27 +2458,15 @@ STAGE PLANS:
                       expressions: key (type: int)
                       outputColumnNames: _col0
                       Statistics: Num rows: 22 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
-                      Map Join Operator
-                        condition map:
-                             Right Outer Join 0 to 1
-                             Left Semi Join 1 to 2
-                        keys:
-                          0 _col0 (type: int)
-                          1 _col0 (type: int)
-                          2 _col0 (type: int)
-                        outputColumnNames: _col0
-                        input vertices:
-                          0 Map 1
-                          2 Map 4
-                        Statistics: Num rows: 24 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: int)
-                          null sort order: z
-                          sort order: +
-                          Statistics: Num rows: 24 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 22 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: all inputs
-        Map 4 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: c
@@ -2505,6 +2493,24 @@ STAGE PLANS:
                           Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                     Left Semi Join 1 to 2
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                  2 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 24 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 24 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix 


### Why are the changes needed?
The hasOuterJoin returns whether the last join condition is outer join. 


### Does this PR introduce _any_ user-facing change?
no 

### Is the change a dependency upgrade?
no


### How was this patch tested?
use exist test
