### PR TITLE
HIVE-27689: Iceberg: Remove unsed iceberg property

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -201,6 +201,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   public static final String COPY_ON_WRITE = "copy-on-write";
   public static final String MERGE_ON_READ = "merge-on-read";
   public static final String STATS = "/stats/";
+  static final String WRITE_KEY = "HiveIcebergStorageHandler_write";
 
   /**
    * Function template for producing a custom sort expression function:
@@ -272,6 +273,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     fallbackToNonVectorizedModeBasedOnProperties(tableDesc.getProperties());
     // For Tez, setting the committer here is enough to make sure it'll be part of the jobConf
     map.put("mapred.output.committer.class", HiveIcebergNoJobCommitter.class.getName());
+    // It means that the table is an output table.
+    tableDesc.getProperties().put(WRITE_KEY, "true");
   }
 
   /**
@@ -300,7 +303,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
     setCommonJobConf(jobConf);
-    if (tableDesc != null && tableDesc.getProperties() != null) {
+    if (tableDesc != null && tableDesc.getProperties() != null &&
+        tableDesc.getProperties().get(WRITE_KEY) != null) {
       String tableName = tableDesc.getTableName();
       Preconditions.checkArgument(!tableName.contains(TABLE_NAME_SEPARATOR),
           "Can not handle table " + tableName + ". Its name contains '" + TABLE_NAME_SEPARATOR + "'");

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -201,7 +201,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   public static final String COPY_ON_WRITE = "copy-on-write";
   public static final String MERGE_ON_READ = "merge-on-read";
   public static final String STATS = "/stats/";
-  static final String WRITE_KEY = "HiveIcebergStorageHandler_write";
+  static final String WRITE_KEY = "iceberg.mr.output.table";
 
   /**
    * Function template for producing a custom sort expression function:

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -226,7 +226,6 @@ public class TestHiveIcebergOutputCommitter {
     conf.setNumReduceTasks(0);
     conf.set(HiveConf.ConfVars.HIVEQUERYID.varname, QUERY_ID);
     conf.set(InputFormatConfig.OUTPUT_TABLES, table.name());
-    conf.set(InputFormatConfig.OPERATION_TYPE_PREFIX + table.name(), Context.Operation.OTHER.name());
     conf.set(InputFormatConfig.TABLE_CATALOG_PREFIX + table.name(),
             table.properties().get(InputFormatConfig.CATALOG_NAME));
     conf.set(InputFormatConfig.SERIALIZED_TABLE_PREFIX + table.name(), SerializationUtil.serializeToBase64(table));

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -116,11 +116,11 @@ STAGE PLANS:
                             write.format.default orc
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                           properties:
-                            HiveIcebergStorageHandler_write true
                             bucketing_version -1
                             columns a,b,c
                             columns.types int:string:int
                             format-version 2
+                            iceberg.mr.output.table true
                             iceberg.mr.table.partition.spec {"spec-id":0,"fields":[{"name":"a_bucket","transform":"bucket[16]","source-id":1,"field-id":1000},{"name":"b_trunc","transform":"truncate[3]","source-id":2,"field-id":1001}]}
                             iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
                             location hdfs://### HDFS PATH ###

--- a/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/ctas_iceberg_partitioned_orc.q.out
@@ -103,7 +103,6 @@ STAGE PLANS:
                             columns.types int:string:int
                             created_with_ctas true
                             format-version 2
-                            iceberg.mr.operation.type.default.tbl_ice OTHER
                             iceberg.mr.serialized.table.default.tbl_ice rO0ABXA=
                             iceberg.mr.table.identifier default.tbl_ice
                             iceberg.mr.table.location hdfs://### HDFS PATH ###
@@ -117,11 +116,11 @@ STAGE PLANS:
                             write.format.default orc
                           output format: org.apache.iceberg.mr.hive.HiveIcebergOutputFormat
                           properties:
+                            HiveIcebergStorageHandler_write true
                             bucketing_version -1
                             columns a,b,c
                             columns.types int:string:int
                             format-version 2
-                            iceberg.mr.operation.type.default.tbl_ice OTHER
                             iceberg.mr.table.partition.spec {"spec-id":0,"fields":[{"name":"a_bucket","transform":"bucket[16]","source-id":1,"field-id":1000},{"name":"b_trunc","transform":"truncate[3]","source-id":2,"field-id":1001}]}
                             iceberg.mr.table.schema {"type":"struct","schema-id":0,"fields":[{"id":1,"name":"a","required":false,"type":"int"},{"id":2,"name":"b","required":false,"type":"string"},{"id":3,"name":"c","required":false,"type":"int"}]}
                             location hdfs://### HDFS PATH ###


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It makes me feel confuesd when reading the code about `InputFormatConfig.OPERATION_TYPE_PREFIX`. This property introduced by HIVE-26102 was originally used to indicate the operation type of a output table, e.g DELETE&UPDATE&MERGE.
But after HIVE-26202 and HIVE-26264, this property won't get actual table operation type and it only can be used to identify the output table.

We should remove this property from current code snippet as this will misunderstand the meaning of the code, and use a proper term to indicate this table is an output table.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
