### PR TITLE
HIVE-23680 : TestDbNotificationListener is unstable

### DIFF
--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-standalone-metastore-server</artifactId>
-      <scope>test</scope>
+      <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -90,6 +90,7 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-standalone-metastore-server</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
@@ -20,95 +20,30 @@ package org.apache.hive.hcatalog.listener;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient.NotificationFilter;
-import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
-import org.apache.hadoop.hive.metastore.MetaStoreEventListenerConstants;
-import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.FireEventRequest;
-import org.apache.hadoop.hive.metastore.api.FireEventRequestData;
-import org.apache.hadoop.hive.metastore.api.FireEventResponse;
-import org.apache.hadoop.hive.metastore.api.Function;
-import org.apache.hadoop.hive.metastore.api.FunctionType;
-import org.apache.hadoop.hive.metastore.api.InsertEventRequestData;
-import org.apache.hadoop.hive.metastore.api.MetaException;
-import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.NotificationEventRequest;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
-import org.apache.hadoop.hive.metastore.api.NotificationEventsCountRequest;
-import org.apache.hadoop.hive.metastore.api.Partition;
-import org.apache.hadoop.hive.metastore.api.PrincipalType;
-import org.apache.hadoop.hive.metastore.api.ResourceType;
-import org.apache.hadoop.hive.metastore.api.ResourceUri;
-import org.apache.hadoop.hive.metastore.api.SerDeInfo;
-import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
-import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.metastore.api.TxnType;
-import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
+import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
-import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
-import org.apache.hadoop.hive.metastore.events.AlterPartitionEvent;
-import org.apache.hadoop.hive.metastore.events.AlterTableEvent;
-import org.apache.hadoop.hive.metastore.events.AlterDatabaseEvent;
-import org.apache.hadoop.hive.metastore.events.BatchAcidWriteEvent;
-import org.apache.hadoop.hive.metastore.events.CreateDatabaseEvent;
-import org.apache.hadoop.hive.metastore.events.CreateFunctionEvent;
-import org.apache.hadoop.hive.metastore.events.CreateTableEvent;
-import org.apache.hadoop.hive.metastore.events.DropDatabaseEvent;
-import org.apache.hadoop.hive.metastore.events.DropFunctionEvent;
-import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;
-import org.apache.hadoop.hive.metastore.events.DropTableEvent;
-import org.apache.hadoop.hive.metastore.events.InsertEvent;
-import org.apache.hadoop.hive.metastore.events.ListenerEvent;
-import org.apache.hadoop.hive.metastore.events.AllocWriteIdEvent;
-import org.apache.hadoop.hive.metastore.events.AcidWriteEvent;
-import org.apache.hadoop.hive.metastore.messaging.AddPartitionMessage;
-import org.apache.hadoop.hive.metastore.messaging.AlterDatabaseMessage;
-import org.apache.hadoop.hive.metastore.messaging.AlterPartitionMessage;
-import org.apache.hadoop.hive.metastore.messaging.AlterTableMessage;
-import org.apache.hadoop.hive.metastore.messaging.CreateDatabaseMessage;
-import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
-import org.apache.hadoop.hive.metastore.messaging.CreateTableMessage;
-import org.apache.hadoop.hive.metastore.messaging.DropDatabaseMessage;
-import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
-import org.apache.hadoop.hive.metastore.messaging.DropPartitionMessage;
-import org.apache.hadoop.hive.metastore.messaging.DropTableMessage;
-import org.apache.hadoop.hive.metastore.messaging.EventMessage.EventType;
-import org.apache.hadoop.hive.metastore.messaging.InsertMessage;
 import org.apache.hadoop.hive.metastore.messaging.MessageDeserializer;
-import org.apache.hadoop.hive.metastore.messaging.MessageFactory;
 import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hive.hcatalog.api.repl.ReplicationV1CompatRule;
-import org.apache.hive.hcatalog.data.Pair;
-import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
@@ -117,12 +52,8 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.Ignore;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL;
+
 
 
 public class TestDbNotificationCleanup {
@@ -135,7 +66,7 @@ public class TestDbNotificationCleanup {
     private static IDriver driver;
     private static MessageDeserializer md;
     private static HiveConf conf;
-    private int startTime;
+
     private long firstEventId;
     private final String testTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "testDbNotif").toString();
 
@@ -148,16 +79,6 @@ public class TestDbNotificationCleanup {
     @Rule
     public TestRule replV1BackwardCompatibleRule = bcompat;
 
-    static {
-        try {
-            md = MessageFactory.getInstance(JSONMessageEncoder.FORMAT).getDeserializer();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-
-
     @SuppressWarnings("rawtypes")
     @BeforeClass
     public static void connectToMetastore() throws Exception {
@@ -165,10 +86,8 @@ public class TestDbNotificationCleanup {
 
         MetastoreConf.setVar(conf,MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS,
                 "org.apache.hive.hcatalog.listener.DbNotificationListener");
-        conf.setBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL, true);
         conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
         conf.setBoolVar(HiveConf.ConfVars.FIRE_EVENTS_FOR_DML, true);
-        conf.setBoolVar(HiveConf.ConfVars.REPLCMENABLED, false);
         conf.setVar(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL, DummyRawStoreFailEvent.class.getName());
         MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL, CLEANUP_SLEEP_TIME, TimeUnit.SECONDS);
         MetastoreConf.setVar(conf, MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY, JSONMessageEncoder.class.getName());
@@ -181,20 +100,12 @@ public class TestDbNotificationCleanup {
 
         msClient = new HiveMetaStoreClient(conf);
         driver = DriverFactory.newDriver(conf);
-        md = JSONMessageEncoder.getInstance().getDeserializer();
 
         bcompat = new ReplicationV1CompatRule(msClient, conf, testsToSkipForReplV1BackwardCompatTesting);
     }
 
     @Before
     public void setup() throws Exception {
-        long now = System.currentTimeMillis() / 1000;
-        startTime = 0;
-        if (now > Integer.MAX_VALUE) {
-            fail("Bummer, time has fallen over the edge");
-        } else {
-            startTime = (int) now;
-        }
         firstEventId = msClient.getCurrentNotificationEventId().getEventId();
         DummyRawStoreFailEvent.setEventSucceed(true);
     }

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
@@ -18,10 +18,6 @@
  */
 package org.apache.hive.hcatalog.listener;
 
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -124,6 +120,9 @@ import org.slf4j.LoggerFactory;
 import org.junit.Ignore;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL;
 
 
 public class TestDbNotificationCleanup {
@@ -135,17 +134,7 @@ public class TestDbNotificationCleanup {
     private static IMetaStoreClient msClient;
     private static IDriver driver;
     private static MessageDeserializer md;
-
     private static HiveConf conf;
-
-    static {
-        try {
-            md = MessageFactory.getInstance(JSONMessageEncoder.FORMAT).getDeserializer();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private int startTime;
     private long firstEventId;
     private final String testTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "testDbNotif").toString();
@@ -158,6 +147,15 @@ public class TestDbNotificationCleanup {
 
     @Rule
     public TestRule replV1BackwardCompatibleRule = bcompat;
+
+    static {
+        try {
+            md = MessageFactory.getInstance(JSONMessageEncoder.FORMAT).getDeserializer();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
 
     @SuppressWarnings("rawtypes")
@@ -212,12 +210,6 @@ public class TestDbNotificationCleanup {
         }
         conf = null;
     }
-
-    @After
-    public void tearDown() {
-
-    }
-
 
 
     @Test

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationCleanup.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hive.hcatalog.listener;
+
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.cli.CliSessionState;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient.NotificationFilter;
+import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
+import org.apache.hadoop.hive.metastore.MetaStoreEventListenerConstants;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.FireEventRequest;
+import org.apache.hadoop.hive.metastore.api.FireEventRequestData;
+import org.apache.hadoop.hive.metastore.api.FireEventResponse;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
+import org.apache.hadoop.hive.metastore.api.InsertEventRequestData;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+import org.apache.hadoop.hive.metastore.api.NotificationEventRequest;
+import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
+import org.apache.hadoop.hive.metastore.api.NotificationEventsCountRequest;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.ResourceType;
+import org.apache.hadoop.hive.metastore.api.ResourceUri;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TxnType;
+import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.AlterPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.AlterTableEvent;
+import org.apache.hadoop.hive.metastore.events.AlterDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.BatchAcidWriteEvent;
+import org.apache.hadoop.hive.metastore.events.CreateDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.CreateFunctionEvent;
+import org.apache.hadoop.hive.metastore.events.CreateTableEvent;
+import org.apache.hadoop.hive.metastore.events.DropDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.DropFunctionEvent;
+import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.DropTableEvent;
+import org.apache.hadoop.hive.metastore.events.InsertEvent;
+import org.apache.hadoop.hive.metastore.events.ListenerEvent;
+import org.apache.hadoop.hive.metastore.events.AllocWriteIdEvent;
+import org.apache.hadoop.hive.metastore.events.AcidWriteEvent;
+import org.apache.hadoop.hive.metastore.messaging.AddPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.EventMessage.EventType;
+import org.apache.hadoop.hive.metastore.messaging.InsertMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageDeserializer;
+import org.apache.hadoop.hive.metastore.messaging.MessageFactory;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
+import org.apache.hadoop.hive.ql.DriverFactory;
+import org.apache.hadoop.hive.ql.IDriver;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hive.hcatalog.api.repl.ReplicationV1CompatRule;
+import org.apache.hive.hcatalog.data.Pair;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.junit.Ignore;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+
+
+public class TestDbNotificationCleanup {
+    private static final Logger LOG = LoggerFactory.getLogger(TestDbNotificationCleanup.class
+            .getName());
+    private static final int EVENTS_TTL = 30;
+    private static final int CLEANUP_SLEEP_TIME = 10;
+    private static Map<String, String> emptyParameters = new HashMap<String, String>();
+    private static IMetaStoreClient msClient;
+    private static IDriver driver;
+    private static MessageDeserializer md;
+
+    private static HiveConf conf;
+
+    static {
+        try {
+            md = MessageFactory.getInstance(JSONMessageEncoder.FORMAT).getDeserializer();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int startTime;
+    private long firstEventId;
+    private final String testTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "testDbNotif").toString();
+
+    private static List<String> testsToSkipForReplV1BackwardCompatTesting =
+            new ArrayList<>(Arrays.asList("cleanupNotifs", "cleanupNotificationWithError","skipCleanedUpEvents"));
+    // Make sure we skip backward-compat checking for those tests that don't generate events
+
+    private static ReplicationV1CompatRule bcompat = null;
+
+    @Rule
+    public TestRule replV1BackwardCompatibleRule = bcompat;
+
+
+    @SuppressWarnings("rawtypes")
+    @BeforeClass
+    public static void connectToMetastore() throws Exception {
+        conf = new HiveConf();
+
+        MetastoreConf.setVar(conf,MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS,
+                "org.apache.hive.hcatalog.listener.DbNotificationListener");
+        conf.setBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL, true);
+        conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+        conf.setBoolVar(HiveConf.ConfVars.FIRE_EVENTS_FOR_DML, true);
+        conf.setBoolVar(HiveConf.ConfVars.REPLCMENABLED, false);
+        conf.setVar(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL, DummyRawStoreFailEvent.class.getName());
+        MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL, CLEANUP_SLEEP_TIME, TimeUnit.SECONDS);
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY, JSONMessageEncoder.class.getName());
+        MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL, EVENTS_TTL, TimeUnit.SECONDS);
+        MetastoreConf.setTimeVar(conf, EVENT_DB_LISTENER_CLEAN_STARTUP_WAIT_INTERVAL, 20, TimeUnit.SECONDS);
+
+        conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
+                "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+        SessionState.start(new CliSessionState(conf));
+
+        msClient = new HiveMetaStoreClient(conf);
+        driver = DriverFactory.newDriver(conf);
+        md = JSONMessageEncoder.getInstance().getDeserializer();
+
+        bcompat = new ReplicationV1CompatRule(msClient, conf, testsToSkipForReplV1BackwardCompatTesting);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        long now = System.currentTimeMillis() / 1000;
+        startTime = 0;
+        if (now > Integer.MAX_VALUE) {
+            fail("Bummer, time has fallen over the edge");
+        } else {
+            startTime = (int) now;
+        }
+        firstEventId = msClient.getCurrentNotificationEventId().getEventId();
+        DummyRawStoreFailEvent.setEventSucceed(true);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+
+        if (msClient != null) {
+            msClient.close();
+        }
+        if (driver != null) {
+            driver.close();
+        }
+        conf = null;
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+
+
+    @Test
+    public void cleanupNotifs() throws Exception {
+        Database db = new Database("cleanup1", "no description", testTempDir, emptyParameters);
+        msClient.createDatabase(db);
+        msClient.dropDatabase("cleanup1");
+
+        LOG.info("Pulling events immediately after createDatabase/dropDatabase");
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(2, rsp.getEventsSize());
+
+        // sleep for expiry time, and then fetch again
+        // sleep twice the TTL interval - things should have been cleaned by then.
+        Thread.sleep(EVENTS_TTL * 2 * 1000);
+
+        LOG.info("Pulling events again after cleanup");
+        NotificationEventResponse rsp2 = msClient.getNextNotification(firstEventId, 0, null);
+        LOG.info("second trigger done");
+        assertEquals(0, rsp2.getEventsSize());
+    }
+
+    /**
+     * Test makes sure that if you use the API {@link HiveMetaStoreClient#getNextNotification(NotificationEventRequest, boolean, NotificationFilter)}
+     * does not error out if the events are cleanedup.
+     */
+    @Test
+    public void skipCleanedUpEvents() throws Exception {
+        Database db = new Database("cleanup1", "no description", testTempDir, emptyParameters);
+        msClient.createDatabase(db);
+        msClient.dropDatabase("cleanup1");
+
+        // sleep for expiry time, and then fetch again
+        // sleep twice the TTL interval - things should have been cleaned by then.
+        Thread.sleep(EVENTS_TTL * 2 * 1000);
+
+        db = new Database("cleanup2", "no description", testTempDir, emptyParameters);
+        msClient.createDatabase(db);
+        msClient.dropDatabase("cleanup2");
+
+        // the firstEventId is before the cleanup happened, so we should just receive the
+        // events which remaining after cleanup.
+        NotificationEventRequest request = new NotificationEventRequest();
+        request.setLastEvent(firstEventId);
+        request.setMaxEvents(-1);
+        NotificationEventResponse rsp2 = msClient.getNextNotification(request, true, null);
+        assertEquals(2, rsp2.getEventsSize());
+        // when we pass the allowGapsInEvents as false the API should error out
+        Exception ex = null;
+        try {
+            NotificationEventResponse rsp = msClient.getNextNotification(request, false, null);
+        } catch (Exception e) {
+            ex = e;
+        }
+        assertNotNull(ex);
+    }
+
+    @Test
+    public void cleanupNotificationWithError() throws Exception {
+        Database db = new Database("cleanup1", "no description", testTempDir, emptyParameters);
+        msClient.createDatabase(db);
+        msClient.dropDatabase("cleanup1");
+
+        LOG.info("Pulling events immediately after createDatabase/dropDatabase");
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(2, rsp.getEventsSize());
+        //this simulates that cleaning thread will error out while cleaning the notifications
+        DummyRawStoreFailEvent.setEventSucceed(false);
+        // sleep for expiry time, and then fetch again
+        // sleep twice the TTL interval - things should have been cleaned by then.
+        Thread.sleep(EVENTS_TTL * 2 * 1000);
+
+        LOG.info("Pulling events again after failing to cleanup");
+        NotificationEventResponse rsp2 = msClient.getNextNotification(firstEventId, 0, null);
+        LOG.info("second trigger done");
+        assertEquals(2, rsp2.getEventsSize());
+        DummyRawStoreFailEvent.setEventSucceed(true);
+        Thread.sleep(EVENTS_TTL * 2 * 1000);
+
+        LOG.info("Pulling events again after cleanup");
+        rsp2 = msClient.getNextNotification(firstEventId, 0, null);
+        LOG.info("third trigger done");
+        assertEquals(0, rsp2.getEventsSize());
+    }
+}
+
+

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
@@ -1441,7 +1441,6 @@ public class TestDbNotificationListener {
   public void sqlInsertPartition() throws Exception {
     String defaultDbName = "default";
     String tblName = "sqlinsptn";
-
     // Event 1
     driver.run("create table " + tblName + " (c int) partitioned by (ds string)");
     // Event 2, 3, 4
@@ -1459,19 +1458,19 @@ public class TestDbNotificationListener {
     // Test toEventId lower than current eventId
     testEventCounts(defaultDbName, firstEventId, firstEventId + 5, null, 5);
 
-    // Event 12, 13, 14
+    // Event 10, 11, 12
     driver.run("insert into table " + tblName + " partition (ds = 'yesterday') values (2)");
-    // Event 15, 16, 17
+    // Event 12, 13, 14
     driver.run("insert into table " + tblName + " partition (ds = 'yesterday') values (3)");
-    // Event 18, 19, 20
-    driver.run("insert into table " + tblName + " partition (ds = 'tomorrow') values (3)");
-    // Event 21
+    // Event 15, 16, 17
+    driver.run("insert into table " + tblName + " partition (ds = 'tomorrow') values (2)");
+    // Event 18
     driver.run("alter table " + tblName + " drop partition (ds = 'tomorrow')");
-    // Event 22, 23, 24
+    // Event 19, 20, 21
     driver.run("insert into table " + tblName + " partition (ds) values (42, 'todaytwo')");
-    // Event 25, 26, 27
+    // Event 22, 23, 24
     driver.run("insert overwrite table " + tblName + " partition(ds='todaytwo') select c from "
-            + tblName + " where 'ds'='today'");
+        + tblName + " where 'ds'='today'");
 
     // Get notifications from metastore
     NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
@@ -112,26 +112,24 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hive.hcatalog.api.repl.ReplicationV1CompatRule;
 import org.apache.hive.hcatalog.data.Pair;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.Ignore;
 
 
 /**
  * Tests DbNotificationListener when used as a transactional event listener
  * (hive.metastore.transactional.event.listeners)
  */
-
 public class TestDbNotificationListener {
   private static final Logger LOG = LoggerFactory.getLogger(TestDbNotificationListener.class
-          .getName());
+      .getName());
   private static final int EVENTS_TTL = 30;
   private static final int CLEANUP_SLEEP_TIME = 10;
   private static Map<String, String> emptyParameters = new HashMap<String, String>();
@@ -152,7 +150,7 @@ public class TestDbNotificationListener {
   private final String testTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "testDbNotif").toString();
 
   private static List<String> testsToSkipForReplV1BackwardCompatTesting =
-          new ArrayList<>(Arrays.asList("cleanupNotifs", "cleanupNotificationWithError", "sqlTempTable"));
+      new ArrayList<>(Arrays.asList("cleanupNotifs", "cleanupNotificationWithError", "sqlTempTable"));
   // Make sure we skip backward-compat checking for those tests that don't generate events
 
   private static ReplicationV1CompatRule bcompat = null;
@@ -166,7 +164,7 @@ public class TestDbNotificationListener {
   // before the tests run, and will pick up an initialized value of bcompat.
 
   /* This class is used to verify that HiveMetaStore calls the non-transactional listeners with the
-   * current event ID set by the DbNotificationListener class */
+    * current event ID set by the DbNotificationListener class */
   public static class MockMetaStoreEventListener extends MetaStoreEventListener {
     private static Stack<Pair<EventType, String>> eventsIds = new Stack<>();
 
@@ -175,7 +173,7 @@ public class TestDbNotificationListener {
         Map<String, String> parameters = event.getParameters();
         if (parameters.containsKey(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME)) {
           Pair<EventType, String> pair =
-                  new Pair<>(eventType, parameters.get(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME));
+              new Pair<>(eventType, parameters.get(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME));
           eventsIds.push(pair);
         }
       }
@@ -278,15 +276,16 @@ public class TestDbNotificationListener {
   public static void connectToMetastore() throws Exception {
     HiveConf conf = new HiveConf();
     conf.setVar(HiveConf.ConfVars.METASTORE_TRANSACTIONAL_EVENT_LISTENERS,
-            DbNotificationListener.class.getName());
+        DbNotificationListener.class.getName());
     conf.setVar(HiveConf.ConfVars.METASTORE_EVENT_LISTENERS, MockMetaStoreEventListener.class.getName());
     conf.setVar(HiveConf.ConfVars.METASTORE_EVENT_DB_LISTENER_TTL, String.valueOf(EVENTS_TTL) + "s");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
     conf.setBoolVar(HiveConf.ConfVars.FIRE_EVENTS_FOR_DML, true);
     conf.setVar(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL, DummyRawStoreFailEvent.class.getName());
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL, CLEANUP_SLEEP_TIME, TimeUnit.SECONDS);
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY, JSONMessageEncoder.class.getName());
     conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
-            "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+        "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     SessionState.start(new CliSessionState(conf));
     msClient = new HiveMetaStoreClient(conf);
     driver = DriverFactory.newDriver(conf);
@@ -319,6 +318,7 @@ public class TestDbNotificationListener {
     }
 
   }
+
   @After
   public void tearDown() {
     MockMetaStoreEventListener.clearEvents();
@@ -486,11 +486,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, TableType.MANAGED_TABLE.toString());
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, TableType.MANAGED_TABLE.toString());
     msClient.createTable(table);
 
     // Get notifications from metastore
@@ -516,8 +516,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     table =
-            new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
       msClient.createTable(table);
@@ -542,18 +542,18 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
-                    new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
+            new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     cols.add(col2);
     table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
-                    new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
+            new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
     // Event 2
     msClient.alter_table(defaultDbName, tblName, table);
 
@@ -601,11 +601,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
@@ -641,8 +641,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     table =
-            new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     msClient.createTable(table);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -668,21 +668,21 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
 
@@ -712,8 +712,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     partition =
-            new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName2, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName2, startTime, startTime, sd,
+            emptyParameters);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
       msClient.add_partition(partition);
@@ -737,26 +737,26 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     Partition newPart =
-            new Partition(Arrays.asList("today"), defaultDbName, tblName, startTime, startTime + 1, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("today"), defaultDbName, tblName, startTime, startTime + 1, sd,
+            emptyParameters);
     // Event 3
     msClient.alter_partition(defaultDbName, tblName, newPart, null);
 
@@ -806,21 +806,21 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     // Event 3
@@ -855,8 +855,8 @@ public class TestDbNotificationListener {
     // a failed event should not create a new notification
     List<String> newpartCol1Vals = Arrays.asList("tomorrow");
     partition =
-            new Partition(newpartCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(newpartCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     msClient.add_partition(partition);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -879,44 +879,44 @@ public class TestDbNotificationListener {
     partCols.add(new FieldSchema("part", "int", ""));
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd1 =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1").toString(), "input", "output", false, 0, serde, null,
-                    null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1").toString(), "input", "output", false, 0, serde, null,
+            null, emptyParameters);
     Table tab1 = new Table("tab1", dbName, "me", startTime, startTime, 0, sd1, partCols,
-            emptyParameters, null, null, null);
+        emptyParameters, null, null, null);
     msClient.createTable(tab1);
     NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
     assertEquals(1, rsp.getEventsSize()); // add_table
 
     StorageDescriptor sd2 =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "2").toString(), "input", "output", false, 0, serde, null,
-                    null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "2").toString(), "input", "output", false, 0, serde, null,
+            null, emptyParameters);
     Table tab2 = new Table("tab2", dbName, "me", startTime, startTime, 0, sd2, partCols,
-            emptyParameters, null, null, null); // add_table
+        emptyParameters, null, null, null); // add_table
     msClient.createTable(tab2);
     rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
     assertEquals(1, rsp.getEventsSize());
 
     StorageDescriptor sd1part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=1").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=1").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     StorageDescriptor sd2part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=2").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=2").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     StorageDescriptor sd3part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=3").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=3").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     Partition part1 = new Partition(Arrays.asList("1"), "default", tab1.getTableName(),
-            startTime, startTime, sd1part, emptyParameters);
+        startTime, startTime, sd1part, emptyParameters);
     Partition part2 = new Partition(Arrays.asList("2"), "default", tab1.getTableName(),
-            startTime, startTime, sd2part, emptyParameters);
+        startTime, startTime, sd2part, emptyParameters);
     Partition part3 = new Partition(Arrays.asList("3"), "default", tab1.getTableName(),
-            startTime, startTime, sd3part, emptyParameters);
+        startTime, startTime, sd3part, emptyParameters);
     msClient.add_partitions(Arrays.asList(part1, part2, part3));
     rsp = msClient.getNextNotification(firstEventId + 2, 0, null);
     assertEquals(1, rsp.getEventsSize()); // add_partition
 
     msClient.exchange_partition(ImmutableMap.of("part", "1"),
-            dbName, tab1.getTableName(), dbName, tab2.getTableName());
+        dbName, tab1.getTableName(), dbName, tab2.getTableName());
 
     rsp = msClient.getNextNotification(firstEventId + 3, 0, null);
     assertEquals(2, rsp.getEventsSize());
@@ -977,8 +977,8 @@ public class TestDbNotificationListener {
     String funcResource = Paths.get(testTempDir, "somewhere").toString();
     String funcResource2 = Paths.get(testTempDir, "somewhere2").toString();
     Function func =
-            new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
-                    FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
+        new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
+            FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
     // Event 1
     msClient.createFunction(func);
 
@@ -1011,9 +1011,9 @@ public class TestDbNotificationListener {
     // a failed event should not create a new notification
     DummyRawStoreFailEvent.setEventSucceed(false);
     func =
-            new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
-                    startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
-                    funcResource2)));
+        new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
+            startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
+                funcResource2)));
     try {
       msClient.createFunction(func);
       fail("Error: create function should've failed");
@@ -1036,8 +1036,8 @@ public class TestDbNotificationListener {
     String funcResource = Paths.get(testTempDir, "somewhere").toString();
     String funcResource2 = Paths.get(testTempDir, "somewhere2").toString();
     Function func =
-            new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
-                    FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
+        new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
+            FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
     // Event 1
     msClient.createFunction(func);
     // Event 2
@@ -1064,9 +1064,9 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     func =
-            new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
-                    startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
-                    funcResource2)));
+        new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
+            startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
+                funcResource2)));
     msClient.createFunction(func);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -1079,7 +1079,6 @@ public class TestDbNotificationListener {
     assertEquals(3, rsp.getEventsSize());
     testEventCounts(defaultDbName, firstEventId, null, null, 3);
   }
-
 
   @Test
   public void insertTable() throws Exception {
@@ -1094,11 +1093,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     // Event 1
     msClient.createTable(table);
 
@@ -1156,8 +1155,8 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
@@ -1166,13 +1165,13 @@ public class TestDbNotificationListener {
 
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     FireEventRequestData data = new FireEventRequestData();
@@ -1187,7 +1186,7 @@ public class TestDbNotificationListener {
     rqst.setPartitionVals(partCol1Vals);
     // Event 3
     verifyInsertEventReceived(defaultDbName, tblName, Arrays.asList(partKeyVals), rqst,
-            firstEventId + 3, 1);
+        firstEventId + 3, 1);
 
     // Verify the eventID was passed to the non-transactional listener
     MockMetaStoreEventListener.popAndVerifyLastEventId(EventType.INSERT, firstEventId + 3);
@@ -1198,13 +1197,13 @@ public class TestDbNotificationListener {
     // fire multiple insert events on partition
     // add some more partitions
     partition =
-            new Partition(Arrays.asList("yesterday"), defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("yesterday"), defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 4
     msClient.add_partition(partition);
     partition =
-            new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 5
     msClient.add_partition(partition);
     data = new FireEventRequestData();
@@ -1240,8 +1239,8 @@ public class TestDbNotificationListener {
     rqst.setTableName(tblName);
 
     verifyInsertEventReceived(defaultDbName, tblName, Arrays
-            .asList(Arrays.asList("yesterday"), Arrays.asList("today"),
-                    Arrays.asList("tomorrow")), rqst, firstEventId + 6, 3);
+        .asList(Arrays.asList("yesterday"), Arrays.asList("today"),
+            Arrays.asList("tomorrow")), rqst, firstEventId + 6, 3);
 
     // negative test. partition values must be set when firing bulk insert events
     data.getInsertDatas().get(1).unsetPartitionVal();
@@ -1252,15 +1251,15 @@ public class TestDbNotificationListener {
       threwException = true;
       Assert.assertTrue(ex instanceof  MetaException);
       Assert.assertTrue(ex.getMessage()
-              .contains("Partition values must be set when firing multiple insert events"));
+          .contains("Partition values must be set when firing multiple insert events"));
     }
     Assert.assertTrue("bulk insert event API didn't "
-            + "throw exception when partition values were not set", threwException);
+        + "throw exception when partition values were not set", threwException);
   }
 
   private void verifyInsertEventReceived(String defaultDbName, String tblName,
-                                         List<List<String>> partKeyVals, FireEventRequest rqst, long expectedStartEventId,
-                                         int expectedNumOfEvents) throws Exception {
+      List<List<String>> partKeyVals, FireEventRequest rqst, long expectedStartEventId,
+      int expectedNumOfEvents) throws Exception {
     FireEventResponse response = msClient.fireListenerEvent(rqst);
     assertTrue("Event id must be set in the fireEvent response", response.isSetEventIds());
     Assert.assertNotNull(response.getEventIds());
@@ -1481,7 +1480,7 @@ public class TestDbNotificationListener {
     driver.run("insert into table " + tblName + " partition (ds) values (42, 'todaytwo')");
     // Event 22, 23, 24
     driver.run("insert overwrite table " + tblName + " partition(ds='todaytwo') select c from "
-            + tblName + " where 'ds'='today'");
+        + tblName + " where 'ds'='today'");
 
     // Get notifications from metastore
     NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
@@ -1512,15 +1511,14 @@ public class TestDbNotificationListener {
     event = rsp.getEvents().get(12);
     assertEquals(firstEventId + 13, event.getEventId());
     assertEquals(EventType.INSERT.toString(), event.getEventType());
-    verifyInsert(event, null, tblName);
+
     event = rsp.getEvents().get(13);
     assertEquals(firstEventId + 14, event.getEventId());
     assertEquals(EventType.ALTER_PARTITION.toString(), event.getEventType());
-    // Parse the message field
+
     event = rsp.getEvents().get(17);
     assertEquals(firstEventId + 18, event.getEventId());
     assertEquals(EventType.ALTER_PARTITION.toString(), event.getEventType());
-
 
     event = rsp.getEvents().get(21);
     assertEquals(firstEventId + 22, event.getEventId());
@@ -1537,7 +1535,6 @@ public class TestDbNotificationListener {
     event = rsp.getEvents().get(26);
     assertEquals(firstEventId + 27, event.getEventId());
     assertEquals(EventType.INSERT.toString(), event.getEventType());
-    //assertTrue(event.getMessage().matches(".*\"ds\":\"todaytwo\".*"));
 
     // Test fromEventId different from the very first
     testEventCounts(defaultDbName, event.getEventId(), null, null, 2);
@@ -1545,6 +1542,7 @@ public class TestDbNotificationListener {
     event = rsp.getEvents().get(28);
     assertEquals(firstEventId + 29, event.getEventId());
     assertEquals(EventType.ALTER_PARTITION.toString(), event.getEventType());
+
   }
 
   private void verifyInsert(NotificationEvent event, String dbName, String tblName) throws Exception {
@@ -1561,5 +1559,6 @@ public class TestDbNotificationListener {
     Iterator<String> files = insertMsg.getFiles().iterator();
     assertTrue(files.hasNext());
   }
+
 
 }

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestDbNotificationListener.java
@@ -119,7 +119,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestDbNotificationListener {
   private static final Logger LOG = LoggerFactory.getLogger(TestDbNotificationListener.class
-          .getName());
+      .getName());
   private static final int EVENTS_TTL = 30;
   private static final int CLEANUP_SLEEP_TIME = 10;
   private static Map<String, String> emptyParameters = new HashMap<String, String>();
@@ -140,7 +140,7 @@ public class TestDbNotificationListener {
   private final String testTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "testDbNotif").toString();
 
   private static List<String> testsToSkipForReplV1BackwardCompatTesting =
-          new ArrayList<>(Arrays.asList("cleanupNotifs", "cleanupNotificationWithError", "sqlTempTable"));
+      new ArrayList<>(Arrays.asList("cleanupNotifs", "cleanupNotificationWithError", "sqlTempTable"));
   // Make sure we skip backward-compat checking for those tests that don't generate events
 
   private static ReplicationV1CompatRule bcompat = null;
@@ -154,7 +154,7 @@ public class TestDbNotificationListener {
   // before the tests run, and will pick up an initialized value of bcompat.
 
   /* This class is used to verify that HiveMetaStore calls the non-transactional listeners with the
-   * current event ID set by the DbNotificationListener class */
+    * current event ID set by the DbNotificationListener class */
   public static class MockMetaStoreEventListener extends MetaStoreEventListener {
     private static Stack<Pair<EventType, String>> eventsIds = new Stack<>();
 
@@ -163,7 +163,7 @@ public class TestDbNotificationListener {
         Map<String, String> parameters = event.getParameters();
         if (parameters.containsKey(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME)) {
           Pair<EventType, String> pair =
-                  new Pair<>(eventType, parameters.get(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME));
+              new Pair<>(eventType, parameters.get(MetaStoreEventListenerConstants.DB_NOTIFICATION_EVENT_ID_KEY_NAME));
           eventsIds.push(pair);
         }
       }
@@ -266,7 +266,7 @@ public class TestDbNotificationListener {
   public static void connectToMetastore() throws Exception {
     HiveConf conf = new HiveConf();
     conf.setVar(HiveConf.ConfVars.METASTORE_TRANSACTIONAL_EVENT_LISTENERS,
-            DbNotificationListener.class.getName());
+        DbNotificationListener.class.getName());
     conf.setVar(HiveConf.ConfVars.METASTORE_EVENT_LISTENERS, MockMetaStoreEventListener.class.getName());
     conf.setVar(HiveConf.ConfVars.METASTORE_EVENT_DB_LISTENER_TTL, String.valueOf(EVENTS_TTL) + "s");
     conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
@@ -275,7 +275,7 @@ public class TestDbNotificationListener {
     MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_CLEAN_INTERVAL, CLEANUP_SLEEP_TIME, TimeUnit.SECONDS);
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY, JSONMessageEncoder.class.getName());
     conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
-            "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+        "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
     SessionState.start(new CliSessionState(conf));
     msClient = new HiveMetaStoreClient(conf);
     driver = DriverFactory.newDriver(conf);
@@ -476,11 +476,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, TableType.MANAGED_TABLE.toString());
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, TableType.MANAGED_TABLE.toString());
     msClient.createTable(table);
 
     // Get notifications from metastore
@@ -506,8 +506,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     table =
-            new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
       msClient.createTable(table);
@@ -532,18 +532,18 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
-                    new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
+            new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     cols.add(col2);
     table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
-                    new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd,
+            new ArrayList<FieldSchema>(), emptyParameters, null, null, null);
     // Event 2
     msClient.alter_table(defaultDbName, tblName, table);
 
@@ -591,11 +591,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
@@ -631,8 +631,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     table =
-            new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName2, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     msClient.createTable(table);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -658,21 +658,21 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
 
@@ -702,8 +702,8 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     partition =
-            new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName2, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName2, startTime, startTime, sd,
+            emptyParameters);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
       msClient.add_partition(partition);
@@ -727,26 +727,26 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     Partition newPart =
-            new Partition(Arrays.asList("today"), defaultDbName, tblName, startTime, startTime + 1, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("today"), defaultDbName, tblName, startTime, startTime + 1, sd,
+            emptyParameters);
     // Event 3
     msClient.alter_partition(defaultDbName, tblName, newPart, null);
 
@@ -796,21 +796,21 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
 
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     // Event 3
@@ -845,8 +845,8 @@ public class TestDbNotificationListener {
     // a failed event should not create a new notification
     List<String> newpartCol1Vals = Arrays.asList("tomorrow");
     partition =
-            new Partition(newpartCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(newpartCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     msClient.add_partition(partition);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -869,44 +869,44 @@ public class TestDbNotificationListener {
     partCols.add(new FieldSchema("part", "int", ""));
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd1 =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1").toString(), "input", "output", false, 0, serde, null,
-                    null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1").toString(), "input", "output", false, 0, serde, null,
+            null, emptyParameters);
     Table tab1 = new Table("tab1", dbName, "me", startTime, startTime, 0, sd1, partCols,
-            emptyParameters, null, null, null);
+        emptyParameters, null, null, null);
     msClient.createTable(tab1);
     NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
     assertEquals(1, rsp.getEventsSize()); // add_table
 
     StorageDescriptor sd2 =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "2").toString(), "input", "output", false, 0, serde, null,
-                    null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "2").toString(), "input", "output", false, 0, serde, null,
+            null, emptyParameters);
     Table tab2 = new Table("tab2", dbName, "me", startTime, startTime, 0, sd2, partCols,
-            emptyParameters, null, null, null); // add_table
+        emptyParameters, null, null, null); // add_table
     msClient.createTable(tab2);
     rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
     assertEquals(1, rsp.getEventsSize());
 
     StorageDescriptor sd1part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=1").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=1").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     StorageDescriptor sd2part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=2").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=2").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     StorageDescriptor sd3part =
-            new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=3").toString(), "input", "output", false, 0,
-                    serde, null, null, emptyParameters);
+        new StorageDescriptor(cols, Paths.get(testTempDir, "1", "part=3").toString(), "input", "output", false, 0,
+            serde, null, null, emptyParameters);
     Partition part1 = new Partition(Arrays.asList("1"), "default", tab1.getTableName(),
-            startTime, startTime, sd1part, emptyParameters);
+        startTime, startTime, sd1part, emptyParameters);
     Partition part2 = new Partition(Arrays.asList("2"), "default", tab1.getTableName(),
-            startTime, startTime, sd2part, emptyParameters);
+        startTime, startTime, sd2part, emptyParameters);
     Partition part3 = new Partition(Arrays.asList("3"), "default", tab1.getTableName(),
-            startTime, startTime, sd3part, emptyParameters);
+        startTime, startTime, sd3part, emptyParameters);
     msClient.add_partitions(Arrays.asList(part1, part2, part3));
     rsp = msClient.getNextNotification(firstEventId + 2, 0, null);
     assertEquals(1, rsp.getEventsSize()); // add_partition
 
     msClient.exchange_partition(ImmutableMap.of("part", "1"),
-            dbName, tab1.getTableName(), dbName, tab2.getTableName());
+        dbName, tab1.getTableName(), dbName, tab2.getTableName());
 
     rsp = msClient.getNextNotification(firstEventId + 3, 0, null);
     assertEquals(2, rsp.getEventsSize());
@@ -967,8 +967,8 @@ public class TestDbNotificationListener {
     String funcResource = Paths.get(testTempDir, "somewhere").toString();
     String funcResource2 = Paths.get(testTempDir, "somewhere2").toString();
     Function func =
-            new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
-                    FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
+        new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
+            FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
     // Event 1
     msClient.createFunction(func);
 
@@ -1001,9 +1001,9 @@ public class TestDbNotificationListener {
     // a failed event should not create a new notification
     DummyRawStoreFailEvent.setEventSucceed(false);
     func =
-            new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
-                    startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
-                    funcResource2)));
+        new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
+            startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
+                funcResource2)));
     try {
       msClient.createFunction(func);
       fail("Error: create function should've failed");
@@ -1026,8 +1026,8 @@ public class TestDbNotificationListener {
     String funcResource = Paths.get(testTempDir, "somewhere").toString();
     String funcResource2 = Paths.get(testTempDir, "somewhere2").toString();
     Function func =
-            new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
-                    FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
+        new Function(funcName, defaultDbName, funcClass, ownerName, PrincipalType.USER, startTime,
+            FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR, funcResource)));
     // Event 1
     msClient.createFunction(func);
     // Event 2
@@ -1054,9 +1054,9 @@ public class TestDbNotificationListener {
     // When hive.metastore.transactional.event.listeners is set,
     // a failed event should not create a new notification
     func =
-            new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
-                    startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
-                    funcResource2)));
+        new Function(funcName2, defaultDbName, funcClass2, ownerName, PrincipalType.USER,
+            startTime, FunctionType.JAVA, Arrays.asList(new ResourceUri(ResourceType.JAR,
+                funcResource2)));
     msClient.createFunction(func);
     DummyRawStoreFailEvent.setEventSucceed(false);
     try {
@@ -1083,11 +1083,11 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, null,
+            emptyParameters, null, null, null);
     // Event 1
     msClient.createTable(table);
 
@@ -1145,8 +1145,8 @@ public class TestDbNotificationListener {
     cols.add(col1);
     SerDeInfo serde = new SerDeInfo("serde", "seriallib", null);
     StorageDescriptor sd =
-            new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
-                    emptyParameters);
+        new StorageDescriptor(cols, serdeLocation, "input", "output", false, 0, serde, null, null,
+            emptyParameters);
     FieldSchema partCol1 = new FieldSchema("ds", "string", "no comment");
     List<FieldSchema> partCols = new ArrayList<FieldSchema>();
     List<String> partCol1Vals = Arrays.asList("today");
@@ -1155,13 +1155,13 @@ public class TestDbNotificationListener {
 
     partCols.add(partCol1);
     Table table =
-            new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
-                    emptyParameters, null, null, null);
+        new Table(tblName, defaultDbName, tblOwner, startTime, startTime, 0, sd, partCols,
+            emptyParameters, null, null, null);
     // Event 1
     msClient.createTable(table);
     Partition partition =
-            new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(partCol1Vals, defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 2
     msClient.add_partition(partition);
     FireEventRequestData data = new FireEventRequestData();
@@ -1176,7 +1176,7 @@ public class TestDbNotificationListener {
     rqst.setPartitionVals(partCol1Vals);
     // Event 3
     verifyInsertEventReceived(defaultDbName, tblName, Arrays.asList(partKeyVals), rqst,
-            firstEventId + 3, 1);
+        firstEventId + 3, 1);
 
     // Verify the eventID was passed to the non-transactional listener
     MockMetaStoreEventListener.popAndVerifyLastEventId(EventType.INSERT, firstEventId + 3);
@@ -1187,13 +1187,13 @@ public class TestDbNotificationListener {
     // fire multiple insert events on partition
     // add some more partitions
     partition =
-            new Partition(Arrays.asList("yesterday"), defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("yesterday"), defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 4
     msClient.add_partition(partition);
     partition =
-            new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName, startTime, startTime, sd,
-                    emptyParameters);
+        new Partition(Arrays.asList("tomorrow"), defaultDbName, tblName, startTime, startTime, sd,
+            emptyParameters);
     // Event 5
     msClient.add_partition(partition);
     data = new FireEventRequestData();
@@ -1229,8 +1229,8 @@ public class TestDbNotificationListener {
     rqst.setTableName(tblName);
 
     verifyInsertEventReceived(defaultDbName, tblName, Arrays
-            .asList(Arrays.asList("yesterday"), Arrays.asList("today"),
-                    Arrays.asList("tomorrow")), rqst, firstEventId + 6, 3);
+        .asList(Arrays.asList("yesterday"), Arrays.asList("today"),
+            Arrays.asList("tomorrow")), rqst, firstEventId + 6, 3);
 
     // negative test. partition values must be set when firing bulk insert events
     data.getInsertDatas().get(1).unsetPartitionVal();
@@ -1241,15 +1241,15 @@ public class TestDbNotificationListener {
       threwException = true;
       Assert.assertTrue(ex instanceof  MetaException);
       Assert.assertTrue(ex.getMessage()
-              .contains("Partition values must be set when firing multiple insert events"));
+          .contains("Partition values must be set when firing multiple insert events"));
     }
     Assert.assertTrue("bulk insert event API didn't "
-            + "throw exception when partition values were not set", threwException);
+        + "throw exception when partition values were not set", threwException);
   }
 
   private void verifyInsertEventReceived(String defaultDbName, String tblName,
-                                         List<List<String>> partKeyVals, FireEventRequest rqst, long expectedStartEventId,
-                                         int expectedNumOfEvents) throws Exception {
+      List<List<String>> partKeyVals, FireEventRequest rqst, long expectedStartEventId,
+      int expectedNumOfEvents) throws Exception {
     FireEventResponse response = msClient.fireListenerEvent(rqst);
     assertTrue("Event id must be set in the fireEvent response", response.isSetEventIds());
     Assert.assertNotNull(response.getEventIds());
@@ -1470,7 +1470,7 @@ public class TestDbNotificationListener {
     driver.run("insert into table " + tblName + " partition (ds) values (42, 'todaytwo')");
     // Event 22, 23, 24
     driver.run("insert overwrite table " + tblName + " partition(ds='todaytwo') select c from "
-            + tblName + " where 'ds'='today'");
+        + tblName + " where 'ds'='today'");
 
     // Get notifications from metastore
     NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListener.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListener.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.Collections;
-import org.apache.hadoop.hive.cli.CliSessionState;ALTER
+import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListener.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListener.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.Collections;
-import org.apache.hadoop.hive.cli.CliSessionState;
+import org.apache.hadoop.hive.cli.CliSessionState;ALTER
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListner.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListner.java
@@ -129,6 +129,8 @@ public class TestTransactionalDbNotificationListner {
     private static IMetaStoreClient msClient;
     private static IDriver driver;
     private static MessageDeserializer md;
+    private int startTime;
+    private long firstEventId;
 
     static {
         try {
@@ -137,9 +139,6 @@ public class TestTransactionalDbNotificationListner {
             throw new RuntimeException(e);
         }
     }
-
-    private int startTime;
-    private long firstEventId;
 
     @SuppressWarnings("rawtypes")
     @BeforeClass
@@ -173,12 +172,6 @@ public class TestTransactionalDbNotificationListner {
         firstEventId = msClient.getCurrentNotificationEventId().getEventId();
         DummyRawStoreFailEvent.setEventSucceed(true);
     }
-
-    @After
-    public void tearDown() {
-
-    }
-
 
     @Test
     public void openTxn() throws Exception {

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListner.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/TestTransactionalDbNotificationListner.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hive.hcatalog.listener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.cli.CliSessionState;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient.NotificationFilter;
+import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
+import org.apache.hadoop.hive.metastore.MetaStoreEventListenerConstants;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.FireEventRequest;
+import org.apache.hadoop.hive.metastore.api.FireEventRequestData;
+import org.apache.hadoop.hive.metastore.api.FireEventResponse;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
+import org.apache.hadoop.hive.metastore.api.InsertEventRequestData;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+import org.apache.hadoop.hive.metastore.api.NotificationEventRequest;
+import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
+import org.apache.hadoop.hive.metastore.api.NotificationEventsCountRequest;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.ResourceType;
+import org.apache.hadoop.hive.metastore.api.ResourceUri;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TxnType;
+import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.AlterPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.AlterTableEvent;
+import org.apache.hadoop.hive.metastore.events.BatchAcidWriteEvent;
+import org.apache.hadoop.hive.metastore.events.CreateDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.CreateFunctionEvent;
+import org.apache.hadoop.hive.metastore.events.CreateTableEvent;
+import org.apache.hadoop.hive.metastore.events.DropDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.DropFunctionEvent;
+import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;
+import org.apache.hadoop.hive.metastore.events.DropTableEvent;
+import org.apache.hadoop.hive.metastore.events.InsertEvent;
+import org.apache.hadoop.hive.metastore.events.OpenTxnEvent;
+import org.apache.hadoop.hive.metastore.events.CommitTxnEvent;
+import org.apache.hadoop.hive.metastore.events.AbortTxnEvent;
+import org.apache.hadoop.hive.metastore.events.ListenerEvent;
+import org.apache.hadoop.hive.metastore.events.AllocWriteIdEvent;
+import org.apache.hadoop.hive.metastore.events.AcidWriteEvent;
+import org.apache.hadoop.hive.metastore.messaging.AddPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.AlterTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropPartitionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropTableMessage;
+import org.apache.hadoop.hive.metastore.messaging.EventMessage.EventType;
+import org.apache.hadoop.hive.metastore.messaging.InsertMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageDeserializer;
+import org.apache.hadoop.hive.metastore.messaging.MessageFactory;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
+import org.apache.hadoop.hive.ql.DriverFactory;
+import org.apache.hadoop.hive.ql.IDriver;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hive.hcatalog.api.repl.ReplicationV1CompatRule;
+import org.apache.hive.hcatalog.data.Pair;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.junit.Ignore;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
+
+
+public class TestTransactionalDbNotificationListner {
+    private static final Logger LOG = LoggerFactory.getLogger(TestTransactionalDbNotificationListner.class
+            .getName());
+    private static IMetaStoreClient msClient;
+    private static IDriver driver;
+    private static MessageDeserializer md;
+
+    static {
+        try {
+            md = MessageFactory.getInstance(JSONMessageEncoder.FORMAT).getDeserializer();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int startTime;
+    private long firstEventId;
+
+    @SuppressWarnings("rawtypes")
+    @BeforeClass
+    public static void connectToMetastore() throws Exception {
+        HiveConf conf = new HiveConf();
+        conf.setVar(HiveConf.ConfVars.METASTORE_TRANSACTIONAL_EVENT_LISTENERS,
+                "org.apache.hive.hcatalog.listener.DbNotificationListener");
+        conf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+        conf.setBoolVar(HiveConf.ConfVars.FIRE_EVENTS_FOR_DML, true);
+        conf.setVar(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL, DummyRawStoreFailEvent.class.getName());
+        MetastoreConf.setVar(conf, MetastoreConf.ConfVars.EVENT_MESSAGE_FACTORY, JSONMessageEncoder.class.getName());
+        conf.setVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
+                "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory");
+        SessionState.start(new CliSessionState(conf));
+        TestTxnDbUtil.setConfValues(conf);
+        TestTxnDbUtil.prepDb(conf);
+        msClient = new HiveMetaStoreClient(conf);
+        driver = DriverFactory.newDriver(conf);
+        md = JSONMessageEncoder.getInstance().getDeserializer();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        long now = System.currentTimeMillis() / 1000;
+        startTime = 0;
+        if (now > Integer.MAX_VALUE) {
+            fail("Bummer, time has fallen over the edge");
+        } else {
+            startTime = (int) now;
+        }
+        firstEventId = msClient.getCurrentNotificationEventId().getEventId();
+        DummyRawStoreFailEvent.setEventSucceed(true);
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+
+    @Test
+    public void openTxn() throws Exception {
+        msClient.openTxn("me", TxnType.READ_ONLY);
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(0, rsp.getEventsSize());
+
+        msClient.openTxn("me", TxnType.DEFAULT);
+        rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        NotificationEvent event = rsp.getEvents().get(0);
+        assertEquals(firstEventId + 1, event.getEventId());
+        assertTrue(event.getEventTime() >= startTime);
+        assertEquals(EventType.OPEN_TXN.toString(), event.getEventType());
+    }
+
+    @Test
+    public void abortTxn() throws Exception {
+
+        long txnId1 = msClient.openTxn("me", TxnType.READ_ONLY);
+        long txnId2 = msClient.openTxn("me", TxnType.DEFAULT);
+
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        msClient.abortTxns(Collections.singletonList(txnId1));
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(0, rsp.getEventsSize());
+
+        msClient.abortTxns(Collections.singletonList(txnId2));
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        NotificationEvent event = rsp.getEvents().get(0);
+        assertEquals(firstEventId + 2, event.getEventId());
+        assertTrue(event.getEventTime() >= startTime);
+        assertEquals(EventType.ABORT_TXN.toString(), event.getEventType());
+    }
+
+    @Test
+    public void rollbackTxn() throws Exception {
+        long txnId1 = msClient.openTxn("me", TxnType.READ_ONLY);
+        long txnId2 = msClient.openTxn("me", TxnType.DEFAULT);
+
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        msClient.rollbackTxn(txnId1);
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(0, rsp.getEventsSize());
+
+        msClient.rollbackTxn(txnId2);
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        NotificationEvent event = rsp.getEvents().get(0);
+        assertEquals(firstEventId + 2, event.getEventId());
+        assertTrue(event.getEventTime() >= startTime);
+        assertEquals(EventType.ABORT_TXN.toString(), event.getEventType());
+    }
+
+    @Test
+    public void commitTxn() throws Exception {
+        long txnId1 = msClient.openTxn("me", TxnType.READ_ONLY);
+        long txnId2 = msClient.openTxn("me", TxnType.DEFAULT);
+
+        NotificationEventResponse rsp = msClient.getNextNotification(firstEventId, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        msClient.commitTxn(txnId1);
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(0, rsp.getEventsSize());
+
+        msClient.commitTxn(txnId2);
+        rsp = msClient.getNextNotification(firstEventId + 1, 0, null);
+        assertEquals(1, rsp.getEventsSize());
+
+        NotificationEvent event = rsp.getEvents().get(0);
+        assertEquals(firstEventId + 2, event.getEventId());
+        assertTrue(event.getEventTime() >= startTime);
+        assertEquals(EventType.COMMIT_TXN.toString(), event.getEventType());
+    }
+
+}


### PR DESCRIPTION


### What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/HIVE-23680
TestDbNotificationListener was flakey as well as broken .
As a part of fix, There are nowtotal 3 test classes based on broken tests in TestDbNotificationListener 
1. TestDbNotificationListener
   Fix of existing tests which includes nontransactional events

2. TestDbNotificationCleanup
 This class includes tests which asserts cleanup of events based on TTL configurations

3. TestTransactionalDbNotificationListner
 This class included tests with transactional event. This needs extra HMS test setup and acid properties setting. 



### Why are the changes needed?

http://34.66.156.144:8080/job/hive-precommit/job/master/35/testReport/
http://130.211.9.232/job/hive-flaky-check/24/

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
No


### How was this patch tested?
http://ci.hive.apache.org/job/hive-flaky-check/722/
http://ci.hive.apache.org/job/hive-flaky-check/721/
http://ci.hive.apache.org/job/hive-flaky-check/720/

