### PR TITLE
HIVE-22961: Drop function in Hive should not send request for drop database to Ranger plugin

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestCreateUdfEntities.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestCreateUdfEntities.java
@@ -53,16 +53,13 @@ public class TestCreateUdfEntities {
         "'org.apache.hadoop.hive.ql.udf.generic.GenericUDFPrintf'  using file '" + "file:///tmp/udf1.jar'", true);
     assertEquals(0, rc);
     WriteEntity outputEntities[] = driver.getPlan().getOutputs().toArray(new WriteEntity[] {});
-    assertEquals(outputEntities.length, 3);
+    assertEquals(outputEntities.length, 2);
 
-    assertEquals(Entity.Type.DATABASE, outputEntities[0].getType());
-    assertEquals("default", outputEntities[0].getDatabase().getName());
+    assertEquals(Entity.Type.FUNCTION, outputEntities[0].getType());
+    assertEquals(funcName, outputEntities[0].getFunction().getFunctionName());
 
-    assertEquals(Entity.Type.FUNCTION, outputEntities[1].getType());
-    assertEquals(funcName, outputEntities[1].getFunction().getFunctionName());
-
-    assertEquals(Entity.Type.LOCAL_DIR, outputEntities[2].getType());
-    assertEquals("file:///tmp/udf1.jar", outputEntities[2].getLocation().toString());
+    assertEquals(Entity.Type.LOCAL_DIR, outputEntities[1].getType());
+    assertEquals("file:///tmp/udf1.jar", outputEntities[1].getLocation().toString());
   }
 
   @Test
@@ -71,16 +68,13 @@ public class TestCreateUdfEntities {
         "'org.apache.hadoop.hive.ql.udf.generic.GenericUDFPrintf'  using file '" + "hdfs:///tmp/udf1.jar'", true);
     assertEquals(0, rc);
     WriteEntity outputEntities[] = driver.getPlan().getOutputs().toArray(new WriteEntity[] {});
-    assertEquals(outputEntities.length, 3);
+    assertEquals(outputEntities.length, 2);
 
-    assertEquals(Entity.Type.DATABASE, outputEntities[0].getType());
-    assertEquals("default", outputEntities[0].getDatabase().getName());
+    assertEquals(Entity.Type.FUNCTION, outputEntities[0].getType());
+    assertEquals(funcName, outputEntities[0].getFunction().getFunctionName());
 
-    assertEquals(Entity.Type.FUNCTION, outputEntities[1].getType());
-    assertEquals(funcName, outputEntities[1].getFunction().getFunctionName());
-
-    assertEquals(Entity.Type.DFS_DIR, outputEntities[2].getType());
-    assertEquals("hdfs:///tmp/udf1.jar", outputEntities[2].getLocation().toString());
+    assertEquals(Entity.Type.DFS_DIR, outputEntities[1].getType());
+    assertEquals("hdfs:///tmp/udf1.jar", outputEntities[1].getLocation().toString());
   }
 
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
@@ -316,22 +316,13 @@ public class TestHiveAuthorizerCheckInvocation {
     List<HivePrivilegeObject> outputs = getHivePrivilegeObjectInputs().getRight();
 
     HivePrivilegeObject funcObj;
-    HivePrivilegeObject dbObj;
-    assertEquals("number of output objects", 2, outputs.size());
-    if(outputs.get(0).getType() == HivePrivilegeObjectType.FUNCTION) {
-      funcObj = outputs.get(0);
-      dbObj = outputs.get(1);
-    } else {
-      funcObj = outputs.get(1);
-      dbObj = outputs.get(0);
-    }
+    assertEquals("number of output objects", 1, outputs.size());
+
+    funcObj = outputs.get(0);
 
     assertEquals("input type", HivePrivilegeObjectType.FUNCTION, funcObj.getType());
     assertTrue("function name", funcName.equalsIgnoreCase(funcObj.getObjectName()));
     assertTrue("db name", dbName.equalsIgnoreCase(funcObj.getDbname()));
-
-    assertEquals("input type", HivePrivilegeObjectType.DATABASE, dbObj.getType());
-    assertTrue("db name", dbName.equalsIgnoreCase(dbObj.getDbname()));
 
     // actually create the permanent function
     driver.run();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/AbstractFunctionAnalyzer.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.ResourceUri;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.FunctionUtils;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.hooks.Entity.Type;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -70,7 +71,7 @@ public abstract class AbstractFunctionAnalyzer extends BaseSemanticAnalyzer {
       }
     }
     if (database != null) {
-      outputs.add(new WriteEntity(database, WriteEntity.WriteType.DDL_NO_LOCK));
+      inputs.add(new ReadEntity(database));
       // Add the permanent function as a WriteEntity
       Function function;
       if (queryState.getHiveOperation().equals(HiveOperation.CREATEFUNCTION)) {

--- a/ql/src/test/results/clientnegative/create_function_nonexistent_class.q.out
+++ b/ql/src/test/results/clientnegative/create_function_nonexistent_class.q.out
@@ -1,6 +1,6 @@
 PREHOOK: query: create function default.badfunc as 'my.nonexistent.class'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.badfunc
 FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask. Unable to load UDF class: java.lang.ClassNotFoundException: my.nonexistent.class
 Please ensure that the JAR file containing this class has been properly installed in the auxiliary directory or was added with ADD JAR command.

--- a/ql/src/test/results/clientnegative/create_function_nonudf_class.q.out
+++ b/ql/src/test/results/clientnegative/create_function_nonudf_class.q.out
@@ -1,6 +1,6 @@
 PREHOOK: query: create function default.badfunc as 'java.lang.String'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.badfunc
 Failed to register default.badfunc using class java.lang.String
 FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask

--- a/ql/src/test/results/clientnegative/drop_database_cascade.q.out
+++ b/ql/src/test/results/clientnegative/drop_database_cascade.q.out
@@ -20,11 +20,11 @@ POSTHOOK: Output: TEST_database@test_table
 POSTHOOK: Output: database:test_database
 PREHOOK: query: CREATE FUNCTION test_func as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:test_database
+PREHOOK: Input: database:test_database
 PREHOOK: Output: test_database.test_func
 POSTHOOK: query: CREATE FUNCTION test_func as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:test_database
+POSTHOOK: Input: database:test_database
 POSTHOOK: Output: test_database.test_func
 PREHOOK: query: USE default
 PREHOOK: type: SWITCHDATABASE
@@ -42,11 +42,11 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@test_table
 PREHOOK: query: CREATE FUNCTION test_func as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_func
 POSTHOOK: query: CREATE FUNCTION test_func as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_func
 PREHOOK: query: DROP DATABASE TEST_database CASCADE
 PREHOOK: type: DROPDATABASE

--- a/ql/src/test/results/clientnegative/udf_local_resource.q.out
+++ b/ql/src/test/results/clientnegative/udf_local_resource.q.out
@@ -1,6 +1,6 @@
 PREHOOK: query: create function lookup as 'org.apache.hadoop.hive.ql.udf.UDFFileLookup' using file '../../data/files/sales.txt'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.lookup
 PREHOOK: Output: hdfs://### HDFS PATH ###
 FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask. Hive warehouse is non-local, but ../../data/files/sales.txt specifies file on local filesystem. Resources on non-local warehouse should specify a non-local scheme/path

--- a/ql/src/test/results/clientnegative/udf_nonexistent_resource.q.out
+++ b/ql/src/test/results/clientnegative/udf_nonexistent_resource.q.out
@@ -1,6 +1,6 @@
 PREHOOK: query: create function lookup as 'org.apache.hadoop.hive.ql.udf.UDFFileLookup' using file 'nonexistent_file.txt'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.lookup
 #### A masked pattern was here ####
 nonexistent_file.txt does not exist

--- a/ql/src/test/results/clientpositive/llap/authorization_create_func1.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_create_func1.q.out
@@ -10,11 +10,11 @@ POSTHOOK: type: CREATEFUNCTION
 POSTHOOK: Output: temp_fn
 PREHOOK: query: create function perm_fn as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.perm_fn
 POSTHOOK: query: create function perm_fn as 'org.apache.hadoop.hive.ql.udf.UDFAscii'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.perm_fn
 PREHOOK: query: drop temporary function temp_fn
 PREHOOK: type: DROPFUNCTION
@@ -24,9 +24,9 @@ POSTHOOK: type: DROPFUNCTION
 POSTHOOK: Output: temp_fn
 PREHOOK: query: drop function perm_fn
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.perm_fn
 POSTHOOK: query: drop function perm_fn
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.perm_fn

--- a/ql/src/test/results/clientpositive/llap/authorization_functions_in_views.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_functions_in_views.q.out
@@ -26,11 +26,11 @@ POSTHOOK: query: drop database if exists test
 POSTHOOK: type: DROPDATABASE
 PREHOOK: query: create function udf_upper as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.udf_upper
 POSTHOOK: query: create function udf_upper as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.udf_upper
 PREHOOK: query: create table base_table(city string)
 PREHOOK: type: CREATETABLE
@@ -63,11 +63,11 @@ POSTHOOK: Input: default@view_using_udf
 #### A masked pattern was here ####
 PREHOOK: query: create function udf_lower as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFLower'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.udf_lower
 POSTHOOK: query: create function udf_lower as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFLower'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.udf_lower
 PREHOOK: query: select udf_lower(upper_city) from view_using_udf
 PREHOOK: type: QUERY
@@ -87,11 +87,11 @@ POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:test
 PREHOOK: query: create function test.UDF_upper as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:test
+PREHOOK: Input: database:test
 PREHOOK: Output: test.udf_upper
 POSTHOOK: query: create function test.UDF_upper as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:test
+POSTHOOK: Input: database:test
 POSTHOOK: Output: test.udf_upper
 PREHOOK: query: select test.UDF_Upper(upper_city) from view_using_udf
 PREHOOK: type: QUERY
@@ -135,11 +135,11 @@ POSTHOOK: Input: default@view_using_udf
 #### A masked pattern was here ####
 PREHOOK: query: drop function test.UDF_Upper
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:test
+PREHOOK: Input: database:test
 PREHOOK: Output: test.udf_upper
 POSTHOOK: query: drop function test.UDF_Upper
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:test
+POSTHOOK: Input: database:test
 POSTHOOK: Output: test.udf_upper
 PREHOOK: query: drop database test
 PREHOOK: type: DROPDATABASE
@@ -151,19 +151,19 @@ POSTHOOK: Input: database:test
 POSTHOOK: Output: database:test
 PREHOOK: query: drop function udf_lower
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.udf_lower
 POSTHOOK: query: drop function udf_lower
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.udf_lower
 PREHOOK: query: drop function udf_upper
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.udf_upper
 POSTHOOK: query: drop function udf_upper
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.udf_upper
 PREHOOK: query: drop view view_using_udf
 PREHOOK: type: DROPVIEW

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -330,11 +330,11 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@table2_n0
 PREHOOK: query: CREATE FUNCTION test_udf2 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf2
 POSTHOOK: query: CREATE FUNCTION test_udf2 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf2
 PREHOOK: query: CREATE TABLE tudf(v string CHECK (test_udf2(v) <> 'vin'))
 PREHOOK: type: CREATETABLE

--- a/ql/src/test/results/clientpositive/llap/create_func1.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_func1.q.out
@@ -1,10 +1,10 @@
 PREHOOK: query: CREATE FUNCTION qtest_get_java_boolean AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaBoolean'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.qtest_get_java_boolean
 POSTHOOK: query: CREATE FUNCTION qtest_get_java_boolean AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaBoolean'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.qtest_get_java_boolean
 PREHOOK: query: select qtest_get_java_boolean('true'), qtest_get_java_boolean('false') from src limit 1
 PREHOOK: type: QUERY
@@ -31,11 +31,11 @@ POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:mydb
 PREHOOK: query: explain create function mydb.func1 as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.func1
 POSTHOOK: query: explain create function mydb.func1 as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.func1
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -48,11 +48,11 @@ STAGE PLANS:
 
 PREHOOK: query: create function mydb.func1 as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.func1
 POSTHOOK: query: create function mydb.func1 as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.func1
 PREHOOK: query: show functions like mydb.func1
 PREHOOK: type: SHOWFUNCTIONS
@@ -81,11 +81,11 @@ POSTHOOK: Input: default@src
 ABC
 PREHOOK: query: explain drop function mydb.func1
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.func1
 POSTHOOK: query: explain drop function mydb.func1
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.func1
 STAGE DEPENDENCIES:
   Stage-0 is a root stage
@@ -97,11 +97,11 @@ STAGE PLANS:
 
 PREHOOK: query: drop function mydb.func1
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.func1
 POSTHOOK: query: drop function mydb.func1
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.func1
 PREHOOK: query: show functions like mydb.func1
 PREHOOK: type: SHOWFUNCTIONS
@@ -178,11 +178,11 @@ POSTHOOK: query: reload function
 POSTHOOK: type: RELOADFUNCTION
 PREHOOK: query: create function mydb.qtest_get_java_boolean as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.qtest_get_java_boolean
 POSTHOOK: query: create function mydb.qtest_get_java_boolean as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.qtest_get_java_boolean
 PREHOOK: query: use default
 PREHOOK: type: SWITCHDATABASE
@@ -216,19 +216,19 @@ POSTHOOK: Input: default@src
 ABC	NULL	ABC
 PREHOOK: query: drop function default.qtest_get_java_boolean
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.qtest_get_java_boolean
 POSTHOOK: query: drop function default.qtest_get_java_boolean
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.qtest_get_java_boolean
 PREHOOK: query: drop function mydb.qtest_get_java_boolean
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:mydb
+PREHOOK: Input: database:mydb
 PREHOOK: Output: mydb.qtest_get_java_boolean
 POSTHOOK: query: drop function mydb.qtest_get_java_boolean
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:mydb
+POSTHOOK: Input: database:mydb
 POSTHOOK: Output: mydb.qtest_get_java_boolean
 PREHOOK: query: drop database mydb cascade
 PREHOOK: type: DROPDATABASE

--- a/ql/src/test/results/clientpositive/llap/llap_udf.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_udf.q.out
@@ -25,11 +25,11 @@ POSTHOOK: Output: test_udf0
 PREHOOK: query: EXPLAIN SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -91,12 +91,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf2(cast(key as string)), test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN
 SELECT test_udf2(cast(key as string)), test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -135,12 +135,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -187,12 +187,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -239,12 +239,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -282,12 +282,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-#### A masked pattern was here ####
+POSTHOOK: Output: hdfs://### HDFS PATH ###
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1

--- a/ql/src/test/results/clientpositive/llap/llap_udf.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_udf.q.out
@@ -25,11 +25,11 @@ POSTHOOK: Output: test_udf0
 PREHOOK: query: EXPLAIN SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -65,38 +65,38 @@ STAGE PLANS:
 
 PREHOOK: query: CREATE FUNCTION test_udf2 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf2
 POSTHOOK: query: CREATE FUNCTION test_udf2 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf2
 PREHOOK: query: CREATE FUNCTION test_udf3 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf3
 POSTHOOK: query: CREATE FUNCTION test_udf3 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFTestGetJavaString'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf3
 PREHOOK: query: CREATE FUNCTION test_udf4 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFEvaluateNPE'
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf4
 POSTHOOK: query: CREATE FUNCTION test_udf4 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFEvaluateNPE'
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf4
 PREHOOK: query: EXPLAIN
 SELECT test_udf2(cast(key as string)), test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT test_udf2(cast(key as string)), test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -135,12 +135,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -177,22 +177,22 @@ STAGE PLANS:
 
 PREHOOK: query: DROP FUNCTION test_udf2
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf2
 POSTHOOK: query: DROP FUNCTION test_udf2
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf2
 PREHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)), test_udf4(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -229,22 +229,22 @@ STAGE PLANS:
 
 PREHOOK: query: DROP FUNCTION test_udf4
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.test_udf4
 POSTHOOK: query: DROP FUNCTION test_udf4
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.test_udf4
 PREHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT test_udf0(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1
@@ -282,12 +282,12 @@ PREHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)) from src_orc_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_orc_n0
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 SELECT test_udf3(cast(key as string)) from src_orc_n0
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_orc_n0
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
   Stage-0 depends on stages: Stage-1

--- a/ql/src/test/results/clientpositive/udf_using.q.out
+++ b/ql/src/test/results/clientpositive/udf_using.q.out
@@ -1,10 +1,10 @@
 #### A masked pattern was here ####
 PREHOOK: type: CREATEFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.lookup
 #### A masked pattern was here ####
 POSTHOOK: type: CREATEFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.lookup
 #### A masked pattern was here ####
 PREHOOK: query: create table udf_using (c1 string)
@@ -46,10 +46,10 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@udf_using
 PREHOOK: query: drop function lookup
 PREHOOK: type: DROPFUNCTION
-PREHOOK: Output: database:default
+PREHOOK: Input: database:default
 PREHOOK: Output: default.lookup
 POSTHOOK: query: drop function lookup
 POSTHOOK: type: DROPFUNCTION
-POSTHOOK: Output: database:default
+POSTHOOK: Input: database:default
 POSTHOOK: Output: default.lookup
 #### A masked pattern was here ####


### PR DESCRIPTION

### What changes were proposed in this pull request?
 Removing database object from Output `HivePrivilegeObject` and adding to input `HivePrivilegeObject` in Create Function and Drop Function authorization. 


### Why are the changes needed?
Create/Drop function should not require DROP/WRITE privileges to the database.

### Does this PR introduce _any_ user-facing change?
Yes, Create/Drop function only requires READ permission to the DB

### Is the change a dependency upgrade?
No


### How was this patch tested?
Tested with existing qtests for create/drop function
