### PR TITLE
HIVE-27696: Docker build from source should include iceberg profile.

### DIFF
--- a/packaging/src/docker/build.sh
+++ b/packaging/src/docker/build.sh
@@ -95,7 +95,7 @@ if [ -n "$HIVE_VERSION" ]; then
 else
     HIVE_VERSION=$(mvn -f "$SOURCE_DIR/pom.xml" -q help:evaluate -Dexpression=project.version -DforceStdout)
     HIVE_TAR="$SOURCE_DIR/packaging/target/apache-hive-$HIVE_VERSION-bin.tar.gz"
-    if  ls $HIVE_TAR || mvn -f $SOURCE_DIR/pom.xml clean package -DskipTests -Pdist; then
+    if  ls $HIVE_TAR || mvn -f $SOURCE_DIR/pom.xml clean package -DskipTests -Pdist -Piceberg; then
       cp "$HIVE_TAR" "$WORK_DIR/"
     else
       echo "Failed to compile Hive Project, exiting..."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add iceberg profile in docker build from source

### Why are the changes needed?

Iceberg works for released versions, but not when building images from source

### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

Tested locally by building the image locally from source & creating an iceberg table.