### PR TITLE
HIVE-27509: query-executors fail to start: java.lang.NoSuchFieldError…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -403,6 +403,7 @@ public class HiveConf extends Configuration {
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_ALLOCATOR_DIRECT.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_USE_LRFU.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_LAMBDA.varname);
+    llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_HOTBUFFERS_PERCENTAGE.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_BP_WRAPPER_SIZE.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_CACHE_ALLOW_SYNTHETIC_FILEID.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_IO_USE_FILEID_PATH.varname);


### PR DESCRIPTION
…: LLAP_LRFU_HOTBUFFERS_PERCENTAGE
[HIVE-27509](https://issues.apache.org/jira/browse/HIVE-27509)

### What changes were proposed in this pull request?
Adding LLAP_LRFU_HOTBUFFERS_PERCENTAGE to llapDaemonVarsSetLocal


### Why are the changes needed?
query-executors fail to start


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No
