### PR TITLE
HIVE-27665: Change HMS PartitionFilter to allow backticks surrounding…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/PartitionFilter.g4
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/parser/PartitionFilter.g4
@@ -16,6 +16,10 @@
 
 grammar PartitionFilter;
 
+@lexer::header {
+import org.apache.commons.lang3.StringUtils;
+}
+
 filter
     : orExpression
     ;
@@ -47,8 +51,13 @@ comparisonOperator
 
 identifier
     : IDENTIFIER #unquotedIdentifer
+    | QUOTEDIDENTIFIER #quotedIdentifier
     ;
 
+QUOTEDIDENTIFIER
+    :
+    ('`'  ( '``' | ~('`') )* '`') { setText(StringUtils.replace(getText().substring(1, getText().length() -1 ), "``", "`")); }
+    ;
 identifierList
     : LPAREN ident+=identifier (COMMA ident+=identifier)* RPAREN
     ;

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartFilterExprUtil.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartFilterExprUtil.java
@@ -70,6 +70,20 @@ public class TestPartFilterExprUtil {
   }
 
   @Test
+  public void testDateColumnNameKeyword() throws MetaException {
+    MetaException exception = assertThrows(MetaException.class,
+            () -> PartFilterExprUtil.parseFilterTree("date='1990-11-10'"));
+
+    assertTrue(exception.getMessage().contains("Error parsing partition filter"));
+  }
+
+  @Test
+  public void testDateColumnNameKeywordWithBackTicks() throws MetaException {
+    checkFilter("`date`='1990-11-10'",
+    "LeafNode{keyName='date', operator='=', value=1990-11-10}");
+  }
+
+  @Test
   public void testSingleColInExpressionWhenDateLiteralTypeIsSpecified() throws MetaException {
     checkFilter("(j) IN (DATE'1990-11-10', DATE'1990-11-11', DATE'1990-11-12')",
     "TreeNode{lhs=TreeNode{lhs=LeafNode{keyName='j', operator='=', value=1990-11-10}, andOr='OR', rhs=LeafNode{keyName='j', operator='=', value=1990-11-11}}, andOr='OR', rhs=LeafNode{keyName='j', operator='=', value=1990-11-12}}");


### PR DESCRIPTION
… the column name.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change will allow a client to send backticks surrounding a column name in a filter expression.  The backticks will be stripped by the parser when it hits the Hive processing code.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A customer has a column name of 'date'.  It used to work for them using a Spark client until DATE was made a keyword in the ParititonFilter.g4 file.  This caused a regression for them and they need this fixed.

We should fix the HS2 client as well to send backticked column names in the filter, but this will be done in a separate Jira.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test added to TestPartFilterExprUtil
