### PR TITLE
HIVE-24771: Fix hang of TransactionalKafkaWriterTest

### DIFF
--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TransactionalKafkaWriterTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/TransactionalKafkaWriterTest.java
@@ -58,7 +58,6 @@ import java.util.stream.IntStream;
 /**
  * Test Transactional Writer.
  */
-@org.junit.Ignore("HIVE-24771")
 public class TransactionalKafkaWriterTest {
 
   private static final String TOPIC = "TOPIC_TEST";


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable TransactionalKafkaWriterTest

### Why are the changes needed?
The flaky test started passing http://ci.hive.apache.org/job/hive-flaky-check/728/ , so enabling the test again.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Existing Unit tests and flaky check.
