### PR TITLE
HIVE-27736: Remove PowerMock from itests-jmh and upgrade mockito

### DIFF
--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -80,18 +80,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/vectorization/mapjoin/load/AbstractHTLoadBench.java
+++ b/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/vectorization/mapjoin/load/AbstractHTLoadBench.java
@@ -45,7 +45,6 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.powermock.api.mockito.PowerMockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +53,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -89,25 +90,25 @@ public abstract class AbstractHTLoadBench {
   @Benchmark
   public void hashTableLoadBench() throws Exception {
     /* Mocking TezContext */
-    this.mockTezContext = PowerMockito.mock(TezContext.class);
-    ProcessorContext mockProcessorContest = PowerMockito.mock(ProcessorContext.class);
-    AbstractLogicalInput mockLogicalInput = PowerMockito.mock(AbstractLogicalInput.class);
-    TezCounters mockTezCounters = PowerMockito.mock(TezCounters.class);
-    TezCounter mockTezCounter = PowerMockito.mock(TezCounter.class);
-    InputContext mockInputContext = PowerMockito.mock(InputContext.class);
+    this.mockTezContext = mock(TezContext.class);
+    ProcessorContext mockProcessorContest = mock(ProcessorContext.class);
+    AbstractLogicalInput mockLogicalInput = mock(AbstractLogicalInput.class);
+    TezCounters mockTezCounters = mock(TezCounters.class);
+    TezCounter mockTezCounter = mock(TezCounter.class);
+    InputContext mockInputContext = mock(InputContext.class);
     // Make sure the KEY estimation is correct to have properly sized HT
-    PowerMockito.when(mockTezCounter.getValue()).thenReturn((long)rowCount);
-    PowerMockito.when(mockTezContext.getInput(any())).thenReturn(mockLogicalInput);
-    PowerMockito.when(mockLogicalInput.getContext()).thenReturn(mockInputContext);
-    PowerMockito.when(mockInputContext.getCounters()).thenReturn(mockTezCounters);
-    PowerMockito.when(mockTezCounters.findCounter(anyString(), anyString())).thenReturn(mockTezCounter);
-    PowerMockito.when(mockTezContext.getTezProcessorContext()).thenReturn(mockProcessorContest);
-    PowerMockito.when(mockTezContext.getTezProcessorContext().getCounters()).thenReturn(mockTezCounters);
-    PowerMockito.when(mockTezContext.getTezProcessorContext().getCounters().findCounter(anyString(), anyString())).
+    when(mockTezCounter.getValue()).thenReturn((long)rowCount);
+    when(mockTezContext.getInput(any())).thenReturn(mockLogicalInput);
+    when(mockLogicalInput.getContext()).thenReturn(mockInputContext);
+    when(mockInputContext.getCounters()).thenReturn(mockTezCounters);
+    when(mockTezCounters.findCounter(anyString(), anyString())).thenReturn(mockTezCounter);
+    when(mockTezContext.getTezProcessorContext()).thenReturn(mockProcessorContest);
+    when(mockTezContext.getTezProcessorContext().getCounters()).thenReturn(mockTezCounters);
+    when(mockTezContext.getTezProcessorContext().getCounters().findCounter(anyString(), anyString())).
         thenReturn(mockTezCounter);
     // Replace streaming Tez-Input with our custom Iterator
-    PowerMockito.when(mockTezContext.getInput(any())).thenReturn(mockLogicalInput);
-    PowerMockito.when(mockLogicalInput.getReader()).thenReturn(customKeyValueReader);
+    when(mockTezContext.getInput(any())).thenReturn(mockLogicalInput);
+    when(mockLogicalInput.getReader()).thenReturn(customKeyValueReader);
     /* Mocking Done*/
     HashTableLoader ht = LOAD_THREADS_NUM == 0 ?
         new LegacyVectorMapJoinFastHashTableLoader(mockTezContext, testDesc.hiveConf, createMapJoinResult.mapJoinOperator) :


### PR DESCRIPTION
This is the next step of removing PowerMock from Hive.

### What changes were proposed in this pull request?
PowerMock removed, mockito-inline introduced with a mockito upgrade to 4.11


### Why are the changes needed?
PowerMock seems to be a dead project.
Prerequisite for moving to Java 11


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes

### How was this patch tested?
- Ran one of the performance tests that uses the modified class
- Precommit tests