### PR TITLE
HIVE-27322: Iceberg: metadata location overrides can cause data breach.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -926,18 +926,25 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     StringBuilder authURI =
         new StringBuilder(ICEBERG_URI_PREFIX).append(encodeString(dbName)).append("/").append(encodeString(tableName))
             .append("?snapshot=");
-    Optional<String> locationProperty = SessionStateUtil.getProperty(conf, hive_metastoreConstants.META_TABLE_LOCATION);
-    if (locationProperty.isPresent()) {
-      Preconditions.checkArgument(locationProperty.get() != null,
-          "Table location is not set in SessionState. Authorization URI cannot be supplied.");
-      // this property is set during the create operation before the hive table was created
-      // we are returning a dummy iceberg metadata file
-      authURI.append(encodeString(URI.create(locationProperty.get()).getPath()))
-          .append(encodeString("/metadata/dummy.metadata.json"));
+    // If metadata location is provided we should use that location for auth, since during create if the
+    // metadata_location is explicitly provided we register a table using that path.
+    Optional<String> metadataLocation =
+        SessionStateUtil.getProperty(conf, BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+    if (metadataLocation.isPresent()) {
+      authURI.append(encodeString(metadataLocation.get()));
     } else {
-      Table table = IcebergTableUtil.getTable(conf, hmsTable);
-      authURI.append(
-          encodeString(URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath()));
+      Optional<String> locationProperty =
+          SessionStateUtil.getProperty(conf, hive_metastoreConstants.META_TABLE_LOCATION);
+      if (locationProperty.isPresent()) {
+        // this property is set during the create operation before the hive table was created
+        // we are returning a dummy iceberg metadata file
+        authURI.append(encodeString(URI.create(locationProperty.get()).getPath()))
+            .append(encodeString("/metadata/dummy.metadata.json"));
+      } else {
+        Table table = IcebergTableUtil.getTable(conf, hmsTable);
+        authURI.append(
+            encodeString(URI.create(((BaseTable) table).operations().current().metadataFileLocation()).getPath()));
+      }
     }
     LOG.debug("Iceberg storage handler authorization URI {}", authURI);
     return new URI(authURI.toString());
@@ -1535,6 +1542,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           .getOrDefault(TableProperties.DELETE_MODE, TableProperties.DELETE_MODE_DEFAULT);
     }
     return COPY_ON_WRITE.equalsIgnoreCase(mode);
+  }
+
+  @Override
+  public void addResourcesForCreateTable(Map<String, String> tblProps, HiveConf hiveConf) {
+    String metadataLocation = tblProps.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+    if (StringUtils.isNotEmpty(metadataLocation)) {
+      SessionStateUtil.addResourceOrThrow(hiveConf, BaseMetastoreTableOperations.METADATA_LOCATION_PROP,
+          metadataLocation);
+    }
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -392,6 +392,14 @@ public interface HiveStorageHandler extends Configurable {
     return false;
   }
 
+  /**
+   * Adds specific configurations to session for create table command.
+   * @param tblProps table properties
+   * @param hiveConf configuration
+   */
+  default void addResourcesForCreateTable(Map<String, String> tblProps, HiveConf hiveConf) {
+  }
+
   enum AcidSupportType {
     NONE,
     WITH_TRANSACTIONS,

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -14083,6 +14083,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           throw new SemanticException(e);
         }
       }
+      try {
+        HiveStorageHandler storageHandler = HiveUtils.getStorageHandler(conf, storageFormat.getStorageHandler());
+        if (storageHandler != null) {
+          storageHandler.addResourcesForCreateTable(tblProps, conf);
+        }
+      } catch (HiveException e) {
+        throw new RuntimeException(e);
+      }
       SessionStateUtil.addResourceOrThrow(conf, META_TABLE_LOCATION, tblLocation);
       break;
     case CTT: // CREATE TRANSACTIONAL TABLE


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pass metadata location to authorizer if that is provided as part of create table

### Why are the changes needed?

Better Authorizaton checks

### Does this PR introduce _any_ user-facing change?

Yes, metadata location will go through auth checks while creating table if they are specified.

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT