### PR TITLE
HIVE-27608 : Backport of HIVE-22106: Remove cross-query synchronization for the partition-eval

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartExprEvalUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartExprEvalUtils.java
@@ -52,7 +52,7 @@ public class PartExprEvalUtils {
    * @return value returned by the expression
    * @throws HiveException
    */
-  static synchronized public Object evalExprWithPart(ExprNodeDesc expr,
+  static public Object evalExprWithPart(ExprNodeDesc expr,
       Partition p, List<VirtualColumn> vcs,
       StructObjectInspector rowObjectInspector) throws HiveException {
     LinkedHashMap<String, String> partSpec = p.getSpec();
@@ -103,7 +103,7 @@ public class PartExprEvalUtils {
         .getPrimitiveJavaObject(evaluateResultO);
   }
 
-  static synchronized public ObjectPair<PrimitiveObjectInspector, ExprNodeEvaluator> prepareExpr(
+  static public ObjectPair<PrimitiveObjectInspector, ExprNodeEvaluator> prepareExpr(
       ExprNodeGenericFuncDesc expr, List<String> partColumnNames,
       List<PrimitiveTypeInfo> partColumnTypeInfos) throws HiveException {
     // Create the row object
@@ -120,7 +120,7 @@ public class PartExprEvalUtils {
     return ObjectPair.create((PrimitiveObjectInspector)evaluateResultOI, evaluator);
   }
 
-  static synchronized public Object evaluateExprOnPart(
+  static public Object evaluateExprOnPart(
       ObjectPair<PrimitiveObjectInspector, ExprNodeEvaluator> pair, Object partColValues)
           throws HiveException {
     return pair.getFirst().getPrimitiveJavaObject(pair.getSecond().evaluate(partColValues));


### PR DESCRIPTION
JIRA link - https://issues.apache.org/jira/browse/HIVE-27608