### PR TITLE
HIVE-27704 : Remove PowerMock from jdbc-handler and upgrade mockito to 4.11

### DIFF
--- a/jdbc-handler/pom.xml
+++ b/jdbc-handler/pom.xml
@@ -112,15 +112,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jdbc-handler/src/test/java/org/apache/hive/storage/jdbc/TestJdbcInputFormat.java
+++ b/jdbc-handler/src/test/java/org/apache/hive/storage/jdbc/TestJdbcInputFormat.java
@@ -59,7 +59,8 @@ public class TestJdbcInputFormat {
   public void setup() throws Exception{
 
     hiveDatabaseAccessorFactory = mockStatic(DatabaseAccessorFactory.class);
-    hiveDatabaseAccessorFactory.when(() -> DatabaseAccessorFactory.getAccessor(any(Configuration.class))).thenReturn(mockDatabaseAccessor);
+    hiveDatabaseAccessorFactory.when(() -> DatabaseAccessorFactory.getAccessor(any(Configuration.class))).
+      thenReturn(mockDatabaseAccessor);
   }
 
   @After

--- a/jdbc-handler/src/test/java/org/apache/hive/storage/jdbc/TestJdbcInputFormat.java
+++ b/jdbc-handler/src/test/java/org/apache/hive/storage/jdbc/TestJdbcInputFormat.java
@@ -17,7 +17,7 @@ package org.apache.hive.storage.jdbc;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde.serdeConstants;
+
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.mapred.InputSplit;
@@ -29,9 +29,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -47,8 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DatabaseAccessorFactory.class)
+@RunWith(MockitoJUnitRunner.class)
 public class TestJdbcInputFormat {
 
   @Mock
@@ -57,7 +55,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testLimitSplit_noSpillOver() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getTotalNumberOfRecords(any(Configuration.class))).thenReturn(15);
@@ -76,7 +74,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testLimitSplit_withSpillOver() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getTotalNumberOfRecords(any(Configuration.class))).thenReturn(15);
@@ -100,7 +98,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_Long() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -128,7 +126,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_Double() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -160,7 +158,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_Decimal() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -190,7 +188,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_Timestamp() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -217,7 +215,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_Date() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -245,7 +243,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_AutoShrink() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));
@@ -271,7 +269,7 @@ public class TestJdbcInputFormat {
 
   @Test
   public void testIntervalSplit_NoSplit() throws HiveJdbcDatabaseAccessException, IOException {
-    PowerMockito.mockStatic(DatabaseAccessorFactory.class);
+    Mockito.mockStatic(DatabaseAccessorFactory.class);
     BDDMockito.given(DatabaseAccessorFactory.getAccessor(any(Configuration.class))).willReturn(mockDatabaseAccessor);
     JdbcInputFormat f = new JdbcInputFormat();
     when(mockDatabaseAccessor.getColumnNames(any(Configuration.class))).thenReturn(Lists.newArrayList("a"));


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
(https://issues.apache.org/jira/browse/HIVE-27704)


### Why are the changes needed?
To upgrade mockito


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
YES


### How was this patch tested?
Precommit tests
