### PR TITLE
HIVE-27716: Precommit: Save log files for first 10 failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,6 +364,12 @@ tar -xzf packaging/target/apache-hive-*-nightly-*-src.tar.gz
           stage('PostProcess') {
             try {
               sh """#!/bin/bash -e
+                FAILED_FILES=`find . -name "TEST*xml" -exec grep -l "<failure" {} \\; 2>/dev/null | head -n 10`
+                for a in \$FAILED_FILES
+                do
+                  RENAME_TMP=`echo \$a | sed s/TEST-//g`
+                  mv \${RENAME_TMP/.xml/-output.txt} \${RENAME_TMP/.xml/-output-save.txt}
+                done
                 # removes all stdout and err for passed tests
                 xmlstarlet ed -L -d 'testsuite/testcase/system-out[count(../failure)=0]' -d 'testsuite/testcase/system-err[count(../failure)=0]' `find . -name 'TEST*xml' -path '*/surefire-reports/*'`
                 # remove all output.txt files


### PR DESCRIPTION
### What changes were proposed in this pull request?
Save some tests logs in case of failing tests.

### Why are the changes needed?
Because currently the artifact is pretty useless, it doesn't contain more info than what's already visible in jenkins.


### Does this PR introduce _any_ user-facing change?
No, it's precommit related.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Jenkins is supposed to pick up Jenkinsfile from the patch. Need to verify at:
http://ci.hive.apache.org/job/hive-precommit/job/PR-4732/1/
verified, first commit:
```
Obtained Jenkinsfile from 2d2ca54feb59480bbc960c5ffd45aa6134e76f2c
```
