### PR TITLE
HIVE-27517 SessionState is not correctly initialized when hive.security.authorization.createtable.group.grants is set to automatically grant privileges

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/PrivilegeRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/PrivilegeRegistry.java
@@ -73,6 +73,9 @@ public class PrivilegeRegistry {
   }
 
   private static Privilege getPrivilegeFromRegistry(PrivilegeType ptype) {
+    if (SessionState.get() == null) {
+        throw new IllegalArgumentException("Current Session State has not been set. Cannot obtain privilege.");
+    }
     return SessionState.get().isAuthorizationModeV2() ? RegistryV2.get(ptype) : Registry.get(ptype);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a check for session state not null before it is used when trying to check the authorization mode of the current session.

### Why are the changes needed?
The null pointer exception should not be handled loosely or completely unhandled.

### Does this PR introduce _any_ user-facing change?
Yes. After this PR trying to reproduce the bug mentioned in the JIRA issue would result in an `IllegalArgumentException` with detailed messages rather than a `NullPointerException`.

### Is the change a dependency upgrade?
No

### How was this patch tested?
Through the UT mentioned in the JIRA issue.
