### PR TITLE
HIVE-27380: Backport of HIVE-24751: Kill trigger in workload manager fails with "No privilege" exception when authorization is disabled. 

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestKillQueryWithAuthorizationDisabled.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestKillQueryWithAuthorizationDisabled.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.jdbc;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.ddl.process.kill.KillQueriesOperation;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.security.SessionStateUserAuthenticator;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class TestKillQueryWithAuthorizationDisabled {
+  private static final Logger LOG = LoggerFactory.getLogger(TestKillQueryWithAuthorizationDisabled.class);
+
+  private static MiniHS2 miniHS2 = null;
+  private static final String tableName = "testKillQueryMinihs2Tbl";
+  private static final String testDbName = "testKillQueryMinihs2";
+  private static final String tag = "killTag";
+
+  private static class ExceptionHolder {
+    Throwable throwable;
+  }
+
+  static class FakeGroupAuthenticator extends SessionStateUserAuthenticator {
+    @Override public List<String> getGroupNames() {
+      List<String> groups = new ArrayList<String>();
+      if (getUserName().equals("user1")) {
+        groups.add("group_a");
+      } else if (getUserName().equals("user2")) {
+        groups.add("group_a");
+        groups.add("group_b");
+      } else if (getUserName().equals(System.getProperty("user.name"))) {
+        groups.add("group_b");
+        groups.add("group_c");
+      }
+      return groups;
+    }
+  }
+
+  public static class SleepMsUDF extends UDF {
+    private static final Logger LOG = LoggerFactory.getLogger(TestKillQueryWithAuthorizationDisabled.class);
+
+    public Integer evaluate(final Integer value, final Integer ms) {
+      try {
+        LOG.info("Sleeping for " + ms + " milliseconds");
+        Thread.sleep(ms);
+      } catch (InterruptedException e) {
+        LOG.warn("Interrupted Exception");
+        // No-op
+      }
+      return value;
+    }
+  }
+
+  static HiveConf defaultConf() throws Exception {
+    String confDir = "../../data/conf/llap/";
+    if (StringUtils.isNotBlank(confDir)) {
+      HiveConf.setHiveSiteLocation(new URL("file://" + new File(confDir).toURI().getPath() + "/hive-site.xml"));
+      System.out.println("Setting hive-site: " + HiveConf.getHiveSiteLocation());
+    }
+    HiveConf defaultConf = new HiveConf();
+    defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+    defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
+    defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_QUERY_RESULTS_CACHE_ENABLED, false);
+    defaultConf.addResource(new URL("file://" + new File(confDir).toURI().getPath() + "/tez-site.xml"));
+    return defaultConf;
+  }
+
+  @BeforeClass public static void beforeTest() throws Exception {
+    HiveConf conf = defaultConf();
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
+    conf.set(HiveConf.ConfVars.HIVE_AUTHENTICATOR_MANAGER.varname, FakeGroupAuthenticator.class.getName());
+    // Disable Hive Authorization
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED, false);
+    MiniHS2.cleanupLocalDir();
+    Class.forName(MiniHS2.getJdbcDriverName());
+    miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
+    Map<String, String> confOverlay = new HashMap<String, String>();
+    miniHS2.start(confOverlay);
+    miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
+
+    Connection conDefault =
+        BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");
+    Statement stmt = conDefault.createStatement();
+    String tblName = testDbName + "." + tableName;
+    String dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
+    Path dataFilePath = new Path(dataFileDir, "kv1.txt");
+    String udfName = SleepMsUDF.class.getName();
+    stmt.execute("drop database if exists " + testDbName + " cascade");
+    stmt.execute("create database " + testDbName);
+    stmt.execute("dfs -put " + dataFilePath.toString() + " " + "kv1.txt");
+    stmt.execute("use " + testDbName);
+    stmt.execute("create table " + tblName + " (int_col int, value string) ");
+    stmt.execute("load data inpath 'kv1.txt' into table " + tblName);
+    stmt.execute("create function sleepMsUDF as '" + udfName + "'");
+
+    stmt.close();
+    conDefault.close();
+  }
+
+  @AfterClass public static void afterTest() {
+    if (miniHS2 != null && miniHS2.isStarted()) {
+      miniHS2.stop();
+    }
+  }
+
+  /**
+   * Test CLI kill command of a query that is running.
+   * We spawn 2 threads - one running the query and
+   * the other attempting to cancel.
+   * We're using a dummy udf to simulate a query,
+   * that runs for a sufficiently long time.
+   * @throws Exception
+   */
+  private void testKillQueryInternal(String user, String killUser, boolean useTag, final ExceptionHolder stmtHolder,
+      final ExceptionHolder tKillHolder) throws Exception {
+    Connection con1 = BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(testDbName), user, "bar");
+    Connection con2 = BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(testDbName), killUser, "bar");
+
+    final Statement stmt2 = con2.createStatement();
+    final HiveStatement stmt = (HiveStatement) con1.createStatement();
+    final StringBuffer stmtQueryId = new StringBuffer();
+
+    // Thread executing the query
+    Thread tExecute = new Thread(() -> {
+      try {
+        String query =
+            "select sleepMsUDF(t1.int_col, 10), t1.int_col, t2.int_col " + "from " + tableName + " t1 join " + tableName
+                + " t2 on t1.int_col = t2.int_col";
+        LOG.info("Executing query: " + query);
+        stmt.execute("set hive.llap.execution.mode = none");
+        stmt.execute("use " + testDbName);
+
+        if (useTag) {
+          stmt.execute("set hive.query.tag = " + tag);
+        }
+        // The test table has 500 rows, so total query time should be ~ 500*100ms = 50 seconds
+        stmt.executeAsync(query);
+        Thread.sleep(1000);
+        stmtQueryId.append(stmt.getQueryId());
+        stmt.getUpdateCount();
+      } catch (SQLException | InterruptedException e) {
+        stmtHolder.throwable = e;
+      }
+    });
+
+    tExecute.start();
+
+    // wait for other thread to create the stmt handle
+    int count = 0;
+    while (++count <= 10) {
+      try {
+        tKillHolder.throwable = null;
+        Thread.sleep(2000);
+        String queryId;
+        if (useTag) {
+          queryId = tag;
+        } else {
+          if (stmtQueryId.length() != 0) {
+            queryId = stmtQueryId.toString();
+          } else {
+            continue;
+          }
+        }
+        System.out.println("Killing query: " + queryId);
+        stmt2.execute("kill query '" + queryId + "'");
+        stmt2.close();
+        break;
+      } catch (SQLException e) {
+        LOG.warn("Exception when kill query", e);
+        tKillHolder.throwable = e;
+      }
+    }
+
+    tExecute.join();
+    try {
+      stmt.close();
+      con1.close();
+      con2.close();
+    } catch (Exception e) {
+      // ignore error
+      LOG.warn("Exception when close stmt and con", e);
+    }
+  }
+
+  @Test public void testKillQueryByIdOwner() throws Exception {
+    ExceptionHolder tExecuteHolder = new ExceptionHolder();
+    ExceptionHolder tKillHolder = new ExceptionHolder();
+    testKillQueryInternal("user1", "user1", false, tExecuteHolder, tKillHolder);
+    assertNotNull("tExecute", tExecuteHolder.throwable);
+    assertEquals(HiveStatement.QUERY_CANCELLED_MESSAGE + " " + KillQueriesOperation.KILL_QUERY_MESSAGE,
+        tExecuteHolder.throwable.getMessage());
+    assertNull("tCancel", tKillHolder.throwable);
+  }
+
+  @Test public void testKillQueryByIdAdmin() throws Exception {
+    ExceptionHolder tExecuteHolder = new ExceptionHolder();
+    ExceptionHolder tKillHolder = new ExceptionHolder();
+    testKillQueryInternal("user1", System.getProperty("user.name"), false, tExecuteHolder, tKillHolder);
+    assertNotNull("tExecute", tExecuteHolder.throwable);
+    assertEquals(HiveStatement.QUERY_CANCELLED_MESSAGE + " " + KillQueriesOperation.KILL_QUERY_MESSAGE,
+        tExecuteHolder.throwable.getMessage());
+    assertNull("tCancel", tKillHolder.throwable);
+  }
+
+  @Test public void testKillQueryByIdNegative() throws Exception {
+    ExceptionHolder tExecuteHolder = new ExceptionHolder();
+    ExceptionHolder tKillHolder = new ExceptionHolder();
+    testKillQueryInternal("user1", "user2", false, tExecuteHolder, tKillHolder);
+    assertNull("tExecute", tExecuteHolder.throwable);
+    assertNotNull("tCancel", tKillHolder.throwable);
+    assertTrue(tKillHolder.throwable.getMessage(), tKillHolder.throwable.getMessage().contains("No privilege"));
+  }
+
+  @Test public void testKillQueryByTagAdmin() throws Exception {
+    ExceptionHolder tExecuteHolder = new ExceptionHolder();
+    ExceptionHolder tKillHolder = new ExceptionHolder();
+    testKillQueryInternal("user1", System.getProperty("user.name"), true, tExecuteHolder, tKillHolder);
+    assertNotNull("tExecute", tExecuteHolder.throwable);
+    assertEquals(HiveStatement.QUERY_CANCELLED_MESSAGE + " " + KillQueriesOperation.KILL_QUERY_MESSAGE,
+        tExecuteHolder.throwable.getMessage());
+    assertNull("tCancel", tKillHolder.throwable);
+  }
+
+}

--- a/service/src/java/org/apache/hive/service/server/KillQueryImpl.java
+++ b/service/src/java/org/apache/hive/service/server/KillQueryImpl.java
@@ -18,11 +18,16 @@
 
 package org.apache.hive.service.server;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.process.kill.KillQueriesOperation;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveAuthzContext;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
 import org.apache.hadoop.hive.ql.session.KillQuery;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.api.protocolrecords.ApplicationsRequestScope;
 import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
@@ -40,96 +45,194 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class KillQueryImpl implements KillQuery {
-  private final static Logger LOG = LoggerFactory.getLogger(KillQueryImpl.class);
+    private final static Logger LOG = LoggerFactory.getLogger(KillQueryImpl.class);
 
-  private final OperationManager operationManager;
+    private final OperationManager operationManager;
+    private final KillQueryZookeeperManager killQueryZookeeperManager;
 
-  public KillQueryImpl(OperationManager operationManager) {
-    this.operationManager = operationManager;
-  }
+    private enum TagOrId {TAG, ID, UNKNOWN}
 
-  public static Set<ApplicationId> getChildYarnJobs(Configuration conf, String tag) throws IOException, YarnException {
-    Set<ApplicationId> childYarnJobs = new HashSet<ApplicationId>();
-    GetApplicationsRequest gar = GetApplicationsRequest.newInstance();
-    gar.setScope(ApplicationsRequestScope.OWN);
-    gar.setApplicationTags(Collections.singleton(tag));
 
-    ApplicationClientProtocol proxy = ClientRMProxy.createRMProxy(conf, ApplicationClientProtocol.class);
-    GetApplicationsResponse apps = proxy.getApplications(gar);
-    List<ApplicationReport> appsList = apps.getApplicationList();
-    for(ApplicationReport appReport : appsList) {
-      childYarnJobs.add(appReport.getApplicationId());
+    public KillQueryImpl(OperationManager operationManager, KillQueryZookeeperManager killQueryZookeeperManager) {
+        this.operationManager = operationManager;
+        this.killQueryZookeeperManager = killQueryZookeeperManager;
     }
 
-    if (childYarnJobs.isEmpty()) {
-      LOG.info("No child applications found");
-    } else {
-      LOG.info("Found child YARN applications: " + StringUtils.join(childYarnJobs, ","));
-    }
+    public static Set<ApplicationId> getChildYarnJobs(Configuration conf, String tag, String doAs, boolean doAsAdmin)
+            throws IOException, YarnException {
+        Set<ApplicationId> childYarnJobs = new HashSet<>();
+        GetApplicationsRequest gar = GetApplicationsRequest.newInstance();
+        gar.setScope(ApplicationsRequestScope.OWN);
+        gar.setApplicationTags(Collections.singleton(tag));
 
-    return childYarnJobs;
-  }
-
-  public static void killChildYarnJobs(Configuration conf, String tag) {
-    try {
-      if (tag == null) {
-        return;
-      }
-      Set<ApplicationId> childYarnJobs = getChildYarnJobs(conf, tag);
-      if (!childYarnJobs.isEmpty()) {
-        YarnClient yarnClient = YarnClient.createYarnClient();
-        yarnClient.init(conf);
-        yarnClient.start();
-        for (ApplicationId app : childYarnJobs) {
-          yarnClient.killApplication(app);
+        ApplicationClientProtocol proxy = ClientRMProxy.createRMProxy(conf, ApplicationClientProtocol.class);
+        GetApplicationsResponse apps = proxy.getApplications(gar);
+        List<ApplicationReport> appsList = apps.getApplicationList();
+        for (ApplicationReport appReport : appsList) {
+            if (doAsAdmin) {
+                childYarnJobs.add(appReport.getApplicationId());
+            } else if (StringUtils.isNotBlank(doAs)) {
+                if (appReport.getApplicationTags().contains(QueryState.USERID_TAG + "=" + doAs)) {
+                    childYarnJobs.add(appReport.getApplicationId());
+                }
+            }
         }
-      }
-    } catch (IOException | YarnException ye) {
-      throw new RuntimeException("Exception occurred while killing child job(s)", ye);
-    }
-  }
 
-  @Override
-  public void killQuery(String queryId, String errMsg, HiveConf conf) throws HiveException {
-    try {
-      String queryTag = null;
-
-      Operation operation = operationManager.getOperationByQueryId(queryId);
-      if (operation == null) {
-        // Check if user has passed the query tag to kill the operation. This is possible if the application
-        // restarts and it does not have the proper query id. The tag can be used in that case to kill the query.
-        operation = operationManager.getOperationByQueryTag(queryId);
-        if (operation == null) {
-          LOG.info("Query not found: " + queryId);
+        if (childYarnJobs.isEmpty()) {
+            LOG.info("No child applications found");
+        } else {
+            LOG.info("Found child YARN applications: " + StringUtils.join(childYarnJobs, ","));
         }
-      } else {
-        // This is the normal flow, where the query is tagged and user wants to kill the query using the query id.
-        queryTag = operation.getQueryTag();
-      }
 
-      if (queryTag == null) {
-        //use query id as tag if user wanted to kill only the yarn jobs after hive server restart. The yarn jobs are
-        //tagged with query id by default. This will cover the case where the application after restarts wants to kill
-        //the yarn jobs with query tag. The query tag can be passed as query id.
-        queryTag = queryId;
-      }
-
-      LOG.info("Killing yarn jobs for query id : " + queryId + " using tag :" + queryTag);
-      killChildYarnJobs(conf, queryTag);
-
-      if (operation != null) {
-        OperationHandle handle = operation.getHandle();
-        operationManager.cancelOperation(handle, errMsg);
-      }
-    } catch (HiveSQLException e) {
-      LOG.error("Kill query failed for query " + queryId, e);
-      throw new HiveException(e.getMessage(), e);
+        return childYarnJobs;
     }
-  }
+
+    public static void killChildYarnJobs(Configuration conf, String tag, String doAs, boolean doAsAdmin) {
+        try {
+            if (tag == null) {
+                return;
+            }
+            LOG.info("Killing yarn jobs using query tag:" + tag);
+            Set<ApplicationId> childYarnJobs = getChildYarnJobs(conf, tag, doAs, doAsAdmin);
+            if (!childYarnJobs.isEmpty()) {
+                YarnClient yarnClient = YarnClient.createYarnClient();
+                yarnClient.init(conf);
+                yarnClient.start();
+                for (ApplicationId app : childYarnJobs) {
+                    yarnClient.killApplication(app);
+                }
+            }
+        } catch (IOException | YarnException ye) {
+            LOG.warn("Exception occurred while killing child job({})", tag, ye);
+        }
+    }
+
+    private static boolean isAdmin() {
+        boolean isAdmin = false;
+        if (SessionState.get().getAuthorizerV2() != null) {
+            try {
+                SessionState.get().getAuthorizerV2()
+                        .checkPrivileges(HiveOperationType.KILL_QUERY, new ArrayList<>(),
+                                new ArrayList<>(), new HiveAuthzContext.Builder().build());
+                isAdmin = true;
+            } catch (Exception e) {
+                LOG.warn("Error while checking privileges", e);
+            }
+        }
+        return isAdmin;
+    }
+
+    private boolean cancelOperation(Operation operation, String doAs, boolean doAsAdmin, String errMsg)
+            throws HiveSQLException {
+        if (doAsAdmin || (!StringUtils.isBlank(doAs) && operation.getParentSession().getUserName().equals(doAs))) {
+            OperationHandle handle = operation.getHandle();
+            operationManager.cancelOperation(handle, errMsg);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isLocalQuery(String queryIdOrTag) {
+        TagOrId tagOrId = TagOrId.UNKNOWN;
+        if (operationManager.getOperationByQueryId(queryIdOrTag) != null) {
+            tagOrId = TagOrId.ID;
+        } else if (!operationManager.getOperationsByQueryTag(queryIdOrTag).isEmpty()) {
+            tagOrId = TagOrId.TAG;
+        }
+        return tagOrId != TagOrId.UNKNOWN;
+    }
+
+    @Override
+    public void killQuery(String queryIdOrTag, String errMsg, HiveConf conf) throws HiveException {
+        killQuery(queryIdOrTag, errMsg, conf, false, SessionState.get().getUserName(), isAdmin());
+    }
+
+    public void killLocalQuery(String queryIdOrTag, HiveConf conf, String doAs, boolean doAsAdmin)
+            throws HiveException {
+        killQuery(queryIdOrTag, null, conf, true, doAs, doAsAdmin);
+    }
+
+    private void killQuery(String queryIdOrTag, String errMsg, HiveConf conf, boolean onlyLocal, String doAs,
+                           boolean doAsAdmin) throws HiveException {
+        errMsg = StringUtils.defaultString(errMsg, KillQueriesOperation.KILL_QUERY_MESSAGE);
+        TagOrId tagOrId = TagOrId.UNKNOWN;
+        Set<Operation> operationsToKill = new HashSet<>();
+        if (operationManager.getOperationByQueryId(queryIdOrTag) != null) {
+            operationsToKill.add(operationManager.getOperationByQueryId(queryIdOrTag));
+            tagOrId = TagOrId.ID;
+            LOG.debug("Query found with id: {}", queryIdOrTag);
+        } else {
+            operationsToKill.addAll(operationManager.getOperationsByQueryTag(queryIdOrTag));
+            if (!operationsToKill.isEmpty()) {
+                tagOrId = TagOrId.TAG;
+                LOG.debug("Query found with tag: {}", queryIdOrTag);
+            }
+        }
+        if (!operationsToKill.isEmpty()){
+            killOperations(queryIdOrTag, errMsg, conf, tagOrId, operationsToKill, doAs, doAsAdmin);
+        } else {
+            LOG.debug("Query not found with tag/id: {}", queryIdOrTag);
+            if (!onlyLocal && killQueryZookeeperManager != null &&
+                    conf.getBoolVar(HiveConf.ConfVars.HIVE_ZOOKEEPER_KILLQUERY_ENABLE)) {
+                try {
+                    LOG.debug("Killing query with zookeeper coordination: " + queryIdOrTag);
+                    killQueryZookeeperManager
+                            .killQuery(queryIdOrTag, SessionState.get().getAuthenticator().getUserName(), isAdmin());
+                } catch (IOException e) {
+                    LOG.error("Kill query failed for queryId: " + queryIdOrTag, e);
+                    throw new HiveException("Unable to kill query locally or on remote servers.", e);
+                }
+            } else {
+                LOG.warn("Unable to kill query with id {}", queryIdOrTag);
+            }
+        }
+    }
+
+    private void killOperations(String queryIdOrTag, String errMsg, HiveConf conf, TagOrId tagOrId,
+                                Set<Operation> operationsToKill, String doAs, boolean doAsAdmin) throws HiveException {
+        try {
+            switch (tagOrId) {
+                case ID:
+                    Operation operation = operationsToKill.iterator().next();
+                    boolean canceled = cancelOperation(operation, doAs, doAsAdmin, errMsg);
+                    if (canceled) {
+                        String queryTag = operation.getQueryTag();
+                        if (queryTag == null) {
+                            queryTag = queryIdOrTag;
+                        }
+                        killChildYarnJobs(conf, queryTag, doAs, doAsAdmin);
+                    } else {
+                        // no privilege to cancel
+                        throw new HiveSQLException("No privilege to kill query id");
+                    }
+                    break;
+                case TAG:
+                    int numCanceled = 0;
+                    for (Operation operationToKill : operationsToKill) {
+                        if (cancelOperation(operationToKill, doAs, doAsAdmin, errMsg)) {
+                            numCanceled++;
+                        }
+                    }
+                    if (numCanceled == 0) {
+                        throw new HiveSQLException("No privilege to kill query tag");
+                    } else {
+                        killChildYarnJobs(conf, queryIdOrTag, doAs, doAsAdmin);
+                    }
+                    break;
+                case UNKNOWN:
+                default:
+                    break;
+            }
+        } catch (HiveSQLException e) {
+            LOG.error("Kill query failed for query " + queryIdOrTag, e);
+            throw new HiveException(e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
This is a backport of Merged PR 496945: Backport [HIVE-24751](https://issues.apache.org/jira/browse/HIVE-24751) : 
Kill trigger in workload manager fails with "No privilege" exception when authorization is disabled

This PR is required for bug fix and improvement for branch-3.2.0 release.
JIRA: [https://issues.apache.org/jira/browse/HIVE-27380](url)