### PR TITLE
HIVE-27324: Hive query with NOT IN condition is giving incorrect results when the sub query table contains the null value

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -125,6 +125,7 @@ minillap.query.files=\
   multi_count_distinct_null.q,\
   newline.q,\
   nonreserved_keywords_insert_into1.q,\
+  notInTest.q,\
   nullscript.q,\
   orc_createas1.q,\
   orc_llap_counters.q,\

--- a/ql/src/test/queries/clientpositive/notInTest.q
+++ b/ql/src/test/queries/clientpositive/notInTest.q
@@ -1,0 +1,48 @@
+set hive.cbo.enable = false;
+
+create table t3 (id int,name string, age int);
+insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45);
+
+create table t4 (id int,name string, age int);
+insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23);
+
+create table t5 (id int,name string, ages int);
+insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23);
+
+select * from t3
+where age not in (select distinct(age) age from t4);
+
+select * from t3
+where t3.age not in (select distinct(age) age from t4);
+
+select * from t3
+where age not in (select distinct(ages) ages from t5);
+
+select * from t3
+where age not in (23,22,18);
+
+explain select * from t3
+        where age not in (select distinct(age) age from t4);
+
+select * from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10);
+
+set hive.cbo.enable = true;
+
+select * from t3
+where age not in (select distinct(age) age from t4);
+
+select * from t3
+where t3.age not in (select distinct(age) age from t4);
+
+select * from t3
+where age not in (select distinct(ages) ages from t5);
+
+select * from t3
+where age not in (23,22,18);
+
+explain select * from t3
+        where age not in (select distinct(age) age from t4);
+
+select * from t3
+where age not in (select distinct(age) from t3 t1 where t1.age > 10);


### PR DESCRIPTION
JIRA Link: [https://issues.apache.org/jira/browse/HIVE-27324](url)

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes changes that when there is a NOT IN operator in the query, and cbo is disabled, for e.g.:
select * from outer_query where (outer_query.outerQuery_col NOT IN (select distinct(subq_col)  subquery_table); there be a check for outer_query.outerQuery_col is not NULL. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As mentioned in the JIRA, a null NOT IN <x,y,.....> case will be encountered and it should return false, that we can see in cbo enabled behaviour. If the changes proposed are not there, the output will contain NULL values in the col referenced, as well.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, 
Earlier, as can be seen in the JIRA, when cbo is disabled,  a ( null not in {x,y,.....}  returns true , but after the changes it returns false, as it should as per sql standards and as done in cbo enabled case.


### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
A test file has been added to MiniLlapCliDriver to include tests containing null not in cases. The tests have been tested against output given for the same when cbo is enabled.