### PR TITLE
HIVE-27675: Support keystore/truststore types for hive/zookeeper i…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3012,6 +3012,10 @@ public class HiveConf extends Configuration {
         "Keystore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
             "Overrides any explicit value set via the zookeeper.ssl.keyStore.password " +
              "system property (note the camelCase)."),
+    HIVE_ZOOKEEPER_SSL_KEYSTORE_TYPE("hive.zookeeper.ssl.keystore.type", "",
+        "Keystore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            "Overrides any explicit value set via the zookeeper.ssl.keyStore.type " +
+            "system property (note the camelCase)."),
     HIVE_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION("hive.zookeeper.ssl.truststore.location", "",
         "Truststore location when using a client-side certificate with TLS connectivity to ZooKeeper. " +
             "Overrides any explicit value set via the zookeeper.ssl.trustStore.location" +
@@ -3020,6 +3024,10 @@ public class HiveConf extends Configuration {
         "Truststore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
             "Overrides any explicit value set via the zookeeper.ssl.trustStore.password " +
              "system property (note the camelCase)."),
+    HIVE_ZOOKEEPER_SSL_TRUSTSTORE_TYPE("hive.zookeeper.ssl.truststore.type", "",
+        "Truststore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            "Overrides any explicit value set via the zookeeper.ssl.trustStore.type " +
+            "system property (note the camelCase)."),
     HIVE_ZOOKEEPER_KILLQUERY_ENABLE("hive.zookeeper.killquery.enable", true,
         "Whether enabled kill query coordination with zookeeper, " +
             "when hive.server2.support.dynamic.service.discovery is enabled."),
@@ -5549,8 +5557,10 @@ public class HiveConf extends Configuration {
             "hive.driver.parallel.compilation.global.limit," +
             "hive.zookeeper.ssl.keystore.location," +
             "hive.zookeeper.ssl.keystore.password," +
+            "hive.zookeeper.ssl.keystore.type," +
             "hive.zookeeper.ssl.truststore.location," +
-            "hive.zookeeper.ssl.truststore.password",
+            "hive.zookeeper.ssl.truststore.password," +
+            "hive.zookeeper.ssl.truststore.type",
         "Comma separated list of configuration options which are immutable at runtime"),
     HIVE_CONF_HIDDEN_LIST("hive.conf.hidden.list",
         METASTOREPWD.varname + "," + HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname
@@ -6376,8 +6386,10 @@ public class HiveConf extends Configuration {
       .sslEnabled(getBoolVar(ConfVars.HIVE_ZOOKEEPER_SSL_ENABLE))
       .keyStoreLocation(getVar(ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_LOCATION))
       .keyStorePassword(keyStorePassword)
+      .keyStoreType(getVar(ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_TYPE))
       .trustStoreLocation(getVar(ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION))
-      .trustStorePassword(trustStorePassword).build();
+      .trustStorePassword(trustStorePassword)
+      .trustStoreType(getVar(ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_TYPE)).build();
   }
 
   public HiveConf() {

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperStorage.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperStorage.java
@@ -55,8 +55,10 @@ public class ZooKeeperStorage implements TempletonStorage {
   public static final String ZK_SSL_ENABLE = "templeton.zookeeper.ssl.client.enable";
   public static final String ZK_KEYSTORE_LOCATION = "templeton.zookeeper.keystore.location";
   public static final String ZK_KEYSTORE_PASSWORD = "templeton.zookeeper.keystore.password";
+  public static final String ZK_KEYSTORE_TYPE = "templeton.zookeeper.keystore.type";
   public static final String ZK_TRUSTSTORE_LOCATION = "templeton.zookeeper.truststore.location";
   public static final String ZK_TRUSTSTORE_PASSWORD = "templeton.zookeeper.truststore.password";
+  public static final String ZK_TRUSTSTORE_TYPE = "templeton.zookeeper.truststore.type";
 
   public static final String ENCODING = "UTF-8";
 
@@ -77,8 +79,10 @@ public class ZooKeeperStorage implements TempletonStorage {
         .sslEnabled(conf.getBoolean(ZK_SSL_ENABLE, false))
         .keyStoreLocation(conf.get(ZK_KEYSTORE_LOCATION, ""))
         .keyStorePassword(conf.get(ZK_KEYSTORE_PASSWORD, ""))
+        .keyStoreType(conf.get(ZK_KEYSTORE_TYPE, ""))
         .trustStoreLocation(conf.get(ZK_TRUSTSTORE_LOCATION, ""))
         .trustStorePassword(conf.get(ZK_TRUSTSTORE_PASSWORD, ""))
+        .trustStoreType(conf.get(ZK_TRUSTSTORE_TYPE, ""))
         .build();
     CuratorFramework zk = xkHelper.getNewZookeeperClient();
     zk.start();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/security/ZooKeeperTokenStoreTestBase.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/security/ZooKeeperTokenStoreTestBase.java
@@ -54,6 +54,7 @@ public abstract class ZooKeeperTokenStoreTestBase {
   private static final String LOCALHOST_KEY_STORE_NAME = "keystore.jks";
   private static final String TRUST_STORE_NAME = "truststore.jks";
   private static final String KEY_STORE_TRUST_STORE_PASSWORD = "HiveJdbc";
+  private static final String KEY_STORE_TRUST_STORE_TYPE = "JKS";
 
   private static MiniZooKeeperCluster zkCluster = null;
   private static int zkPort = -1;
@@ -96,10 +97,14 @@ public abstract class ZooKeeperTokenStoreTestBase {
           dataFileDir + File.separator + LOCALHOST_KEY_STORE_NAME);
       conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_KEYSTORE_PASSWORD,
           KEY_STORE_TRUST_STORE_PASSWORD);
+      conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_KEYSTORE_TYPE,
+          KEY_STORE_TRUST_STORE_TYPE);
       conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_LOCATION,
           dataFileDir + File.separator + TRUST_STORE_NAME);
       conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_PASSWORD,
           KEY_STORE_TRUST_STORE_PASSWORD);
+      conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_TYPE,
+          KEY_STORE_TRUST_STORE_TYPE);
       conf.set(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_SSL_ENABLE, "true");
 
     }

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestRestrictedList.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestRestrictedList.java
@@ -105,8 +105,10 @@ public class TestRestrictedList {
     addToExpectedRestrictedMap("hive.driver.parallel.compilation.global.limit");
     addToExpectedRestrictedMap("hive.zookeeper.ssl.keystore.location");
     addToExpectedRestrictedMap("hive.zookeeper.ssl.keystore.password");
+    addToExpectedRestrictedMap("hive.zookeeper.ssl.keystore.type");
     addToExpectedRestrictedMap("hive.zookeeper.ssl.truststore.location");
     addToExpectedRestrictedMap("hive.zookeeper.ssl.truststore.password");
+    addToExpectedRestrictedMap("hive.zookeeper.ssl.truststore.type");
 
     checkRestrictedListMatch();
   }

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/server/InformationSchemaWithPrivilegeTestBase.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/server/InformationSchemaWithPrivilegeTestBase.java
@@ -180,6 +180,7 @@ public abstract class InformationSchemaWithPrivilegeTestBase {
   private static final String LOCALHOST_KEY_STORE_NAME = "keystore.jks";
   private static final String TRUST_STORE_NAME = "truststore.jks";
   private static final String KEY_STORE_TRUST_STORE_PASSWORD = "HiveJdbc";
+  private static final String KEY_STORE_TRUST_STORE_TYPE = "JKS";
 
   private static MiniHS2 miniHS2 = null;
   private static MiniZooKeeperCluster zkCluster = null;
@@ -223,10 +224,14 @@ public abstract class InformationSchemaWithPrivilegeTestBase {
           dataFileDir + File.separator + LOCALHOST_KEY_STORE_NAME);
       confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_PASSWORD.varname,
           KEY_STORE_TRUST_STORE_PASSWORD);
+      confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_TYPE.varname,
+          KEY_STORE_TRUST_STORE_TYPE);
       confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION.varname,
           dataFileDir + File.separator + TRUST_STORE_NAME);
       confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_PASSWORD.varname,
           KEY_STORE_TRUST_STORE_PASSWORD);
+      confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_TYPE.varname,
+          KEY_STORE_TRUST_STORE_TYPE);
       confOverlay.put(ConfVars.HIVE_ZOOKEEPER_SSL_ENABLE.varname, "true");
     }
     miniHS2.start(confOverlay);

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -1009,7 +1009,9 @@ public class HiveConnection implements java.sql.Connection {
         JdbcConnectionParams.SUNJSSE_ALGORITHM_STRING);
       String keyStorePath = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE);
       String keyStorePassword = Utils.getPassword(sessConfMap, JdbcConnectionParams.SSL_KEY_STORE_PASSWORD);
-      KeyStore sslKeyStore = KeyStore.getInstance(JdbcConnectionParams.SSL_KEY_STORE_TYPE);
+      String keyStoreType = sessConfMap.get(JdbcConnectionParams.SSL_KEY_STORE_TYPE);
+      keyStoreType = (!StringUtils.isBlank(keyStoreType)) ? keyStoreType : KeyStore.getDefaultType();
+      KeyStore sslKeyStore = KeyStore.getInstance(keyStoreType);
 
       if (keyStorePath == null || keyStorePath.isEmpty()) {
         throw new IllegalArgumentException(JdbcConnectionParams.SSL_KEY_STORE

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -146,8 +146,10 @@ public class Utils {
     public static final String ZOOKEEPER_SSL_ENABLE = "zooKeeperSSLEnable";
     public static final String ZOOKEEPER_KEYSTORE_LOCATION = "zooKeeperKeystoreLocation";
     public static final String ZOOKEEPER_KEYSTORE_PASSWORD= "zooKeeperKeystorePassword";
+    public static final String ZOOKEEPER_KEYSTORE_TYPE= "zooKeeperKeystoreType";
     public static final String ZOOKEEPER_TRUSTSTORE_LOCATION  = "zooKeeperTruststoreLocation";
     public static final String ZOOKEEPER_TRUSTSTORE_PASSWORD = "zooKeeperTruststorePassword";
+    public static final String ZOOKEEPER_TRUSTSTORE_TYPE = "zooKeeperTruststoreType";
     // Default namespace value on ZooKeeper.
     // This value is used if the param "zooKeeperNamespace" is not specified in the JDBC Uri.
     static final String ZOOKEEPER_DEFAULT_NAMESPACE = "hiveserver2";
@@ -185,7 +187,7 @@ public class Utils {
     static final String TRUE = "true";
     static final String SSL_KEY_STORE = "sslKeyStore";
     static final String SSL_KEY_STORE_PASSWORD = "keyStorePassword";
-    static final String SSL_KEY_STORE_TYPE = "JKS";
+    static final String SSL_KEY_STORE_TYPE = "keyStoreType";
     static final String SUNX509_ALGORITHM_STRING = "SunX509";
     static final String SUNJSSE_ALGORITHM_STRING = "SunJSSE";
    // --------------- End 2 way ssl options ----------------------------
@@ -207,8 +209,10 @@ public class Utils {
     private boolean zooKeeperSslEnabled = false;
     private String zookeeperKeyStoreLocation = "";
     private String zookeeperKeyStorePassword = "";
+    private String zookeeperKeyStoreType;
     private String zookeeperTrustStoreLocation = "";
     private String zookeeperTrustStorePassword = "";
+    private String zookeeperTrustStoreType;
     private String currentHostZnodePath;
     private final List<String> rejectedHostZnodePaths = new ArrayList<String>();
 
@@ -233,8 +237,10 @@ public class Utils {
       this.zooKeeperSslEnabled = params.zooKeeperSslEnabled;
       this.zookeeperKeyStoreLocation = params.zookeeperKeyStoreLocation;
       this.zookeeperKeyStorePassword = params.zookeeperKeyStorePassword;
+      this.zookeeperKeyStoreType = params.zookeeperKeyStoreType;
       this.zookeeperTrustStoreLocation = params.zookeeperTrustStoreLocation;
       this.zookeeperTrustStorePassword = params.zookeeperTrustStorePassword;
+      this.zookeeperTrustStoreType = params.zookeeperTrustStoreType;
 
       this.currentHostZnodePath = params.currentHostZnodePath;
       this.rejectedHostZnodePaths.addAll(rejectedHostZnodePaths);
@@ -291,12 +297,20 @@ public class Utils {
       return zookeeperKeyStorePassword;
     }
 
+    public String getZookeeperKeyStoreType() {
+      return zookeeperKeyStoreType;
+    }
+
     public String getZookeeperTrustStoreLocation() {
       return zookeeperTrustStoreLocation;
     }
 
     public String getZookeeperTrustStorePassword() {
       return zookeeperTrustStorePassword;
+    }
+
+    public String getZookeeperTrustStoreType() {
+      return zookeeperTrustStoreType;
     }
 
     public List<String> getRejectedHostZnodePaths() {
@@ -359,12 +373,20 @@ public class Utils {
       this.zookeeperKeyStorePassword = zookeeperKeyStorePassword;
     }
 
+    public void setZookeeperKeyStoreType(String zookeeperKeyStoreType) {
+      this.zookeeperKeyStoreType = zookeeperKeyStoreType;
+    }
+
     public void setZookeeperTrustStoreLocation(String zookeeperTrustStoreLocation) {
       this.zookeeperTrustStoreLocation = zookeeperTrustStoreLocation;
     }
 
     public void setZookeeperTrustStorePassword(String zookeeperTrustStorePassword) {
       this.zookeeperTrustStorePassword = zookeeperTrustStorePassword;
+    }
+
+    public void setZookeeperTrustStoreType(String zookeeperTrustStoreType) {
+      this.zookeeperTrustStoreType = zookeeperTrustStoreType;
     }
 
     public void setCurrentHostZnodePath(String currentHostZnodePath) {

--- a/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
@@ -103,11 +103,15 @@ class ZooKeeperHiveClientHelper {
       connParams.setZookeeperKeyStorePassword(
           StringUtils.defaultString(Utils.getPassword(sessionConf, JdbcConnectionParams.ZOOKEEPER_KEYSTORE_PASSWORD),
               ""));
+      connParams.setZookeeperKeyStoreType(
+          StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_KEYSTORE_TYPE),""));
       connParams.setZookeeperTrustStoreLocation(
           StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_LOCATION), ""));
       connParams.setZookeeperTrustStorePassword(
           StringUtils.defaultString(Utils.getPassword(sessionConf, JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_PASSWORD),
               ""));
+      connParams.setZookeeperTrustStoreType(
+          StringUtils.defaultString(sessionConf.get(JdbcConnectionParams.ZOOKEEPER_TRUSTSTORE_TYPE),""));
     }
   }
 
@@ -119,8 +123,9 @@ class ZooKeeperHiveClientHelper {
             .retryPolicy(new ExponentialBackoffRetry(1000, 3))
             .zookeeperFactory(
             new SSLZookeeperFactory(connParams.isZooKeeperSslEnabled(), connParams.getZookeeperKeyStoreLocation(),
-                connParams.getZookeeperKeyStorePassword(), connParams.getZookeeperTrustStoreLocation(),
-                connParams.getZookeeperTrustStorePassword()))
+                connParams.getZookeeperKeyStorePassword(), connParams.getZookeeperKeyStoreType(),
+                connParams.getZookeeperTrustStoreLocation(),
+                connParams.getZookeeperTrustStorePassword(), connParams.getZookeeperTrustStoreType()))
             .build();
     zooKeeperClient.start();
     return zooKeeperClient;

--- a/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
@@ -238,8 +238,10 @@ public abstract class ZkRegistryBase<InstanceType extends ServiceInstance> {
         .sslEnabled(HiveConf.getBoolVar(conf, ConfVars.HIVE_ZOOKEEPER_SSL_ENABLE))
         .keyStoreLocation(HiveConf.getVar(conf, ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_LOCATION))
         .keyStorePassword(keyStorePassword)
+        .keyStoreType(HiveConf.getVar(conf, ConfVars.HIVE_ZOOKEEPER_SSL_KEYSTORE_TYPE))
         .trustStoreLocation(HiveConf.getVar(conf, ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION))
         .trustStorePassword(trustStorePassword)
+        .trustStoreType(HiveConf.getVar(conf, ConfVars.HIVE_ZOOKEEPER_SSL_TRUSTSTORE_TYPE))
         .build().getNewZookeeperClient(zooKeeperAclProvider, namespace);
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/SSLZookeeperFactory.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/SSLZookeeperFactory.java
@@ -27,6 +27,8 @@ import org.apache.zookeeper.common.ClientX509Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.KeyStore;
+
 /**
  * Factory to create Zookeeper clients with the zookeeper.client.secure enabled,
  * allowing SSL communication with the Zookeeper server.
@@ -38,22 +40,26 @@ public class SSLZookeeperFactory implements ZookeeperFactory {
   private boolean sslEnabled;
   private String keyStoreLocation;
   private String keyStorePassword;
+  private String keyStoreType;
   private String trustStoreLocation;
   private String trustStorePassword;
+  private String trustStoreType;
 
   public SSLZookeeperFactory(boolean sslEnabled, String keyStoreLocation, String keyStorePassword,
-      String trustStoreLocation, String trustStorePassword) {
+      String keyStoreType, String trustStoreLocation, String trustStorePassword, String trustStoreType) {
 
     this.sslEnabled = sslEnabled;
     this.keyStoreLocation = keyStoreLocation;
     this.keyStorePassword = keyStorePassword;
+    this.keyStoreType = (!StringUtils.isBlank(keyStoreType)) ? keyStoreType : KeyStore.getDefaultType();
     this.trustStoreLocation = trustStoreLocation;
     this.trustStorePassword = trustStorePassword;
+    this.trustStoreType = (!StringUtils.isBlank(trustStoreType)) ? trustStoreType : KeyStore.getDefaultType();
     if (sslEnabled) {
-      if (StringUtils.isEmpty(keyStoreLocation)) {
+      if (StringUtils.isBlank(keyStoreLocation)) {
         LOG.warn("Missing keystoreLocation parameter");
       }
-      if (StringUtils.isEmpty(trustStoreLocation)) {
+      if (StringUtils.isBlank(trustStoreLocation)) {
         LOG.warn("Missing trustStoreLocation parameter");
       }
     }
@@ -71,8 +77,10 @@ public class SSLZookeeperFactory implements ZookeeperFactory {
     ClientX509Util x509Util = new ClientX509Util();
     clientConfig.setProperty(x509Util.getSslKeystoreLocationProperty(), this.keyStoreLocation);
     clientConfig.setProperty(x509Util.getSslKeystorePasswdProperty(), this.keyStorePassword);
+    clientConfig.setProperty(x509Util.getSslKeystoreTypeProperty(), this.keyStoreType);
     clientConfig.setProperty(x509Util.getSslTruststoreLocationProperty(), this.trustStoreLocation);
     clientConfig.setProperty(x509Util.getSslTruststorePasswdProperty(), this.trustStorePassword);
+    clientConfig.setProperty(x509Util.getSslTruststoreTypeProperty(), this.trustStoreType);
     return new ZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly, clientConfig);
   }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/ZooKeeperHiveHelper.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/ZooKeeperHiveHelper.java
@@ -71,8 +71,10 @@ public class ZooKeeperHiveHelper {
     private boolean sslEnabled = false;
     private String keyStoreLocation = null;
     private String keyStorePassword = null;
+    private String keyStoreType = null;
     private String trustStoreLocation = null;
     private String trustStorePassword = null;
+    private String trustStoreType = null;
 
     public ZooKeeperHiveHelper build() {
       return new ZooKeeperHiveHelper(this);
@@ -128,6 +130,11 @@ public class ZooKeeperHiveHelper {
       return this;
     }
 
+    public ZooKeeperHiveHelperBuilder keyStoreType(String keyStoreType) {
+      this.keyStoreType = keyStoreType;
+      return this;
+    }
+
     public ZooKeeperHiveHelperBuilder trustStoreLocation(String trustStoreLocation) {
       this.trustStoreLocation = trustStoreLocation;
       return this;
@@ -135,6 +142,11 @@ public class ZooKeeperHiveHelper {
 
     public ZooKeeperHiveHelperBuilder trustStorePassword(String trustStorePassword) {
       this.trustStorePassword = trustStorePassword;
+      return this;
+    }
+
+    public ZooKeeperHiveHelperBuilder trustStoreType(String trustStoreType) {
+      this.trustStoreType = trustStoreType;
       return this;
     }
 
@@ -178,12 +190,20 @@ public class ZooKeeperHiveHelper {
       return keyStorePassword;
     }
 
+    public String getKeyStoreType() {
+      return keyStoreType;
+    }
+
     public String getTrustStoreLocation() {
       return trustStoreLocation;
     }
 
     public String getTrustStorePassword() {
       return trustStorePassword;
+    }
+
+    public String getTrustStoreType() {
+      return trustStoreType;
     }
   }
 
@@ -233,8 +253,10 @@ public class ZooKeeperHiveHelper {
         new SSLZookeeperFactory(sslEnabled,
             builder.getKeyStoreLocation(),
             builder.getKeyStorePassword(),
+            builder.getKeyStoreType(),
             builder.getTrustStoreLocation(),
-            builder.getTrustStorePassword());
+            builder.getTrustStorePassword(),
+            builder.getTrustStoreType());
 
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1531,6 +1531,11 @@ public class MetastoreConf {
         "Keystore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
             "Overrides any explicit value set via the zookeeper.ssl.keyStore.password" +
             "system property (note the camelCase)."),
+    THRIFT_ZOOKEEPER_SSL_KEYSTORE_TYPE("metastore.zookeeper.ssl.keystore.type",
+        "hive.zookeeper.ssl.keystore.type", "",
+        "Keystore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            "Overrides any explicit value set via the zookeeper.ssl.keyStore.type" +
+            "system property (note the camelCase)."),
     THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION("metastore.zookeeper.ssl.truststore.location",
         "hive.zookeeper.ssl.truststore.location", "",
         "Truststore location when using a client-side certificate with TLS connectivity to ZooKeeper. " +
@@ -1540,6 +1545,11 @@ public class MetastoreConf {
         "hive.zookeeper.ssl.truststore.password", "",
         "Truststore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
             "Overrides any explicit value set via the zookeeper.ssl.trustStore.password " +
+            "system property (note the camelCase)."),
+    THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_TYPE("metastore.zookeeper.ssl.truststore.type",
+        "hive.zookeeper.ssl.truststore.type", "",
+        "Truststore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            "Overrides any explicit value set via the zookeeper.ssl.trustStore.type" +
             "system property (note the camelCase)."),
     THRIFT_URI_SELECTION("metastore.thrift.uri.selection", "hive.metastore.uri.selection", "RANDOM",
         new StringSetValidator("RANDOM", "SEQUENTIAL"),
@@ -2592,8 +2602,10 @@ public class MetastoreConf {
         .sslEnabled(MetastoreConf.getBoolVar(conf, ConfVars.THRIFT_ZOOKEEPER_SSL_ENABLE))
         .keyStoreLocation(MetastoreConf.getVar(conf, ConfVars.THRIFT_ZOOKEEPER_SSL_KEYSTORE_LOCATION))
         .keyStorePassword(keyStorePassword)
+        .keyStoreType(MetastoreConf.getVar(conf, ConfVars.THRIFT_ZOOKEEPER_SSL_KEYSTORE_TYPE))
         .trustStoreLocation(MetastoreConf.getVar(conf, ConfVars.THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION))
-        .trustStorePassword(trustStorePassword).build();
+        .trustStorePassword(trustStorePassword)
+        .trustStoreType(MetastoreConf.getVar(conf, ConfVars.THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_TYPE)).build();
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/MetastoreDelegationTokenManager.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/MetastoreDelegationTokenManager.java
@@ -52,10 +52,14 @@ public class MetastoreDelegationTokenManager {
       "hive.cluster.delegation.token.store.zookeeper.keystore.location";
   public static final String DELEGATION_TOKEN_STORE_ZK_KEYSTORE_PASSWORD =
       "hive.cluster.delegation.token.store.zookeeper.keystore.password";
+  public static final String DELEGATION_TOKEN_STORE_ZK_KEYSTORE_TYPE =
+      "hive.cluster.delegation.token.store.zookeeper.keystore.type";
   public static final String DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_LOCATION =
       "hive.cluster.delegation.token.store.zookeeper.truststore.location";
   public static final String DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_PASSWORD =
       "hive.cluster.delegation.token.store.zookeeper.truststore.password";
+  public static final String DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_TYPE =
+      "hive.cluster.delegation.token.store.zookeeper.truststore.type";
 
   public MetastoreDelegationTokenManager() {
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/ZooKeeperTokenStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/ZooKeeperTokenStore.java
@@ -69,8 +69,10 @@ public class ZooKeeperTokenStore implements DelegationTokenStore {
   private boolean sslEnabled;
   private String keyStoreLocation;
   private String keyStorePassword;
+  private String keyStoreType;
   private String trustStoreLocation;
   private String trustStorePassword;
+  private String trustStoreType;
 
   private List<ACL> newNodeAcl;
   private Configuration conf;
@@ -144,8 +146,10 @@ public class ZooKeeperTokenStore implements DelegationTokenStore {
               .sslEnabled(sslEnabled)
               .keyStoreLocation(keyStoreLocation)
               .keyStorePassword(keyStorePassword)
+              .keyStoreType(keyStoreType)
               .trustStoreLocation(trustStoreLocation)
               .trustStorePassword(trustStorePassword)
+              .trustStoreType(trustStoreType)
               .build();
           zkSession = zkHelper.getNewZookeeperClient(aclDefaultProvider);
           zkSession.start();
@@ -499,10 +503,14 @@ public class ZooKeeperTokenStore implements DelegationTokenStore {
           keyStoreLocation = MetastoreConf.getVar(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_KEYSTORE_LOCATION);
           keyStorePassword =
               MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_KEYSTORE_PASSWORD);
+          keyStoreType =
+              MetastoreConf.getVar(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_KEYSTORE_TYPE);
           trustStoreLocation =
               MetastoreConf.getVar(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_LOCATION);
           trustStorePassword =
               MetastoreConf.getPassword(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_PASSWORD);
+          trustStoreType =
+              MetastoreConf.getVar(conf, MetastoreConf.ConfVars.THRIFT_ZOOKEEPER_SSL_TRUSTSTORE_TYPE);
         } catch (IOException ex) {
           throw new RuntimeException("Failed to read zookeeper configuration passwords", ex);
         }
@@ -517,10 +525,12 @@ public class ZooKeeperTokenStore implements DelegationTokenStore {
           keyStoreLocation = conf.get(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_KEYSTORE_LOCATION, "");
           char[] pwd = conf.getPassword(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_KEYSTORE_PASSWORD);
           keyStorePassword = pwd == null ? null : new String(pwd);
+          keyStoreType = conf.get(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_KEYSTORE_TYPE, "");
           trustStoreLocation =
               conf.get(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_LOCATION, "");
           pwd = conf.getPassword(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_PASSWORD);
           trustStorePassword = pwd == null ? null : new String(pwd);
+          trustStoreType = conf.get(MetastoreDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_TRUSTSTORE_TYPE, "");
         } catch (IOException ex) {
           throw new RuntimeException("Failed to read zookeeper configuration passwords", ex);
         }


### PR DESCRIPTION
…ntegration (Naveen Gangam)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
We have various points in the hive codebase that communicate with zookeeper service.
Apache Hive JDBC Driver fetches the HS2 URLs for service discovery.
Hive Server2 uses ZK to register itself for service discovery, table locking, ZK TokenStore etc.
Hive Metastore also uses ZK to register itself for service discovery, ZK Tokenstore

If Zookeeper is TLS enabled with a different keystore/truststore type, we need to be able to specify this type when establishing this connection. Otherwise, it defaults to JKS which may not be the case all the time.

### Why are the changes needed?
To be able to support service discovery (and other features) that use zookeeper in hive, we have to allow for a keystore/truststore type to be specified in the config.

### Does this PR introduce _any_ user-facing change?
No, its backward compatible. But only in cases where non-JKS storetypes are used, we will need additional configuration either in the JDBC URL or in the hive-site.xml for HS2/HMS services.

### Is the change a dependency upgrade?
No

### How was this patch tested?
UTs