### PR TITLE
HIVE-27620 : Backport of HIVE-25945: Upgrade H2 database version to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <flatbuffers.version>1.2.0-3f79e055</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <h2database.version>1.3.166</h2database.version>
+    <h2database.version>2.1.210</h2database.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
JIRA link - https://issues.apache.org/jira/browse/HIVE-27620