### PR TITLE
HIVE-27610 : Backport of HIVE-22161: UDF: FunctionRegistry synchronizes on org.apache.hadoop.h…

### DIFF
--- a/common/src/java/org/apache/hive/common/util/AnnotationUtils.java
+++ b/common/src/java/org/apache/hive/common/util/AnnotationUtils.java
@@ -23,17 +23,15 @@ import java.lang.reflect.Method;
 
 public class AnnotationUtils {
 
-  // to avoid https://bugs.openjdk.java.net/browse/JDK-7122142
+  // until JDK8, this had a lock around annotationClass to avoid
+  // https://bugs.openjdk.java.net/browse/JDK-7122142
   public static <T extends Annotation> T getAnnotation(Class<?> clazz, Class<T> annotationClass) {
-    synchronized (annotationClass) {
-      return clazz.getAnnotation(annotationClass);
-    }
+    return clazz.getAnnotation(annotationClass);
   }
 
-  // to avoid https://bugs.openjdk.java.net/browse/JDK-7122142
+  // until JDK8, this had a lock around annotationClass to avoid
+  // https://bugs.openjdk.java.net/browse/JDK-7122142
   public static <T extends Annotation> T getAnnotation(Method method, Class<T> annotationClass) {
-    synchronized (annotationClass) {
-      return method.getAnnotation(annotationClass);
-    }
+    return method.getAnnotation(annotationClass);
   }
 }


### PR DESCRIPTION
JIRA link - https://issues.apache.org/jira/browse/HIVE-27610