### PR TITLE
HIVE-27687 Logger variable should be static final as its creation takes more time in query compilation

### DIFF
--- a/contrib/src/java/org/apache/hadoop/hive/contrib/serde2/RegexSerDe.java
+++ b/contrib/src/java/org/apache/hadoop/hive/contrib/serde2/RegexSerDe.java
@@ -76,6 +76,8 @@ import org.apache.hadoop.io.Writable;
     RegexSerDe.INPUT_REGEX_CASE_SENSITIVE })
 public class RegexSerDe extends AbstractEncodingAwareSerDe {
 
+  private static final Logger LOG = LoggerFactory.getLogger(RegexSerDe.class);
+
   public static final String INPUT_REGEX = "input.regex";
   public static final String OUTPUT_FORMAT_STRING = "output.format.string";
   public static final String INPUT_REGEX_CASE_SENSITIVE = "input.regex.case.insensitive";
@@ -173,7 +175,7 @@ public class RegexSerDe extends AbstractEncodingAwareSerDe {
       if (unmatchedRows >= nextUnmatchedRows) {
         nextUnmatchedRows = getNextNumberToDisplay(nextUnmatchedRows);
         // Report the row
-        log.warn("{} unmatched rows are found: {}", unmatchedRows, rowText);
+        LOG.warn("{} unmatched rows are found: {}", unmatchedRows, rowText);
       }
       return null;
     }
@@ -187,7 +189,7 @@ public class RegexSerDe extends AbstractEncodingAwareSerDe {
         if (partialMatchedRows >= nextPartialMatchedRows) {
           nextPartialMatchedRows = getNextNumberToDisplay(nextPartialMatchedRows);
           // Report the row
-          log.warn("" + partialMatchedRows
+          LOG.warn("" + partialMatchedRows
               + " partially unmatched rows are found, " + " cannot find group "
               + c + ": " + rowText);
         }

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -42,12 +42,16 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hive.hcatalog.common.HCatException;
 import org.apache.hive.hcatalog.data.schema.HCatSchema;
 import org.apache.hive.hcatalog.data.schema.HCatSchemaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SerDeSpec(schemaProps = {serdeConstants.LIST_COLUMNS,
                           serdeConstants.LIST_COLUMN_TYPES,
                           serdeConstants.TIMESTAMP_FORMATS,
                           serdeConstants.SERIALIZATION_ENCODING})
 public class JsonSerDe extends AbstractEncodingAwareSerDe {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JsonSerDe.class);
 
   private HCatSchema schema;
 
@@ -65,8 +69,8 @@ public class JsonSerDe extends AbstractEncodingAwareSerDe {
     cachedObjectInspector = HCatRecordObjectInspectorFactory.getHCatRecordObjectInspector(rowTypeInfo);
     try {
       schema = HCatSchemaUtils.getHCatSchema(rowTypeInfo).get(0).getStructSubSchema();
-      log.debug("schema : {}", schema);
-      log.debug("fields : {}", schema.getFieldNames());
+      LOG.debug("schema : {}", schema);
+      LOG.debug("fields : {}", schema.getFieldNames());
     } catch (HCatException e) {
       throw new SerDeException(e);
     }

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -65,6 +67,8 @@ import java.util.stream.Collectors;
  */
 @SerDeSpec(schemaProps = { serdeConstants.LIST_COLUMNS, serdeConstants.LIST_COLUMN_TYPES }) public class KafkaSerDe
     extends AbstractSerDe {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaSerDe.class);
 
   /**
    * Delegate SerDe used to Serialize and DeSerialize data form/to Kafka.
@@ -129,7 +133,7 @@ import java.util.stream.Collectors;
       String schemaFromProperty = properties.getProperty(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), "");
       Preconditions.checkArgument(!schemaFromProperty.isEmpty(), "Avro Schema is empty Can not go further");
       Schema schema = AvroSerdeUtils.getSchemaFor(schemaFromProperty);
-      log.debug("Building Avro Reader with schema {}", schemaFromProperty);
+      LOG.debug("Building Avro Reader with schema {}", schemaFromProperty);
       bytesConverter = getByteConverterForAvroDelegate(schema, properties);
     } else {
       bytesConverter = new BytesWritableConverter();

--- a/serde/src/java/org/apache/hadoop/hive/serde2/AbstractEncodingAwareSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/AbstractEncodingAwareSerDe.java
@@ -43,7 +43,7 @@ public abstract class AbstractEncodingAwareSerDe extends AbstractSerDe {
     super.initialize(configuration, tableProperties, partitionProperties);
     charset = Charset.forName(properties.getProperty(serdeConstants.SERIALIZATION_ENCODING, "UTF-8"));
     if (this.charset.equals(Charsets.ISO_8859_1) || this.charset.equals(Charsets.US_ASCII)) {
-      log.warn("The data may not be properly converted to target charset " + charset);
+      log.warn("{} The data may not be properly converted to target charset {}", getClass().getName(), charset);
     }
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/AbstractSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/AbstractSerDe.java
@@ -44,7 +44,7 @@ import com.google.common.base.Preconditions;
  */
 public abstract class AbstractSerDe implements Deserializer, Serializer {
 
-  protected Logger log = LoggerFactory.getLogger(getClass());
+  protected static final Logger log = LoggerFactory.getLogger(AbstractSerDe.class);
 
   protected Optional<Configuration> configuration;
   protected Properties properties;
@@ -90,7 +90,7 @@ public abstract class AbstractSerDe implements Deserializer, Serializer {
     Preconditions.checkArgument(this.columnNames.size() == this.columnTypes.size(),
         "Column names must match count of column types");
 
-    log.debug("SerDe initialized: [{}][{}]", this.configuration, this.properties);
+    log.debug("{} initialized: [{}][{}]", getClass().getName(), this.configuration, this.properties);
   }
 
   protected List<String> parseColumnNames() {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/RegexSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/RegexSerDe.java
@@ -45,6 +45,8 @@ import org.apache.hadoop.io.Writable;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * RegexSerDe uses regular expression (regex) to deserialize data. It doesn't
@@ -70,6 +72,8 @@ import com.google.common.collect.Lists;
     serdeConstants.LIST_COLUMNS, serdeConstants.LIST_COLUMN_TYPES, serdeConstants.SERIALIZATION_ENCODING,
     RegexSerDe.INPUT_REGEX, RegexSerDe.INPUT_REGEX_CASE_SENSITIVE })
 public class RegexSerDe extends AbstractEncodingAwareSerDe {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RegexSerDe.class);
 
   public static final String INPUT_REGEX = "input.regex";
   public static final String INPUT_REGEX_CASE_SENSITIVE = "input.regex.case.insensitive";
@@ -101,7 +105,7 @@ public class RegexSerDe extends AbstractEncodingAwareSerDe {
 
     // output format string is not supported anymore, warn user of deprecation
     if (null != properties.getProperty("output.format.string")) {
-      log.warn("output.format.string has been deprecated");
+      LOG.warn("output.format.string has been deprecated");
     }
 
     // Parse the configuration parameters
@@ -173,7 +177,7 @@ public class RegexSerDe extends AbstractEncodingAwareSerDe {
       unmatchedRowsCount++;
         if (!alreadyLoggedNoMatch) {
          // Report the row if its the first time
-         log.warn("" + unmatchedRowsCount + " unmatched rows are found: " + rowText);
+         LOG.warn("" + unmatchedRowsCount + " unmatched rows are found: " + rowText);
          alreadyLoggedNoMatch = true;
       }
       return null;
@@ -255,7 +259,7 @@ public class RegexSerDe extends AbstractEncodingAwareSerDe {
          partialMatchedRowsCount++;
          if (!alreadyLoggedPartialMatch) {
          // Report the row if its the first row
-         log.warn("" + partialMatchedRowsCount
+         LOG.warn("" + partialMatchedRowsCount
             + " partially unmatched rows are found, " + " cannot find group "
             + c + ": " + rowText);
            alreadyLoggedPartialMatch = true;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Logger variable in AbstractSerDe class was non static. This needs to be a static final in order to prevent multiple copies of Logger variable for the same set of classes.



### Why are the changes needed?
Multiple copies of Logger variable creation adds up time in the compilation of a query.


### Does this PR introduce _any_ user-facing change?
No


### Is the change a dependency upgrade?
No


### How was this patch tested?
Tested in the local machine before and after the patch and verified by checking the time and also the flamegraph
