### PR TITLE
HIVE-27649: Support ORDER BY clause in subqueries with set operators

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -108,7 +108,7 @@ atomjoinSource
     :  tableSource (lateralView^)*
     |  virtualTableSource (lateralView^)*
     |  (LPAREN (KW_WITH|KW_SELECT|KW_MAP|KW_REDUCE|KW_FROM)) => subQuerySource (lateralView^)*
-    |  (LPAREN LPAREN atomSelectStatement RPAREN setOperator ) => subQuerySource (lateralView^)*
+    |  (LPAREN LPAREN selectStatement RPAREN setOperator ) => subQuerySource (lateralView^)*
     |  (LPAREN valuesSource) => subQuerySource (lateralView^)*
     |  partitionedTableFunction (lateralView^)*
     |  LPAREN! joinSource RPAREN!

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
@@ -297,12 +297,21 @@ public class TestParseDriver {
   @Test
   public void testFromSubqueryIsSetop() throws Exception {
     String q =
-        "explain select key from ((select key from src order by key) union (select key from src))subq ";
+        "explain select key from ((select key from src) union (select key from src))subq ";
     System.out.println(q);
 
     ASTNode root = parseDriver.parse(q).getTree();
     System.out.println(root.dump());
 
+  }
+
+  @Test
+  public void testSubQueryWithSetOpSupportsOrderBy() throws Exception {
+    String q = "SELECT a FROM ((SELECT a FROM t1 ORDER BY a) UNION ALL (SELECT a FROM t2 DISTRIBUTE BY a)) B";
+    System.out.println(q);
+
+    ASTNode root = parseDriver.parse(q).getTree();
+    System.out.println(root.dump());
   }
 
   @Test

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriver.java
@@ -297,7 +297,7 @@ public class TestParseDriver {
   @Test
   public void testFromSubqueryIsSetop() throws Exception {
     String q =
-        "explain select key from ((select key from src) union (select key from src))subq ";
+        "explain select key from ((select key from src order by key) union (select key from src))subq ";
     System.out.println(q);
 
     ASTNode root = parseDriver.parse(q).getTree();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
When the query is parsed, we end up in the subQuerySource rule because atomSelectStatement, by definition, cannot contain SORT BY, ORDER BY, CLUSTER BY, DISTRIBUTE BY or LIMIT clauses. An exception is thrown because subQuerySource requires an identifier which is not present nor needed in this particular scenario.

Changing `atomSelectStatement` to `selectStatement` solves the issue because `selectStatement` supports SORT BY, ORDER BY, CLUSTER BY, DISTRIBUTE BY and LIMIT clauses.

### Why are the changes needed?
Up until 3.1.2, it was possible to use SORT BY, ORDER BY, CLUSTER BY, DISTRIBUTE BY or LIMIT clauses in a subquery along with a set operator (ex: UNION). These clauses are [officially supported in subqueries](https://cwiki.apache.org/confluence/display/Hive/Supported+Features%3A++Apache+Hive+3.1). The language manual of the UNION clause [states the same thing](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Union#LanguageManualUnion-ApplyingSubclauses). 

However, changes introduced in 3.1.2 broke that feature.

### Does this PR introduce _any_ user-facing change?
Yes. Queries such as `select key from ((select key from src order by key) union (select key from src))subq` will now succeed instead of failing with an exception.

### Is the change a dependency upgrade?
No

### How was this patch tested?
A new unit test was added.
