### PR TITLE
HIVE-27597: Implement data connector for Hive to Hive federation over…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/AbstractDataConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/AbstractDataConnectorProvider.java
@@ -148,4 +148,7 @@ public abstract class AbstractDataConnectorProvider implements IDataConnectorPro
   abstract protected String getOutputClass();
 
   abstract protected String getTableLocation(String tblName);
+
+  abstract protected String getDatasourceType();
+
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/DataConnectorProviderFactory.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.DERBY_TYPE;
+import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.HIVE_JDBC_TYPE;
 import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.MSSQL_TYPE;
 import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.MYSQL_TYPE;
 import static org.apache.hadoop.hive.metastore.dataconnector.IDataConnectorProvider.ORACLE_TYPE;
@@ -98,6 +99,7 @@ public class DataConnectorProviderFactory {
     String type = connector.getType();
     switch (type) {
     case DERBY_TYPE:
+    case HIVE_JDBC_TYPE:
     case MSSQL_TYPE:
     case MYSQL_TYPE:
     case ORACLE_TYPE:

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/IDataConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/IDataConnectorProvider.java
@@ -41,6 +41,7 @@ public interface IDataConnectorProvider {
   public static final String ORACLE_TYPE = "oracle";
   public static final String MSSQL_TYPE = "mssql";
   public static final String DERBY_TYPE = "derby";
+  public static final String HIVE_JDBC_TYPE = "hivejdbc";
 
   DataConnector connector = null;
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/JDBCConnectorProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/JDBCConnectorProviderFactory.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore.dataconnector;
 
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.dataconnector.jdbc.DerbySQLConnectorProvider;
+import org.apache.hadoop.hive.metastore.dataconnector.jdbc.HiveJDBCConnectorProvider;
 import org.apache.hadoop.hive.metastore.dataconnector.jdbc.MySQLConnectorProvider;
 import org.apache.hadoop.hive.metastore.dataconnector.jdbc.PostgreSQLConnectorProvider;
 import org.apache.hadoop.hive.metastore.dataconnector.jdbc.OracleConnectorProvider;
@@ -49,6 +50,10 @@ public class JDBCConnectorProviderFactory {
 
     case MSSQL_TYPE:
       provider = new MSSQLConnectorProvider(dbName, connector);
+      break;
+
+    case HIVE_JDBC_TYPE:
+      provider = new HiveJDBCConnectorProvider(dbName, connector);
       break;
 
     default:

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
@@ -75,7 +75,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
   private static final String JDBC_INPUTFORMAT_CLASS = "org.apache.hive.storage.jdbc.JdbcInputFormat".intern();
   private static final String JDBC_OUTPUTFORMAT_CLASS = "org.apache.hive.storage.jdbc.JdbcOutputFormat".intern();
 
-  String type = null; // MYSQL, POSTGRES, ORACLE, DERBY, MSSQL, DB2 etc.
+  String type = null; // MYSQL, POSTGRES, ORACLE, DERBY, MSSQL, DB2, HIVEJDBC etc.
   String jdbcUrl = null;
   String username = null;
   String password = null; // TODO convert to byte array
@@ -270,7 +270,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
 
       table = buildTableFromColsList(tableName, cols);
       //Setting the table properties.
-      table.getParameters().put(JDBC_DATABASE_TYPE, this.type);
+      table.getParameters().put(JDBC_DATABASE_TYPE, getDatasourceType());
       table.getParameters().put(JDBC_DRIVER, this.driverClassName);
       table.getParameters().put(JDBC_TABLE, tableName);
       table.getParameters().put(JDBC_SCHEMA, scoped_db);
@@ -415,4 +415,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     connectorPropMap.forEach((k, v) -> connectionProperties.put(k, v));
     return connectionProperties;
   }
+
+  @Override
+  protected String getDatasourceType() { return type; };
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
@@ -111,7 +111,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     try {
       Class.forName(driverClassName);
     } catch (ClassNotFoundException cnfe) {
-      LOG.warn("Driver class not found in classpath:" + driverClassName);
+      LOG.warn("Driver class not found in classpath: {}" + driverClassName);
       throw new RuntimeException("Driver class not found:" + driverClass.getClass().getName(), cnfe);
     }
   }
@@ -121,7 +121,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       close();
       handle = DriverManager.getDriver(jdbcUrl).connect(jdbcUrl, getConnectionProperties());
     } catch (SQLException sqle) {
-      LOG.warn("Could not connect to remote data source at " + jdbcUrl);
+      LOG.warn("Could not connect to remote data source at {}", jdbcUrl);
       throw new ConnectException("Could not connect to remote datasource at " + jdbcUrl + ",cause:" + sqle.getMessage());
     }
   }
@@ -155,7 +155,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       if (handle instanceof Connection)
         return ((Connection) handle).isClosed();
     } catch (SQLException e) {
-      LOG.warn("Could not determine whether jdbc connection is closed or not to "+ jdbcUrl, e);
+      LOG.warn("Could not determine whether jdbc connection, to {}, is closed or not: {} ", jdbcUrl, e);
     }
     return true;
   }
@@ -165,7 +165,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       try {
         ((Connection)handle).close();
       } catch (SQLException sqle) {
-        LOG.warn("Could not close jdbc connection to " + jdbcUrl, sqle);
+        LOG.warn("Could not close jdbc connection to {}: {}", jdbcUrl, sqle);
         throw new RuntimeException(sqle);
       }
     }
@@ -191,7 +191,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
         return tables;
       }
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve tables from remote datasource, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve tables from remote datasource, cause: {}", sqle.getMessage());
       throw new MetaException("Error retrieving remote table:" + sqle);
     } finally {
       try {
@@ -221,7 +221,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
         return tables;
       }
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve table names from remote datasource, cause: {}", sqle.getMessage());
       throw new MetaException("Error retrieving remote table:" + sqle);
     } finally {
       try {
@@ -239,7 +239,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     try {
       rs = getConnection().getMetaData().getTables(getCatalogName(), getDatabaseName(), null, new String[] { "TABLE" });
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve table names from remote datasource, cause: {}", sqle.getMessage());
       throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
     }
     return rs;
@@ -255,7 +255,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     try {
       rs = getConnection().getMetaData().getTables(getCatalogName(), getDatabaseName(), null, new String[] { "TABLE" });
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve table names from remote datasource, cause: {}", sqle.getMessage());
       throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
     }
     return rs;
@@ -308,8 +308,8 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       }
       return table;
     } catch (Exception e) {
-      LOG.warn("Exception retrieving remote table " + scoped_db + "." + tableName + " via data connector "
-              + connector.getName());
+      LOG.warn("Exception retrieving remote table {}.{} via data connector {}", scoped_db, tableName
+              ,connector.getName());
       throw new MetaException("Error retrieving remote table:" + e);
     } finally {
       try {
@@ -325,7 +325,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     try {
       rs = getConnection().getMetaData().getTables(getCatalogName(), getDatabaseName(), regex, new String[]{"TABLE"});
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve tables from JDBC table, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve tables from JDBC table, cause: {}", sqle.getMessage());
       throw sqle;
     }
     return rs;
@@ -336,7 +336,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     try {
       rs = getConnection().getMetaData().getColumns(getCatalogName(), getDatabaseName(), tableName, null);
     } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve columns from JDBC table, cause:" + sqle.getMessage());
+      LOG.warn("Could not retrieve columns from JDBC table, cause: {}", sqle.getMessage());
       throw sqle;
     }
     return rs;
@@ -425,7 +425,7 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
       try {
         return warehouse.getDefaultTablePath(scoped_db, tableName, true).toString();
       } catch (MetaException e) {
-        LOG.info("Error determining default table path, cause:" + e.getMessage());
+        LOG.info("Error determining default table path, cause: {}", e.getMessage());
       }
     }
     return "some_dummy_path";
@@ -440,5 +440,5 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
   }
 
   @Override
-  protected String getDatasourceType() { return type; };
+  protected String getDatasourceType() { return type; }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/AbstractJDBCConnectorProvider.java
@@ -234,9 +234,32 @@ public abstract class AbstractJDBCConnectorProvider extends AbstractDataConnecto
     return null;
   }
 
-  protected abstract ResultSet fetchTableMetadata(String tableName) throws MetaException;
+  protected ResultSet fetchTableMetadata(String tableName) throws MetaException {
+    ResultSet rs = null;
+    try {
+      rs = getConnection().getMetaData().getTables(getCatalogName(), getDatabaseName(), null, new String[] { "TABLE" });
+    } catch (SQLException sqle) {
+      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+    }
+    return rs;
+  }
 
-  protected abstract ResultSet fetchTableNames() throws MetaException;
+  /**
+   * Returns a list of all table names from the remote database.
+   * @return List A collection of all the table names, null if there are no tables.
+   * @throws MetaException To indicate any failures with executing this API
+   */
+  protected ResultSet fetchTableNames() throws MetaException {
+    ResultSet rs = null;
+    try {
+      rs = getConnection().getMetaData().getTables(getCatalogName(), getDatabaseName(), null, new String[] { "TABLE" });
+    } catch (SQLException sqle) {
+      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
+    }
+    return rs;
+  }
 
   protected abstract String getCatalogName();
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/DerbySQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/DerbySQLConnectorProvider.java
@@ -38,23 +38,6 @@ public class DerbySQLConnectorProvider extends AbstractJDBCConnectorProvider {
   }
 
   /**
-   * Returns a list of all table names from the remote database.
-   * @return List A collection of all the table names, null if there are no tables.
-   * @throws MetaException To indicate any failures with executing this API
-   */
-  @Override
-  protected ResultSet fetchTableNames() throws MetaException {
-    ResultSet rs = null;
-    try {
-      rs = getConnection().getMetaData().getTables(scoped_db, null, null, new String[] { "TABLE" });
-    } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
-    }
-    return rs;
-  }
-
-  /**
    * Fetch a single table with the given name, returns a Hive Table object from the remote database
    * @return Table A Table object for the matching table, null otherwise.
    * @throws MetaException To indicate any failures with executing this API

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/HiveJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/HiveJDBCConnectorProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore.dataconnector.jdbc;
+
+import org.apache.hadoop.hive.metastore.ColumnType;
+import org.apache.hadoop.hive.metastore.api.DataConnector;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class HiveJDBCConnectorProvider extends AbstractJDBCConnectorProvider {
+  private static Logger LOG = LoggerFactory.getLogger(HiveJDBCConnectorProvider.class);
+
+  private static final String DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver".intern();
+
+  public HiveJDBCConnectorProvider(String dbName, DataConnector dataConn) {
+    super(dbName, dataConn, DRIVER_CLASS);
+  }
+
+  /**
+   * Returns a list of all table names from the remote database.
+   * @return List A collection of all the table names, null if there are no tables.
+   * @throws MetaException To indicate any failures with executing this API
+   */
+  @Override protected ResultSet fetchTableNames() throws MetaException {
+    ResultSet rs = null;
+    try {
+      rs = getConnection().getMetaData().getTables(scoped_db, null, null, new String[] { "TABLE" });
+    } catch (SQLException sqle) {
+      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
+      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
+    }
+    return rs;
+  }
+
+  /**
+   * Fetch a single table with the given name, returns a Hive Table object from the remote database
+   * @return Table A Table object for the matching table, null otherwise.
+   * @throws MetaException To indicate any failures with executing this API
+   * @param tableName
+   */
+  @Override public ResultSet fetchTableMetadata(String tableName) throws MetaException {
+    ResultSet rs = null;
+    try {
+      rs = getConnection().getMetaData().getColumns(null, scoped_db, tableName, null);
+    } catch (Exception ex) {
+      LOG.warn("Could not retrieve table names from remote datasource, cause:" + ex.getMessage());
+      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + ex);
+    }
+    return rs;
+}
+
+  @Override protected String getCatalogName() {
+    return null;
+  }
+
+  @Override protected String getDatabaseName() {
+    return scoped_db;
+  }
+
+  protected String getDataType(String dbDataType, int size) {
+    String mappedType = super.getDataType(dbDataType, size);
+    if (!mappedType.equalsIgnoreCase(ColumnType.VOID_TYPE_NAME)) {
+      return mappedType;
+    }
+
+    // map any db specific types here.
+    switch (dbDataType.toLowerCase())
+    {
+      case "string":
+        mappedType = ColumnType.STRING_TYPE_NAME;
+        break;
+      default:
+        mappedType = ColumnType.VOID_TYPE_NAME;
+        break;
+    }
+    return mappedType;
+  }
+
+  @Override protected  String getDatasourceType() { return "HIVE"; }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/HiveJDBCConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/HiveJDBCConnectorProvider.java
@@ -29,7 +29,7 @@ import java.sql.SQLException;
 
 public class HiveJDBCConnectorProvider extends AbstractJDBCConnectorProvider {
   private static final Logger LOG = LoggerFactory.getLogger(HiveJDBCConnectorProvider.class);
-  private static final String DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver".intern();
+  private static final String DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";
   // for Hive the type for connector is "HIVEJDBC" where as on the table we want it to be "HIVE"
   protected static final String mappedType = "HIVE";
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MSSQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MSSQLConnectorProvider.java
@@ -39,28 +39,6 @@ public class MSSQLConnectorProvider extends AbstractJDBCConnectorProvider {
         driverClassName = DRIVER_CLASS;
     }
 
-    @Override protected ResultSet fetchTableMetadata(String tableName) throws MetaException {
-        ResultSet rs = null;
-        try {
-            rs = getConnection().getMetaData().getColumns(null, scoped_db, tableName, null);
-        } catch (Exception ex) {
-            LOG.warn("Could not retrieve table names from remote datasource, cause:" + ex.getMessage());
-            throw new MetaException("Could not retrieve table names from remote datasource, cause:" + ex);
-        }
-        return rs;
-    }
-
-    @Override protected ResultSet fetchTableNames() throws MetaException {
-        ResultSet rs = null;
-        try {
-            rs = getConnection().getMetaData().getTables(null, scoped_db, null, new String[] { "TABLE" });
-        } catch (SQLException sqle) {
-            LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-            throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
-        }
-        return rs;
-    }
-
     @Override protected String getCatalogName() {
         return null;
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
@@ -38,22 +38,6 @@ public class MySQLConnectorProvider extends AbstractJDBCConnectorProvider {
   }
 
   /**
-   * Returns a list of all table names from the remote database.
-   * @return List A collection of all the table names, null if there are no tables.
-   * @throws MetaException To indicate any failures with executing this API
-   */
-  @Override protected ResultSet fetchTableNames() throws MetaException {
-    ResultSet rs = null;
-    try {
-      rs = getConnection().getMetaData().getTables(scoped_db, null, null, new String[] { "TABLE" });
-    } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
-    }
-    return rs;
-  }
-
-  /**
    * Fetch a single table with the given name, returns a Hive Table object from the remote database
    * @return Table A Table object for the matching table, null otherwise.
    * @throws MetaException To indicate any failures with executing this API

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/OracleConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/OracleConnectorProvider.java
@@ -39,28 +39,6 @@ public class OracleConnectorProvider extends AbstractJDBCConnectorProvider {
         driverClassName = DRIVER_CLASS;
     }
 
-    @Override protected ResultSet fetchTableMetadata(String tableName) throws MetaException {
-        ResultSet rs = null;
-        try {
-            rs = getConnection().getMetaData().getColumns(null, scoped_db, tableName, null);
-        } catch (Exception ex) {
-            LOG.warn("Could not retrieve table names from remote datasource, cause:" + ex.getMessage());
-            throw new MetaException("Could not retrieve table names from remote datasource, cause:" + ex);
-        }
-        return rs;
-    }
-
-    @Override protected ResultSet fetchTableNames() throws MetaException {
-        ResultSet rs = null;
-        try {
-            rs = getConnection().getMetaData().getTables(null, scoped_db, null, new String[] { "TABLE" });
-        } catch (SQLException sqle) {
-            LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-            throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle);
-        }
-        return rs;
-    }
-
     @Override protected String getCatalogName() {
         return null;
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/PostgreSQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/PostgreSQLConnectorProvider.java
@@ -35,21 +35,6 @@ public class PostgreSQLConnectorProvider extends AbstractJDBCConnectorProvider {
     super(dbName, dataConn, DRIVER_CLASS);
   }
 
-  @Override protected ResultSet fetchTableMetadata(String tableName) throws MetaException {
-    ResultSet rs = null;
-    try {
-      rs = getConnection().getMetaData().getTables(scoped_db, null, null, new String[] { "TABLE" });
-    } catch (SQLException sqle) {
-      LOG.warn("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-      throw new MetaException("Could not retrieve table names from remote datasource, cause:" + sqle.getMessage());
-    }
-    return rs;
-  }
-
-  @Override protected ResultSet fetchTableNames() throws MetaException {
-    return null;
-  }
-
   @Override protected String getCatalogName() {
     return scoped_db;
   }


### PR DESCRIPTION
… JDBC (Naveen Gangam)

### What changes were proposed in this pull request?
In HIVE-23291 and HIVE-23302, we added support adding a JDBCStorageHandler based table for remote Hive table. This enables defining a table in hive on one cluster that points to a table in another cluster. Users can perform queries (selects, joins, ctas etc) between this JDBC-storage-handler based table and other local tables.

However, it becomes cumbersome to map each table individually between these clusters. With HIVE-24396, we added support for connectors that allow us to map databases instead of tables. The table metadata is mapped at runtime over a live connector. This allows hive to pull the latest table metadata instead of having a static metadata in HMS.

This PR does not support Kerberos at this point. But that could be a separate enhancement. (the mechanics of kerberos auth may not fit into the current way it works for password-based data sources)

**create connector hive_jdbc 
    type 'hivejdbc' 
    url 'jdbc:hive2://nightly.hive.apache.org:10000' 
    with DCPROPERTIES (
        "hive.sql.dbcp.username"="hive", 
        "hive.sql.dbcp.password"="hive"
    );**

**create remote database nightly_default using hive_jdbc with DBPROPERTIES("connector.remoteDbName"="default");**

Sample working demo:
0: jdbc:hive2://localhost:10000> **_create connector hive_jdbc type 'hivejdbc' url 'jdbc:hive2://nightly.hive.apache.org:10000' with DCPROPERTIES ("hive.sql.dbcp.username"="hive", "hive.sql.dbcp.password"="hive");_**
INFO  : Compiling command(queryId=ngangam_20230918152209_83f300d9-58e1-42fd-a7b4-b5c82e5bbc63): create connector hive_jdbc type 'hivejdbc' url 'jdbc:hive2://nightly.hive.apache.org:10000' with DCPROPERTIES ("hive.sql.dbcp.username"="hive", "hive.sql.dbcp.password"="hive")
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:null, properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152209_83f300d9-58e1-42fd-a7b4-b5c82e5bbc63); Time taken: 1.698 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152209_83f300d9-58e1-42fd-a7b4-b5c82e5bbc63): create connector hive_jdbc type 'hivejdbc' url 'jdbc:hive2://nightly.hive.apache.org:10000' with DCPROPERTIES ("hive.sql.dbcp.username"="hive", "hive.sql.dbcp.password"="hive")
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152209_83f300d9-58e1-42fd-a7b4-b5c82e5bbc63); Time taken: 0.25 seconds
INFO  : OK
No rows affected (2.274 seconds)

0: jdbc:hive2://localhost:10000> **_create remote database nightly_default using hive_jdbc with DBPROPERTIES("connector.remoteDbName"="default");_**
INFO  : Compiling command(queryId=ngangam_20230918152225_58e8bfd4-9cf0-4505-9aa3-012be57e23d6): create remote database nightly_default using hive_jdbc with DBPROPERTIES("connector.remoteDbName"="default")
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:null, properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152225_58e8bfd4-9cf0-4505-9aa3-012be57e23d6); Time taken: 0.014 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152225_58e8bfd4-9cf0-4505-9aa3-012be57e23d6): create remote database nightly_default using hive_jdbc with DBPROPERTIES("connector.remoteDbName"="default")
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152225_58e8bfd4-9cf0-4505-9aa3-012be57e23d6); Time taken: 0.06 seconds
INFO  : OK
No rows affected (0.092 seconds)

0: jdbc:hive2://localhost:10000> **_use nightly_default;_**
INFO  : Compiling command(queryId=ngangam_20230918152528_7af75a5a-54a3-48f0-90cb-209cf236c204): use nightly_default
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:null, properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152528_7af75a5a-54a3-48f0-90cb-209cf236c204); Time taken: 0.003 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152528_7af75a5a-54a3-48f0-90cb-209cf236c204): use nightly_default
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152528_7af75a5a-54a3-48f0-90cb-209cf236c204); Time taken: 0.158 seconds
INFO  : OK
No rows affected (0.176 seconds)

0: jdbc:hive2://localhost:10000> **_show tables;_**
INFO  : Compiling command(queryId=ngangam_20230918152530_5b5c754b-db5f-47ae-a880-b181757cfa4e): show tables
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:[FieldSchema(name:tab_name, type:string, comment:from deserializer)], properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152530_5b5c754b-db5f-47ae-a880-b181757cfa4e); Time taken: 0.01 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152530_5b5c754b-db5f-47ae-a880-b181757cfa4e): show tables
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152530_5b5c754b-db5f-47ae-a880-b181757cfa4e); Time taken: 3.8 seconds
INFO  : OK
+------------+
|  tab_name  |
+------------+
| sample_07  |
| sample_08  |
| web_logs   |
+------------+
3 rows selected (3.84 seconds)

0: jdbc:hive2://localhost:10000> **_describe formatted web_logs;_**
INFO  : Compiling command(queryId=ngangam_20230918152542_170176a0-92ff-408b-9133-eab9a1953c23): describe formatted web_logs
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:[FieldSchema(name:col_name, type:string, comment:from deserializer), FieldSchema(name:data_type, type:string, comment:from deserializer), FieldSchema(name:comment, type:string, comment:from deserializer)], properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152542_170176a0-92ff-408b-9133-eab9a1953c23); Time taken: 0.661 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152542_170176a0-92ff-408b-9133-eab9a1953c23): describe formatted web_logs
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152542_170176a0-92ff-408b-9133-eab9a1953c23); Time taken: 2.704 seconds
INFO  : OK
+-------------------------------+------------------------------------------------+----------------------------------------------------+
|           col_name            |                   data_type                    |                      comment                       |
+-------------------------------+------------------------------------------------+----------------------------------------------------+
| _version_                     | bigint                                         | from deserializer                                  |
| app                           | string                                         | from deserializer                                  |
| bytes                         | int                                            | from deserializer                                  |
| city                          | string                                         | from deserializer                                  |
| client_ip                     | string                                         | from deserializer                                  |
| code                          | smallint                                       | from deserializer                                  |
| country_code                  | string                                         | from deserializer                                  |
| country_code3                 | string                                         | from deserializer                                  |
| country_name                  | string                                         | from deserializer                                  |
| device_family                 | string                                         | from deserializer                                  |
| extension                     | string                                         | from deserializer                                  |
| latitude                      | float                                          | from deserializer                                  |
| longitude                     | float                                          | from deserializer                                  |
| method                        | string                                         | from deserializer                                  |
| os_family                     | string                                         | from deserializer                                  |
| os_major                      | string                                         | from deserializer                                  |
| protocol                      | string                                         | from deserializer                                  |
| record                        | string                                         | from deserializer                                  |
| referer                       | string                                         | from deserializer                                  |
| region_code                   | string                                         | from deserializer                                  |
| request                       | string                                         | from deserializer                                  |
| subapp                        | string                                         | from deserializer                                  |
| time                          | string                                         | from deserializer                                  |
| url                           | string                                         | from deserializer                                  |
| user_agent                    | string                                         | from deserializer                                  |
| user_agent_family             | string                                         | from deserializer                                  |
| user_agent_major              | string                                         | from deserializer                                  |
| id                            | string                                         | from deserializer                                  |
| date                          | string                                         | from deserializer                                  |
|                               | NULL                                           | NULL                                               |
| # Detailed Table Information  | NULL                                           | NULL                                               |
| Database:                     | nightly_default                                | NULL                                               |
| OwnerType:                    | USER                                           | NULL                                               |
| Owner:                        | null                                           | NULL                                               |
| CreateTime:                   | UNKNOWN                                        | NULL                                               |
| LastAccessTime:               | UNKNOWN                                        | NULL                                               |
| Retention:                    | 0                                              | NULL                                               |
| Location:                     | file:/tmp/warehouse/external/web_logs          | NULL                                               |
| Table Type:                   | EXTERNAL_TABLE                                 | NULL                                               |
| Table Parameters:             | NULL                                           | NULL                                               |
|                               | EXTERNAL                                       | TRUE                                               |
|                               | hive.sql.database.type                         | HIVE                                               |
|                               | hive.sql.dbcp.password                         | hive                                               |
|                               | hive.sql.dbcp.username                         | hive                                               |
|                               | hive.sql.jdbc.driver                           | org.apache.hive.jdbc.HiveDriver                    |
|                               | hive.sql.jdbc.url                              | jdbc:hive2://nightly.hive.apache.org:10000 |
|                               | hive.sql.schema                                | default                                            |
|                               | hive.sql.table                                 | web_logs                                           |
|                               | storage_handler                                | org.apache.hive.storage.jdbc.JdbcStorageHandler    |
|                               | NULL                                           | NULL                                               |
| # Storage Information         | NULL                                           | NULL                                               |
| SerDe Library:                | org.apache.hive.storage.jdbc.JdbcSerDe         | NULL                                               |
| InputFormat:                  | org.apache.hive.storage.jdbc.JdbcInputFormat   | NULL                                               |
| OutputFormat:                 | org.apache.hive.storage.jdbc.JdbcOutputFormat  | NULL                                               |
| Compressed:                   | No                                             | NULL                                               |
| Num Buckets:                  | 0                                              | NULL                                               |
| Bucket Columns:               | []                                             | NULL                                               |
| Sort Columns:                 | []                                             | NULL                                               |
| Storage Desc Params:          | NULL                                           | NULL                                               |
|                               | serialization.format                           | 1                                                  |
+-------------------------------+------------------------------------------------+----------------------------------------------------+
60 rows selected (3.392 seconds)

0: jdbc:hive2://localhost:10000> **_describe formatted sample_07;_**
INFO  : Compiling command(queryId=ngangam_20230918152648_6ea35ff8-324c-427a-96a5-9007835202f6): describe formatted sample_07
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:[FieldSchema(name:col_name, type:string, comment:from deserializer), FieldSchema(name:data_type, type:string, comment:from deserializer), FieldSchema(name:comment, type:string, comment:from deserializer)], properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152648_6ea35ff8-324c-427a-96a5-9007835202f6); Time taken: 0.641 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152648_6ea35ff8-324c-427a-96a5-9007835202f6): describe formatted sample_07
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=ngangam_20230918152648_6ea35ff8-324c-427a-96a5-9007835202f6); Time taken: 2.532 seconds
INFO  : OK
+-------------------------------+------------------------------------------------+----------------------------------------------------+
|           col_name            |                   data_type                    |                      comment                       |
+-------------------------------+------------------------------------------------+----------------------------------------------------+
| code                          | string                                         | from deserializer                                  |
| description                   | string                                         | from deserializer                                  |
| total_emp                     | int                                            | from deserializer                                  |
| salary                        | int                                            | from deserializer                                  |
|                               | NULL                                           | NULL                                               |
| # Detailed Table Information  | NULL                                           | NULL                                               |
| Database:                     | nightly_default                                | NULL                                               |
| OwnerType:                    | USER                                           | NULL                                               |
| Owner:                        | null                                           | NULL                                               |
| CreateTime:                   | UNKNOWN                                        | NULL                                               |
| LastAccessTime:               | UNKNOWN                                        | NULL                                               |
| Retention:                    | 0                                              | NULL                                               |
| Location:                     | file:/tmp/warehouse/external/sample_07         | NULL                                               |
| Table Type:                   | EXTERNAL_TABLE                                 | NULL                                               |
| Table Parameters:             | NULL                                           | NULL                                               |
|                               | EXTERNAL                                       | TRUE                                               |
|                               | hive.sql.database.type                         | HIVE                                               |
|                               | hive.sql.dbcp.password                         | hive                                               |
|                               | hive.sql.dbcp.username                         | hive                                               |
|                               | hive.sql.jdbc.driver                           | org.apache.hive.jdbc.HiveDriver                    |
|                               | hive.sql.jdbc.url                              | jdbc:hive2://nightly.hive.apache.org:10000 |
|                               | hive.sql.schema                                | default                                            |
|                               | hive.sql.table                                 | sample_07                                          |
|                               | storage_handler                                | org.apache.hive.storage.jdbc.JdbcStorageHandler    |
|                               | NULL                                           | NULL                                               |
| # Storage Information         | NULL                                           | NULL                                               |
| SerDe Library:                | org.apache.hive.storage.jdbc.JdbcSerDe         | NULL                                               |
| InputFormat:                  | org.apache.hive.storage.jdbc.JdbcInputFormat   | NULL                                               |
| OutputFormat:                 | org.apache.hive.storage.jdbc.JdbcOutputFormat  | NULL                                               |
| Compressed:                   | No                                             | NULL                                               |
| Num Buckets:                  | 0                                              | NULL                                               |
| Bucket Columns:               | []                                             | NULL                                               |
| Sort Columns:                 | []                                             | NULL                                               |
| Storage Desc Params:          | NULL                                           | NULL                                               |
|                               | serialization.format                           | 1                                                  |
+-------------------------------+------------------------------------------------+----------------------------------------------------+
35 rows selected (3.198 seconds)

0: jdbc:hive2://localhost:10000> **_set hive.execution.engine=mr;_**
Error: Error while processing statement: hive execution engine mr is not supported. (state=42000,code=1)

0: jdbc:hive2://localhost:10000> **_select count(*) from sample_07 where salary > 50000;_**
INFO  : Compiling command(queryId=ngangam_20230918152746_0cce0ed6-58ab-477a-805b-a97dca077ff1): select count(*) from sample_07 where salary > 50000
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Created Hive schema: Schema(fieldSchemas:[FieldSchema(name:_c0, type:bigint, comment:null)], properties:null)
INFO  : Completed compiling command(queryId=ngangam_20230918152746_0cce0ed6-58ab-477a-805b-a97dca077ff1); Time taken: 5.674 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=ngangam_20230918152746_0cce0ed6-58ab-477a-805b-a97dca077ff1): select count(*) from sample_07 where salary > 50000
WARN  : Hive-on-MR is deprecated in Hive 2 and may not be available in the future versions. Consider using a different execution engine (i.e. tez, impala) or using Hive 1.X releases.
INFO  : Query ID = ngangam_20230918152746_0cce0ed6-58ab-477a-805b-a97dca077ff1
INFO  : Total jobs = 1
INFO  : Launching Job 1 out of 1
INFO  : Starting task [Stage-1:MAPRED] in serial mode
INFO  : Number of reduce tasks determined at compile time: 1
INFO  : In order to change the average load for a reducer (in bytes):
INFO  :   set hive.exec.reducers.bytes.per.reducer=<number>
INFO  : In order to limit the maximum number of reducers:
INFO  :   set hive.exec.reducers.max=<number>
INFO  : In order to set a constant number of reducers:
INFO  :   set mapreduce.job.reduces=<number>
INFO  : number of splits:1
INFO  : Submitting tokens for job: job_local1498163518_0001
INFO  : Executing with tokens: []
INFO  : The url to track the job: http://localhost:8080/
INFO  : Job running in-process (local Hadoop)
INFO  : 2023-09-18 15:27:55,391 Stage-1 map = 0%,  reduce = 0%
INFO  : 2023-09-18 15:27:59,418 Stage-1 map = 100%,  reduce = 100%
INFO  : Ended Job = job_local1498163518_0001
INFO  : MapReduce Jobs Launched: 
INFO  : Stage-Stage-1:  HDFS Read: 0 HDFS Write: 0 SUCCESS
INFO  : Total MapReduce CPU Time Spent: 0 msec
INFO  : Completed executing command(queryId=ngangam_20230918152746_0cce0ed6-58ab-477a-805b-a97dca077ff1); Time taken: 7.418 seconds
INFO  : OK
+------+
| _c0  |
+------+
| 292  |
+------+
1 row selected (13.157 seconds)

0: jdbc:hive2://localhost:10000> 

### Why are the changes needed?
This connector enables users to map databases between 2 hive clusters and federate queries over JDBC between tables in the 2 clusters.

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO

### How was this patch tested?
Manually
