### PR TITLE
HIVE-27694: Include HiveIcebergSerDe in the default list of serdes us…

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1362,7 +1362,8 @@ public class MetastoreConf {
             "org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe," +
             "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe," +
             "org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe," +
-            "org.apache.hadoop.hive.serde2.OpenCSVSerde",
+            "org.apache.hadoop.hive.serde2.OpenCSVSerde," +
+            "org.apache.iceberg.mr.hive.HiveIcebergSerDe",
         "SerDes retrieving schema from metastore. This is an internal parameter."),
     SERDES_WITHOUT_FROM_DESERIALIZER("metastore.serdes.without.from.deserializer",
         "hive.metastore.serdes.without.from.deserializer",


### PR DESCRIPTION
…ing HMS (Naveen Gangam)
### What changes were proposed in this pull request?
A change to default config value for "**metastore.serdes.using.metastore.for.schema**" that has a list of serdes that use HMS for their table metadata. This list current is
org.apache.hadoop.hive.ql.io.orc.OrcSerde
org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe
org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe
org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe
org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
org.apache.hadoop.hive.serde2.OpenCSVSerde

The proposed change adds the following to this list.
org.apache.iceberg.mr.hive.HiveIcebergSerDe

### Why are the changes needed?
Without this change, DatabaseMetaData APIs will not work for Iceberg tables in Hive.

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO

### How was this patch tested?
Manually