### PR TITLE
HIVE-27532: Missing semicolon in show create table output

### DIFF
--- a/hbase-handler/src/test/results/positive/hbase_queries.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_queries.q.out
@@ -1024,6 +1024,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE IF EXISTS hbase_table_9
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default

--- a/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctlt_iceberg.q.out
@@ -51,7 +51,8 @@ TBLPROPERTIES (
   'uuid'='#Masked#', 
   'write.delete.mode'='merge-on-read', 
   'write.merge.mode'='merge-on-read', 
-  'write.update.mode'='merge-on-read')
+  'write.update.mode'='merge-on-read'
+);
 PREHOOK: query: select count(*) from target
 PREHOOK: type: QUERY
 PREHOOK: Input: default@target
@@ -133,7 +134,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: create table emp_like1 like emp_iceberg stored by iceberg
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -171,7 +173,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: create table emp (id int) partitioned by (company string)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -201,6 +204,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table emp_like2 like emp stored by iceberg
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -238,7 +242,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: create managed table man_table (id int) Stored as orc TBLPROPERTIES ('transactional'='true')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_v2_deletes.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_v2_deletes.q.out
@@ -39,7 +39,8 @@ TBLPROPERTIES (
   'write.delete.mode'='merge-on-read', 
   'write.format.default'='orc', 
   'write.merge.mode'='merge-on-read', 
-  'write.update.mode'='merge-on-read')
+  'write.update.mode'='merge-on-read'
+);
 PREHOOK: query: insert into ice01 values (1),(2),(3),(4)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -152,7 +153,8 @@ TBLPROPERTIES (
   'write.delete.mode'='merge-on-read', 
   'write.format.default'='orc', 
   'write.merge.mode'='merge-on-read', 
-  'write.update.mode'='merge-on-read')
+  'write.update.mode'='merge-on-read'
+);
 PREHOOK: query: delete from ice01 where id=5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ice01
@@ -299,7 +301,8 @@ TBLPROPERTIES (
   'write.delete.mode'='merge-on-read', 
   'write.format.default'='orc', 
   'write.merge.mode'='merge-on-read', 
-  'write.update.mode'='merge-on-read')
+  'write.update.mode'='merge-on-read'
+);
 PREHOOK: query: delete from icepart01 where id=5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@icepart01

--- a/iceberg/iceberg-handler/src/test/results/positive/show_create_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/show_create_iceberg_table.q.out
@@ -40,7 +40,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: DROP TABLE IF EXISTS ice_t_transform
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default
@@ -95,7 +96,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: DROP TABLE IF EXISTS ice_t_transform_prop
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default
@@ -151,7 +153,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: DROP TABLE IF EXISTS ice_t_identity_part
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default
@@ -195,7 +198,8 @@ TBLPROPERTIES (
   'snapshot-count'='0', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);
 PREHOOK: query: DROP TABLE IF EXISTS ice_data
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default
@@ -248,4 +252,5 @@ TBLPROPERTIES (
   'snapshot-count'='1', 
   'table_type'='ICEBERG', 
 #### A masked pattern was here ####
-  'uuid'='#Masked#')
+  'uuid'='#Masked#'
+);

--- a/kudu-handler/src/test/results/positive/kudu_queries.q.out
+++ b/kudu-handler/src/test/results/positive/kudu_queries.q.out
@@ -1285,6 +1285,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'kudu.table_name'='default.kudu_all_types', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DESCRIBE all_types_table
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@all_types_table

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseOperation.java
@@ -61,16 +61,17 @@ public class ShowCreateDatabaseOperation extends DDLOperation<ShowCreateDatabase
       createDbCommand.append(HiveStringUtils.escapeHiveCommand(database.getDescription())).append("'\n");
     }
     createDbCommand.append("LOCATION\n  '");
-    createDbCommand.append(database.getLocationUri()).append("'\n");
+    createDbCommand.append(database.getLocationUri()).append("'");
     if (database.getManagedLocationUri() != null) {
-      createDbCommand.append("MANAGEDLOCATION\n  '");
-      createDbCommand.append(database.getManagedLocationUri()).append("'\n");
+      createDbCommand.append("\nMANAGEDLOCATION\n  '");
+      createDbCommand.append(database.getManagedLocationUri()).append("'");
     }
     String propertiesToString = ShowUtils.propertiesToString(database.getParameters(), Collections.emptySet());
     if (!propertiesToString.isEmpty()) {
-      createDbCommand.append("WITH DBPROPERTIES (\n");
-      createDbCommand.append(propertiesToString).append(")\n");
+      createDbCommand.append("\nWITH DBPROPERTIES (\n");
+      createDbCommand.append(propertiesToString).append("\n)");
     }
+    createDbCommand.append(";\n");
 
     outStream.write(createDbCommand.toString().getBytes(StandardCharsets.UTF_8));
     return 0;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLPlanUtils.java
@@ -144,7 +144,8 @@ public class DDLPlanUtils {
       "<" + ROW_FORMAT + ">\n" +
       "<" + LOCATION_BLOCK + ">" +
       "TBLPROPERTIES (\n" +
-      "<" + PROPERTIES + ">)";
+      "<" + PROPERTIES + ">\n" +
+      ");";
 
   private static final String CREATE_VIEW_TEMPLATE =
     "CREATE VIEW <if(" + DATABASE_NAME + ")>`<" + DATABASE_NAME + ">`.<endif>`<" + TABLE_NAME +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ExplainTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ExplainTask.java
@@ -453,7 +453,7 @@ public class ExplainTask extends Task<ExplainWork> implements Serializable {
   }
 
   public void addCreateTableStatement(Table table, List<String> tableCreateStmt , DDLPlanUtils ddlPlanUtils) {
-    tableCreateStmt.add(ddlPlanUtils.getCreateTableCommand(table, false) + ";");
+    tableCreateStmt.add(ddlPlanUtils.getCreateTableCommand(table, false));
   }
 
   public void addPKandBasicStats(Table tbl, List<String> basicDef, DDLPlanUtils ddlPlanUtils){

--- a/ql/src/test/results/clientpositive/beeline/escape_comments.q.out
+++ b/ql/src/test/results/clientpositive/beeline/escape_comments.q.out
@@ -72,6 +72,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted escape_comments_tbl1
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: escape_comments_db@escape_comments_tbl1

--- a/ql/src/test/results/clientpositive/create_table.q.out
+++ b/ql/src/test/results/clientpositive/create_table.q.out
@@ -30,6 +30,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test11
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test11
@@ -98,6 +99,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test12
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test12
@@ -166,6 +168,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test21
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test21
@@ -234,6 +237,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test22
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test22
@@ -300,6 +304,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test31
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test31
@@ -364,6 +369,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test32
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test32
@@ -425,6 +431,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted ` default`.` table41`
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@table41

--- a/ql/src/test/results/clientpositive/llap/alter6.q.out
+++ b/ql/src/test/results/clientpositive/llap/alter6.q.out
@@ -69,3 +69,4 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);

--- a/ql/src/test/results/clientpositive/llap/avro_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/avro_decimal.q.out
@@ -261,6 +261,7 @@ TBLPROPERTIES (
   'avro.schema.literal'='{"type":"record","name":"DecimalTest","namespace":"com.example.test","fields":[{"name":"Decimal24_6","type":["null",{"type":"bytes","logicalType":"decimal","precision":"24","scale":"6"}]}]}', 
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: desc test_quoted_scale_precision
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test_quoted_scale_precision

--- a/ql/src/test/results/clientpositive/llap/constraints_explain_ddl.q.out
+++ b/ql/src/test/results/clientpositive/llap/constraints_explain_ddl.q.out
@@ -99,6 +99,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.customer_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (c_custkey) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.customer_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -170,6 +171,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.customer_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (c_custkey) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.customer_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -251,6 +253,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -334,6 +337,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -480,6 +484,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -626,6 +631,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -867,6 +873,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`dates_removal_n0`(
   `d_datekey` bigint, 
   `d_id` bigint, 
@@ -897,6 +904,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.customer_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (c_custkey) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.customer_removal_n0 UPDATE STATISTICS SET('numRows'='1','rawDataSize'='22' );
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
@@ -1107,6 +1115,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dates_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (d_datekey,d_id) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS SET('numRows'='2','rawDataSize'='102' );
 ALTER TABLE default.dates_removal_n0 UPDATE STATISTICS FOR COLUMN d_date SET('avgColLen'='0.0','maxColLen'='0','numNulls'='2','numDVs'='1' );
@@ -1310,6 +1319,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.customer_removal_n0 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (c_custkey) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.customer_removal_n0 UPDATE STATISTICS SET('numRows'='1','rawDataSize'='22' );
 ALTER TABLE default.customer_removal_n0 UPDATE STATISTICS FOR COLUMN c_address SET('avgColLen'='0.0','maxColLen'='0','numNulls'='1','numDVs'='1' );
@@ -1500,6 +1510,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -1564,6 +1575,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -1629,6 +1641,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -1694,6 +1707,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -1823,6 +1837,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -1954,6 +1969,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -2104,6 +2120,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -2286,6 +2303,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -2354,6 +2372,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='6','rawDataSize'='28' );
 ALTER TABLE default.dest_g21 UPDATE STATISTICS FOR COLUMN key1 SET('lowValue'='1','highValue'='6','numNulls'='0','numDVs'='6' );
@@ -2513,6 +2532,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.tconst UPDATE STATISTICS SET('numRows'='3','rawDataSize'='25' );
 ALTER TABLE default.tconst CHANGE COLUMN i i int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 ALTER TABLE default.tconst UPDATE STATISTICS FOR COLUMN d_year SET('avgColLen'='4.0','maxColLen'='4','numNulls'='0','numDVs'='3' );
@@ -2642,6 +2662,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.tconst UPDATE STATISTICS SET('numRows'='3','rawDataSize'='25' );
 ALTER TABLE default.tconst CHANGE COLUMN i i int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 ALTER TABLE default.tconst UPDATE STATISTICS FOR COLUMN d_year SET('avgColLen'='4.0','maxColLen'='4','numNulls'='0','numDVs'='3' );
@@ -2772,6 +2793,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.tconst UPDATE STATISTICS SET('numRows'='3','rawDataSize'='25' );
 ALTER TABLE default.tconst CHANGE COLUMN i i int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 ALTER TABLE default.tconst UPDATE STATISTICS FOR COLUMN d_year SET('avgColLen'='4.0','maxColLen'='4','numNulls'='0','numDVs'='3' );
@@ -2901,6 +2923,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.tconst UPDATE STATISTICS SET('numRows'='3','rawDataSize'='25' );
 ALTER TABLE default.tconst CHANGE COLUMN i i int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 ALTER TABLE default.tconst UPDATE STATISTICS FOR COLUMN d_year SET('avgColLen'='4.0','maxColLen'='4','numNulls'='0','numDVs'='3' );
@@ -3090,6 +3113,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.tconst UPDATE STATISTICS SET('numRows'='3','rawDataSize'='25' );
 ALTER TABLE default.tconst CHANGE COLUMN i i int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 ALTER TABLE default.tconst UPDATE STATISTICS FOR COLUMN d_year SET('avgColLen'='4.0','maxColLen'='4','numNulls'='0','numDVs'='3' );
@@ -3291,6 +3315,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g21 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.dest_g21 ADD CONSTRAINT #### A masked pattern was here #### UNIQUE (key1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.dest_g21 CHANGE COLUMN key1 key1 int CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
@@ -3354,6 +3379,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.dest_g24 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.dest_g24 ADD CONSTRAINT #### A masked pattern was here #### UNIQUE (key1) DISABLE NOVALIDATE RELY;
 
@@ -3673,6 +3699,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -3703,6 +3730,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -3957,6 +3985,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -3987,6 +4016,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -4271,6 +4301,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -4301,6 +4332,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -4666,6 +4698,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -4696,6 +4729,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -5148,6 +5182,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`date_dim`(
   `d_date_sk` int, 
   `d_date_id` string, 
@@ -5188,6 +5223,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -5218,6 +5254,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.date_dim UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -5800,6 +5837,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -5830,6 +5868,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -6092,6 +6131,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -6122,6 +6162,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -6419,6 +6460,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -6449,6 +6491,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -6743,6 +6786,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `default`.`customer`(
   `c_customer_sk` int, 
   `c_customer_id` string, 
@@ -6773,6 +6817,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.store_sales ADD CONSTRAINT pk_ss PRIMARY KEY (ss_item_sk,ss_ticket_number) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.store_sales UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.customer ADD CONSTRAINT pk_c PRIMARY KEY (c_customer_sk) DISABLE NOVALIDATE RELY;
@@ -7033,6 +7078,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.web_sales ADD CONSTRAINT pk1 PRIMARY KEY (ws_order_number,ws_item_sk) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.web_sales UPDATE STATISTICS SET('numRows'='2','rawDataSize'='14' );
 ALTER TABLE default.web_sales UPDATE STATISTICS FOR COLUMN ws_item_sk SET('lowValue'='1','highValue'='1','numNulls'='0','numDVs'='1' );
@@ -7372,6 +7418,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table1_n13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7432,6 +7479,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table2_n8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7485,6 +7533,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table3_n1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7539,6 +7588,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table4_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7592,6 +7642,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table5_n4 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7646,6 +7697,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table6_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7700,6 +7752,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table7_n3 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (a) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table7_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -7755,6 +7808,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7809,6 +7863,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table9 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (a,b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table9 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -7864,6 +7919,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table10 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -7919,6 +7975,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table11 ADD CONSTRAINT pk11 PRIMARY KEY (a) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table11 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -7974,6 +8031,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table12 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8029,6 +8087,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table13 CHANGE COLUMN a a string CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 
@@ -8083,6 +8142,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table14 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table14 CHANGE COLUMN a a string CONSTRAINT nn14_1 NOT NULL DISABLE NOVALIDATE RELY;
 
@@ -8137,6 +8197,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table15 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8191,6 +8252,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table16 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8245,6 +8307,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table17 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table17 ADD CONSTRAINT uk17_1 UNIQUE (a) DISABLE NOVALIDATE RELY;
 
@@ -8300,6 +8363,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table18 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table18 ADD CONSTRAINT uk18_1 UNIQUE (b) DISABLE NOVALIDATE RELY;
 
@@ -8354,6 +8418,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table19 ADD CONSTRAINT pk19_1 PRIMARY KEY (b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table19 ADD CONSTRAINT fk19_2 FOREIGN KEY (a) REFERENCES default.table19(b) DISABLE NOVALIDATE RELY;
@@ -8409,6 +8474,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table20 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table20 ADD CONSTRAINT uk20_1 UNIQUE (b) DISABLE NOVALIDATE RELY;
 
@@ -8464,6 +8530,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table21 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8518,6 +8585,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table22 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8572,6 +8640,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table1_n13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8629,6 +8698,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table2_n8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8682,6 +8752,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table3_n1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8736,6 +8807,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table4_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8789,6 +8861,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table5_n4 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8843,6 +8916,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table6_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -8897,6 +8971,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table7_n3 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (a) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table7_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -8952,6 +9027,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9006,6 +9082,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table9 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (a,b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table9 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -9061,6 +9138,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table10 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9116,6 +9194,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table11 ADD CONSTRAINT pk11 PRIMARY KEY (a) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table11 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -9171,6 +9250,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table12 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9226,6 +9306,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table13 CHANGE COLUMN a a string CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 
@@ -9280,6 +9361,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table14 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table14 CHANGE COLUMN a a string CONSTRAINT nn14_1 NOT NULL DISABLE NOVALIDATE RELY;
 
@@ -9334,6 +9416,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table15 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9388,6 +9471,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table16 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9442,6 +9526,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table17 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table17 ADD CONSTRAINT uk17_1 UNIQUE (a) DISABLE NOVALIDATE RELY;
 
@@ -9497,6 +9582,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table18 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table18 ADD CONSTRAINT uk18_1 UNIQUE (b) DISABLE NOVALIDATE RELY;
 
@@ -9551,6 +9637,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table19 ADD CONSTRAINT pk19_1 PRIMARY KEY (b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table19 ADD CONSTRAINT fk19_2 FOREIGN KEY (a) REFERENCES default.table19(b) DISABLE NOVALIDATE RELY;
@@ -9606,6 +9693,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table20 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table20 ADD CONSTRAINT uk20_1 UNIQUE (b) DISABLE NOVALIDATE RELY;
 
@@ -9661,6 +9749,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table21 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9715,6 +9804,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table22 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9825,6 +9915,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table2_n8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9881,6 +9972,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table3_n1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9935,6 +10027,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table4_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -9989,6 +10082,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table6_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10043,6 +10137,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10097,6 +10192,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table16 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10152,6 +10248,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table18 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10206,6 +10303,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table2_n8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10262,6 +10360,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table3_n1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10316,6 +10415,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table4_n0 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10370,6 +10470,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table6_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10424,6 +10525,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10478,6 +10580,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table16 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10533,6 +10636,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table18 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10635,6 +10739,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table2_n8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10691,6 +10796,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table3_n1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table3_n1 ADD CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES default.table2_n8(a) DISABLE NOVALIDATE RELY;
 
@@ -10745,6 +10851,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table6_n3 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10799,6 +10906,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table8 ADD CONSTRAINT pk8_2 PRIMARY KEY (a,b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table8 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -10854,6 +10962,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table16 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10909,6 +11018,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table18 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -10979,6 +11089,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table12 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11037,6 +11148,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.table13 CHANGE COLUMN a a string CONSTRAINT #### A masked pattern was here #### NOT NULL DISABLE NOVALIDATE RELY;
 
@@ -11099,6 +11211,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table12 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11182,6 +11295,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11239,6 +11353,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11301,6 +11416,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11358,6 +11474,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11420,6 +11537,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11482,6 +11600,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE dbconstraint.table2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -11561,6 +11680,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.table23 ADD CONSTRAINT pk23_1 PRIMARY KEY (b) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.table23 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 

--- a/ql/src/test/results/clientpositive/llap/create_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_table.q.out
@@ -30,6 +30,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test11
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test11
@@ -98,6 +99,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test12
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test12
@@ -166,6 +168,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test21
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test21
@@ -234,6 +237,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test22
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test22
@@ -300,6 +304,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test31
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test31
@@ -364,6 +369,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted test32
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test32
@@ -425,6 +431,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted ` default`.` table41`
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@table41

--- a/ql/src/test/results/clientpositive/llap/create_table_explain_ddl.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_table_explain_ddl.q.out
@@ -29,6 +29,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -93,6 +94,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'c'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -158,6 +160,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -223,6 +226,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -288,6 +292,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -355,6 +360,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -423,6 +429,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -507,6 +514,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -571,6 +579,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'c'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -636,6 +645,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -701,6 +711,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -766,6 +777,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -833,6 +845,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -901,6 +914,7 @@ TBLPROPERTIES (
   'c'='4', 
   'd'='3', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter1_db.alter1 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -983,6 +997,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -1056,6 +1071,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE default.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1133,6 +1149,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE default.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1218,6 +1235,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -1291,6 +1309,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE default.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1368,6 +1387,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE default.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1477,6 +1497,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -1550,6 +1571,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE alter2_db.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE alter2_db.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1627,6 +1649,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE alter2_db.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE alter2_db.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1712,6 +1735,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -1785,6 +1809,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE alter2_db.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE alter2_db.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
@@ -1862,6 +1887,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE alter2_db.alter2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE alter2_db.alter2 ADD IF NOT EXISTS PARTITION (insertdate='2008-01-01');
 ALTER TABLE alter2_db.alter2 PARTITION (insertdate='2008-01-01') UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );

--- a/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
+++ b/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
@@ -77,7 +77,8 @@ TBLPROPERTIES (
   'hive.sql.jdbc.driver'='com.mysql.jdbc.Driver', 
   'hive.sql.jdbc.url'='jdbc:mysql://localhost:3306/qtestDB', 
   'hive.sql.schema'='qtestDB', 
-  'hive.sql.table'='country')
+  'hive.sql.table'='country'
+);
 PREHOOK: query: SELECT * FROM country
 PREHOOK: type: QUERY
 PREHOOK: Input: db_mysql@country

--- a/ql/src/test/results/clientpositive/llap/explain_ddl_nested_part.q.out
+++ b/ql/src/test/results/clientpositive/llap/explain_ddl_nested_part.q.out
@@ -82,6 +82,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.test ADD IF NOT EXISTS PARTITION (i=1,j=1);
 ALTER TABLE default.test PARTITION (i=1,j=1) UPDATE STATISTICS SET('numRows'='1','rawDataSize'='1' );
@@ -371,6 +372,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.test2 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 -- ALTER TABLE default.test2 ADD IF NOT EXISTS PARTITION (i=1,j=1,s='__HIVE_DEFAULT_PARTITION__',t='__HIVE_DEFAULT_PARTITION__');
 -- ALTER TABLE default.test2 PARTITION (i=1,j=1,s='__HIVE_DEFAULT_PARTITION__',t='__HIVE_DEFAULT_PARTITION__') UPDATE STATISTICS SET('numRows'='1','rawDataSize'='1' );

--- a/ql/src/test/results/clientpositive/llap/external_table_purge.q.out
+++ b/ql/src/test/results/clientpositive/llap/external_table_purge.q.out
@@ -127,6 +127,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'external.table.purge'='false', 
 #### A masked pattern was here ####
+);
 test.comment=Table should have data
 PREHOOK: query: select count(*) from etp_1
 PREHOOK: type: QUERY
@@ -178,6 +179,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'external.table.purge'='true', 
 #### A masked pattern was here ####
+);
 test.comment=Table should have data
 PREHOOK: query: select count(*) from etp_1
 PREHOOK: type: QUERY
@@ -471,6 +473,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'external.table.purge'='false', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: alter table etp_2 add partition (p1='part1')
 PREHOOK: type: ALTERTABLE_ADDPARTS
 PREHOOK: Output: default@etp_2
@@ -542,6 +545,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'external.table.purge'='true', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: alter table etp_2 add partition (p1='part1')
 PREHOOK: type: ALTERTABLE_ADDPARTS
 PREHOOK: Output: default@etp_2

--- a/ql/src/test/results/clientpositive/llap/json_serde1.q.out
+++ b/ql/src/test/results/clientpositive/llap/json_serde1.q.out
@@ -139,6 +139,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table json_serde1_4 (a array<string>,b map<string,int>)
   row format serde 'org.apache.hive.hcatalog.data.JsonSerDe'
   WITH SERDEPROPERTIES ('serialization.encoding'='ISO8859_1')

--- a/ql/src/test/results/clientpositive/llap/mm_iow_temp.q.out
+++ b/ql/src/test/results/clientpositive/llap/mm_iow_temp.q.out
@@ -40,7 +40,8 @@ OUTPUTFORMAT
 LOCATION
 #### A masked pattern was here ####
 TBLPROPERTIES (
-  'bucketing_version'='2')
+  'bucketing_version'='2'
+);
 PREHOOK: query: select * from temptable1 order by key limit 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@temptable1

--- a/ql/src/test/results/clientpositive/llap/nullformat.q.out
+++ b/ql/src/test/results/clientpositive/llap/nullformat.q.out
@@ -98,6 +98,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: INSERT OVERWRITE TABLE null_tab1 SELECT a,b FROM base_tab
 PREHOOK: type: QUERY
 PREHOOK: Input: default@base_tab

--- a/ql/src/test/results/clientpositive/llap/nullformatCTAS.q.out
+++ b/ql/src/test/results/clientpositive/llap/nullformatCTAS.q.out
@@ -190,6 +190,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 1.01
 1.01
 1.01

--- a/ql/src/test/results/clientpositive/llap/partition_explain_ddl.q.out
+++ b/ql/src/test/results/clientpositive/llap/partition_explain_ddl.q.out
@@ -31,6 +31,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 
@@ -142,6 +143,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.add_part_test ADD IF NOT EXISTS PARTITION (ds='2010-01-01');
 ALTER TABLE default.add_part_test PARTITION (ds='2010-01-01') UPDATE STATISTICS SET('numRows'='19','rawDataSize'='267' );
@@ -263,6 +265,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE default.add_part_test ADD IF NOT EXISTS PARTITION (ds='2010-01-01');
 ALTER TABLE default.add_part_test PARTITION (ds='2010-01-01') UPDATE STATISTICS SET('numRows'='19','rawDataSize'='267' );
@@ -416,6 +419,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE add_part_test_db.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE add_part_test_db.add_part_test ADD IF NOT EXISTS PARTITION (ds='2010-01-01');
 ALTER TABLE add_part_test_db.add_part_test PARTITION (ds='2010-01-01') UPDATE STATISTICS SET('numRows'='19','rawDataSize'='267' );
@@ -537,6 +541,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE add_part_test_db.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE add_part_test_db.add_part_test ADD IF NOT EXISTS PARTITION (ds='2010-01-01');
 ALTER TABLE add_part_test_db.add_part_test PARTITION (ds='2010-01-01') UPDATE STATISTICS SET('numRows'='19','rawDataSize'='267' );
@@ -639,6 +644,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE add_part_test_db.add_part_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE add_part_test_db.add_part_test ADD IF NOT EXISTS PARTITION (ds='2010-01-01');
 ALTER TABLE add_part_test_db.add_part_test PARTITION (ds='2010-01-01') UPDATE STATISTICS SET('numRows'='19','rawDataSize'='267' );
@@ -887,6 +893,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db_bdpbase.default_partition_test UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE db_bdpbase.default_partition_test ADD IF NOT EXISTS PARTITION (sports='Badminton');
 ALTER TABLE db_bdpbase.default_partition_test PARTITION (sports='Badminton') UPDATE STATISTICS SET('numRows'='26','rawDataSize'='985' );

--- a/ql/src/test/results/clientpositive/llap/quotedid_basic.q.out
+++ b/ql/src/test/results/clientpositive/llap/quotedid_basic.q.out
@@ -290,6 +290,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select ` "%&'()*+,-/;<=>?[]_|{}$^!~#@``` from ` "%&'()*+,-/:;<=>?[]_|{}$^!~#@```
 PREHOOK: type: QUERY
 PREHOOK: Input: default@"%&'()*+,-/:;<=>?[]_|{}$^!~#@`

--- a/ql/src/test/results/clientpositive/llap/quotedid_basic_standard.q.out
+++ b/ql/src/test/results/clientpositive/llap/quotedid_basic_standard.q.out
@@ -307,6 +307,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select " ""%&'()*+,-/;<=>?[]_|{}$^!~#@`" from " ""%&'()*+,-/:;<=>?[]_|{}$^!~#@`"
 PREHOOK: type: QUERY
 PREHOOK: Input: default@"%&'()*+,-/:;<=>?[]_|{}$^!~#@`
@@ -359,6 +360,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select ` "%&'()*+,-/;<=>?[]_|{}$^!~#@``` from ` "%&'()*+,-/:;<=>?[]_|{}$^!~#@```
 PREHOOK: type: QUERY
 PREHOOK: Input: default@"%&'()*+,-/:;<=>?[]_|{}$^!~#@`

--- a/ql/src/test/results/clientpositive/llap/read_only_hook.q.out
+++ b/ql/src/test/results/clientpositive/llap/read_only_hook.q.out
@@ -34,6 +34,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 POSTHOOK: query: DESC DATABASE default
 POSTHOOK: type: DESCDATABASE
 POSTHOOK: Input: database:default

--- a/ql/src/test/results/clientpositive/llap/repl_2_exim_basic.q.out
+++ b/ql/src/test/results/clientpositive/llap/repl_2_exim_basic.q.out
@@ -200,6 +200,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from managed_t_imported
 PREHOOK: type: QUERY
 PREHOOK: Input: default@managed_t_imported
@@ -281,6 +282,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'repl.last.id'='0', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from managed_t_r_imported
 PREHOOK: type: QUERY
 PREHOOK: Input: default@managed_t_r_imported
@@ -362,6 +364,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from ext_t_imported
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ext_t_imported
@@ -443,6 +446,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'repl.last.id'='0', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from ext_t_r_imported
 PREHOOK: type: QUERY
 PREHOOK: Input: default@ext_t_r_imported

--- a/ql/src/test/results/clientpositive/llap/repl_3_exim_metadata.q.out
+++ b/ql/src/test/results/clientpositive/llap/repl_3_exim_metadata.q.out
@@ -127,6 +127,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'repl.last.id'='0', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from repldst
 PREHOOK: type: QUERY
 PREHOOK: Input: default@repldst
@@ -202,6 +203,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'repl.last.id'='0', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from repldst_md
 PREHOOK: type: QUERY
 PREHOOK: Input: default@repldst_md

--- a/ql/src/test/results/clientpositive/llap/repl_4_exim_nocolstat.q.out
+++ b/ql/src/test/results/clientpositive/llap/repl_4_exim_nocolstat.q.out
@@ -127,6 +127,7 @@ TBLPROPERTIES (
   'bucketing_version'='2', 
   'repl.last.id'='0', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: select * from repldst
 PREHOOK: type: QUERY
 PREHOOK: Input: default@repldst

--- a/ql/src/test/results/clientpositive/llap/set_tblproperties.q.out
+++ b/ql/src/test/results/clientpositive/llap/set_tblproperties.q.out
@@ -54,6 +54,7 @@ TBLPROPERTIES (
   'b'='y', 
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t UNSET TBLPROPERTIES('a', 'b')
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@t
@@ -100,3 +101,4 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);

--- a/ql/src/test/results/clientpositive/llap/show_create_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table.q.out
@@ -111,6 +111,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.test ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (col1,col2) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.test ADD CONSTRAINT c4_unique UNIQUE (col4) DISABLE NOVALIDATE RELY;
 ALTER TABLE test.test CHANGE COLUMN col2 col2 timestamp CONSTRAINT  DEFAULT CURRENT_TIMESTAMP() ENABLE NOVALIDATE RELY;
@@ -137,6 +138,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.test2 ADD CONSTRAINT #### A masked pattern was here #### PRIMARY KEY (col) DISABLE NOVALIDATE RELY;
 PREHOOK: query: SHOW CREATE TABLE TEST3
 PREHOOK: type: SHOW_CREATETABLE
@@ -159,6 +161,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE default.test3 ADD CONSTRAINT #### A masked pattern was here #### FOREIGN KEY (col1) REFERENCES default.test(col1) DISABLE NOVALIDATE RELY;
 ALTER TABLE default.test3 ADD CONSTRAINT #### A masked pattern was here #### FOREIGN KEY (col2) REFERENCES default.test(col2) DISABLE NOVALIDATE RELY;
 PREHOOK: query: CREATE TABLE TEST_RESERVED (
@@ -214,3 +217,4 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);

--- a/ql/src/test/results/clientpositive/llap/show_create_table_alter.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_alter.q.out
@@ -33,6 +33,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE tmp_showcrt1_n1 SET TBLPROPERTIES ('comment'='temporary table', 'EXTERNAL'='FALSE')
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tmp_showcrt1_n1
@@ -67,6 +68,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE tmp_showcrt1_n1 SET TBLPROPERTIES ('comment'='changed comment', 'EXTERNAL'='TRUE')
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tmp_showcrt1_n1
@@ -101,6 +103,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE tmp_showcrt1_n1 SET TBLPROPERTIES ('SORTBUCKETCOLSPREFIX'='FALSE')
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tmp_showcrt1_n1
@@ -135,6 +138,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE tmp_showcrt1_n1 SET TBLPROPERTIES ('storage_handler'='org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler')
 PREHOOK: type: ALTERTABLE_PROPERTIES
 PREHOOK: Input: default@tmp_showcrt1_n1
@@ -169,6 +173,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n1
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n1

--- a/ql/src/test/results/clientpositive/llap/show_create_table_db_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_db_table.q.out
@@ -68,6 +68,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: SHOW CREATE TABLE tmp_feng.tmp_showcrt2
 PREHOOK: type: SHOW_CREATETABLE
 PREHOOK: Input: tmp_feng@tmp_showcrt2
@@ -90,6 +91,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: SHOW CREATE TABLE tmp_feng.tmp_showcrt3
 PREHOOK: type: SHOW_CREATETABLE
 PREHOOK: Input: tmp_feng@tmp_showcrt3
@@ -113,6 +115,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: SHOW CREATE TABLE tmp_feng.tmp_showcrt4
 PREHOOK: type: SHOW_CREATETABLE
 PREHOOK: Input: tmp_feng@tmp_showcrt4
@@ -133,6 +136,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_feng.tmp_showcrt1
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: tmp_feng@tmp_showcrt1

--- a/ql/src/test/results/clientpositive/llap/show_create_table_delimited.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_delimited.q.out
@@ -41,6 +41,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1
@@ -82,6 +83,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: drop table esc_special_delimiter
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@esc_special_delimiter
@@ -123,6 +125,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: drop table esc_special_delimiter
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@esc_special_delimiter
@@ -164,6 +167,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: drop table esc_special_delimiter
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@esc_special_delimiter
@@ -205,6 +209,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: drop table esc_special_delimiter
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@esc_special_delimiter

--- a/ql/src/test/results/clientpositive/llap/show_create_table_partitioned.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_partitioned.q.out
@@ -33,6 +33,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n2
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n2

--- a/ql/src/test/results/clientpositive/llap/show_create_table_serde.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_serde.q.out
@@ -38,6 +38,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n0
@@ -86,6 +87,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n0
@@ -136,6 +138,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n0
@@ -181,6 +184,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: DROP TABLE tmp_showcrt1_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@tmp_showcrt1_n0

--- a/ql/src/test/results/clientpositive/llap/show_create_table_temp_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/show_create_table_temp_table.q.out
@@ -30,7 +30,8 @@ OUTPUTFORMAT
 LOCATION
 #### A masked pattern was here ####
 TBLPROPERTIES (
-  'bucketing_version'='2')
+  'bucketing_version'='2'
+);
 PREHOOK: query: drop table tmp1
 PREHOOK: type: DROPTABLE
 PREHOOK: Output: database:default
@@ -62,7 +63,8 @@ OUTPUTFORMAT
 LOCATION
 #### A masked pattern was here ####
 TBLPROPERTIES (
-  'bucketing_version'='2')
+  'bucketing_version'='2'
+);
 PREHOOK: query: drop table tmpdb.tmp_not_null_tbl
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: tmpdb@tmp_not_null_tbl

--- a/ql/src/test/results/clientpositive/llap/strict_managed_tables2.q.out
+++ b/ql/src/test/results/clientpositive/llap/strict_managed_tables2.q.out
@@ -62,6 +62,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table smt2_tab2 (c1 string, c2 string)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -92,6 +93,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='default', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table smt2_tab3 (c1 string, c2 string) stored as orc
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -122,6 +124,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='default', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create external table smt2_tab4 (c1 string, c2 string) stored as orc
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -150,6 +153,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table smt2_tab5 (c1 string, c2 string)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -180,6 +184,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: create table smt2_tab6 (c1 string, c2 string) stored as textfile
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
@@ -210,6 +215,7 @@ TBLPROPERTIES (
   'transactional'='true', 
   'transactional_properties'='insert_only', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: drop table if exists smt2_tab1
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@smt2_tab1

--- a/ql/src/test/results/clientpositive/llap/table_storage.q.out
+++ b/ql/src/test/results/clientpositive/llap/table_storage.q.out
@@ -26,6 +26,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t CLUSTERED BY (key) SORTED BY (key) INTO 2 BUCKETS
 PREHOOK: type: ALTERTABLE_CLUSTER_SORT
 PREHOOK: Input: default@t
@@ -78,6 +79,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t INTO 3 BUCKETS
 PREHOOK: type: ALTERTABLE_BUCKETNUM
 PREHOOK: Input: default@t
@@ -125,6 +127,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t NOT SORTED
 PREHOOK: type: ALTERTABLE_CLUSTER_SORT
 PREHOOK: Input: default@t
@@ -172,6 +175,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t NOT CLUSTERED
 PREHOOK: type: ALTERTABLE_CLUSTER_SORT
 PREHOOK: Input: default@t
@@ -216,6 +220,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t SKEWED BY (key) ON (("a"), ("b")) STORED AS DIRECTORIES
 PREHOOK: type: ALTERTABLE_SKEWED
 PREHOOK: Input: default@t
@@ -266,6 +271,8 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
+#### A masked pattern was here ####
 PREHOOK: type: ALTERTBLPART_SKEWED_LOCATION
 PREHOOK: Input: default@t
 PREHOOK: Output: default@t
@@ -315,6 +322,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t NOT SKEWED
 PREHOOK: type: ALTERTABLE_SKEWED
 PREHOOK: Input: default@t
@@ -359,6 +367,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t SET FILEFORMAT parquet
 PREHOOK: type: ALTERTABLE_FILEFORMAT
 PREHOOK: Input: default@t
@@ -406,6 +415,8 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
+#### A masked pattern was here ####
 PREHOOK: type: ALTERTABLE_LOCATION
 PREHOOK: Input: default@t
 PREHOOK: Output: default@t
@@ -452,6 +463,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t SET SERDE "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
 PREHOOK: type: ALTERTABLE_SERIALIZER
 PREHOOK: Input: default@t
@@ -497,6 +509,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t SET SERDEPROPERTIES('property1'='value1', 'property2'='value2')
 PREHOOK: type: ALTERTABLE_SERDEPROPERTIES
 PREHOOK: Input: default@t
@@ -547,6 +560,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: EXPLAIN ALTER TABLE t UNSET SERDEPROPERTIES('property1')
 PREHOOK: type: ALTERTABLE_SERDEPROPERTIES
 PREHOOK: Input: default@t
@@ -595,6 +609,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE t UNSET SERDEPROPERTIES('property1')
 PREHOOK: type: ALTERTABLE_SERDEPROPERTIES
 PREHOOK: Input: default@t
@@ -625,6 +640,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE t SET SERDEPROPERTIES('property1'='value1')
 PREHOOK: type: ALTERTABLE_SERDEPROPERTIES
 PREHOOK: Input: default@t
@@ -656,6 +672,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: ALTER TABLE t UNSET SERDEPROPERTIES('property1', 'property2')
 PREHOOK: type: ALTERTABLE_SERDEPROPERTIES
 PREHOOK: Input: default@t
@@ -684,3 +701,4 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);

--- a/ql/src/test/results/clientpositive/llap/unicode_comments.q.out
+++ b/ql/src/test/results/clientpositive/llap/unicode_comments.q.out
@@ -64,6 +64,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: describe formatted unicode_comments_tbl1
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: unicode_comments_db@unicode_comments_tbl1

--- a/ql/src/test/results/clientpositive/llap/views_explain_ddl.q.out
+++ b/ql/src/test/results/clientpositive/llap/views_explain_ddl.q.out
@@ -167,6 +167,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v1_n17` AS SELECT `table1_n19`.`key`, `table1_n19`.`value` FROM `db1`.`table1_n19`;
@@ -228,6 +229,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v2_n10` AS SELECT `t1`.`key`, `t1`.`value` FROM `db1`.`table1_n19` `t1`;
@@ -288,6 +290,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `db1`.`table1_n19`(
   `key` string, 
   `value` string)
@@ -302,6 +305,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table2_n13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -454,6 +458,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v4_n3` AS SELECT `table1_n19`.`key`, `table1_n19`.`value` FROM `db1`.`table1_n19`;
@@ -512,6 +517,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v5_n1` AS SELECT `t1`.`key`, `t1`.`value` FROM `db1`.`table1_n19` `t1`;
@@ -572,6 +578,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 CREATE TABLE `db1`.`table1_n19`(
   `key` string, 
   `value` string)
@@ -586,6 +593,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table2_n13 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
@@ -738,6 +746,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v7` AS SELECT `table1_n19`.`key` from `db1`.`table1_n19`;
@@ -796,6 +805,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 ALTER TABLE db1.table1_n19 UPDATE STATISTICS SET('numRows'='0','rawDataSize'='0' );
 
 CREATE VIEW `db1`.`v8` AS SELECT `table1_n19`.`key` from `db1`.`table1_n19`;

--- a/ql/src/test/results/clientpositive/llap/whroot_external1.q.out
+++ b/ql/src/test/results/clientpositive/llap/whroot_external1.q.out
@@ -26,6 +26,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_managed1 select * from src where key = '0'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -73,6 +74,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_ext1 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -158,6 +160,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_ext2 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -247,6 +250,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_db.wre1_ext3 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -332,6 +336,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_db.wre1_ext4 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -415,6 +420,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_ext5 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -498,6 +504,7 @@ LOCATION
 TBLPROPERTIES (
   'bucketing_version'='2', 
 #### A masked pattern was here ####
+);
 PREHOOK: query: insert into table wre1_db.wre1_ext6 select * from src where key < 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`SHOW CREATE TABLE` doesn't add a `;` in the `CREATE` output. This patch corrects the behaviour.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without this change, `SHOW CREATE TABLE` output is incorrect.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this is technically a user facing change as the show create table output has changed with the addition of the semicolon.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
`mvn test -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile=show_create_table.q`