### PR TITLE
HIVE-27645: Refactor assertFalse(equals()) using assertNotEquals & @Test(excepted) using assertThrows

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
@@ -87,6 +87,7 @@ import static org.apache.hadoop.hive.conf.SystemVariables.SET_COLUMN_NAME;
 import static org.apache.hadoop.hive.ql.exec.ExplainTask.EXPL_COLUMN_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -3238,16 +3239,16 @@ public class TestJdbcDriver2 {
 
     stmt1.executeAsync("repl status query_id_test with ('hive.query.id' = 'hiveCustomTag')");
     String queryId1 = stmt1.getQueryId();
-    assertFalse("hiveCustomTag".equals(queryId1));
-    assertFalse(queryId.equals(queryId1));
+    assertNotEquals("hiveCustomTag", queryId1);
+    assertNotEquals(queryId, queryId1);
     assertFalse(queryId1.isEmpty());
     stmt1.getUpdateCount();
 
     stmt.executeAsync("select count(*) from " + dataTypeTableName);
     queryId = stmt.getQueryId();
-    assertFalse("hiveCustomTag".equals(queryId));
+    assertNotEquals("hiveCustomTag", queryId);
     assertFalse(queryId.isEmpty());
-    assertFalse(queryId.equals(queryId1));
+    assertNotEquals(queryId, queryId1);
     stmt.getUpdateCount();
 
     stmt.execute("drop database query_id_test");

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
@@ -90,6 +90,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -3290,9 +3291,11 @@ public class TestJdbcDriver2 {
   }
 
   // Test that opening a JDBC connection to a non-existent database throws a HiveSQLException
-  @Test(expected = HiveSQLException.class)
+  @Test
   public void testConnectInvalidDatabase() throws SQLException {
-    DriverManager.getConnection("jdbc:hive2:///databasedoesnotexist", "", "");
+    assertThrows(HiveSQLException.class, () -> {
+      DriverManager.getConnection("jdbc:hive2:///databasedoesnotexist", "", "");
+    });
   }
 
   @Test


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

The first smell is when inappropriate assertions are used, while there exist better alternatives. For example, in [TestJdbcDriver2.java](https://github.com/apache/hive/commit/04a9ddaa91c549a3c3041a45ab9871c4bc70f76d#diff-71a2f75f4a5dc07d285255a36e87deaab739ca7c486c2b1ddc3930f69f46783d), I refactored `assertFalse(queryId.equals(queryId1));` with `assertNotEquals(queryId, queryId1);`.

The second smell is when exception handling can alternatively be implemented using assertion rather than annotation. For example, in [TestJdbcDriver2.java](https://github.com/apache/hive/commit/04a9ddaa91c549a3c3041a45ab9871c4bc70f76d#diff-71a2f75f4a5dc07d285255a36e87deaab739ca7c486c2b1ddc3930f69f46783d), I used `assertThrows(HiveSQLException.class, () -> {...});` instead of `@Test(expected = HiveSQLException.class)`.

While there could be several cases like this, we aim in this pull request to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.