### PR TITLE
HIVE-27557 - Fix Hive Metastore Schema Validation to Prevent Leading and Trailing Whitespace in Schema Names

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -230,6 +230,12 @@ public class MetaStoreUtils {
         allowedSpecialCharacters.append(c);
       }
     }
+
+    // Check for leading or trailing spaces in the name
+    if (name != null && !name.equals(name.trim())) {
+      return false;  
+    }
+    
     tpat = Pattern.compile("[\\w" + Pattern.quote(allowedSpecialCharacters.toString()) + "]+");
     Matcher m = tpat.matcher(name);
     return m.matches();


### PR DESCRIPTION
### What changes were proposed in this pull request?
The proposed changes in this pull request were to address an issue where Presto schema was misbehaving, causing corruption in the schema. Additionally, it was showing all the schemas as tables under a new schema when a schema name with leading whitespace was created using the CREATE SCHEMA query. The pull request aimed to fix this issue by introducing proper validation to prevent leading or trailing whitespace in schema names.

### Why are the changes needed?
The changes were needed to fix the misbehavior of Presto schema, which was causing schema corruption and incorrect display of schemas as tables. The issue was triggered when creating a new schema with leading whitespace in the name using the CREATE SCHEMA query. By introducing proper validation to disallow leading and trailing whitespace in schema names, the problem could be resolved.

### Does this PR introduce any user-facing change?
No, this pull request does not introduce any user-facing change. It focuses on internal validation to ensure the correctness of schema names and does not impact how users interact with the system.

### Is the change a dependency upgrade?
No, this pull request is not related to a dependency upgrade. It addresses an issue within the existing codebase without updating any external dependencies.

### How was this patch tested?
The patch was tested by patching a Hive Metastore running on a virtual machine (VM) with PrestoDB. The validation changes were applied, and the behavior was observed to verify that the issue was resolved, and schemas were displayed correctly without corruption.