### PR TITLE
HIVE-27558: HBase table query does not push BETWEEN predicate to storage layer

### DIFF
--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -427,6 +428,10 @@ public class HBaseStorageHandler extends DefaultStorageHandler
       ExprNodeDesc predicate) {
     ColumnMapping keyMapping = hBaseSerDe.getHBaseSerdeParam().getKeyColumnMapping();
     ColumnMapping tsMapping = hBaseSerDe.getHBaseSerdeParam().getTimestampColumnMapping();
+
+    // converts 'BETWEEN' predicate to '<= AND >=' predicate
+    predicate = convertBetweenToLTOrEqualAndGTOrEqual(predicate);
+
     IndexPredicateAnalyzer analyzer = HiveHBaseTableInputFormat.newIndexPredicateAnalyzer(
         keyMapping.columnName, keyMapping.isComparable(),
         tsMapping == null ? null : tsMapping.columnName);
@@ -503,6 +508,19 @@ public class HBaseStorageHandler extends DefaultStorageHandler
             continue;
           }
         }
+
+        // In HBase, Keys are sorted lexicographically so the byte representation of negative values comes after the positive values
+        // So don't pushdown the predicate if any constant value is a negative number.
+        // if first condition constant value is less than 0 then don't pushdown the predicate
+        if (((Number) searchConditions.get(0).getConstantDesc().getValue()).longValue() < 0 && scSize == 2) {
+          residualPredicate = extractResidualCondition(analyzer, searchConditions, residualPredicate);
+          continue;
+        }
+        // if second condition constant value is less than 0 then don't pushdown the predicate
+        if (scSize == 2 && ((Number) searchConditions.get(1).getConstantDesc().getValue()).longValue() < 0) {
+          residualPredicate = extractResidualCondition(analyzer, searchConditions, residualPredicate);
+          continue;
+        }
       }
 
       // This one can be pushed
@@ -514,6 +532,31 @@ public class HBaseStorageHandler extends DefaultStorageHandler
     decomposedPredicate.pushedPredicate = pushedPredicate;
     decomposedPredicate.residualPredicate = residualPredicate;
     return decomposedPredicate;
+  }
+
+  private static ExprNodeDesc convertBetweenToLTOrEqualAndGTOrEqual(ExprNodeDesc predicate) {
+    if (predicate instanceof ExprNodeGenericFuncDesc && ((ExprNodeGenericFuncDesc) predicate).getGenericUDF() instanceof GenericUDFBetween && "false".equalsIgnoreCase(
+        predicate.getChildren().get(0).getExprString())) {
+      try {
+        List<ExprNodeDesc> betweenInputs = predicate.getChildren();
+        List<ExprNodeDesc> gtOrEqualInputs = Arrays.asList(betweenInputs.get(1), betweenInputs.get(2));
+        List<ExprNodeDesc> ltOrEqualInputs = Arrays.asList(betweenInputs.get(1), betweenInputs.get(3));
+
+        ExprNodeGenericFuncDesc gtOrEqual =
+            ExprNodeGenericFuncDesc.newInstance(FunctionRegistry.getFunctionInfo(">=").getGenericUDF(), ">=",
+                gtOrEqualInputs);
+        ExprNodeGenericFuncDesc ltOrEqual =
+            ExprNodeGenericFuncDesc.newInstance(FunctionRegistry.getFunctionInfo("<=").getGenericUDF(), "<=",
+                ltOrEqualInputs);
+        List<ExprNodeDesc> andInputs = Arrays.asList(ltOrEqual, gtOrEqual);
+
+        predicate = ExprNodeGenericFuncDesc.newInstance(FunctionRegistry.getFunctionInfo("and").getGenericUDF(), "and",
+            andInputs);
+      } catch (Exception se) {
+        LOG.warn("Unable to convert 'BETWEEN' predicate to '>= AND <=' predicate.", se);
+      }
+    }
+    return predicate;
   }
 
   private static ExprNodeGenericFuncDesc extractStorageHandlerCondition(IndexPredicateAnalyzer analyzer,

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseStorageHandler.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.HiveCustomStorageHandlerUtils;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBetween;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrLessThan;

--- a/hbase-handler/src/test/queries/positive/hbase_between_pushdown.q
+++ b/hbase-handler/src/test/queries/positive/hbase_between_pushdown.q
@@ -1,0 +1,28 @@
+--! qt:dataset:src
+
+CREATE EXTERNAL TABLE hbase_pushdown(key int, value string)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES ("hbase.columns.mapping" = ":key#binary,cf:string")
+TBLPROPERTIES ("external.table.purge" = "true");
+
+INSERT OVERWRITE TABLE hbase_pushdown SELECT * FROM src;
+INSERT INTO hbase_pushdown VALUES(-10, 'NegativeValue10'),(-9, 'NegativeValue9'),(-5, 'NegativeValue5'),(-2, 'NegativeValue2');
+
+explain select * from hbase_pushdown where key >= 90 and key <= 100;
+select * from hbase_pushdown where key >= 90 and key <= 100;
+
+-- In HBase, Keys are sorted lexicographically so the byte representation of negative values comes after the positive values
+-- So don't pushdown the predicate if any constant value is a negative number.
+explain select * from hbase_pushdown where key >= -5 and key <= 5;
+select * from hbase_pushdown where key >= -5 and key <= 5;
+
+-- Here the predicate can be pushed down even though value is negative as its not a range predicate.
+explain select * from hbase_pushdown where key = -5;
+select * from hbase_pushdown where key = -5;
+
+
+set hive.optimize.ppd.storage=false;
+
+-- Now 'BETWEEN' predicate will not convert to '<= AND >=', also 'BETWEEN' predicate will not be pushed down
+explain select * from hbase_pushdown where key >= 90 and key <= 100;
+select * from hbase_pushdown where key >= 90 and key <= 100;

--- a/hbase-handler/src/test/results/positive/hbase_between_pushdown.q.out
+++ b/hbase-handler/src/test/results/positive/hbase_between_pushdown.q.out
@@ -1,0 +1,217 @@
+PREHOOK: query: CREATE EXTERNAL TABLE hbase_pushdown(key int, value string)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES ("hbase.columns.mapping" = ":key#binary,cf:string")
+TBLPROPERTIES ("external.table.purge" = "true")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@hbase_pushdown
+POSTHOOK: query: CREATE EXTERNAL TABLE hbase_pushdown(key int, value string)
+STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+WITH SERDEPROPERTIES ("hbase.columns.mapping" = ":key#binary,cf:string")
+TBLPROPERTIES ("external.table.purge" = "true")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@hbase_pushdown
+PREHOOK: query: INSERT OVERWRITE TABLE hbase_pushdown SELECT * FROM src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@hbase_pushdown
+POSTHOOK: query: INSERT OVERWRITE TABLE hbase_pushdown SELECT * FROM src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@hbase_pushdown
+PREHOOK: query: INSERT INTO hbase_pushdown VALUES(-10, 'NegativeValue10'),(-9, 'NegativeValue9'),(-5, 'NegativeValue5'),(-2, 'NegativeValue2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@hbase_pushdown
+POSTHOOK: query: INSERT INTO hbase_pushdown VALUES(-10, 'NegativeValue10'),(-9, 'NegativeValue9'),(-5, 'NegativeValue5'),(-2, 'NegativeValue2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@hbase_pushdown
+PREHOOK: query: explain select * from hbase_pushdown where key >= 90 and key <= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_pushdown where key >= 90 and key <= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: hbase_pushdown
+          filterExpr: ((key <= 100) and (key >= 90)) (type: boolean)
+          Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: key (type: int), value (type: string)
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+            ListSink
+
+PREHOOK: query: select * from hbase_pushdown where key >= 90 and key <= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_pushdown where key >= 90 and key <= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+90	val_90
+92	val_92
+95	val_95
+96	val_96
+97	val_97
+98	val_98
+100	val_100
+PREHOOK: query: explain select * from hbase_pushdown where key >= -5 and key <= 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_pushdown where key >= -5 and key <= 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: hbase_pushdown
+            Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ((key <= 5) and (key >= -5)) (type: boolean)
+              Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: key (type: int), value (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+      Execution mode: vectorized
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from hbase_pushdown where key >= -5 and key <= 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_pushdown where key >= -5 and key <= 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+0	val_0
+2	val_2
+4	val_4
+5	val_5
+-5	NegativeValue5
+-2	NegativeValue2
+PREHOOK: query: explain select * from hbase_pushdown where key = -5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_pushdown where key = -5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: hbase_pushdown
+          filterExpr: (key = -5) (type: boolean)
+          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: -5 (type: int), value (type: string)
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+            ListSink
+
+PREHOOK: query: select * from hbase_pushdown where key = -5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_pushdown where key = -5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+-5	NegativeValue5
+PREHOOK: query: explain select * from hbase_pushdown where key >= 90 and key <= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from hbase_pushdown where key >= 90 and key <= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: hbase_pushdown
+            Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: key BETWEEN 90 AND 100 (type: boolean)
+              Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: key (type: int), value (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+      Execution mode: vectorized
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from hbase_pushdown where key >= 90 and key <= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+POSTHOOK: query: select * from hbase_pushdown where key >= 90 and key <= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@hbase_pushdown
+#### A masked pattern was here ####
+90	val_90
+92	val_92
+95	val_95
+96	val_96
+97	val_97
+98	val_98
+100	val_100


### PR DESCRIPTION
HIVE-27558: HBase table query does not push BETWEEN predicate to storage layer

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In HBaseStorageHandler, converting 'BETWEEN' predicate back again to '<= AND >=' prediacte and pushing it down to the HBase. Also in HBase, Keys are sorted lexicographically so the byte representation of negative values comes after the positive values so not pushing down the predicate if any constant value is a negative number. If it is not a range predicate like equality condition then it can be pushed down even the constant value is a negative number.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As a part of optimization, '<= AND >=' predicate will be converted as 'BETWEEN' predicate but HBase don't support BETWEEN so this predicate is not pushing down which resulting into a performance issue. Now the 'BETWEEN' predicate is again converting back to '<= AND >=' so that it can be pushed down.  

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
_mvn test -Dtest=TestHBaseCliDriver -Dqfile=hbase_between_pushdown.q -pl itests/qtest -Pitests_