### PR TITLE
HIVE-27525:Ease the write permissions on external table during create table operation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/events/CreateTableEvent.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.events
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.events.PreCreateTableEvent;
 import org.apache.hadoop.hive.metastore.events.PreEventContext;
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
@@ -81,7 +82,7 @@ public class CreateTableEvent extends HiveMetaStoreAuthorizableEvent {
     ret.add(getHivePrivilegeObject(database));
     ret.add(getHivePrivilegeObject(table));
 
-    if (StringUtils.isNotEmpty(uri)) {
+    if (StringUtils.isNotEmpty(uri) && table.getTableType() != TableType.EXTERNAL_TABLE.toString()) {
       ret.add(new HivePrivilegeObject(HivePrivilegeObjectType.DFS_URI, null, uri));
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
@@ -134,6 +134,22 @@ public class TestHiveMetaStoreAuthorizer {
   }
 
   @Test
+  public void testI_CreateExternalTable_authorizedUser() throws Exception {
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(authorizedUser));
+    try {
+      Table table = new TableBuilder()
+              .setTableName(tblName)
+              .setType(TableType.EXTERNAL_TABLE.name())
+              .addCol("name", ColumnType.STRING_TYPE_NAME)
+              .setOwner(authorizedUser)
+              .build(conf);
+      hmsHandler.create_table(table);
+    } catch (Exception e) {
+      // No Exception for create table for authorized user
+    }
+  }
+
+  @Test
   public void testC_CreateView_anyUser() throws Exception {
     UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(authorizedUser));
     try {

--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/TestHiveMetaStoreAuthorizer.java
@@ -134,22 +134,6 @@ public class TestHiveMetaStoreAuthorizer {
   }
 
   @Test
-  public void testI_CreateExternalTable_authorizedUser() throws Exception {
-    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(authorizedUser));
-    try {
-      Table table = new TableBuilder()
-              .setTableName(tblName)
-              .setType(TableType.EXTERNAL_TABLE.name())
-              .addCol("name", ColumnType.STRING_TYPE_NAME)
-              .setOwner(authorizedUser)
-              .build(conf);
-      hmsHandler.create_table(table);
-    } catch (Exception e) {
-      // No Exception for create table for authorized user
-    }
-  }
-
-  @Test
   public void testC_CreateView_anyUser() throws Exception {
     UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(authorizedUser));
     try {

--- a/ql/src/test/queries/clientpositive/auth_create_ext_table_1.q
+++ b/ql/src/test/queries/clientpositive/auth_create_ext_table_1.q
@@ -1,0 +1,15 @@
+dfs ${system:test.dfs.mkdir} ${system:test.tmp.dir}/a_ext_create_tab1;
+dfs -touchz ${system:test.tmp.dir}/a_ext_create_tab1/1.txt;
+dfs -chmod 555 ${system:test.tmp.dir}/a_ext_create_tab1/1.txt;
+
+dfs ${system:test.dfs.mkdir} ${system:test.tmp.dir}/a_ext_create_tab2;
+dfs -chmod 555 ${system:test.tmp.dir}/a_ext_create_tab2;
+
+set hive.metastore.pre.event.listeners=org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.HiveMetaStoreAuthorizer;
+set hive.security.authorization.manager=org.apache.hadoop.hive.ql.security.authorization.plugin.fallback.FallbackHiveAuthorizerFactory;
+
+-- Attempt to Create external table without having write permissions on table dir should not result in error
+CREATE EXTERNAL TABLE t1(i int) location '${system:test.tmp.dir}/a_ext_create_tab1';
+Select * from t1;
+
+CREATE EXTERNAL TABLE LikeExternalTable LIKE t1 location '${system:test.tmp.dir}/a_ext_create_tab2';

--- a/ql/src/test/results/clientpositive/llap/auth_create_ext_table_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/auth_create_ext_table_1.q.out
@@ -1,0 +1,27 @@
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: Select * from t1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: Select * from t1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@LikeExternalTable
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@LikeExternalTable


### PR DESCRIPTION

### What changes were proposed in this pull request?
Exclude `DFS_URI` from output `HivePrivilegeObject` if the table is an External table.


### Why are the changes needed?
To address security concerns where currently users had to be granted unnecessary write permissions on an external file location when the table is only used for reading the data.


### Does this PR introduce _any_ user-facing change?
Yes, External table creation will be successful but Update/ delete operation will fail without write permissions on table location.

### Is the change a dependency upgrade?
No


### How was this patch tested? 
mvn test -Dtest.output.overwrite=true -Dtest=TestMiniLlapLocalCliDriver -Dqfile=auth_create_ext_table_1.q
