### PR TITLE
HIVE-27631: Fix CCE when set fs.hdfs.impl other than DistributedFileSystem

### DIFF
--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1519,7 +1519,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
   public HadoopShims.HdfsEncryptionShim createHdfsEncryptionShim(FileSystem fs, Configuration conf) throws IOException {
     if (isHdfsEncryptionSupported()) {
       URI uri = fs.getUri();
-      if ("hdfs".equals(uri.getScheme())) {
+      if ("hdfs".equals(uri.getScheme()) && fs instanceof DistributedFileSystem) {
         return new HdfsEncryptionShim(uri, conf);
       }
     }


### PR DESCRIPTION
My suggestion is that we should not judge hdfs by scheme "hdfs", instead, we can judege `hdfs` by the class or className.

Since we can use `fs.hdfs.impl=alluxio.hadoop.ShimFileSystem` to another hadoop filesystem implementation. 

![image](https://github.com/apache/hive/assets/17329931/889fbec4-83fd-4fef-a099-5de05eaabbb1)
