### PR TITLE
HIVE-27657: Change hive.fetch.task.conversion.threshold default value

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3536,8 +3536,8 @@ public class HiveConf extends Configuration {
     HIVEFETCHTASKCACHING("hive.fetch.task.caching", true,
         "Enabling the caching of the result of fetch tasks eliminates the chance of running into a failing read." +
             " On the other hand, if enabled, the hive.fetch.task.conversion.threshold must be adjusted accordingly. That" +
-            " is 1GB by default which must be lowered in case of enabled caching to prevent the consumption of too much memory."),
-    HIVEFETCHTASKCONVERSIONTHRESHOLD("hive.fetch.task.conversion.threshold", 1073741824L,
+            " is 200MB by default which must be lowered in case of enabled caching to prevent the consumption of too much memory."),
+    HIVEFETCHTASKCONVERSIONTHRESHOLD("hive.fetch.task.conversion.threshold", 209715200L,
         "Input threshold for applying hive.fetch.task.conversion. If target table is native, input length\n" +
         "is calculated by summation of file lengths. If it's not native, storage handler for the table\n" +
         "can optionally implement org.apache.hadoop.hive.ql.metadata.InputEstimator interface."),


### PR DESCRIPTION
[HIVE-27657](https://issues.apache.org/jira/browse/HIVE-27657)

### What changes were proposed in this pull request?
Change the default value of hive.fetch.task.conversion.threshold from 1GB to 200MB

### Why are the changes needed?
With the introduction of [fetch task caching](https://github.com/apache/hive/blob/d0a06239b09396d1b7a6414d85011f9a20f8486a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java#L3532-L3535), HS2 may quickly run out of memory if there are multiple parallel queries with fetch task.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No
