### PR TITLE
HIVE-27622: Backport of HIVE-26078: Upgrade gson to 2.8.9 (Ashish Sharma, reviewed by Adesh Rao)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <curator.version>2.12.0</curator.version>
     <jsr305.version>3.0.0</jsr305.version>
     <tephra.version>0.6.0</tephra.version>
-    <gson.version>2.2.4</gson.version>
+    <gson.version>2.8.9</gson.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
JIRA link - https://issues.apache.org/jira/browse/HIVE-27622