### PR TITLE
HIVE-26127: Insert overwrite throws FileNotFound when destination partition is deleted

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4278,7 +4278,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
       // But not sure why we changed not to delete the oldPath in HIVE-8750 if it is
       // not the destf or its subdir?
       isOldPathUnderDestf = isSubDir(oldPath, destPath, oldFs, destFs, false);
-      if (isOldPathUnderDestf) {
+      if (isOldPathUnderDestf && oldFs.exists(oldPath)) {
         cleanUpOneDirectoryForReplace(oldPath, oldFs, pathFilter, conf, purge, isNeedRecycle);
       }
     } catch (IOException e) {


### PR DESCRIPTION


### What changes were proposed in this pull request?
Backports HIVE-26127 to branch-3. This is a reopen of https://github.com/apache/hive/pull/3561 which was reviewed previously but I missed merging it at that time.


### Why are the changes needed?
Fixes a bug which affects Spark 3 users.


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
No


### How was this patch tested?
This PR is a simple backport from master branch and relies on the existing tests including in the original PR.
