### PR TITLE
HIVE-27575: MASK_HASH UDF generate a log per row

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFMaskHash.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFMaskHash.java
@@ -53,43 +53,35 @@ class MaskHashTransformer extends AbstractTransformer {
 
   private static final Logger LOG = LoggerFactory.getLogger(MaskHashTransformer.class);
 
-  private boolean isConfigured;
-  private boolean isSHA512;
+  private boolean isSHA512 = false;
   @Override
   public void init(ObjectInspector[] arguments, int startIdx) {
   }
 
   public void setSHA512(boolean val) {
     if (val) {
-      LOG.info("Use SHA512 for masking");
+      LOG.info("Using SHA512 for masking");
     } else {
-      LOG.info("Use SHA256 for masking");
+      LOG.info("Using SHA256 for masking");
     }
-    this.isConfigured = true;
     this.isSHA512 = val;
   }
 
   @Override
   String transform(final String value) {
-    if (!isConfigured) {
-      setIsSHA512FromSessionConf();
-    }
-    if (isSHA512) {
+    if (getIsSHA512FromSessionConf() || isSHA512) {
       return DigestUtils.sha512Hex(value);
     } else {
       return DigestUtils.sha256Hex(value);
     }
   }
 
-  private void setIsSHA512FromSessionConf() {
-    final boolean isSha512;
+  private boolean getIsSHA512FromSessionConf() {
     if (SessionState.get() != null) {
-      isSha512 = "sha512".equalsIgnoreCase(
+      return "sha512".equalsIgnoreCase(
           HiveConf.getVar(SessionState.get().getConf(), HiveConf.ConfVars.HIVE_MASKING_ALGO).trim());
-    } else {
-      isSha512 = false;
     }
-    setSHA512(isSha512);
+    return false;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid too many logs from being written.
https://issues.apache.org/jira/browse/HIVE-27575

### Why are the changes needed?

Prevent disk-full or overhead.

### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

I checked the log is written only once.

```
hive-hiveserver2-859d7686f7-xwhrh: 2023-08-07T22:35:11,886  INFO [6a60330d-5988-48fb-9a94-23d9f6e5f334 HiveServer2-Handler-Pool: Thread-59] generic.MaskHashTransformer: Use SHA256 for masking
```