### PR TITLE
HIVE-27702: Remove PowerMock from beeline and upgrade mockito to 4.11

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -25,7 +25,6 @@
   <name>Hive Beeline</name>
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <powermock.version>2.0.2</powermock.version>
   </properties>
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifactId -->
@@ -182,15 +181,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/beeline/src/test/org/apache/hive/beeline/schematool/TestHiveSchemaTool.java
+++ b/beeline/src/test/org/apache/hive/beeline/schematool/TestHiveSchemaTool.java
@@ -25,9 +25,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,27 +36,26 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
-@PrepareForTest({ HiveSchemaHelper.class, HiveSchemaTool.HiveSchemaToolCommandBuilder.class })
+
+@RunWith(MockitoJUnitRunner.class)
 public class TestHiveSchemaTool {
 
   String scriptFile = System.getProperty("java.io.tmpdir") + File.separator + "someScript.sql";
   @Mock
   private HiveConf hiveConf;
+  private MockedStatic<HiveSchemaHelper> hiveSchemaHelperMockedStatic;
   private HiveSchemaTool.HiveSchemaToolCommandBuilder builder;
   private String pasword = "reallySimplePassword";
 
   @Before
   public void setup() throws IOException {
-    mockStatic(HiveSchemaHelper.class);
-    when(HiveSchemaHelper
+    hiveSchemaHelperMockedStatic = mockStatic(HiveSchemaHelper.class);
+    hiveSchemaHelperMockedStatic.when(() -> HiveSchemaHelper
         .getValidConfVar(eq(MetastoreConf.ConfVars.CONNECT_URL_KEY), same(hiveConf)))
         .thenReturn("someURL");
-    when(HiveSchemaHelper
+    hiveSchemaHelperMockedStatic.when(() -> HiveSchemaHelper
         .getValidConfVar(eq(MetastoreConf.ConfVars.CONNECTION_DRIVER), same(hiveConf)))
         .thenReturn("someDriver");
 
@@ -73,7 +71,7 @@ public class TestHiveSchemaTool {
     HiveSchemaHelper.getValidConfVar(eq(MetastoreConf.ConfVars.CONNECT_URL_KEY), same(hiveConf));
     HiveSchemaHelper
         .getValidConfVar(eq(MetastoreConf.ConfVars.CONNECTION_DRIVER), same(hiveConf));
-
+    hiveSchemaHelperMockedStatic.close();
     new File(scriptFile).delete();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-27702

### What changes were proposed in this pull request?

- Remove PowerMock from beeline
- Mockito-inline dependency added


### Why are the changes needed?
* PowerMock seems to be a dead project.
* Prerequisite for moving to Java 11


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Precommit tests
