### PR TITLE
HIVE-27676: Reuse the add_partitions logic for add_partition in ObjetStore

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.metastore;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_USE_CUSTOM_POOL;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.newMetaException;
 import static org.apache.hadoop.hive.metastore.utils.StringUtils.normalizeIdentifier;
 
 import java.io.IOException;
@@ -2660,81 +2661,7 @@ public class ObjectStore implements RawStore, Configurable {
     boolean success = false;
     openTransaction();
     try {
-      List<MTablePrivilege> tabGrants = null;
-      List<MTableColumnPrivilege> tabColumnGrants = null;
-      MTable table = this.getMTable(catName, dbName, tblName);
-      if (table == null) {
-        throw new InvalidObjectException("Unable to add partitions because "
-            + TableName.getQualified(catName, dbName, tblName) +
-            " does not exist");
-      }
-      if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
-        tabGrants = this.listAllTableGrants(catName, dbName, tblName);
-        tabColumnGrants = this.listTableAllColumnGrants(catName, dbName, tblName);
-      }
-      List<MPartition> mParts = new ArrayList<>();
-      List<List<MPartitionPrivilege>> mPartPrivilegesList = new ArrayList<>();
-      List<List<MPartitionColumnPrivilege>> mPartColPrivilegesList = new ArrayList<>();
-      for (Partition part : parts) {
-        if (!part.getTableName().equals(tblName) || !part.getDbName().equals(dbName)) {
-          throw new MetaException("Partition does not belong to target table "
-              + dbName + "." + tblName + ": " + part);
-        }
-        MPartition mpart = convertToMPart(part, table, true);
-        mParts.add(mpart);
-        int now = (int) (System.currentTimeMillis() / 1000);
-        List<MPartitionPrivilege> mPartPrivileges = new ArrayList<>();
-        if (tabGrants != null) {
-          for (MTablePrivilege tab: tabGrants) {
-            MPartitionPrivilege mPartPrivilege = new MPartitionPrivilege(tab.getPrincipalName(), tab.getPrincipalType(),
-                mpart, tab.getPrivilege(), now, tab.getGrantor(), tab.getGrantorType(), tab.getGrantOption(),
-                tab.getAuthorizer());
-            mPartPrivileges.add(mPartPrivilege);
-          }
-        }
-
-        List<MPartitionColumnPrivilege> mPartColumnPrivileges = new ArrayList<>();
-        if (tabColumnGrants != null) {
-          for (MTableColumnPrivilege col : tabColumnGrants) {
-            MPartitionColumnPrivilege mPartColumnPrivilege = new MPartitionColumnPrivilege(col.getPrincipalName(),
-                col.getPrincipalType(), mpart, col.getColumnName(), col.getPrivilege(), now, col.getGrantor(),
-                col.getGrantorType(), col.getGrantOption(), col.getAuthorizer());
-            mPartColumnPrivileges.add(mPartColumnPrivilege);
-          }
-        }
-        mPartPrivilegesList.add(mPartPrivileges);
-        mPartColPrivilegesList.add(mPartColumnPrivileges);
-      }
-      if (CollectionUtils.isNotEmpty(mParts)) {
-        GetHelper<Void> helper = new GetHelper<Void>(null, null, null, true,
-            true) {
-          @Override
-          protected Void getSqlResult(GetHelper<Void> ctx) throws MetaException {
-            directSql.addPartitions(mParts, mPartPrivilegesList, mPartColPrivilegesList);
-            return null;
-          }
-
-          @Override
-          protected Void getJdoResult(GetHelper<Void> ctx) {
-            List<Object> toPersist = new ArrayList<>(mParts);
-            mPartPrivilegesList.forEach(toPersist::addAll);
-            mPartColPrivilegesList.forEach(toPersist::addAll);
-            pm.makePersistentAll(toPersist);
-            pm.flush();
-            return null;
-          }
-
-          @Override
-          protected String describeResult() {
-            return "add partitions";
-          }
-        };
-        try {
-          helper.run(false);
-        } catch (NoSuchObjectException e) {
-          throw new MetaException(e.getMessage());
-        }
-      }
+      addPartitionsInternal(catName, dbName, tblName, parts);
       success = commitTransaction();
     } finally {
       if (!success) {
@@ -2742,6 +2669,85 @@ public class ObjectStore implements RawStore, Configurable {
       }
     }
     return success;
+  }
+
+  private void addPartitionsInternal(String catName, String dbName,
+                                     String tblName, List<Partition> parts)
+      throws MetaException, InvalidObjectException {
+    List<MTablePrivilege> tabGrants = null;
+    List<MTableColumnPrivilege> tabColumnGrants = null;
+    MTable table = this.getMTable(catName, dbName, tblName);
+    if (table == null) {
+      throw new InvalidObjectException("Unable to add partitions because "
+          + TableName.getQualified(catName, dbName, tblName) +
+          " does not exist");
+    }
+    if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
+      tabGrants = this.listAllTableGrants(catName, dbName, tblName);
+      tabColumnGrants = this.listTableAllColumnGrants(catName, dbName, tblName);
+    }
+    List<MPartition> mParts = new ArrayList<>();
+    List<List<MPartitionPrivilege>> mPartPrivilegesList = new ArrayList<>();
+    List<List<MPartitionColumnPrivilege>> mPartColPrivilegesList = new ArrayList<>();
+    for (Partition part : parts) {
+      if (!part.getTableName().equals(tblName) || !part.getDbName().equals(dbName)) {
+        throw new MetaException("Partition does not belong to target table "
+            + dbName + "." + tblName + ": " + part);
+      }
+      MPartition mpart = convertToMPart(part, table, true);
+      mParts.add(mpart);
+      int now = (int) (System.currentTimeMillis() / 1000);
+      List<MPartitionPrivilege> mPartPrivileges = new ArrayList<>();
+      if (tabGrants != null) {
+        for (MTablePrivilege tab: tabGrants) {
+          MPartitionPrivilege mPartPrivilege = new MPartitionPrivilege(tab.getPrincipalName(), tab.getPrincipalType(),
+              mpart, tab.getPrivilege(), now, tab.getGrantor(), tab.getGrantorType(), tab.getGrantOption(),
+              tab.getAuthorizer());
+          mPartPrivileges.add(mPartPrivilege);
+        }
+      }
+
+      List<MPartitionColumnPrivilege> mPartColumnPrivileges = new ArrayList<>();
+      if (tabColumnGrants != null) {
+        for (MTableColumnPrivilege col : tabColumnGrants) {
+          MPartitionColumnPrivilege mPartColumnPrivilege = new MPartitionColumnPrivilege(col.getPrincipalName(),
+              col.getPrincipalType(), mpart, col.getColumnName(), col.getPrivilege(), now, col.getGrantor(),
+              col.getGrantorType(), col.getGrantOption(), col.getAuthorizer());
+          mPartColumnPrivileges.add(mPartColumnPrivilege);
+        }
+      }
+      mPartPrivilegesList.add(mPartPrivileges);
+      mPartColPrivilegesList.add(mPartColumnPrivileges);
+    }
+    if (CollectionUtils.isNotEmpty(mParts)) {
+      GetHelper<Void> helper = new GetHelper<Void>(null, null, null, true, true) {
+        @Override
+        protected Void getSqlResult(GetHelper<Void> ctx) throws MetaException {
+          directSql.addPartitions(mParts, mPartPrivilegesList, mPartColPrivilegesList);
+          return null;
+        }
+
+        @Override
+        protected Void getJdoResult(GetHelper<Void> ctx) {
+          List<Object> toPersist = new ArrayList<>(mParts);
+          mPartPrivilegesList.forEach(toPersist::addAll);
+          mPartColPrivilegesList.forEach(toPersist::addAll);
+          pm.makePersistentAll(toPersist);
+          pm.flush();
+          return null;
+        }
+
+        @Override
+        protected String describeResult() {
+          return "add partitions";
+        }
+      };
+      try {
+        helper.run(false);
+      } catch (NoSuchObjectException e) {
+        throw newMetaException(e);
+      }
+    }
   }
 
   private boolean isValidPartition(
@@ -2824,62 +2830,18 @@ public class ObjectStore implements RawStore, Configurable {
   @Override
   public boolean addPartition(Partition part) throws InvalidObjectException,
       MetaException {
-    boolean success = false;
-    boolean commited = false;
-
+    boolean committed = false;
     try {
       openTransaction();
       String catName = part.isSetCatName() ? part.getCatName() : getDefaultCatalog(conf);
-      MTable table = this.getMTable(catName, part.getDbName(), part.getTableName());
-      if (table == null) {
-        throw new InvalidObjectException("Unable to add partition because "
-            + TableName.getQualified(catName, part.getDbName(), part.getTableName()) +
-            " does not exist");
-      }
-      List<MTablePrivilege> tabGrants = null;
-      List<MTableColumnPrivilege> tabColumnGrants = null;
-      if ("TRUE".equalsIgnoreCase(table.getParameters().get("PARTITION_LEVEL_PRIVILEGE"))) {
-        tabGrants = this.listAllTableGrants(catName, part.getDbName(), part.getTableName());
-        tabColumnGrants = this.listTableAllColumnGrants(
-            catName, part.getDbName(), part.getTableName());
-      }
-      MPartition mpart = convertToMPart(part, table, true);
-      pm.makePersistent(mpart);
-
-      int now = (int) (System.currentTimeMillis() / 1000);
-      List<Object> toPersist = new ArrayList<>();
-      if (tabGrants != null) {
-        for (MTablePrivilege tab: tabGrants) {
-          MPartitionPrivilege partGrant = new MPartitionPrivilege(tab
-              .getPrincipalName(), tab.getPrincipalType(),
-              mpart, tab.getPrivilege(), now, tab.getGrantor(), tab
-                  .getGrantorType(), tab.getGrantOption(), tab.getAuthorizer());
-          toPersist.add(partGrant);
-        }
-      }
-
-      if (tabColumnGrants != null) {
-        for (MTableColumnPrivilege col : tabColumnGrants) {
-          MPartitionColumnPrivilege partColumn = new MPartitionColumnPrivilege(col
-              .getPrincipalName(), col.getPrincipalType(), mpart, col
-              .getColumnName(), col.getPrivilege(), now, col.getGrantor(), col
-              .getGrantorType(), col.getGrantOption(), col.getAuthorizer());
-          toPersist.add(partColumn);
-        }
-
-        if (CollectionUtils.isNotEmpty(toPersist)) {
-          pm.makePersistentAll(toPersist);
-        }
-      }
-
-      commited = commitTransaction();
-      success = true;
+      addPartitionsInternal(catName, part.getDbName(), part.getTableName(), Arrays.asList(part));
+      committed = commitTransaction();
     } finally {
-      if (!commited) {
+      if (!committed) {
         rollbackTransaction();
       }
     }
-    return success;
+    return committed;
   }
 
   @Override

--- a/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkTool.java
+++ b/standalone-metastore/metastore-tools/metastore-benchmarks/src/main/java/org/apache/hadoop/hive/metastore/tools/BenchmarkTool.java
@@ -274,7 +274,7 @@ public class BenchmarkTool implements Runnable {
             () -> benchmarkDeleteWithPartitions(bench, bData, 1, nParameters[0]))
         .add("dropTableMetadataWithPartitions",
             () -> benchmarkDeleteMetaOnlyWithPartitions(bench, bData, 1, nParameters[0]))
-        .add("addPartition", () -> benchmarkCreatePartition(bench, bData))
+        .add("addPartition", () -> benchmarkCreatePartition(bench, bData, 1))
         .add("dropPartition", () -> benchmarkDropPartition(bench, bData, 1))
         .add("listPartition", () -> benchmarkListPartition(bench, bData))
         .add("getPartition",
@@ -315,6 +315,8 @@ public class BenchmarkTool implements Runnable {
               () -> benchmarkRenameTable(bench, bData, howMany))
           .add("dropDatabase" + '.' + howMany,
               () -> benchmarkDropDatabase(bench, bData, howMany))
+          .add("addPartition" + '.' + howMany,
+              () -> benchmarkCreatePartition(bench, bData, howMany))
           .add("dropPartition" + '.' + howMany,
               () -> benchmarkDropPartition(bench, bData, howMany))
           .add("openTxns" + '.' + howMany,


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Create a new common function named `addPartitionsInternal`
2. Both `add_partitions` and `add_partition`  call this new common function.


### Why are the changes needed?
1. Get the performance improvement in direct SQL for `add_partition`
3. Code cleaner, reduce the duplicate code.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
1. pass all existing add partition related tests
2. add a benchmark test:
```shell
java -jar ./hmsbench-jar-with-dependencies.jar -H localhost --savedata /tmp/benchdata --sanitize -N 10 -N 100 -N 1000 -o bench_results_direct.csv -C -d testbench_http --params=100  -E 'drop.*' -E 'renameTable.*' -E 'getTableObjectsByName.*' -E 'listTables.*' -E 'listPartitions.*' -E 'getPartitions.*' -E 'getPartitionsByNames.*' -E 'getPartitionNames.*' -E 'listPartition' -E 'getPartition'  -E 'getNid' -E 'listDatabases' -E 'getTable' -E 'createTable' -E 'addPartitions.*'
```

- before this patch
```shell
Operation                      Mean     Med      Min      Max      Err%
addPartition                   19.93    16.76    15.30    41.84    29.67
addPartition.10                182.9    181.5    173.9    210.3    3.079
addPartition.100               1846     1835     1792     2392     4.179
addPartition.1000              1.850e+04 1.834e+04 1.806e+04 2.024e+04 2.422
```
- after this patch
```shell
Operation                      Mean     Med      Min      Max      Err%
addPartition                   18.18    15.14    14.44    38.62    32.95
addPartition.10                177.4    175.7    167.0    234.9    4.943
addPartition.100               1797     1783     1735     2288     5.009
addPartition.1000              1.791e+04 1.775e+04 1.750e+04 1.985e+04 2.294
```