### PR TITLE
HIVE-27637: Compare highest write ID of compaction records when tryin…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -1169,7 +1169,7 @@ public class TestCompactor extends TestCompactorBase {
 
     // After the cleaner runs TXN_COMPONENTS and COMPACTION_QUEUE should have zero rows, also the folders should have been deleted.
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), (singleSession && partialAbort) ? 3 : 2, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), (singleSession && partialAbort) ? 1 : 0, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from COMPACTION_QUEUE");
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
@@ -1241,7 +1241,7 @@ public class TestCompactor extends TestCompactorBase {
     runCleaner(conf);
     // After the cleaner runs TXN_COMPONENTS and COMPACTION_QUEUE should have zero rows, also the folders should have been deleted.
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 2, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from COMPACTION_QUEUE");
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
@@ -1317,7 +1317,7 @@ public class TestCompactor extends TestCompactorBase {
     runCleaner(conf);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
     Partition p1 = msClient.getPartition(dbName, tblName, "a=1"),
@@ -1367,7 +1367,7 @@ public class TestCompactor extends TestCompactorBase {
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
 
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -1130,7 +1130,7 @@ public class TestCompactor extends TestCompactorBase {
     cleaner.run();
 
     int count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 2, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
   }
 
   private void assertAndCompactCleanAbort(String dbName, String tblName, boolean partialAbort, boolean singleSession) throws Exception {
@@ -1176,7 +1176,6 @@ public class TestCompactor extends TestCompactorBase {
 
     RemoteIterator<LocatedFileStatus> it =
         fs.listFiles(new Path(table.getSd().getLocation()), true);
-
     if (it.hasNext() && !partialAbort) {
       Assert.fail("Expected cleaner to drop aborted delta & base directories, FileStatus[] stat " + Arrays.toString(stat));
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -1130,7 +1130,7 @@ public class TestCompactor extends TestCompactorBase {
     cleaner.run();
 
     int count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 2, count);
   }
 
   private void assertAndCompactCleanAbort(String dbName, String tblName, boolean partialAbort, boolean singleSession) throws Exception {
@@ -1169,13 +1169,14 @@ public class TestCompactor extends TestCompactorBase {
 
     // After the cleaner runs TXN_COMPONENTS and COMPACTION_QUEUE should have zero rows, also the folders should have been deleted.
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), (singleSession && partialAbort) ? 1 : 0, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), (singleSession && partialAbort) ? 3 : 2, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from COMPACTION_QUEUE");
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
 
     RemoteIterator<LocatedFileStatus> it =
         fs.listFiles(new Path(table.getSd().getLocation()), true);
+
     if (it.hasNext() && !partialAbort) {
       Assert.fail("Expected cleaner to drop aborted delta & base directories, FileStatus[] stat " + Arrays.toString(stat));
     }
@@ -1240,7 +1241,7 @@ public class TestCompactor extends TestCompactorBase {
     runCleaner(conf);
     // After the cleaner runs TXN_COMPONENTS and COMPACTION_QUEUE should have zero rows, also the folders should have been deleted.
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 2, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from COMPACTION_QUEUE");
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
@@ -1316,7 +1317,7 @@ public class TestCompactor extends TestCompactorBase {
     runCleaner(conf);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
 
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
     Partition p1 = msClient.getPartition(dbName, tblName, "a=1"),
@@ -1366,7 +1367,7 @@ public class TestCompactor extends TestCompactorBase {
     Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from COMPACTION_QUEUE"), 0, count);
 
     count = TestTxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS");
-    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 0, count);
+    Assert.assertEquals(TestTxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"), 1, count);
 
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -1084,6 +1084,15 @@ public class TestCompactionTxnHandler {
     res = txnHandler.lock(req);
     assertSame(res.getState(), LockState.ACQUIRED);
 
+    CompactionRequest rqst = new CompactionRequest("mydb", "mytable", CompactionType.MINOR);
+    rqst.setPartitionname("mypartition=myvalue");
+    txnHandler.compact(rqst);
+
+    CompactionInfo ci = txnHandler.findNextToCompact(aFindNextCompactRequest("fred", WORKER_VERSION));
+    assertNotNull(ci);
+    ci.highestWriteId = 41;
+    txnHandler.updateCompactorState(ci, 0);
+
     List<CompactionInfo> potentials = txnHandler.findReadyToCleanAborts(1, 0);
     assertEquals(1, potentials.size());
     CompactionInfo potentialToCleanAbort = potentials.get(0);

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -1086,6 +1086,9 @@ public class TestCompactionTxnHandler {
 
     List<CompactionInfo> potentials = txnHandler.findReadyToCleanAborts(1, 0);
     assertEquals(1, potentials.size());
+    CompactionInfo potentialToCleanAbort = potentials.get(0);
+    assertEquals("mydb", potentialToCleanAbort.dbname);
+    assertEquals("yourtable", potentialToCleanAbort.tableName);
   }
 
   private static FindNextCompactRequest aFindNextCompactRequest(String workerId, String workerVersion) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -316,24 +316,17 @@ public class TestAbortedTxnCleaner extends TestHandler {
     long openTxnId1 = openTxn();
     long openTxnId2 = openTxn();
     long openTxnId3 = openTxn();
-    long openTxnId4 = openTxn();
     long writeId2 = ms.allocateTableWriteId(openTxnId2, t.getDbName(), t.getTableName());
     long writeId3 = ms.allocateTableWriteId(openTxnId3, t.getDbName(), t.getTableName());
     long writeId1 = ms.allocateTableWriteId(openTxnId1, t.getDbName(), t.getTableName());
-    long writeId4 = ms.allocateTableWriteId(openTxnId4, t.getDbName(), t.getTableName());
     assert writeId2 < writeId1 && writeId2 < writeId3;
     acquireLock(t, null, openTxnId3);
     acquireLock(t, null, openTxnId2);
     acquireLock(t, null, openTxnId1);
-    acquireLock(t, null, openTxnId4);
     addDeltaFile(t, null, writeId3, writeId3, 2);
     addDeltaFile(t, null, writeId1, writeId1, 2);
     addDeltaFile(t, null, writeId2, writeId2, 2);
 
-    List<Long> txnsToAbort = new ArrayList<>();
-    txnsToAbort.add(openTxnId2);
-    txnsToAbort.add(openTxnId4);
-    ms.abortTxns(txnsToAbort);
     ms.commitTxn(openTxnId3);
 
     HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 0);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -284,6 +284,7 @@ public class TestAbortedTxnCleaner extends TestHandler {
     cleaner.setCleanupHandlers(Arrays.asList(mockedTaskHandler));
     cleaner.run();
 
+    Mockito.verifyNoInteractions(mockedFSRemover);
     Mockito.verify(mockedTaskHandler, Mockito.times(1)).getTasks();
 
     directories = getDirectories(conf, t, null);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -119,55 +119,6 @@ public class TestAbortedTxnCleaner extends TestHandler {
   }
 
   @Test
-  public void testAbortedCleaningWithThreeTxnsWithDiffWriteIds() throws Exception {
-    String dbName = "default", tableName = "handler_unpart_writeid_test";
-    Table t = newTable(dbName, tableName, false);
-
-    // Add 2 committed deltas and 2 aborted deltas
-    addDeltaFileWithTxnComponents(t, null, 2, false);
-    addDeltaFileWithTxnComponents(t, null, 2, true);
-    addDeltaFileWithTxnComponents(t, null, 2, true);
-    addDeltaFileWithTxnComponents(t, null, 2, false);
-
-    long openTxnId1 = openTxn();
-    long openTxnId2 = openTxn();
-    long openTxnId3 = openTxn();
-    long openTxnId4 = openTxn();
-    long writeId2 = ms.allocateTableWriteId(openTxnId2, t.getDbName(), t.getTableName());
-    long writeId3 = ms.allocateTableWriteId(openTxnId3, t.getDbName(), t.getTableName());
-    long writeId1 = ms.allocateTableWriteId(openTxnId1, t.getDbName(), t.getTableName());
-    long writeId4 = ms.allocateTableWriteId(openTxnId4, t.getDbName(), t.getTableName());
-    assert writeId2 < writeId1 && writeId2 < writeId3;
-    acquireLock(t, null, openTxnId3);
-    acquireLock(t, null, openTxnId2);
-    acquireLock(t, null, openTxnId1);
-    acquireLock(t, null, openTxnId4);
-    addDeltaFile(t, null, writeId3, writeId3, 2);
-    addDeltaFile(t, null, writeId1, writeId1, 2);
-    addDeltaFile(t, null, writeId2, writeId2, 2);
-
-    List<Long> txnsToAbort = new ArrayList<>();
-    txnsToAbort.add(openTxnId2);
-    txnsToAbort.add(openTxnId4);
-    ms.abortTxns(txnsToAbort);
-    ms.commitTxn(openTxnId3);
-
-    HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 0);
-    MetadataCache metadataCache = new MetadataCache(true);
-    FSRemover mockedFSRemover = Mockito.spy(new FSRemover(conf, ReplChangeManager.getInstance(conf), metadataCache));
-    TaskHandler mockedTaskHandler = Mockito.spy(new AbortedTxnCleaner(conf, txnHandler, metadataCache,
-            false, mockedFSRemover));
-    Cleaner cleaner = new Cleaner();
-    cleaner.setConf(conf);
-    cleaner.init(new AtomicBoolean(true));
-    cleaner.setCleanupHandlers(Arrays.asList(mockedTaskHandler));
-    cleaner.run();
-
-    List<Path> directories = getDirectories(conf, t, null);
-    Assert.assertEquals(5, directories.size());
-  }
-
-  @Test
   public void testCleaningOfAbortedDirectoriesForMultiplePartitions() throws Exception {
     String dbName = "default", tableName = "handler_part_multiple_test", partName1 = "today1", partName2 = "today2";
     Table t = newTable(dbName, tableName, true);
@@ -339,6 +290,55 @@ public class TestAbortedTxnCleaner extends TestHandler {
     directories = getDirectories(conf, t, null);
     // The table is already compacted, so we must see 1 base delta
     Assert.assertEquals(1, directories.size());
+  }
+
+  @Test
+  public void testAbortedCleaningWithThreeTxnsWithDiffWriteIds() throws Exception {
+    String dbName = "default", tableName = "handler_unpart_writeid_test";
+    Table t = newTable(dbName, tableName, false);
+
+    // Add 2 committed deltas and 2 aborted deltas
+    addDeltaFileWithTxnComponents(t, null, 2, false);
+    addDeltaFileWithTxnComponents(t, null, 2, true);
+    addDeltaFileWithTxnComponents(t, null, 2, true);
+    addDeltaFileWithTxnComponents(t, null, 2, false);
+
+    long openTxnId1 = openTxn();
+    long openTxnId2 = openTxn();
+    long openTxnId3 = openTxn();
+    long openTxnId4 = openTxn();
+    long writeId2 = ms.allocateTableWriteId(openTxnId2, t.getDbName(), t.getTableName());
+    long writeId3 = ms.allocateTableWriteId(openTxnId3, t.getDbName(), t.getTableName());
+    long writeId1 = ms.allocateTableWriteId(openTxnId1, t.getDbName(), t.getTableName());
+    long writeId4 = ms.allocateTableWriteId(openTxnId4, t.getDbName(), t.getTableName());
+    assert writeId2 < writeId1 && writeId2 < writeId3;
+    acquireLock(t, null, openTxnId3);
+    acquireLock(t, null, openTxnId2);
+    acquireLock(t, null, openTxnId1);
+    acquireLock(t, null, openTxnId4);
+    addDeltaFile(t, null, writeId3, writeId3, 2);
+    addDeltaFile(t, null, writeId1, writeId1, 2);
+    addDeltaFile(t, null, writeId2, writeId2, 2);
+
+    List<Long> txnsToAbort = new ArrayList<>();
+    txnsToAbort.add(openTxnId2);
+    txnsToAbort.add(openTxnId4);
+    ms.abortTxns(txnsToAbort);
+    ms.commitTxn(openTxnId3);
+
+    HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 0);
+    MetadataCache metadataCache = new MetadataCache(true);
+    FSRemover mockedFSRemover = Mockito.spy(new FSRemover(conf, ReplChangeManager.getInstance(conf), metadataCache));
+    TaskHandler mockedTaskHandler = Mockito.spy(new AbortedTxnCleaner(conf, txnHandler, metadataCache,
+            false, mockedFSRemover));
+    Cleaner cleaner = new Cleaner();
+    cleaner.setConf(conf);
+    cleaner.init(new AtomicBoolean(true));
+    cleaner.setCleanupHandlers(Arrays.asList(mockedTaskHandler));
+    cleaner.run();
+
+    List<Path> directories = getDirectories(conf, t, null);
+    Assert.assertEquals(5, directories.size());
   }
 
   @ParameterizedTest

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -286,6 +286,9 @@ public class TestAbortedTxnCleaner extends TestHandler {
 
     Mockito.verifyNoInteractions(mockedFSRemover);
     Mockito.verify(mockedTaskHandler, Mockito.times(1)).getTasks();
+    String compactionQueuePresence = "SELECT COUNT(*) FROM \"COMPACTION_QUEUE\" " +
+            " WHERE \"CQ_DATABASE\" = '" + dbName+ "' AND \"CQ_TABLE\" = '" + tableName + "' AND \"CQ_PARTITION\" IS NULL";
+    Assert.assertEquals(1, TestTxnDbUtil.countQueryAgent(conf, compactionQueuePresence));
 
     directories = getDirectories(conf, t, null);
     // Both base and delta files are present since the cleaner skips them as there is a newer write.
@@ -327,6 +330,7 @@ public class TestAbortedTxnCleaner extends TestHandler {
     addDeltaFile(t, null, writeId1, writeId1, 2);
     addDeltaFile(t, null, writeId2, writeId2, 2);
 
+    ms.abortTxns(Collections.singletonList(openTxnId2));
     ms.commitTxn(openTxnId3);
 
     HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 0);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -251,7 +251,7 @@ public class TestAbortedTxnCleaner extends TestHandler {
   }
 
   @Test
-  public void testCleaningOfAbortedSkipsDirectoriesBelowBase() throws Exception {
+  public void testCleaningOfAbortedDirectoriesBelowBase() throws Exception {
     String dbName = "default", tableName = "handler_unpart_below_test";
     Table t = newTable(dbName, tableName, false);
 
@@ -287,9 +287,18 @@ public class TestAbortedTxnCleaner extends TestHandler {
     Mockito.verify(mockedTaskHandler, Mockito.times(1)).getTasks();
 
     directories = getDirectories(conf, t, null);
-    // Both base and delta files are present since we cleaner skips them as there is a newer write.
+    // Both base and delta files are present since the cleaner skips them as there is a newer write.
     Assert.assertEquals(5, directories.size());
     Assert.assertEquals(1, directories.stream().filter(dir -> dir.getName().startsWith(AcidUtils.BASE_PREFIX)).count());
+
+    // Run compaction and clean up
+    startInitiator();
+    startWorker();
+    startCleaner();
+
+    directories = getDirectories(conf, t, null);
+    // The table is already compacted, so we must see 1 base delta
+    Assert.assertEquals(1, directories.size());
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/handler/TestAbortedTxnCleaner.java
@@ -251,7 +251,7 @@ public class TestAbortedTxnCleaner extends TestHandler {
   }
 
   @Test
-  public void testCleaningOfAbortedDirectoriesBelowBase() throws Exception {
+  public void testCleaningOfAbortedSkipsDirectoriesBelowBase() throws Exception {
     String dbName = "default", tableName = "handler_unpart_below_test";
     Table t = newTable(dbName, tableName, false);
 
@@ -284,12 +284,12 @@ public class TestAbortedTxnCleaner extends TestHandler {
     cleaner.setCleanupHandlers(Arrays.asList(mockedTaskHandler));
     cleaner.run();
 
-    Mockito.verify(mockedFSRemover, Mockito.times(1)).clean(any(CleanupRequest.class));
     Mockito.verify(mockedTaskHandler, Mockito.times(1)).getTasks();
 
     directories = getDirectories(conf, t, null);
-    // The table is already compacted, so we must see 1 base delta
-    Assert.assertEquals(1, directories.size());
+    // Both base and delta files are present since we cleaner skips them as there is a newer write.
+    Assert.assertEquals(5, directories.size());
+    Assert.assertEquals(1, directories.stream().filter(dir -> dir.getName().startsWith(AcidUtils.BASE_PREFIX)).count());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
@@ -82,9 +82,9 @@ public class ReadyToCleanAbortHandler implements QueryHandler<List<CompactionInf
           " WHERE \"cq\".\"CQ_DATABASE\" = \"res1\".\"TC_DATABASE\" AND \"cq\".\"CQ_TABLE\" = \"res1\".\"TC_TABLE\"" +
           " AND (\"cq\".\"CQ_PARTITION\" = \"res1\".\"TC_PARTITION\"" +
           " OR (\"cq\".\"CQ_PARTITION\" IS NULL AND \"res1\".\"TC_PARTITION\" IS NULL))" +
-          " AND \"cq\".\"CQ_HIGHEST_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\"" +
+          " AND \"cq\".\"CQ_HIGHEST_WRITE_ID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\"" +
           " AND \"cq\".\"CQ_STATE\" " +
-          " IN (\"i\", \"w\", \"r\"))";
+          " IN ('i', 'w', 'r'))";
 
   private final long abortedTimeThreshold;
   private final int abortedThreshold;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
@@ -77,12 +77,12 @@ public class ReadyToCleanAbortHandler implements QueryHandler<List<CompactionInf
           " AND (\"res1\".\"TC_PARTITION\" = \"res3\".\"CQ_PARTITION\" " +
           " OR (\"res1\".\"TC_PARTITION\" IS NULL AND \"res3\".\"CQ_PARTITION\" IS NULL))" +
           " WHERE (\"res3\".\"RETRY_RECORD_CHECK\" <= 0 OR \"res3\".\"RETRY_RECORD_CHECK\" IS NULL) " +
-              "AND NOT EXISTS (SELECT 1 " +
-              "                 FROM \"TXN_COMPONENTS\" AS \"txns\" " +
-              "                 WHERE \"txns\".\"TC_DATABASE\" = \"res1\".\"TC_DATABASE\" AND \"txns\".\"TC_TABLE\" = \"res1\".\"TC_TABLE\" " +
-              "                    AND (\"txns\".\"TC_PARTITION\" = \"res1\".\"TC_PARTITION\" " +
-              "                         OR (\"txns\".\"TC_PARTITION\" IS NULL AND \"res1\".\"TC_PARTITION\" IS NULL))" +
-              "                    AND \"txns\".\"TC_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\")";
+          " AND NOT EXISTS (SELECT 1 " +
+          " FROM \"COMPACTION_QUEUE\" AS \"cq\" " +
+          " WHERE \"cq\".\"CQ_DATABASE\" = \"res1\".\"TC_DATABASE\" AND \"cq\".\"CQ_TABLE\" = \"res1\".\"TC_TABLE\" " +
+          " AND (\"cq\".\"CQ_PARTITION\" = \"res1\".\"TC_PARTITION\" " +
+          " OR (\"cq\".\"CQ_PARTITION\" IS NULL AND \"res1\".\"TC_PARTITION\" IS NULL))" +
+          " AND \"cq\".\"CQ_HIGHEST_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\")";
 
   private final long abortedTimeThreshold;
   private final int abortedThreshold;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
@@ -84,7 +84,7 @@ public class ReadyToCleanAbortHandler implements QueryHandler<List<CompactionInf
           " OR (\"cq\".\"CQ_PARTITION\" IS NULL AND \"res1\".\"TC_PARTITION\" IS NULL))" +
           " AND \"cq\".\"CQ_HIGHEST_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\"" +
           " AND \"cq\".\"CQ_STATE\" " +
-          " IN (\"i\", \"w\", \"r\")";
+          " IN (\"i\", \"w\", \"r\"))";
 
   private final long abortedTimeThreshold;
   private final int abortedThreshold;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/ReadyToCleanAbortHandler.java
@@ -76,13 +76,15 @@ public class ReadyToCleanAbortHandler implements QueryHandler<List<CompactionInf
           " AND \"res1\".\"TC_TABLE\" = \"res3\".\"CQ_TABLE\" " +
           " AND (\"res1\".\"TC_PARTITION\" = \"res3\".\"CQ_PARTITION\" " +
           " OR (\"res1\".\"TC_PARTITION\" IS NULL AND \"res3\".\"CQ_PARTITION\" IS NULL))" +
-          " WHERE (\"res3\".\"RETRY_RECORD_CHECK\" <= 0 OR \"res3\".\"RETRY_RECORD_CHECK\" IS NULL) " +
+          " WHERE (\"res3\".\"RETRY_RECORD_CHECK\" <= 0 OR \"res3\".\"RETRY_RECORD_CHECK\" IS NULL)" +
           " AND NOT EXISTS (SELECT 1 " +
           " FROM \"COMPACTION_QUEUE\" AS \"cq\" " +
-          " WHERE \"cq\".\"CQ_DATABASE\" = \"res1\".\"TC_DATABASE\" AND \"cq\".\"CQ_TABLE\" = \"res1\".\"TC_TABLE\" " +
-          " AND (\"cq\".\"CQ_PARTITION\" = \"res1\".\"TC_PARTITION\" " +
+          " WHERE \"cq\".\"CQ_DATABASE\" = \"res1\".\"TC_DATABASE\" AND \"cq\".\"CQ_TABLE\" = \"res1\".\"TC_TABLE\"" +
+          " AND (\"cq\".\"CQ_PARTITION\" = \"res1\".\"TC_PARTITION\"" +
           " OR (\"cq\".\"CQ_PARTITION\" IS NULL AND \"res1\".\"TC_PARTITION\" IS NULL))" +
-          " AND \"cq\".\"CQ_HIGHEST_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\")";
+          " AND \"cq\".\"CQ_HIGHEST_WRITEID\" > \"res1\".\"MAX_ABORTED_WRITE_ID\"" +
+          " AND \"cq\".\"CQ_STATE\" " +
+          " IN (\"i\", \"w\", \"r\")";
 
   private final long abortedTimeThreshold;
   private final int abortedThreshold;


### PR DESCRIPTION
Compare highest write ID of compaction records when trying to get the potential table/partitions for abort cleanup.

Idea: If there exists a highest write ID of a record in COMPACTION_QUEUE for a table/partition which is greater than the max(aborted write ID) for that table/partition, then we can potentially ignore abort cleanup for such tables/partitions. This is because compaction will perform cleanup of obsolete deltas and aborted deltas hence doing abort cleanup is redundant here.

This is more of an optimisation since it can potentially save some filesystem operations (mainly file-listing during construction of Acid state).

### What changes were proposed in this pull request?
Skip abort cleanup for tables/partitions if there is a newer write id on them.

### Why are the changes needed?
Reduce redundancy

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
New test added.