### PR TITLE
HIVE-27659: Make partition order configurable if the metastore does not return all partitions

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -846,6 +846,62 @@ public class TestHive {
     }
   }
 
+  @Test
+  public void testGetPartitionsWithMaxLimit() throws Exception {
+    String dbName = Warehouse.DEFAULT_DATABASE_NAME;
+    String tableName = "table_for_get_partitions_with_max_limit";
+
+    try {
+      Map<String, String> part_spec = new HashMap<String, String>();
+
+      Table table = createPartitionedTable(dbName, tableName);
+      part_spec.clear();
+      part_spec.put("ds", "2025-06-30");
+      part_spec.put("hr", "11");
+      hm.createPartition(table, part_spec);
+
+      Thread.sleep(1);
+      part_spec.clear();
+      part_spec.put("ds", "2023-04-15");
+      part_spec.put("hr", "12");
+      hm.createPartition(table, part_spec);
+
+      Thread.sleep(1);
+      part_spec.clear();
+      part_spec.put("ds", "2023-09-01");
+      part_spec.put("hr", "10");
+      hm.createPartition(table, part_spec);
+
+      // Default
+      Assert.assertEquals(
+          ((List<Partition>) hm.getPartitions(table, new HashMap(), (short) 1)).get(0).getTPartition().getValues(),
+          Arrays.asList("2023-04-15", "12"));
+
+      // Sort by "PARTITIONS"."CREATE_TIME" desc
+      hm.setMetaConf(MetastoreConf.ConfVars.PARTITION_ORDER_EXPR.getVarname(), "\"PARTITIONS\".\"CREATE_TIME\" desc");
+      Assert.assertEquals(
+          ((List<Partition>) hm.getPartitions(table, new HashMap(), (short) 1)).get(0).getTPartition().getValues(),
+          Arrays.asList("2023-09-01", "10"));
+
+      // Sort by "PART_NAME" desc
+      hm.setMetaConf(MetastoreConf.ConfVars.PARTITION_ORDER_EXPR.getVarname(), "\"PART_NAME\" desc");
+      Assert.assertEquals(
+          ((List<Partition>) hm.getPartitions(table, new HashMap(), (short) 1)).get(0).getTPartition().getValues(),
+          Arrays.asList("2025-06-30", "11"));
+
+      // Test MetaStoreClient
+      Assert.assertEquals(
+          hm.getMSC().listPartitions(table.getDbName(), table.getTableName(), (short) 1).get(0).getValues(),
+          Arrays.asList("2025-06-30", "11"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + StringUtils.stringifyException(e));
+    } finally {
+      hm.setMetaConf(MetastoreConf.ConfVars.PARTITION_ORDER_EXPR.getVarname(),
+         MetastoreConf.ConfVars.PARTITION_ORDER_EXPR.getDefaultVal().toString());
+      cleanUpTableQuietly(dbName, tableName);
+    }
+  }
+
   private void checkPartitionsConsistency(Table tbl) throws Exception {
     Set<Partition> allParts = hm.getAllPartitionsOf(tbl);
     List<Partition> allParts2 = hm.getPartitions(tbl);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -758,6 +758,10 @@ public class MetastoreConf {
         "The default partition name in case the dynamic partition column value is null/empty string or any other values that cannot be escaped. \n" +
             "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
             "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
+    PARTITION_ORDER_EXPR("metastore.partition.order.expr",
+        "hive.exec.partition.order.expr", "\"PART_NAME\" asc",
+        "The default partition order if we are not returning all partitions. "
+            + "It can be sorted based on any column in the PARTITIONS table (e.g., \"CREATE_TIME\" desc, \"LAST_ACCESS_TIME\" desc etc)"),
     DELEGATION_KEY_UPDATE_INTERVAL("metastore.cluster.delegation.key.update-interval",
         "hive.cluster.delegation.key.update-interval", 1, TimeUnit.DAYS, ""),
     DELEGATION_TOKEN_GC_INTERVAL("metastore.cluster.delegation.token.gc-interval",

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -251,10 +251,10 @@ public class MetastoreConf {
       ConfVars.TRY_DIRECT_SQL_DDL,
       ConfVars.CLIENT_SOCKET_TIMEOUT,
       ConfVars.PARTITION_NAME_WHITELIST_PATTERN,
+      ConfVars.PARTITION_ORDER_EXPR,
       ConfVars.CAPABILITY_CHECK,
       ConfVars.DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES,
-      ConfVars.EXPRESSION_PROXY_CLASS,
-      ConfVars.PARTITION_ORDER_EXPR
+      ConfVars.EXPRESSION_PROXY_CLASS
   };
 
   static {
@@ -759,10 +759,6 @@ public class MetastoreConf {
         "The default partition name in case the dynamic partition column value is null/empty string or any other values that cannot be escaped. \n" +
             "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
             "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
-    PARTITION_ORDER_EXPR("metastore.partition.order.expr",
-        "hive.metastore.partition.order.expr", "\"PART_NAME\" asc",
-        "The default partition order if the metastore does not return all partitions. \n"
-            + "It can be sorted based on any column in the PARTITIONS table (e.g., \"PARTITIONS\".\"CREATE_TIME\" desc, \"PARTITIONS\".\"LAST_ACCESS_TIME\" desc etc)"),
     DELEGATION_KEY_UPDATE_INTERVAL("metastore.cluster.delegation.key.update-interval",
         "hive.cluster.delegation.key.update-interval", 1, TimeUnit.DAYS, ""),
     DELEGATION_TOKEN_GC_INTERVAL("metastore.cluster.delegation.token.gc-interval",
@@ -1271,6 +1267,10 @@ public class MetastoreConf {
     PARTITION_NAME_WHITELIST_PATTERN("metastore.partition.name.whitelist.pattern",
         "hive.metastore.partition.name.whitelist.pattern", "",
         "Partition names will be checked against this regex pattern and rejected if not matched."),
+    PARTITION_ORDER_EXPR("metastore.partition.order.expr",
+        "hive.metastore.partition.order.expr", "\"PART_NAME\" asc",
+        "The default partition order if the metastore does not return all partitions. \n" +
+            "It can be sorted based on any column in the PARTITIONS table (e.g., \"PARTITIONS\".\"CREATE_TIME\" desc, \"PARTITIONS\".\"LAST_ACCESS_TIME\" desc etc)"),
     PART_INHERIT_TBL_PROPS("metastore.partition.inherit.table.properties",
         "hive.metastore.partition.inherit.table.properties", "",
         "List of comma separated keys occurring in table properties which will get inherited to newly created partitions. \n" +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -759,9 +759,9 @@ public class MetastoreConf {
             "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
             "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
     PARTITION_ORDER_EXPR("metastore.partition.order.expr",
-        "hive.exec.partition.order.expr", "\"PART_NAME\" asc",
+        "hive.exec.partition.order.expr", "\"PARTITIONS\".\"CREATE_TIME\" desc",
         "The default partition order if we are not returning all partitions. "
-            + "It can be sorted based on any column in the PARTITIONS table (e.g., \"CREATE_TIME\" desc, \"LAST_ACCESS_TIME\" desc etc)"),
+            + "It can be sorted based on any column in the PARTITIONS table (e.g., \"PARTITIONS\".\"CREATE_TIME\" desc, \"PARTITIONS\".\"LAST_ACCESS_TIME\" desc etc)"),
     DELEGATION_KEY_UPDATE_INTERVAL("metastore.cluster.delegation.key.update-interval",
         "hive.cluster.delegation.key.update-interval", 1, TimeUnit.DAYS, ""),
     DELEGATION_TOKEN_GC_INTERVAL("metastore.cluster.delegation.token.gc-interval",

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -253,7 +253,8 @@ public class MetastoreConf {
       ConfVars.PARTITION_NAME_WHITELIST_PATTERN,
       ConfVars.CAPABILITY_CHECK,
       ConfVars.DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES,
-      ConfVars.EXPRESSION_PROXY_CLASS
+      ConfVars.EXPRESSION_PROXY_CLASS,
+      ConfVars.PARTITION_ORDER_EXPR
   };
 
   static {
@@ -759,8 +760,8 @@ public class MetastoreConf {
             "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
             "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
     PARTITION_ORDER_EXPR("metastore.partition.order.expr",
-        "hive.exec.partition.order.expr", "\"PARTITIONS\".\"CREATE_TIME\" desc",
-        "The default partition order if we are not returning all partitions. "
+        "hive.metastore.partition.order.expr", "\"PART_NAME\" asc",
+        "The default partition order if the metastore does not return all partitions. \n"
             + "It can be sorted based on any column in the PARTITIONS table (e.g., \"PARTITIONS\".\"CREATE_TIME\" desc, \"PARTITIONS\".\"LAST_ACCESS_TIME\" desc etc)"),
     DELEGATION_KEY_UPDATE_INTERVAL("metastore.cluster.delegation.key.update-interval",
         "hive.cluster.delegation.key.update-interval", 1, TimeUnit.DAYS, ""),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -149,6 +149,7 @@ class MetaStoreDirectSql {
   private final int batchSize;
   private final boolean convertMapNullsToEmptyStrings;
   private final String defaultPartName;
+  private final String partOrderExpr;
 
   /**
    * Whether direct SQL can be used with the current datastore backing {@link #pm}.
@@ -220,6 +221,7 @@ class MetaStoreDirectSql {
     convertMapNullsToEmptyStrings =
         MetastoreConf.getBoolVar(conf, ConfVars.ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS);
     defaultPartName = MetastoreConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
+    partOrderExpr = MetastoreConf.getVar(conf, ConfVars.PARTITION_ORDER_EXPR);
 
     String jdoIdFactory = MetastoreConf.getVar(conf, ConfVars.IDENTIFIER_FACTORY);
     if (! ("datanucleus1".equalsIgnoreCase(jdoIdFactory))){
@@ -901,7 +903,7 @@ class MetaStoreDirectSql {
     final String catNameLcase = normalizeSpace(catName).toLowerCase();
 
     // We have to be mindful of order during filtering if we are not returning all partitions.
-    String orderForFilter = (max != null) ? " order by \"PART_NAME\" asc" : "";
+    String orderForFilter = (max != null) ? " order by " + partOrderExpr : "";
 
     String queryText =
         "select " + PARTITIONS + ".\"PART_ID\" from " + PARTITIONS + ""

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -149,7 +149,6 @@ class MetaStoreDirectSql {
   private final int batchSize;
   private final boolean convertMapNullsToEmptyStrings;
   private final String defaultPartName;
-  private final String partOrderExpr;
 
   /**
    * Whether direct SQL can be used with the current datastore backing {@link #pm}.
@@ -221,7 +220,6 @@ class MetaStoreDirectSql {
     convertMapNullsToEmptyStrings =
         MetastoreConf.getBoolVar(conf, ConfVars.ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS);
     defaultPartName = MetastoreConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
-    partOrderExpr = MetastoreConf.getVar(conf, ConfVars.PARTITION_ORDER_EXPR);
 
     String jdoIdFactory = MetastoreConf.getVar(conf, ConfVars.IDENTIFIER_FACTORY);
     if (! ("datanucleus1".equalsIgnoreCase(jdoIdFactory))){
@@ -903,7 +901,7 @@ class MetaStoreDirectSql {
     final String catNameLcase = normalizeSpace(catName).toLowerCase();
 
     // We have to be mindful of order during filtering if we are not returning all partitions.
-    String orderForFilter = (max != null) ? " order by " + partOrderExpr : "";
+    String orderForFilter = (max != null) ? " order by " + MetastoreConf.getVar(conf, ConfVars.PARTITION_ORDER_EXPR) : "";
 
     String queryText =
         "select " + PARTITIONS + ".\"PART_ID\" from " + PARTITIONS + ""

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -3959,7 +3959,7 @@ public class ObjectStore implements RawStore, Configurable {
         LOG.info(
             "Redirecting to directSQL enabled API: db: {} tbl: {} partVals: {}",
             db_name, tbl_name, Joiner.on(',').join(part_vals));
-        return getPartitions(catName, db_name, tbl_name, -1);
+        return getPartitions(catName, db_name, tbl_name, max_parts);
       }
       LOG.debug("executing listPartitionNamesPsWithAuth");
       Collection parts = getPartitionPsQueryResults(catName, db_name, tbl_name,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes partition order configurable if the metastore does not return all partitions.

### Why are the changes needed?

We want to improve performance of limit-only queries on many partitioned tables.
For example: `SELECT * FROM large_partition_table limit 10`.
But we want to get the latest partition data. After this PR, we can `set metastore.partition.order.expr="PARTITIONS"."CREATE_TIME"` to achieve it.

### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.

### How was this patch tested?

Unit test.
