### PR TITLE
HIVE-27616 : Backport of HIVE-20619: Include MultiDelimitSerDe in HiveServer2 By Default

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/MultiDelimitSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/MultiDelimitSerDe.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.contrib.serde2;
+package org.apache.hadoop.hive.serde2;
 
 import java.io.IOException;
 import java.util.List;


### PR DESCRIPTION
JIRA link - https://issues.apache.org/jira/browse/HIVE-27616