### PR TITLE
HIVE-27664: AlterTableSetLocationAnalyzer threw a confusing exception…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
@@ -56,8 +56,8 @@ public class AlterTableSetLocationAnalyzer extends AbstractAlterTableAnalyzer {
     } catch (FileNotFoundException e) {
       // Only check host/port pair is valid, whether the file exist or not does not matter
     } catch (Exception e) {
-      throw new SemanticException("Cannot connect to namenode, please check if host/port pair for " + newLocation +
-          " is valid", e);
+      throw new SemanticException("Unable to check path:" + newLocation +
+          " Error: " + e.getMessage());
     }
 
     outputs.add(toWriteEntity(newLocation));

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
@@ -56,7 +56,7 @@ public class AlterTableSetLocationAnalyzer extends AbstractAlterTableAnalyzer {
     } catch (FileNotFoundException e) {
       // Only check host/port pair is valid, whether the file exist or not does not matter
     } catch (Exception e) {
-      throw new SemanticException("Unable to get path:" + newLocation , e);
+      throw new SemanticException("Can not establish connection to server for " + newLocation , e);
     }
 
     outputs.add(toWriteEntity(newLocation));

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/set/location/AlterTableSetLocationAnalyzer.java
@@ -56,8 +56,7 @@ public class AlterTableSetLocationAnalyzer extends AbstractAlterTableAnalyzer {
     } catch (FileNotFoundException e) {
       // Only check host/port pair is valid, whether the file exist or not does not matter
     } catch (Exception e) {
-      throw new SemanticException("Unable to check path:" + newLocation +
-          " Error: " + e.getMessage());
+      throw new SemanticException("Unable to get path:" + newLocation , e);
     }
 
     outputs.add(toWriteEntity(newLocation));

--- a/ql/src/test/results/clientnegative/alter_table_wrong_location.q.out
+++ b/ql/src/test/results/clientnegative/alter_table_wrong_location.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table testwrongloc(id int)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@testwrongloc
-FAILED: SemanticException Unable to get path:hdfs://### HDFS PATH ###
+FAILED: SemanticException Can not establish connection to server for hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/alter_table_wrong_location.q.out
+++ b/ql/src/test/results/clientnegative/alter_table_wrong_location.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table testwrongloc(id int)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@testwrongloc
-FAILED: SemanticException Cannot connect to namenode, please check if host/port pair for hdfs://### HDFS PATH ### is valid
+FAILED: SemanticException Unable to get path:hdfs://### HDFS PATH ###


### PR DESCRIPTION
… "Cannot connect to namenode"

### What changes were proposed in this pull request?
@Override
protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
throws SemanticException {
String newLocation = unescapeSQLString(command.getChild(0).getText());
try

{ // To make sure host/port pair is valid, the status of the location does not matter FileSystem.get(new URI(newLocation), conf).getFileStatus(new Path(newLocation)); }
catch (FileNotFoundException e)

{ // Only check host/port pair is valid, whether the file exist or not does not matter }
catch (Exception e)

{ throw new SemanticException("Cannot connect to namenode, please check if host/port pair for " + newLocation + " is valid", e); }
When the

"FileSystem.get(new URI(newLocation), conf).getFileStatus(new Path(newLocation))"

code throws a "Permission denied" exception, the Beeline client will receive the confusing exception "Cannot connect to namenode, please check if host/port pair for". In reality, the issue is not with the namenode.


### Why are the changes needed?
Change AlterTableSetLocationAnalyzer Log

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
No test need
