### PR TITLE
HIVE-27679: Ranger Yarn Queue policies are not applying correctly, rework done for HIVE-26352

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/YarnQueueHelper.java
@@ -93,6 +93,14 @@ public class YarnQueueHelper {
     lastKnownGoodUrl = 0;
   }
 
+  /**
+   * Checks yarn queue access of a given user for a given queue, and throws
+   * HiveException in case the user doesn't have access to the queue.
+   * @param  queueName the yarn queue name
+   * @param  userName the username
+   * @throws IOException when doAs throws an exception, we simply throw it
+   * InterruptedException when doAs throws an exception, we simply throw it
+   */
   public void checkQueueAccess(
       String queueName, String userName) throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
@@ -101,8 +109,9 @@ public class YarnQueueHelper {
         checkQueueAccessInternal(queueName, userName);
         return null;
       });
-    } catch (Exception exception) {
+    } catch (InterruptedException exception) {
       LOG.error("Cannot check queue access against UGI: " + ugi, exception);
+      throw new IOException(exception);
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Ranger Yarn Queue policies are not applying correctly, rework done for HIVE-26352



### Why are the changes needed?
Swallowing all exceptions not correct here, We should catch only required exception type that is IO exception in this case.


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
CI runs and existed UT
