### PR TITLE
HIVE-27701: Remove PowerMock from llap-client

### DIFF
--- a/llap-client/pom.xml
+++ b/llap-client/pom.xml
@@ -131,6 +131,12 @@
     </dependency>
     <!-- test inter-project -->
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -203,18 +209,6 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
It is the next step of removing PowerMock from Hive. 

### What changes were proposed in this pull request?
PowerMock removed, mockito-inline introduced with a mockito upgrade to 4.11


### Why are the changes needed?
PowerMock seems to be a dead project.
Prerequisite for moving to Java 11


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Precommit tests
