### PR TITLE
HIVE-27661: Auth mode inferred from the Authorization header

### DIFF
--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestIsAuthTypeEnabled.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestIsAuthTypeEnabled.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.minikdc;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.auth.HttpAuthUtils;
+import org.apache.hive.service.auth.saml.HiveSamlUtils;
+import org.apache.hive.service.cli.thrift.ThriftHttpServlet;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.apache.hive.service.auth.HiveAuthConstants.AuthTypes;
+import static org.apache.hive.service.cli.thrift.ThriftHttpServlet.HIVE_DELEGATION_TOKEN_HEADER;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the logic that determines whether a given authentication mode
+ * should be checked based on the Authorization header.
+ */
+public class TestIsAuthTypeEnabled {
+
+  private static final int MOCK_JWKS_SERVER_PORT = 8089;
+  private static final File jwtVerificationJWKSFile =
+    new File("src/test/resources/auth.jwt/jwt-verification-jwks.json");
+
+  @ClassRule
+  public static final WireMockRule MOCK_JWKS_SERVER = new WireMockRule(MOCK_JWKS_SERVER_PORT);
+
+  @Before
+  public void setUp() throws Exception {
+    MOCK_JWKS_SERVER.stubFor(get("/jwks")
+      .willReturn(ok()
+        .withBody(Files.readAllBytes(jwtVerificationJWKSFile.toPath()))));
+  }
+
+  @Test
+  public void testIsAuthTypeEnabled() throws Exception {
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when Kerberos authentication is enabled
+      // and Kerberos authentication is initiated with "Authorization: Negotiate ..." header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.LDAP, AuthTypes.KERBEROS, AuthTypes.SAML)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Negotiate anyToken"))),
+        AuthTypes.KERBEROS
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when Kerberos authentication is disabled
+      // and Kerberos authentication is initiated with "Authorization: Negotiate ..." header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Negotiate anyToken"))),
+        AuthTypes.KERBEROS
+      )
+    );
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when Kerberos authentication is enabled
+      // and delegation token received in X-Hive-Delegation-Token header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.LDAP, AuthTypes.KERBEROS, AuthTypes.SAML)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HIVE_DELEGATION_TOKEN_HEADER,
+          Optional.of("any Hive delegation token"))),
+        AuthTypes.KERBEROS
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when Kerberos authentication is disabled
+      // and delegation token received in X-Hive-Delegation-Token header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HIVE_DELEGATION_TOKEN_HEADER,
+          Optional.of("any Hive delegation token"))),
+        AuthTypes.KERBEROS
+      )
+    );
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when JWT authentication is enabled
+      // and JWT authentication is initiated with "Authorization: Bearer jwt...token" header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.JWT, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Bearer any.jwt.token"))),
+        AuthTypes.JWT
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when JWT authentication is disabled
+      // and JWT authentication is initiated with "Authorization: Bearer jwt...token" header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Bearer any.jwt.token"))),
+        AuthTypes.JWT
+      )
+    );
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when SAML authentication is enabled
+      // and SAML authentication is initiated with "Authorization: Bearer saml.token" header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Bearer anySamlToken"))),
+        AuthTypes.SAML
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when SAML authentication is disabled
+      // and SAML authentication is initiated with "Authorization: Bearer saml.token" header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Bearer anySamlToken"))),
+        AuthTypes.SAML
+      )
+    );
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when SAML authentication is enabled,
+      // no "Authorization" header received, but X-Hive-Token-Response-Port header
+      // indicates SAML authentication
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HiveSamlUtils.SSO_TOKEN_RESPONSE_PORT,
+          Optional.of("4321"))),
+        AuthTypes.SAML
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when SAML authentication is disabled,
+      // no "Authorization" header received and X-Hive-Token-Response-Port header
+      // is present
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HiveSamlUtils.SSO_TOKEN_RESPONSE_PORT,
+          Optional.of("4321"))),
+        AuthTypes.SAML
+      )
+    );
+
+    assertTrue(
+      // isAuthTypeEnabled should be true when LDAP authentication is enabled
+      // and LDAP authentication is initiated with "Authorization: Basic ..." header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Basic base64EncodedCredentials"))),
+        AuthTypes.LDAP
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when LDAP authentication is disabled
+      // and LDAP authentication is initiated with "Authorization: Basic ..." header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.KERBEROS, AuthTypes.SAML)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(ImmutableMap.of(HttpAuthUtils.AUTHORIZATION,
+          Optional.of("Basic base64EncodedCredentials"))),
+        AuthTypes.LDAP
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when JWT authentication is enabled
+      // but there is no JWT token in the Authorization header
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.JWT, AuthTypes.SAML, AuthTypes.LDAP)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(),
+        AuthTypes.JWT
+      )
+    );
+
+    assertFalse(
+      // isAuthTypeEnabled should be false when JWT authentication is enabled
+      // but checking Kerberos authentication
+      createThriftHttpServletWithAuthTypes(
+        ImmutableList.of(AuthTypes.JWT, AuthTypes.SAML, AuthTypes.LDAP, AuthTypes.KERBEROS)
+      ).isAuthTypeEnabled(
+        createMockHttpServletRequest(),
+        AuthTypes.KERBEROS
+      )
+    );
+
+  }
+
+  private HttpServletRequest createMockHttpServletRequest() {
+    return createMockHttpServletRequest(ImmutableMap.of());
+  }
+
+  private HttpServletRequest createMockHttpServletRequest(Map<String, Optional<String>> headers) {
+    HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
+    headers.entrySet().stream().forEach(
+      entry -> Mockito
+        .when(httpServletRequest.getHeader(entry.getKey()))
+        .thenReturn(entry.getValue().orElse(null))
+    );
+    return httpServletRequest;
+  }
+
+  private ThriftHttpServlet createThriftHttpServletWithAuthTypes(List<AuthTypes> authTypesList)
+          throws Exception {
+    HiveConf hiveConf = new HiveConf();
+    String authType = authTypesList.stream().map(Object::toString)
+      .collect(Collectors.joining(","));
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_SERVER2_AUTHENTICATION, authType);
+    // the content of the URL below is the same as jwtVerificationJWKSFile
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_SERVER2_AUTHENTICATION_JWT_JWKS_URL,
+  "http://localhost:" + MOCK_JWKS_SERVER_PORT + "/jwks");
+    return new ThriftHttpServlet(null, null, null, null, null, hiveConf);
+  }
+}

--- a/jdbc/src/java/org/apache/hive/jdbc/HttpBasicAuthInterceptor.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HttpBasicAuthInterceptor.java
@@ -53,10 +53,4 @@ public class HttpBasicAuthInterceptor extends HttpRequestInterceptorBase {
     Header basicAuthHeader = authScheme.authenticate(credentials, httpRequest, httpContext);
     httpRequest.addHeader(basicAuthHeader);
   }
-
-  @Override
-  protected String getAuthType() {
-    // Let the server determine which particular password based method is using.
-    return "UIDPWD";
-  }
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/HttpKerberosRequestInterceptor.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HttpKerberosRequestInterceptor.java
@@ -70,9 +70,4 @@ public class HttpKerberosRequestInterceptor extends HttpRequestInterceptorBase {
       kerberosLock.unlock();
     }
   }
-
-  @Override
-  protected String getAuthType() {
-    return "KERBEROS";
-  }
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/HttpRequestInterceptorBase.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HttpRequestInterceptorBase.java
@@ -21,7 +21,6 @@ package org.apache.hive.jdbc;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.hadoop.hive.conf.Constants;
@@ -51,13 +50,6 @@ public abstract class HttpRequestInterceptorBase implements HttpRequestIntercept
   // Abstract function to add HttpAuth Header
   protected abstract void addHttpAuthHeader(HttpRequest httpRequest, HttpContext httpContext)
     throws Exception;
-
-  /**
-   * The auth method to tell the server to choose right auth mechanism to
-   * validate the request, especially when the server supports multiple auth methods in parallel.
-   * @return the auth method the client is using, should not be null or empty
-   */
-  protected abstract String getAuthType();
 
   public HttpRequestInterceptorBase(CookieStore cs, String cn, boolean isSSL,
       Map<String, String> additionalHeaders, Map<String, String> customCookies) {
@@ -111,7 +103,6 @@ public abstract class HttpRequestInterceptorBase implements HttpRequestIntercept
           httpRequest.addHeader(entry.getKey(), entry.getValue());
         }
       }
-      httpRequest.addHeader(Utils.JdbcConnectionParams.AUTH_TYPE, Objects.requireNonNull(getAuthType()));
       // Add custom cookies if passed to the jdbc driver
       if (customCookies != null) {
         String cookieHeaderKeyValues = "";

--- a/jdbc/src/java/org/apache/hive/jdbc/HttpTokenAuthInterceptor.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HttpTokenAuthInterceptor.java
@@ -44,10 +44,4 @@ public class HttpTokenAuthInterceptor extends HttpRequestInterceptorBase {
     throws Exception {
     httpRequest.addHeader(HIVE_DELEGATION_TOKEN_HEADER, tokenStr);
   }
-
-  @Override
-  protected String getAuthType() {
-    // The auth token is Kerberos based
-    return "KERBEROS";
-  }
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/jwt/HttpJwtAuthRequestInterceptor.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/jwt/HttpJwtAuthRequestInterceptor.java
@@ -46,9 +46,4 @@ public class HttpJwtAuthRequestInterceptor extends HttpRequestInterceptorBase {
   protected void addHttpAuthHeader(HttpRequest httpRequest, HttpContext httpContext) {
     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, HttpAuthUtils.BEARER + " " + signedJwt);
   }
-
-  @Override
-  protected String getAuthType() {
-    return "JWT";
-  }
 }

--- a/jdbc/src/java/org/apache/hive/jdbc/saml/HttpSamlAuthRequestInterceptor.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/saml/HttpSamlAuthRequestInterceptor.java
@@ -64,9 +64,4 @@ public class HttpSamlAuthRequestInterceptor extends HttpRequestInterceptorBase {
       httpRequest.addHeader(HiveSamlUtils.SSO_TOKEN_RESPONSE_PORT, port);
     }
   }
-
-  @Override
-  protected String getAuthType() {
-    return "SAML";
-  }
 }

--- a/service/src/java/org/apache/hive/service/auth/AuthType.java
+++ b/service/src/java/org/apache/hive/service/auth/AuthType.java
@@ -138,13 +138,6 @@ public class AuthType {
     return "";
   }
 
-  public boolean isLoadedFirst(HiveAuthConstants.AuthTypes type) {
-    if (!isEnabled(type) || authTypes.isEmpty()) {
-      return false;
-    }
-    return authTypes.get(0) == type;
-  }
-
   public boolean isPasswordBasedAuth(HiveAuthConstants.AuthTypes type) {
     return PASSWORD_BASED_TYPES.contains(type);
   }

--- a/service/src/test/org/apache/hive/service/auth/TestAuthType.java
+++ b/service/src/test/org/apache/hive/service/auth/TestAuthType.java
@@ -95,11 +95,6 @@ public class TestAuthType {
           HiveAuthConstants.AuthTypes authMech = EnumUtils.getEnumIgnoreCase(HiveAuthConstants.AuthTypes.class,
               authMethods[i]);
           Assert.assertTrue(authType.isEnabled(authMech));
-          if (i == 0) {
-            Assert.assertTrue(authType.isLoadedFirst(authMech));
-          } else {
-            Assert.assertFalse(authType.isLoadedFirst(authMech));
-          }
         }
       }
     } catch (Exception e) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Since the implementation of HIVE-27352, if a client tool communicating over http transport wants to use an authentication mode other than the first allowed authentication mode, it must include the name of the chosen auth mode in an http header named "auth". However, the same information can also be obtained from the content of the standard http Authorization header, so the auth header is not really needed. This PR removes the "auth" header and infers the authorization mode to be used by client from the value of the Authorization header. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Old jdbc driver builds, other compatible client tools do not send an "auth" header when using http transport, but use the standard http Authorization header. If the same functionality can be implemented using the value of the Authorization header, then backwards compatibility can be preserved.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested with a new unit test and with manual tests in CDP PVC DS (LDAP, Kerberos and JWT auth enabled).
