### PR TITLE
HIVE-27586: Parse dates from strings ignoring trailing (potentialy) invalid chars

### DIFF
--- a/common/src/test/org/apache/hive/common/util/TestDateParser.java
+++ b/common/src/test/org/apache/hive/common/util/TestDateParser.java
@@ -61,6 +61,14 @@ public class TestDateParser {
   }
 
   @Test
+  public void testParseDateFromTimestampWithCommonTimeDelimiter() {
+    for (String d : new String[] { "T", " ", "-", ".", "_" }) {
+      String ts = "2023-08-03" + d + "01:02:03";
+      assertEquals("Parsing " + ts, Date.of(2023, 8, 3), DateParser.parseDate(ts));
+    }
+  }
+
+  @Test
   public void testInvalidCases() throws Exception {
     checkInvalidCase("2001");
     checkInvalidCase("2001-01");

--- a/common/src/test/org/apache/hive/common/util/TestDateParser.java
+++ b/common/src/test/org/apache/hive/common/util/TestDateParser.java
@@ -62,10 +62,18 @@ public class TestDateParser {
 
   @Test
   public void testParseDateFromTimestampWithCommonTimeDelimiter() {
-    for (String d : new String[] { "T", " ", "-", ".", "_" }) {
+    for (String d : new String[] { "T", " ", "-", ".", "_", "" }) {
       String ts = "2023-08-03" + d + "01:02:03";
       assertEquals("Parsing " + ts, Date.of(2023, 8, 3), DateParser.parseDate(ts));
     }
+  }
+
+  @Test
+  public void testParseDateFromValidDateLiteralWithTrailingDigits() {
+    assertEquals(Date.of(2023, 8, 8), DateParser.parseDate("2023-08-0800"));
+    // The result may seem unexpected but for many "08-08-20" is a valid date so there is no reason to reject
+    // "08-08-2023" and return null unless in the future Hive becomes stricter in terms of parsing dates.
+    assertEquals(Date.of(8, 8, 20), DateParser.parseDate("08-08-2023"));
   }
 
   @Test

--- a/ql/src/test/queries/clientpositive/check_constraint.q
+++ b/ql/src/test/queries/clientpositive/check_constraint.q
@@ -36,8 +36,8 @@ create table tmulti(url string NOT NULL ENABLE, userName string, numClicks int C
 explain alter table tmulti add constraint un1 UNIQUE (userName, numClicks) DISABLE;
 alter table tmulti add constraint un1 UNIQUE (userName, numClicks) DISABLE;
 DESC formatted tmulti;
-EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018');
-INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018');
+EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12');
+INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12');
 Select * from tmulti;
 
 -- alter table add constraint
@@ -45,16 +45,16 @@ truncate table tmulti;
 alter table tmulti add constraint chk1 CHECK (userName != NULL);
 alter table tmulti add constraint chk2 CHECK (numClicks <= 10000 AND userName != '');
 DESC formatted tmulti;
-EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018');
-INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018');
+EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12');
+INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12');
 Select * from tmulti;
 Drop table tmulti;
 
 -- case insentivity
 create table tcase(url string NOT NULL ENABLE, userName string, d date, numClicks int CHECK (numclicks > 0));
 DESC formatted tcase;
-EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48);
-INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48);
+EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48);
+INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48);
 Select * from tcase ;
 Drop table tcase;
 

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -501,11 +501,11 @@ Table:              	default.tmulti
 Constraint Name:    	#### A masked pattern was here ####	 
 Column Name:numclicks	Check Value:numClicks > 0	 
 	 	 
-PREHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+PREHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tmulti
-POSTHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+POSTHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tmulti
@@ -526,7 +526,7 @@ STAGE PLANS:
                   Row Limit Per Split: 1
                   Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: array(const struct('hive.apache.com','user1',48,'12-01-2018')) (type: array<struct<col1:string,col2:string,col3:int,col4:string>>)
+                    expressions: array(const struct('hive.apache.com','user1',48,'2018-01-12')) (type: array<struct<col1:string,col2:string,col3:int,col4:string>>)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     UDTF Operator
@@ -567,11 +567,11 @@ STAGE PLANS:
               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
               name: default.tmulti
 
-PREHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+PREHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tmulti
-POSTHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+POSTHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tmulti
@@ -587,7 +587,7 @@ POSTHOOK: query: Select * from tmulti
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tmulti
 #### A masked pattern was here ####
-hive.apache.com	user1	48	NULL
+hive.apache.com	user1	48	2018-01-12
 PREHOOK: query: truncate table tmulti
 PREHOOK: type: TRUNCATETABLE
 PREHOOK: Output: default@tmulti
@@ -672,11 +672,11 @@ Column Name:null    	Check Value:numClicks <= 10000 AND userName != ''
 Constraint Name:    	#### A masked pattern was here ####	 
 Column Name:numclicks	Check Value:numClicks > 0	 
 	 	 
-PREHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+PREHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tmulti
-POSTHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+POSTHOOK: query: EXPLAIN INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tmulti
@@ -697,7 +697,7 @@ STAGE PLANS:
                   Row Limit Per Split: 1
                   Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: array(const struct('hive.apache.com','user1',48,'12-01-2018')) (type: array<struct<col1:string,col2:string,col3:int,col4:string>>)
+                    expressions: array(const struct('hive.apache.com','user1',48,'2018-01-12')) (type: array<struct<col1:string,col2:string,col3:int,col4:string>>)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     UDTF Operator
@@ -738,11 +738,11 @@ STAGE PLANS:
               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
               name: default.tmulti
 
-PREHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+PREHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tmulti
-POSTHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '12-01-2018')
+POSTHOOK: query: INSERT INTO tmulti values('hive.apache.com', 'user1', 48, '2018-01-12')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tmulti
@@ -758,7 +758,7 @@ POSTHOOK: query: Select * from tmulti
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tmulti
 #### A masked pattern was here ####
-hive.apache.com	user1	48	NULL
+hive.apache.com	user1	48	2018-01-12
 PREHOOK: query: Drop table tmulti
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmulti
@@ -823,11 +823,11 @@ Table:              	default.tcase
 Constraint Name:    	#### A masked pattern was here ####	 
 Column Name:numclicks	Check Value:numclicks > 0	 
 	 	 
-PREHOOK: query: EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48)
+PREHOOK: query: EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tcase
-POSTHOOK: query: EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48)
+POSTHOOK: query: EXPLAIN INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tcase
@@ -848,7 +848,7 @@ STAGE PLANS:
                   Row Limit Per Split: 1
                   Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: array(const struct('hive.apache.com','user1','12-01-2018',48)) (type: array<struct<col1:string,col2:string,col3:string,col4:int>>)
+                    expressions: array(const struct('hive.apache.com','user1','2018-01-12',48)) (type: array<struct<col1:string,col2:string,col3:string,col4:int>>)
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     UDTF Operator
@@ -889,11 +889,11 @@ STAGE PLANS:
               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
               name: default.tcase
 
-PREHOOK: query: INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48)
+PREHOOK: query: INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tcase
-POSTHOOK: query: INSERT INTO tcase values('hive.apache.com', 'user1', '12-01-2018', 48)
+POSTHOOK: query: INSERT INTO tcase values('hive.apache.com', 'user1', '2018-01-12', 48)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tcase
@@ -909,7 +909,7 @@ POSTHOOK: query: Select * from tcase
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tcase
 #### A masked pattern was here ####
-hive.apache.com	user1	NULL	48
+hive.apache.com	user1	2018-01-12	48
 PREHOOK: query: Drop table tcase
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tcase


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Change `DateParser` to allow partial parsing of the input string and late resolution.
2. Remove special handling of 'T' and space ' ' in date parser

## Why are the changes needed?

1. Return valid dates (not nulls) from timestamp strings with delimiters other than space and 'T' (e.g., `2023-08-03_16:02:00`)
2. Improve backwards compatibility by allowing partial parsing supported before HIVE-20007
3. Handle trailing invalid chars in a uniform way. Now `2023-08-03TGARBAGE` and `2023-08-03_GARBAGE` both return `2023-08-03`

## Does this PR introduce any user-facing change?

Various SQL functions and operations on dates will now return a valid date instead of `null`. A list of affected functions and concrete examples are present in HIVE-27586.

## How was this patch tested?

New + existing tests
```
mvn test -Dtest=TestDateParser
```