### PR TITLE
HIVE-27700: backport of HIVE-19081: Add partition should prevent loading acid files (Igor Kry…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -461,7 +461,7 @@ public enum ErrorMsg {
     "Grouping sets size cannot be greater than 64"),
   REBUILD_NO_MATERIALIZED_VIEW(10412, "Rebuild command only valid for materialized views"),
   LOAD_DATA_ACID_FILE(10413,
-      "\"{0}\" was created created by Acid write - it cannot be loaded into anther Acid table",
+      "\"{0}\" was created by Acid write - it cannot be loaded into anther Acid table",
       true),
   ACID_OP_ON_INSERTONLYTRAN_TABLE(10414, "Attempt to do update or delete on table {0} that is " +
     "insert-only transactional", true),

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hive.ql.exec.Utilities.COPY_KEYWORD;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,6 +71,8 @@ import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.LoadSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.CreateTableDesc;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -2323,5 +2327,44 @@ public class AcidUtils {
       lockComponents.add(comp);
     }
     return lockComponents;
+  }
+
+  /**
+   * Safety check to make sure a file take from one acid table is not added into another acid table
+   * since the ROW__IDs embedded as part a write to one table won't make sense in different
+   * table/cluster.
+   */
+  public static void validateAcidFiles(Table table, FileStatus[] srcs, FileSystem fs) throws SemanticException {
+    if (!AcidUtils.isFullAcidTable(table)) {
+      return;
+    }
+    validateAcidFiles(srcs, fs);
+  }
+
+  private static void validateAcidFiles(FileStatus[] srcs, FileSystem fs) throws SemanticException {
+    try {
+      for (FileStatus oneSrc : srcs) {
+        if (!AcidUtils.MetaDataFile.isRawFormatFile(oneSrc.getPath(), fs)) {
+          throw new SemanticException(ErrorMsg.LOAD_DATA_ACID_FILE, oneSrc.getPath().toString());
+        }
+      }
+    } catch (IOException ex) {
+      throw new SemanticException(ex);
+    }
+  }
+
+  /**
+   * Safety check to make sure the given location is not the location of acid table and
+   * all it's files  will be not added into another acid table
+   */
+  public static void validateAcidPartitionLocation(String location, Configuration conf) throws SemanticException {
+    try {
+      URI uri = new URI(location);
+      FileSystem fs = FileSystem.get(uri, conf);
+      FileStatus[] fileStatuses = LoadSemanticAnalyzer.matchFilesOrDir(fs, new Path(uri));
+      validateAcidFiles(fileStatuses, fs);
+    } catch (IOException | URISyntaxException ex) {
+      throw new SemanticException(ErrorMsg.INVALID_PATH.getMsg(ex.getMessage()), ex);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/DDLSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/DDLSemanticAnalyzer.java
@@ -3625,6 +3625,7 @@ public class DDLSemanticAnalyzer extends BaseSemanticAnalyzer {
     for (int index = 0; index < addPartitionDesc.getPartitionCount(); index++) {
       OnePartitionDesc desc = addPartitionDesc.getPartition(index);
       if (desc.getLocation() != null) {
+        AcidUtils.validateAcidPartitionLocation(desc.getLocation(), conf);
         if(addPartitionDesc.isIfNotExists()) {
           //Don't add partition data if it already exists
           Partition oldPart = getPartition(tab, desc.getPartSpec(), false);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -185,7 +185,7 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
           return null;
         }
       }
-      validateAcidFiles(table, srcs, fileSystem);
+      AcidUtils.validateAcidFiles(table, srcs, fileSystem);
       // Do another loop if table is bucketed
       List<String> bucketCols = table.getBucketCols();
       if (bucketCols != null && !bucketCols.isEmpty()) {
@@ -222,27 +222,6 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     return Lists.newArrayList(srcs);
   }
 
-  /**
-   * Safety check to make sure a file take from one acid table is not added into another acid table
-   * since the ROW__IDs embedded as part a write to one table won't make sense in different
-   * table/cluster.
-   */
-  private static void validateAcidFiles(Table table, FileStatus[] srcs, FileSystem fs)
-      throws SemanticException {
-    if(!AcidUtils.isFullAcidTable(table)) {
-      return;
-    }
-    try {
-      for (FileStatus oneSrc : srcs) {
-        if (!AcidUtils.MetaDataFile.isRawFormatFile(oneSrc.getPath(), fs)) {
-          throw new SemanticException(ErrorMsg.LOAD_DATA_ACID_FILE, oneSrc.getPath().toString());
-        }
-      }
-    }
-    catch(IOException ex) {
-      throw new SemanticException(ex);
-    }
-  }
 
   @Override
   public void init(boolean clearPartsCache) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnAddPartition.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnAddPartition.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,10 @@ public class TestTxnAddPartition extends TxnCommandsBaseForTests {
       ).getPath().replaceAll("\\\\", "/");
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+
 
   @Override
   String getTestDataDir() {
@@ -275,5 +280,24 @@ public class TestTxnAddPartition extends TxnCommandsBaseForTests {
   @Ignore
   @Test
   public void testLocks() throws Exception {
+  }
+
+
+  @Test
+  public void addPartitionTransactional() throws Exception {
+    exception.expect(RuntimeException.class);
+    exception.expectMessage("was created by Acid write");
+
+    runStatementOnDriver("drop table if exists T");
+    runStatementOnDriver("drop table if exists Tstage");
+    runStatementOnDriver("create table T (a int, b int) partitioned by (p int) " +
+        "clustered by (a) into 2 buckets stored as orc tblproperties('transactional'='true')");
+    runStatementOnDriver("create table Tstage (a int, b int)  partitioned by (p int) clustered by (a) into 2 " +
+        "buckets stored as orc tblproperties('transactional'='true')");
+
+    runStatementOnDriver("insert into Tstage partition(p=1) values(0,2),(1,4)");
+
+    runStatementOnDriver("ALTER TABLE T ADD PARTITION (p=0) location '"
+        + getWarehouseDir() + "/tstage/p=1/delta_0000001_0000001_0000/bucket_00001'");
   }
 }


### PR DESCRIPTION
This is a backport of [HIVE-19081](https://issues.apache.org/jira/browse/HIVE-19081):  Add partition should prevent loading acid files
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27700](https://issues.apache.org/jira/browse/HIVE-27700)