### PR TITLE
HIVE-27553: Fix After upgrading from Hive1 to Hive3, Decimal computation experiences a loss of precision

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5725,7 +5725,10 @@ public class HiveConf extends Configuration {
 
     HIVE_ADDITIONAL_CONFIG_FILES("hive.additional.config.files", "",
             "The names of additional config files, such as ldap-site.xml," +
-                    "tez-site.xml, etc in comma separated list.");
+                    "tez-site.xml, etc in comma separated list."),
+
+    HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS("hive.sql.decimalOperations.allowPrecisionLoss", true,
+            "It defaults to true, which means the new behavior described here(HIVE-15331);  if set to false, hive uses previous rules. see HIVE-27553 for details\n");
 
     public final String varname;
     public final String altName;

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPDivide.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPDivide.java
@@ -115,9 +115,7 @@ public class GenericUDFOPDivide extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
-            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
-            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    boolean allowLoss = HiveConf.getBoolVar(SessionState.getSessionConf(), HiveConf.ConfVars. HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
     if (allowLoss) {
       // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
       // e1 / e2

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPMod.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPMod.java
@@ -127,9 +127,7 @@ public class GenericUDFOPMod extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
-            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
-            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    boolean allowLoss = HiveConf.getBoolVar(SessionState.getSessionConf(), HiveConf.ConfVars. HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
     if (allowLoss) {
       // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
       // e1 % e2

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPMultiply.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPMultiply.java
@@ -109,9 +109,7 @@ public class GenericUDFOPMultiply extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
-            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
-            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    boolean allowLoss = HiveConf.getBoolVar(SessionState.getSessionConf(), HiveConf.ConfVars. HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
     if (allowLoss) {
       // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
       // e1 * e2

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericMinus.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericMinus.java
@@ -19,9 +19,11 @@
 package org.apache.hadoop.hive.ql.udf.generic;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressions;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.gen.*;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
@@ -85,14 +87,25 @@ public class GenericUDFOPNumericMinus extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
-    // e1 + e2
-    // Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
-    // Scale: max(s1, s2)
-    int intPart = Math.max(prec1 - scale1, prec2 - scale2);
-    int scale = Math.max(scale1, scale2);
-    int prec =  intPart + scale + 1;
-    return adjustPrecScale(prec, scale);
+    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
+            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
+            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    if (allowLoss) {
+      // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
+      // e1 + e2
+      // Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
+      // Scale: max(s1, s2)
+      int intPart = Math.max(prec1 - scale1, prec2 - scale2);
+      int scale = Math.max(scale1, scale2);
+      int prec = intPart + scale + 1;
+      return adjustPrecScale(prec, scale);
+    } else {
+      int intPart = Math.max(prec1 - scale1, prec2 - scale2);
+      int scale = Math.max(scale1, scale2);
+      int prec =  Math.min(intPart + scale + 1, HiveDecimal.MAX_PRECISION);
+      return TypeInfoFactory.getDecimalTypeInfo(prec, scale);
+    }
+
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericMinus.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericMinus.java
@@ -87,9 +87,7 @@ public class GenericUDFOPNumericMinus extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
-            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
-            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    boolean allowLoss = HiveConf.getBoolVar(SessionState.getSessionConf(), HiveConf.ConfVars. HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
     if (allowLoss) {
       // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
       // e1 + e2

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericPlus.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericPlus.java
@@ -19,9 +19,11 @@
 package org.apache.hadoop.hive.ql.udf.generic;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressions;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.gen.*;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
@@ -94,14 +96,25 @@ public class GenericUDFOPNumericPlus extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
-    // e1 + e2
-    // Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
-    // Scale: max(s1, s2)
-    int intPart = Math.max(prec1 - scale1, prec2 - scale2);
-    int scale = Math.max(scale1, scale2);
-    int prec =  intPart + scale + 1;
-    return adjustPrecScale(prec, scale);
+    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
+            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
+            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    if (allowLoss) {
+      // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
+      // e1 + e2
+      // Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
+      // Scale: max(s1, s2)
+      int intPart = Math.max(prec1 - scale1, prec2 - scale2);
+      int scale = Math.max(scale1, scale2);
+      int prec = intPart + scale + 1;
+      return adjustPrecScale(prec, scale);
+    } else {
+      int intPart = Math.max(prec1 - scale1, prec2 - scale2);
+      int scale = Math.max(scale1, scale2);
+      int prec =  Math.min(intPart + scale + 1, HiveDecimal.MAX_PRECISION);
+      return TypeInfoFactory.getDecimalTypeInfo(prec, scale);
+    }
+
   }
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericPlus.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNumericPlus.java
@@ -96,9 +96,7 @@ public class GenericUDFOPNumericPlus extends GenericUDFBaseNumeric {
 
   @Override
   protected DecimalTypeInfo deriveResultDecimalTypeInfo(int prec1, int scale1, int prec2, int scale2) {
-    boolean allowLoss = SessionState.get() == null || SessionState.get().getConf() == null ?
-            new HiveConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS) :
-            SessionState.get().getConf().getBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
+    boolean allowLoss = HiveConf.getBoolVar(SessionState.getSessionConf(), HiveConf.ConfVars. HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS);
     if (allowLoss) {
       // From https://msdn.microsoft.com/en-us/library/ms190476.aspx
       // e1 + e2

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPDivide.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPDivide.java
@@ -239,6 +239,21 @@ public class TestGenericUDFOPDivide extends AbstractTestGenericUDFOPNumeric {
     testDecimalDivisionResultType(38, 0, 38, 0, 38, 6);
   }
 
+  @Test
+  public void testDecimalDivisionResultTypeNotAllowLoss() throws HiveException {
+    SessionState.get().getConf().setBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS, false);
+    testDecimalDivisionResultType(5, 2, 3, 2, 11, 6);
+    testDecimalDivisionResultType(38, 18, 38, 18, 38, 18);
+    testDecimalDivisionResultType(38, 18, 20, 0, 38, 27);
+    testDecimalDivisionResultType(20, 0, 8, 5, 34, 9);
+    testDecimalDivisionResultType(10, 0, 10, 0, 21, 11);
+    testDecimalDivisionResultType(5, 2, 5, 5, 16, 8);
+    testDecimalDivisionResultType(10, 10, 5, 0, 16, 16);
+    testDecimalDivisionResultType(10, 10, 5, 5, 21, 16);
+    testDecimalDivisionResultType(38, 38, 38, 38, 38, 18);
+    testDecimalDivisionResultType(38, 0, 38, 0, 38, 18);
+  }
+
   private void testDecimalDivisionResultType(int prec1, int scale1, int prec2, int scale2, int prec3, int scale3)
       throws HiveException {
     GenericUDFOPDivide udf = new GenericUDFOPDivide();

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPMinus.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPMinus.java
@@ -393,4 +393,15 @@ public class TestGenericUDFOPMinus extends AbstractTestGenericUDFOPNumeric {
     TimestampWritableV2 res = (TimestampWritableV2) udf.evaluate(args);
     Assert.assertEquals(Timestamp.valueOf("2000-12-30 23:59:59.445"), res.getTimestamp());
   }
+
+  @Test
+  public void testDecimalMinusResultType() throws HiveException {
+    verifyReturnType(new GenericUDFOPMinus(), "decimal(38,1)", "decimal(38,10)", "decimal(38,6)");
+  }
+
+  @Test
+  public void testDecimalMinusResultTypeNotAllowLoss() throws HiveException {
+    SessionState.get().getConf().setBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS, false);
+    verifyReturnType(new GenericUDFOPMinus(), "decimal(38,1)", "decimal(38,10)", "decimal(38,10)");
+  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPMultiply.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPMultiply.java
@@ -252,4 +252,15 @@ public class TestGenericUDFOPMultiply extends AbstractTestGenericUDFOPNumeric {
     verifyReturnType(new GenericUDFOPMultiply(), "decimal(38,38)", "decimal(38,0)", "decimal(38,6)");
     verifyReturnType(new GenericUDFOPMultiply(), "decimal(20,2)", "decimal(20,0)", "decimal(38,2)");
   }
+
+  @Test
+  public void testDecimalMultiplyResultType() throws HiveException {
+    verifyReturnType(new GenericUDFOPMultiply(), "decimal(38,10)", "decimal(38,10)", "decimal(38,6)");
+  }
+
+  @Test
+  public void testDecimalMultiplyResultTypeNotAllowLoss() throws HiveException {
+    SessionState.get().getConf().setBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS, false);
+    verifyReturnType(new GenericUDFOPMultiply(), "decimal(38,10)", "decimal(38,10)", "decimal(38,20)");
+  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPPlus.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFOPPlus.java
@@ -492,4 +492,15 @@ public class TestGenericUDFOPPlus extends AbstractTestGenericUDFOPNumeric {
     TimestampWritableV2 res = (TimestampWritableV2) udf.evaluate(args);
     Assert.assertEquals(Timestamp.valueOf("2001-01-02 2:3:4.567"), res.getTimestamp());
   }
+
+  @Test
+  public void testDecimalPlusResultType() throws HiveException {
+    verifyReturnType(new GenericUDFOPNumericPlus(), "decimal(38,10)", "decimal(38,10)", "decimal(38,9)");
+  }
+
+  @Test
+  public void testDecimalPlusResultTypeNotAllowLoss() throws HiveException {
+    SessionState.get().getConf().setBoolVar(HiveConf.ConfVars.HIVE_SQL_DECIMAL_OPERATIONS_ALLOW_PRECISION_LOSS, false);
+    verifyReturnType(new GenericUDFOPNumericPlus(), "decimal(38,10)", "decimal(38,10)", "decimal(38,10)");
+  }
 }


### PR DESCRIPTION
[HIVE-27553](https://issues.apache.org/jira/browse/HIVE-27553): Fix After upgrading from Hive1 to Hive3, Decimal computation experiences a loss of precision


### What changes were proposed in this pull request?

I would like to introduce a configuration parameter, `hive.sql.decimalOperations.allowPrecisionLoss`, to effectively tackle this issue.
By default, its value is set to true, thereby embracing the new behavior as described in [HIVE-15331](https://issues.apache.org/jira/browse/HIVE-15331).
Alternatively, if it is set to false, Hive will adhere to the previous rules, as elaborated in [HIVE-27553](https://issues.apache.org/jira/browse/HIVE-27553).

This solution takes its cues from Spark's methodology (`spark.sql.decimalOperations.allowPrecisionLoss`), as extensively outlined in the [Spark SQL Migration Guide ](https://spark.apache.org/docs/2.4.0/sql-migration-guide-upgrade.html#upgrading-from-spark-sql-22-to-23)for the transition from version 2.2 to 2.3 .


### Why are the changes needed?
The purpose of resolving this issue is to assist those who intend to upgrade from Hive 1.0 to 3.0+/4.0+.
They may encounter discrepancies in decimal computation behavior between versions. By means of this configuration, compatibility with the previous computation behavior can be ensured.


### Does this PR introduce _any_ user-facing change?

When the hive.sql.decimalOperations.allowPrecisionLoss parameter is utilized with its default configuration, it does not have any user-facing implications.
If this parameter is changed to false, This impact is : decimal computations will be performed using the computation methodology of Hive 1.0.

### Is the change a dependency upgrade?
No


### How was this patch tested?
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPDivide#testDecimalDivisionResultTypeNotAllowLoss
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPMinus#testDecimalMinusResultType
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPMinus#testDecimalMinusResultTypeNotAllowLoss
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPMultiply#testDecimalMultiplyResultType
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPMultiply#testDecimalMultiplyResultTypeNotAllowLoss
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPPlus#testDecimalPlusResultType
org.apache.hadoop.hive.ql.udf.generic.TestGenericUDFOPPlus#testDecimalPlusResultType
