### PR TITLE
HIVE-27632: Filter decimal vector expression with coalesce fixed

### DIFF
--- a/ql/src/test/results/clientpositive/llap/vector_coalesce.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_coalesce.q.out
@@ -645,3 +645,152 @@ NULL	31	31
 NULL	31	31
 NULL	61	61
 NULL	NULL	NULL
+PREHOOK: query: create database test
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:test
+POSTHOOK: query: create database test
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:test
+PREHOOK: query: use test
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:test
+POSTHOOK: query: use test
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:test
+PREHOOK: query: CREATE EXTERNAL TABLE test.ext_1(
+   ord_key string,
+   col2 string,
+   col3 decimal(18,6),
+   col4 String,
+   col5 decimal(18,6))
+   CLUSTERED BY (
+   ord_key)
+ SORTED BY (
+   ord_key ASC)
+ INTO 64 BUCKETS
+ ROW FORMAT SERDE
+   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+ TBLPROPERTIES (
+   'TRANSLATED_TO_EXTERNAL'='TRUE',
+   'external.table.purge'='TRUE',
+   'orc.output.codec'='snappy')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:test
+PREHOOK: Output: test@ext_1
+POSTHOOK: query: CREATE EXTERNAL TABLE test.ext_1(
+   ord_key string,
+   col2 string,
+   col3 decimal(18,6),
+   col4 String,
+   col5 decimal(18,6))
+   CLUSTERED BY (
+   ord_key)
+ SORTED BY (
+   ord_key ASC)
+ INTO 64 BUCKETS
+ ROW FORMAT SERDE
+   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+ TBLPROPERTIES (
+   'TRANSLATED_TO_EXTERNAL'='TRUE',
+   'external.table.purge'='TRUE',
+   'orc.output.codec'='snappy')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:test
+POSTHOOK: Output: test@ext_1
+PREHOOK: query: CREATE EXTERNAL TABLE test.ext_2(
+   Col1 string,
+   col2 string,
+   Col3 decimal(18,6),
+   col4 string,
+   col5 string)
+ CLUSTERED BY (
+   col2)
+ SORTED BY (
+   col2 ASC)
+ INTO 64 BUCKETS
+ ROW FORMAT SERDE
+   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+ TBLPROPERTIES (
+   'TRANSLATED_TO_EXTERNAL'='TRUE',
+   'external.table.purge'='TRUE',
+   'orc.output.codec'='snappy')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:test
+PREHOOK: Output: test@ext_2
+POSTHOOK: query: CREATE EXTERNAL TABLE test.ext_2(
+   Col1 string,
+   col2 string,
+   Col3 decimal(18,6),
+   col4 string,
+   col5 string)
+ CLUSTERED BY (
+   col2)
+ SORTED BY (
+   col2 ASC)
+ INTO 64 BUCKETS
+ ROW FORMAT SERDE
+   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+ STORED AS INPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+ OUTPUTFORMAT
+   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+ TBLPROPERTIES (
+   'TRANSLATED_TO_EXTERNAL'='TRUE',
+   'external.table.purge'='TRUE',
+   'orc.output.codec'='snappy')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:test
+POSTHOOK: Output: test@ext_2
+PREHOOK: query: insert into test.ext_1 (col2) values('a')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: test@ext_1
+POSTHOOK: query: insert into test.ext_1 (col2) values('a')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: test@ext_1
+POSTHOOK: Lineage: ext_1.col2 SCRIPT []
+POSTHOOK: Lineage: ext_1.col3 SIMPLE []
+POSTHOOK: Lineage: ext_1.col4 SIMPLE []
+POSTHOOK: Lineage: ext_1.col5 SIMPLE []
+POSTHOOK: Lineage: ext_1.ord_key SIMPLE []
+PREHOOK: query: insert into test.ext_2 (col2) values ('a')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: test@ext_2
+POSTHOOK: query: insert into test.ext_2 (col2) values ('a')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: test@ext_2
+POSTHOOK: Lineage: ext_2.col1 SIMPLE []
+POSTHOOK: Lineage: ext_2.col2 SCRIPT []
+POSTHOOK: Lineage: ext_2.col3 SIMPLE []
+POSTHOOK: Lineage: ext_2.col4 SIMPLE []
+POSTHOOK: Lineage: ext_2.col5 SIMPLE []
+PREHOOK: query: select ord_key,test1.col5 FROM test.ext_1 test1
+left outer join test.ext_2 test2 on (test1.col4 = test2.col4)
+where (NVL(test1.col5, 0) = 0) limit 10
+PREHOOK: type: QUERY
+PREHOOK: Input: test@ext_1
+PREHOOK: Input: test@ext_2
+#### A masked pattern was here ####
+POSTHOOK: query: select ord_key,test1.col5 FROM test.ext_1 test1
+left outer join test.ext_2 test2 on (test1.col4 = test2.col4)
+where (NVL(test1.col5, 0) = 0) limit 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: test@ext_1
+POSTHOOK: Input: test@ext_2
+#### A masked pattern was here ####
+NULL	NULL


### PR DESCRIPTION
All Generic* functions that support decimal64 vector expressions are annotated with "VectorizedExpressionsSupportDecimal64". The coalesce function in GenericUDFCoalesce does not have this annotation, but there was code in VectorizationContext that assumed coalesce supported Decimal64. This code has now been changed so that both do not support Decimal64.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fixed issue when there was a coalesece function on a decimal in a filter condition. One part of the code claims Decimal64 is not supported while another part of the code created Decimal64 datatypes.  The latter part has now been changed so that Decimal64 datatypes are not supported.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Got a ClassCastException without this code.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test added that was failing before the fix.