### PR TITLE
HIVE-25615: Fix Hive on tez will generate at least one MapContainer per 0 length file

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ColumnarSplitSizeEstimator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/ColumnarSplitSizeEstimator.java
@@ -35,6 +35,9 @@ public class ColumnarSplitSizeEstimator implements SplitSizeEstimator {
   @Override
   public long getEstimatedSize(InputSplit inputSplit) throws IOException {
     long colProjSize = inputSplit.getLength();
+    if (colProjSize == 0) {
+      return colProjSize;
+    }
 
     if (inputSplit instanceof ColumnarSplit) {
       colProjSize = ((ColumnarSplit) inputSplit).getColumnarProjectionSize();

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
@@ -613,6 +614,20 @@ public class TestInputOutputFormat {
       assertEquals(1, splitSizeEstimator.getEstimatedSize(split));
     }
     assertEquals(4, splits.size());
+  }
+
+  @Test
+  public void testSplitSizeEstimator() throws HiveException, IOException {
+    String mockPath = "split_size_estimator";
+    InputSplit[] splits = {
+            new FileSplit(new Path(mockPath + "/0_0"), 0, 0, new String[]{"host1"}),
+            new FileSplit(new Path(mockPath + "/0_1"), 0, 1, new String[]{"host1"}),
+            new FileSplit(new Path(mockPath + "/0_2"), 0, 1, new String[]{"host1"})
+    };
+    ColumnarSplitSizeEstimator splitSizeEstimator = new ColumnarSplitSizeEstimator();
+    assertEquals(0, splitSizeEstimator.getEstimatedSize(splits[0]));
+    assertEquals(1, splitSizeEstimator.getEstimatedSize(splits[1]));
+    assertEquals(1, splitSizeEstimator.getEstimatedSize(splits[2]));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the length of the InputSplit is found to be 0, return 0 immediately.


### Why are the changes needed?
When tez read a table with many  0 length files, ColumnarSplitSizeEstimator will return Integer.MAX_VALUE bytes length for every 0 length file.Then,TezSplitGrouper will treat those files as big files,and generate at least one MapContainer per 0 file to handle it.This is incorrect and even wasteful.


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
org.apache.hadoop.hive.ql.io.orc.TestInputOutputFormat#testSplitSizeEstimator
