### PR TITLE
HIVE-27686 ORC upgraded to 1.8.5.

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -398,7 +398,6 @@ public class TestCompactor extends TestCompactorBase {
             .getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "1396", parameters.get("totalSize"));
 
     parameters = partitions
             .stream()
@@ -408,7 +407,6 @@ public class TestCompactor extends TestCompactorBase {
             .getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "1453", parameters.get("totalSize"));
 
     //Do a major compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tblName, CompactionType.MAJOR);
@@ -433,7 +431,6 @@ public class TestCompactor extends TestCompactorBase {
             .getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "808", parameters.get("totalSize"));
 
     parameters = partitions
             .stream()
@@ -443,7 +440,6 @@ public class TestCompactor extends TestCompactorBase {
             .getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "1453", parameters.get("totalSize"));
   }
 
   /**
@@ -486,7 +482,6 @@ public class TestCompactor extends TestCompactorBase {
     Map<String, String> parameters = Hive.get().getTable(tblName).getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "2", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "1446", parameters.get("totalSize"));
 
     //Do a major compaction
     CompactionRequest rqst = new CompactionRequest(dbName, tblName, CompactionType.MAJOR);
@@ -504,7 +499,6 @@ public class TestCompactor extends TestCompactorBase {
     parameters = Hive.get().getTable(tblName).getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "783", parameters.get("totalSize"));
   }
 
   @Test

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -108,8 +108,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     conf.setBoolVar(HiveConf.ConfVars.TXN_WRITE_X_LOCK, optimisticLock);
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "1000");
-    conf.set("tez.grouping.max-size", "80000");
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
@@ -145,8 +145,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         Assert.fail("In case of TXN_WRITE_X_LOCK = true, the transaction must be retried instead of being aborted.");
       }
       aborted = true;
-      Assert.assertEquals(e.getCause().getClass(), LockException.class);
-      Assert.assertEquals(e.getCauseMessage(), "Transaction manager has aborted the transaction txnid:21.  Reason: Aborting [txnid:21,24] due to a write conflict on default/rebalance_test committed by [txnid:20,24] d/u");
+      Assert.assertEquals(LockException.class, e.getCause().getClass());
+      Assert.assertEquals( "Transaction manager has aborted the transaction txnid:21.  Reason: Aborting [txnid:21,24] due to a write conflict on default/rebalance_test committed by [txnid:20,24] d/u", e.getCauseMessage());
       // Delete the record, so the rest of the test can be the same in both cases
       executeStatementOnDriver("DELETE FROM " + tableName + " WHERE b = 12", driver);
     } finally {
@@ -177,24 +177,26 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":4}\t13\t13",
         },
         {
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
+            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t4\t4",
             "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":7}\t3\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
+            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t2\t4",
             "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":9}\t5\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":10}\t6\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":11}\t5\t3",
         },
         {
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t6\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t4\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t2\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":15}\t3\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":16}\t6\t2",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t5\t2",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t6\t4",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":11}\t5\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t3\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t2\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t4\t3",
+        },
+        {
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":15}\t6\t3",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":16}\t5\t2",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t6\t2",
         },
     };
     verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"}, "base_0000007_v0000020");
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002", "bucket_00003"}, "base_0000007_v0000020");
   }
 
   @Test
@@ -204,8 +206,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     conf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "1000");
-    conf.set("tez.grouping.max-size", "80000");
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
@@ -228,27 +230,29 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":2}\t15\t15",
             "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":3}\t14\t14",
             "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":4}\t13\t13",
-            "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":5}\t12\t12",
         },
         {
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
+            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":5}\t12\t12",
+            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":6}\t4\t4",
             "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":7}\t3\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
+            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":8}\t2\t4",
             "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":9}\t5\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":10}\t6\t4",
-            "{\"writeid\":7,\"bucketid\":536936448,\"rowid\":11}\t5\t3",
         },
         {
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t6\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t4\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t2\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":15}\t3\t3",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":16}\t6\t2",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t5\t2",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":10}\t6\t4",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":11}\t5\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":12}\t3\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":13}\t2\t3",
+            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":14}\t4\t3",
+        },
+        {
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":15}\t6\t3",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":16}\t5\t2",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t6\t2",
         },
     };
     verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"}, "base_0000007_v0000020");
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"}, "base_0000007_v0000020");
   }
 
   @Test
@@ -258,8 +262,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     conf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "1000");
-    conf.set("tez.grouping.max-size", "80000");
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
@@ -279,27 +283,30 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":2}\t6\t3",
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":5}\t5\t3",
         },
         {
+
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":5}\t5\t3",
             "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":6}\t2\t4",
             "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":7}\t3\t3",
             "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":8}\t4\t4",
             "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":9}\t4\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":10}\t2\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":11}\t3\t4",
         },
         {
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":10}\t2\t3",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":11}\t3\t4",
             "{\"writeid\":2,\"bucketid\":537001984,\"rowid\":12}\t12\t12",
             "{\"writeid\":3,\"bucketid\":537001984,\"rowid\":13}\t13\t13",
             "{\"writeid\":4,\"bucketid\":537001984,\"rowid\":14}\t14\t14",
-            "{\"writeid\":5,\"bucketid\":537001984,\"rowid\":15}\t15\t15",
-            "{\"writeid\":6,\"bucketid\":537001984,\"rowid\":16}\t16\t16",
-            "{\"writeid\":7,\"bucketid\":537001984,\"rowid\":17}\t17\t17",
+        },
+        {
+            "{\"writeid\":5,\"bucketid\":537067520,\"rowid\":15}\t15\t15",
+            "{\"writeid\":6,\"bucketid\":537067520,\"rowid\":16}\t16\t16",
+            "{\"writeid\":7,\"bucketid\":537067520,\"rowid\":17}\t17\t17",
         },
     };
     verifyRebalance(testDataProvider, tableName, null, expectedBuckets,
-        new String[] {"bucket_00000", "bucket_00001", "bucket_00002"}, "base_0000007_v0000020");
+        new String[] {"bucket_00000", "bucket_00001", "bucket_00002","bucket_00003"}, "base_0000007_v0000020");
   }
 
   @Test
@@ -440,8 +447,8 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     conf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
 
     //set grouping size to have 3 buckets, and re-create driver with the new config
-    conf.set("tez.grouping.min-size", "1000");
-    conf.set("tez.grouping.max-size", "80000");
+    conf.set("tez.grouping.min-size", "400");
+    conf.set("tez.grouping.max-size", "5000");
     driver = new Driver(conf);
 
     final String tableName = "rebalance_test";
@@ -509,7 +516,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Table table = msClient.getTable("default", tableName);
     FileSystem fs = FileSystem.get(conf);
     Assert.assertEquals("Test setup does not match the expected: different buckets",
-        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0"),
+        Arrays.asList("bucket_00000_0", "bucket_00001_0", "bucket_00002_0","bucket_00003_0"),
         CompactorTestUtil.getBucketFileNames(fs, table, null, "base_0000001"));
     String[][] expectedBuckets = new String[][] {
         {
@@ -519,7 +526,6 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":3}\t6\t4",
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":4}\t5\t2",
             "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":5}\t5\t3",
-            "{\"writeid\":1,\"bucketid\":536870912,\"rowid\":6}\t2\t4",
             "{\"writeid\":2,\"bucketid\":536870912,\"rowid\":0}\t12\t12",
             "{\"writeid\":3,\"bucketid\":536870912,\"rowid\":0}\t13\t13",
             "{\"writeid\":4,\"bucketid\":536870912,\"rowid\":0}\t14\t14",
@@ -528,13 +534,16 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
             "{\"writeid\":7,\"bucketid\":536870912,\"rowid\":0}\t17\t17",
         },
         {
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t3\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":1}\t4\t4",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":2}\t4\t3",
-            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":3}\t2\t3",
+            "{\"writeid\":1,\"bucketid\":536936448,\"rowid\":0}\t2\t4",
         },
         {
-             "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t3\t4",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":0}\t3\t3",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":1}\t4\t4",
+            "{\"writeid\":1,\"bucketid\":537001984,\"rowid\":2}\t4\t3",
+        },
+        {
+            "{\"writeid\":1,\"bucketid\":537067520,\"rowid\":0}\t2\t3",
+            "{\"writeid\":1,\"bucketid\":537067520,\"rowid\":1}\t3\t4",
         },
     };
     AcidOutputFormat.Options options = new AcidOutputFormat.Options(conf);
@@ -826,7 +835,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     parameters = Hive.get().getTable(tblName).getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "2", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "735", parameters.get("totalSize"));
+    Assert.assertEquals("The total table size is differing from the expected", "736", parameters.get("totalSize"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <postgres.version>42.5.1</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
     <opencsv.version>2.3</opencsv.version>
-    <orc.version>1.8.3</orc.version>
+    <orc.version>1.8.5</orc.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <powermock.version>2.0.2</powermock.version>
     <mina.version>2.0.0-M5</mina.version>

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnNoBuckets.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnNoBuckets.java
@@ -848,7 +848,7 @@ ekoifman:apache-hive-3.0.0-SNAPSHOT-bin ekoifman$ tree /Users/ekoifman/dev/hiver
             .getParameters();
     Assert.assertEquals("The number of files is differing from the expected", "1", parameters.get("numFiles"));
     Assert.assertEquals("The number of rows is differing from the expected", "4", parameters.get("numRows"));
-    Assert.assertEquals("The total table size is differing from the expected", "704", parameters.get("totalSize"));
+    Assert.assertEquals("The total table size is differing from the expected", "705", parameters.get("totalSize"));
   }
 
   @Test

--- a/ql/src/test/queries/clientpositive/acid_bloom_filter_orc_file_dump.q
+++ b/ql/src/test/queries/clientpositive/acid_bloom_filter_orc_file_dump.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(File Version:)(.+)/$1#Masked#/
 SET hive.vectorized.execution.enabled=FALSE;
 SET hive.mapred.mode=nonstrict;
 

--- a/ql/src/test/queries/clientpositive/acid_no_buckets.q
+++ b/ql/src/test/queries/clientpositive/acid_no_buckets.q
@@ -1,4 +1,5 @@
 --! qt:dataset:srcpart
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 --this has 4 groups of tests
 --Acid tables w/o bucketing
 --the tests with bucketing (make sure we get the same results)

--- a/ql/src/test/queries/clientpositive/default_constraint.q
+++ b/ql/src/test/queries/clientpositive/default_constraint.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 -- create table
 -- numeric type
 

--- a/ql/src/test/queries/clientpositive/deleteAnalyze.q
+++ b/ql/src/test/queries/clientpositive/deleteAnalyze.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.stats.autogather=true;
 set hive.explain.user=true;
 

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 -- SORT_QUERY_RESULTS
 
 set hive.vectorized.execution.enabled=false;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_4.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_4.q
@@ -1,6 +1,6 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 -- Test Incremental rebuild of materialized view with aggregate but without count(*)
 -- when source tables have delete operations since last rebuild.
-
 SET hive.vectorized.execution.enabled=false;
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_by_text_multi_db.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_by_text_multi_db.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_dummy.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_dummy.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 -- SORT_QUERY_RESULTS
 
 SET hive.vectorized.execution.enabled=false;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_multi_db.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_multi_db.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_time_window.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_time_window.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 set hive.strict.checks.cartesian.product=false;

--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_time_window_2.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_time_window_2.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 set hive.strict.checks.cartesian.product=false;

--- a/ql/src/test/queries/clientpositive/orc_analyze.q
+++ b/ql/src/test/queries/clientpositive/orc_analyze.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.mapred.mode=nonstrict;
 set hive.exec.submitviachild=false;

--- a/ql/src/test/queries/clientpositive/orc_file_dump.q
+++ b/ql/src/test/queries/clientpositive/orc_file_dump.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(File Version:)(.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.mapred.mode=nonstrict;
 

--- a/ql/src/test/queries/clientpositive/orc_llap_counters.q
+++ b/ql/src/test/queries/clientpositive/orc_llap_counters.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.compute.query.using.stats=false;
 set hive.mapred.mode=nonstrict;

--- a/ql/src/test/queries/clientpositive/orc_llap_counters1.q
+++ b/ql/src/test/queries/clientpositive/orc_llap_counters1.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.mapred.mode=nonstrict;
 SET hive.optimize.index.filter=true;

--- a/ql/src/test/queries/clientpositive/orc_merge10.q
+++ b/ql/src/test/queries/clientpositive/orc_merge10.q
@@ -1,6 +1,6 @@
 --! qt:dataset:src
 --! qt:dataset:part
-
+--! qt:replace:/(File Version:)(.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 set hive.compute.query.using.stats=false;
 set hive.mapred.mode=nonstrict;

--- a/ql/src/test/queries/clientpositive/orc_merge11.q
+++ b/ql/src/test/queries/clientpositive/orc_merge11.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(File Version:)(.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 
 DROP TABLE orcfile_merge1_n2;

--- a/ql/src/test/queries/clientpositive/orc_merge12.q
+++ b/ql/src/test/queries/clientpositive/orc_merge12.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(File Version:)(.+)/$1#Masked#/
 set hive.vectorized.execution.enabled=false;
 
 CREATE TABLE `alltypesorc3xcols`(

--- a/ql/src/test/queries/clientpositive/row__id.q
+++ b/ql/src/test/queries/clientpositive/row__id.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(.+)(Data size: \d+)(.+)/$1#Masked#$3/
 -- tid is flaky when compute column stats
 set hive.stats.column.autogather=false;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;

--- a/ql/src/test/queries/clientpositive/smb_mapjoin_1.q
+++ b/ql/src/test/queries/clientpositive/smb_mapjoin_1.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(totalSize\s+)(\S+|\s+|.+)/$1#Masked#/
 set hive.strict.checks.bucketing=false;
 
 

--- a/ql/src/test/queries/clientpositive/sqlmerge_stats.q
+++ b/ql/src/test/queries/clientpositive/sqlmerge_stats.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 -- SORT_QUERY_RESULTS
 
 set hive.mapred.mode=nonstrict;

--- a/ql/src/test/queries/clientpositive/stats_histogram.q
+++ b/ql/src/test/queries/clientpositive/stats_histogram.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.stats.kll.enable=true;
 set metastore.stats.fetch.bitvector=true;
 set metastore.stats.fetch.kll=true;

--- a/ql/src/test/queries/clientpositive/stats_histogram_null.q
+++ b/ql/src/test/queries/clientpositive/stats_histogram_null.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.stats.kll.enable=true;
 set metastore.stats.fetch.bitvector=true;
 set metastore.stats.fetch.kll=true;

--- a/ql/src/test/queries/clientpositive/stats_part2.q
+++ b/ql/src/test/queries/clientpositive/stats_part2.q
@@ -1,3 +1,4 @@
+--! qt:replace:/(\s+totalSize\s+)\S+(\s+)/$1#Masked#/
 set hive.stats.dbclass=fs;
 set hive.stats.fetch.column.stats=true;
 set datanucleus.cache.collections=false;

--- a/ql/src/test/results/clientpositive/beeline/materialized_view_create_rewrite.q.out
+++ b/ql/src/test/results/clientpositive/beeline/materialized_view_create_rewrite.q.out
@@ -63,7 +63,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	408
-totalSize	474
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create materialized view if not exists cmv_mat_view2_n4
 as select a, c from cmv_basetable_n10 where a = 3
@@ -99,7 +99,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	232
-totalSize	340
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: explain
 select a, c from cmv_basetable_n10 where a = 3

--- a/ql/src/test/results/clientpositive/beeline/smb_mapjoin_1.q.out
+++ b/ql/src/test/results/clientpositive/beeline/smb_mapjoin_1.q.out
@@ -60,7 +60,7 @@ POSTHOOK: Input: default@smb_bucket_1_n3
 	numRows             	0                   
 	rawDataSize         	0                   
 	serialization.format	1                   
-	totalSize           	208                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 # Detailed Table Information	NULL	NULL
 # Storage Information	NULL	NULL

--- a/ql/src/test/results/clientpositive/llap/acid_bloom_filter_orc_file_dump.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_bloom_filter_orc_file_dump.q.out
@@ -78,7 +78,7 @@ PREHOOK: Input: default@bloomtest
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 1
 Compression: ZLIB
 Compression size: 32768
@@ -195,7 +195,7 @@ ________________________________________________________________________________
 -- END ORC FILE DUMP --
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 1
 Compression: ZLIB
 Compression size: 32768

--- a/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_no_buckets.q.out
@@ -336,7 +336,7 @@ Table Parameters:
 	numPartitions       	4                   
 	numRows             	2003                
 	rawDataSize         	0                   
-	totalSize           	18100               
+	totalSize           	#Masked#               
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -446,7 +446,7 @@ Table Parameters:
 	numPartitions       	4                   
 	numRows             	2003                
 	rawDataSize         	0                   
-	totalSize           	18100               
+	totalSize           	#Masked#               
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/default_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/default_constraint.q.out
@@ -1566,7 +1566,7 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	bucketing_version   	2                   
 	numFiles            	1                   
-	totalSize           	1107                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -1740,7 +1740,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	2                   
-	totalSize           	2213                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -1818,7 +1818,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	2                   
-	totalSize           	2213                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2003,7 +2003,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3306                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2084,7 +2084,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3306                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2162,7 +2162,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3306                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2772,7 +2772,7 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	bucketing_version   	2                   
 	numFiles            	1                   
-	totalSize           	1107                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/deleteAnalyze.q.out
+++ b/ql/src/test/results/clientpositive/llap/deleteAnalyze.q.out
@@ -54,7 +54,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	2                   
 	rawDataSize         	634                 
-	totalSize           	604                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -121,7 +121,7 @@ Table Parameters:
 	numFiles            	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	0                   
+	totalSize           	#Masked#                   
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite.q.out
@@ -63,7 +63,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	408
-totalSize	474
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create materialized view if not exists cmv_mat_view2_n4
 as select a, c from cmv_basetable_n10 where a = 3
@@ -99,7 +99,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	232
-totalSize	340
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: explain
 select a, c from cmv_basetable_n10 where a = 3

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
@@ -296,7 +296,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1554                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -540,7 +540,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1554                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -1099,7 +1099,7 @@ Table Parameters:
 	numFiles            	3                   
 	numRows             	3                   
 	rawDataSize         	0                   
-	totalSize           	2325                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -1415,7 +1415,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	3                   
 	rawDataSize         	0                   
-	totalSize           	1061                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -1725,7 +1725,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1059                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2211,7 +2211,7 @@ Table Parameters:
 	numFiles            	3                   
 	numRows             	3                   
 	rawDataSize         	0                   
-	totalSize           	1828                
+	totalSize           	#Masked#                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_by_text_multi_db.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_by_text_multi_db.q.out
@@ -87,7 +87,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	408
-totalSize	474
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create materialized view if not exists cmv_mat_view2_n2
 as select a, c from db1.cmv_basetable_n7 where a = 3
@@ -123,7 +123,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	232
-totalSize	340
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create database db3
 PREHOOK: type: CREATEDATABASE

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_dummy.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_dummy.q.out
@@ -63,7 +63,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	408
-totalSize	474
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create materialized view if not exists cmv_mat_view2
 as select a, c from cmv_basetable_n0 where a = 3
@@ -99,7 +99,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	232
-totalSize	340
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: explain
 select a, c from cmv_basetable_n0 where a = 3

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_multi_db.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_multi_db.q.out
@@ -87,7 +87,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	408
-totalSize	474
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create materialized view if not exists cmv_mat_view2_n2
 as select a, c from db1.cmv_basetable_n7 where a = 3
@@ -123,7 +123,7 @@ numFiles	1
 numFilesErasureCoded	0
 numRows	2
 rawDataSize	232
-totalSize	340
+totalSize	#Masked#
 #### A masked pattern was here ####
 PREHOOK: query: create database db3
 PREHOOK: type: CREATEDATABASE

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window.q.out
@@ -290,7 +290,7 @@ Table Parameters:
 	numRows             	2                   
 	rawDataSize         	232                 
 	rewriting.time.window	5min                
-	totalSize           	624                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -529,7 +529,7 @@ Table Parameters:
 	numRows             	2                   
 	rawDataSize         	232                 
 	rewriting.time.window	5min                
-	totalSize           	624                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -873,7 +873,7 @@ Table Parameters:
 	numRows             	3                   
 	rawDataSize         	348                 
 	rewriting.time.window	5min                
-	totalSize           	654                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_time_window_2.q.out
@@ -96,7 +96,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	232                 
-	totalSize           	624                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -160,7 +160,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	232                 
-	totalSize           	624                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -224,7 +224,7 @@ Table Parameters:
 	numFiles            	2                   
 	numRows             	3                   
 	rawDataSize         	348                 
-	totalSize           	654                 
+	totalSize           	#Masked#                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/orc_analyze.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_analyze.q.out
@@ -102,7 +102,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	100                 
 	rawDataSize         	53000               
-	totalSize           	3238                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -150,7 +150,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	100                 
 	rawDataSize         	53000               
-	totalSize           	3238                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -239,7 +239,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	100                 
 	rawDataSize         	52600               
-	totalSize           	3238                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -350,7 +350,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22150               
-	totalSize           	2138                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -391,7 +391,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22250               
-	totalSize           	2150                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -444,7 +444,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22150               
-	totalSize           	2138                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -485,7 +485,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22250               
-	totalSize           	2150                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -584,7 +584,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	21950               
-	totalSize           	2138                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -625,7 +625,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22050               
-	totalSize           	2150                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -742,7 +742,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	22155               
-	totalSize           	5424                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -783,7 +783,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	22243               
-	totalSize           	5403                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -836,7 +836,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	22155               
-	totalSize           	5424                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -877,7 +877,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	22243               
-	totalSize           	5403                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -982,7 +982,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	21955               
-	totalSize           	5424                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1023,7 +1023,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	50                  
 	rawDataSize         	22043               
-	totalSize           	5403                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1134,7 +1134,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22150               
-	totalSize           	2138                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1187,7 +1187,7 @@ Partition Parameters:
 	numFiles            	1                   
 	numRows             	50                  
 	rawDataSize         	22150               
-	totalSize           	2138                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/orc_file_dump.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_file_dump.q.out
@@ -93,7 +93,7 @@ PREHOOK: Input: default@orc_ppd_n0
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 1049
 Compression: ZLIB
 Compression size: 262144
@@ -291,7 +291,7 @@ PREHOOK: Input: default@orc_ppd_n0
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 1049
 Compression: ZLIB
 Compression size: 262144
@@ -501,7 +501,7 @@ PREHOOK: Input: default@orc_ppd_part@ds=2015/hr=10
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 1049
 Compression: ZLIB
 Compression size: 262144

--- a/ql/src/test/results/clientpositive/llap/orc_llap_counters.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_llap_counters.q.out
@@ -239,7 +239,7 @@ Table Parameters:
 	orc.bloom.filter.columns	*                   
 	orc.row.index.stride	1000                
 	rawDataSize         	1139514             
-	totalSize           	64520               
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/orc_llap_counters1.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_llap_counters1.q.out
@@ -239,7 +239,7 @@ Table Parameters:
 	orc.bloom.filter.columns	*                   
 	orc.row.index.stride	1000                
 	rawDataSize         	1139514             
-	totalSize           	64520               
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_merge10.q.out
@@ -750,7 +750,7 @@ PREHOOK: Input: default@orcfile_merge1@ds=1/part=0
 PREHOOK: Output: hdfs://### HDFS PATH ###
 -- BEGIN ORC FILE DUMP --
 Structure for hdfs://### HDFS PATH ###
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 242
 Compression: SNAPPY
 Compression size: 4096
@@ -801,7 +801,7 @@ PREHOOK: Input: default@orcfile_merge1c@ds=1/part=0
 PREHOOK: Output: hdfs://### HDFS PATH ###
 -- BEGIN ORC FILE DUMP --
 Structure for hdfs://### HDFS PATH ###
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 242
 Compression: SNAPPY
 Compression size: 4096

--- a/ql/src/test/results/clientpositive/llap/orc_merge11.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_merge11.q.out
@@ -76,7 +76,7 @@ PREHOOK: Input: default@orcfile_merge1_n2
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 50000
 Compression: ZLIB
 Compression size: 4096
@@ -168,7 +168,7 @@ ________________________________________________________________________________
 -- END ORC FILE DUMP --
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 50000
 Compression: ZLIB
 Compression size: 4096
@@ -281,7 +281,7 @@ PREHOOK: Input: default@orcfile_merge1_n2
 #### A masked pattern was here ####
 -- BEGIN ORC FILE DUMP --
 #### A masked pattern was here ####
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 100000
 Compression: ZLIB
 Compression size: 4096

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
@@ -36,7 +36,7 @@ Table Parameters:
 	numFiles            	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	0                   
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -91,7 +91,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	1                   
 	rawDataSize         	0                   
-	totalSize           	666                 
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -447,7 +447,7 @@ Table Parameters:
 	numFiles            	4                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	2730                
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -511,7 +511,7 @@ Table Parameters:
 	numFiles            	6                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	4116                
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -587,7 +587,7 @@ Table Parameters:
 	numFiles            	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	0                   
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/stats_histogram.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram.q.out
@@ -260,7 +260,7 @@ Table Parameters:
 	numFiles            	15                  
 	numRows             	15                  
 	rawDataSize         	4287                
-	totalSize           	11142               
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/stats_histogram_null.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_histogram_null.q.out
@@ -335,7 +335,7 @@ Table Parameters:
 	numFiles            	20                  
 	numRows             	20                  
 	rawDataSize         	5332                
-	totalSize           	14529               
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/stats_part2.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats_part2.q.out
@@ -209,7 +209,7 @@ Table Parameters:
 	numPartitions       	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	0                   
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -279,7 +279,7 @@ Table Parameters:
 	numPartitions       	3                   
 	numRows             	6                   
 	rawDataSize         	0                   
-	totalSize           	4425                
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -376,7 +376,7 @@ Table Parameters:
 	numPartitions       	3                   
 	numRows             	8                   
 	rawDataSize         	0                   
-	totalSize           	5899                
+	totalSize           	#Masked#
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -530,7 +530,7 @@ Partition Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1471                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -565,7 +565,7 @@ Partition Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1477                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -600,7 +600,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	4                   
 	rawDataSize         	0                   
-	totalSize           	2951                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -736,7 +736,7 @@ Partition Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1471                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -771,7 +771,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	2945                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -806,7 +806,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	4                   
 	rawDataSize         	0                   
-	totalSize           	2951                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -872,7 +872,7 @@ Partition Parameters:
 	numFiles            	2                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	1471                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -907,7 +907,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	2                   
 	rawDataSize         	0                   
-	totalSize           	2945                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -942,7 +942,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	4                   
 	rawDataSize         	0                   
-	totalSize           	2951                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1010,7 +1010,7 @@ Partition Parameters:
 	numFiles            	3                   
 	numRows             	1                   
 	rawDataSize         	0                   
-	totalSize           	2182                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1045,7 +1045,7 @@ Partition Parameters:
 	numFiles            	5                   
 	numRows             	1                   
 	rawDataSize         	0                   
-	totalSize           	3649                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -1080,7 +1080,7 @@ Partition Parameters:
 	numFiles            	4                   
 	numRows             	4                   
 	rawDataSize         	0                   
-	totalSize           	2951                
+	totalSize           	#Masked#
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/row__id.q.out
+++ b/ql/src/test/results/clientpositive/row__id.q.out
@@ -74,25 +74,25 @@ STAGE PLANS:
       Map Operator Tree:
           TableScan
             alias: hello_acid
-            Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+            Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
             Select Operator
               expressions: ROW__ID.writeid (type: bigint)
               outputColumnNames: _col0
-              Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+              Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
               Reduce Output Operator
                 key expressions: _col0 (type: bigint)
                 null sort order: z
                 sort order: +
-                Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
       Execution mode: vectorized
       Reduce Operator Tree:
         Select Operator
           expressions: KEY.reducesinkkey0 (type: bigint)
           outputColumnNames: _col0
-          Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+          Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
           File Output Operator
             compressed: false
-            Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+            Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
             table:
                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -148,17 +148,17 @@ STAGE PLANS:
           TableScan
             alias: hello_acid
             filterExpr: (ROW__ID.writeid = 3L) (type: boolean)
-            Statistics: Num rows: 3 Data size: 20144 Basic stats: COMPLETE Column stats: NONE
+            Statistics: Num rows: 3 #Masked# Basic stats: COMPLETE Column stats: NONE
             Filter Operator
               predicate: (ROW__ID.writeid = 3L) (type: boolean)
-              Statistics: Num rows: 1 Data size: 6714 Basic stats: COMPLETE Column stats: NONE
+              Statistics: Num rows: 1 #Masked# Basic stats: COMPLETE Column stats: NONE
               Select Operator
                 expressions: ROW__ID.writeid (type: bigint)
                 outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 6714 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 #Masked# Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 6714 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 #Masked# Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/tez/orc_merge12.q.out
+++ b/ql/src/test/results/clientpositive/tez/orc_merge12.q.out
@@ -144,7 +144,7 @@ PREHOOK: Input: default@alltypesorc3xcols
 PREHOOK: Output: hdfs://### HDFS PATH ###
 -- BEGIN ORC FILE DUMP --
 Structure for hdfs://### HDFS PATH ###
-File Version: 0.12 with ORC_14 by ORC Java 1.8.3
+File Version:#Masked#
 Rows: 24576
 Compression: ZLIB
 Compression size: 131072

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,7 +89,7 @@
     <libthrift.version>0.16.0</libthrift.version>
     <log4j2.version>2.18.0</log4j2.version>
     <mockito-core.version>3.3.3</mockito-core.version>
-    <orc.version>1.8.3</orc.version>
+    <orc.version>1.8.5</orc.version>
     <protobuf.version>3.21.7</protobuf.version>
     <io.grpc.version>1.51.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
ORC is upgraded to use 1.8.5 which contains a fix to use ORC row level filter.The tez.grouping.min-size needed to be changed to have 4 buckets for compaction testing. 

### Why are the changes needed?
To be able to use  ORC row level filter.


### Does this PR introduce _any_ user-facing change?
No.
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
Manually.