### PR TITLE
HIVE-27723: Prevent localizing the same original file more than once if symlinks are present

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -1392,7 +1392,7 @@ public final class FileUtils {
    * Resolves a symlink on a local filesystem. In case of any exceptions or scheme other than "file"
    * it simply returns the original path. Refer to DEBUG level logs for further details.
    * @param path input path to be resolved
-   * @param conf a Configuration instance to be used while resolving the FileSystem
+   * @param conf a Configuration instance to be used while e.g. resolving the FileSystem if necessary
    * @return the resolved target Path or the original if the input Path is not a symlink
    * @throws IOException
    */
@@ -1412,14 +1412,6 @@ public final class FileUtils {
       LOG.debug("scheme '{}' is not supported for resolving symlinks", scheme);
       return path;
     }
-
-    FileSystem srcFs;
-    if (scheme != null) {
-      srcFs = path.getFileSystem(conf);
-    } else {
-      srcFs = FileSystem.getLocal(conf);
-    }
-    LOG.debug("resolveSymlink path: {}, srcFs class: {}, scheme: {}", path, srcFs.getClass().getName(), scheme);
 
     try {
       java.nio.file.Path srcPath = Paths.get(path.toUri());

--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -1401,23 +1401,39 @@ public final class FileUtils {
       throw new IllegalArgumentException("Cannot resolve symlink for a null Path");
     }
 
-    String scheme = path.toUri().getScheme();
+    URI uri = path.toUri();
+    String scheme = uri.getScheme();
 
     /*
      * If you're about to extend this method to e.g. HDFS, simply remove this check.
      * There is a known exception reproduced by whroot_external1.q, which can be referred to,
      * which is because java.nio is not prepared by default for other schemes like "hdfs".
      */
-    if (!"file".equalsIgnoreCase(scheme)) {
+    if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
       LOG.debug("scheme '{}' is not supported for resolving symlinks", scheme);
       return path;
     }
 
+    // we're expecting 'file' scheme, so if scheme == null, we need to add it to path before resolving,
+    // otherwise Paths.get will fail with java.lang.IllegalArgumentException: Missing scheme
+    if (scheme == null) {
+      try {
+        uri =  new URI("file", uri.getAuthority(), uri.toString(), null, null);
+      } catch (URISyntaxException e) {
+        // e.g. in case of relative URI, we cannot create a new URI
+        LOG.debug("URISyntaxException while creating uri from path without scheme {}", path, e);
+        return path;
+      }
+    }
+
     try {
-      java.nio.file.Path srcPath = Paths.get(path.toUri());
-      return new Path(srcPath.toRealPath().toUri());
+      java.nio.file.Path srcPath = Paths.get(uri);
+      URI targetUri = srcPath.toRealPath().toUri();
+      // stick to the original scheme
+      return new Path(scheme, targetUri.getAuthority(),
+          Path.getPathWithoutSchemeAndAuthority(new Path(targetUri)).toString());
     } catch (Exception e) {
-      LOG.debug("exception while calling toRealPath of {}", path, e);
+      LOG.debug("Exception while calling toRealPath of {}", path, e);
       return path;
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1217,11 +1217,12 @@ public class DagUtils {
       if (!StringUtils.isNotBlank(file)) {
         continue;
       }
-      if (skipFileSet != null && skipFileSet.contains(new Path(file))) {
+      Path path = new Path(file);
+      if (skipFileSet != null && skipFileSet.contains(path)) {
         LOG.info("Skipping vertex resource " + file + " that already exists in the session");
         continue;
       }
-      Path path = FileUtils.resolveSymlinks(new Path(file), conf);
+      path = FileUtils.resolveSymlinks(path, conf);
       Path hdfsFilePath = new Path(hdfsDirPathStr, getResourceBaseName(path));
       LocalResource localResource = localizeResource(path, hdfsFilePath, type, conf);
       tmpResourcesMap.put(file, localResource);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1221,9 +1221,9 @@ public class DagUtils {
         LOG.info("Skipping vertex resource " + file + " that already exists in the session");
         continue;
       }
-      Path hdfsFilePath = new Path(hdfsDirPathStr, getResourceBaseName(new Path(file)));
-      LocalResource localResource = localizeResource(new Path(file),
-          hdfsFilePath, type, conf);
+      Path path = FileUtils.resolveSymlinks(new Path(file), conf);
+      Path hdfsFilePath = new Path(hdfsDirPathStr, getResourceBaseName(path));
+      LocalResource localResource = localizeResource(path, hdfsFilePath, type, conf);
       tmpResourcesMap.put(file, localResource);
     }
     return tmpResourcesMap;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConfUtil;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -92,6 +93,7 @@ import org.apache.hadoop.hive.ql.exec.tez.monitoring.TezJobMonitor;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -815,7 +817,8 @@ public class TezSessionState {
    * @throws LoginException when we are unable to determine the user.
    * @throws URISyntaxException when current jar location cannot be determined.
    */
-  private LocalResource createJarLocalResource(String localJarPath)
+  @VisibleForTesting
+  LocalResource createJarLocalResource(String localJarPath)
       throws IOException, LoginException, IllegalArgumentException {
     // TODO Reduce the number of lookups that happen here. This shouldn't go to HDFS for each call.
     // The hiveJarDir can be determined once per client.
@@ -823,7 +826,7 @@ public class TezSessionState {
     assert destDirStatus != null;
     Path destDirPath = destDirStatus.getPath();
 
-    Path localFile = new Path(localJarPath);
+    Path localFile = FileUtils.resolveSymlinks(new Path(localJarPath), conf);
     String sha = getSha(localFile);
 
     String destFileName = localFile.getName();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
@@ -65,6 +65,6 @@ public class TestTezSessionState {
     LocalResource l2 = sessionState.createJarLocalResource(symlinkPath.toUri().toString());
 
     // local resources point to the same original resource
-    Assert.assertEquals(l1.getResource().toPath().toUri(), l2.getResource().toPath().toUri());
+    Assert.assertEquals(l1.getResource().toPath(), l2.getResource().toPath());
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec.tez;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTezSessionState {
+
+  private class TestTezSessionPoolManager extends TezSessionPoolManager {
+    public TestTezSessionPoolManager() {
+      super();
+    }
+
+    @Override
+    public void setupPool(HiveConf conf) throws Exception {
+      super.setupPool(conf);
+    }
+
+    @Override
+    public TezSessionPoolSession createSession(String sessionId, HiveConf conf) {
+      return new SampleTezSessionState(sessionId, this, conf);
+    }
+  }
+
+  @Test
+  public void testSymlinkedLocalFilesAreLocalizedOnce() throws Exception {
+    Path jarPath = Files.createTempFile("jar", "");
+    Path symlinkPath = Paths.get(jarPath.toString() + ".symlink");
+    Files.createSymbolicLink(symlinkPath, jarPath);
+
+    // write some data into the fake jar, it's not a 0 length file in real life
+    Files.write(jarPath, "testSymlinkedLocalFilesToBeLocalized".getBytes(), StandardOpenOption.APPEND);
+
+    Assert.assertTrue(Files.isSymbolicLink(symlinkPath));
+
+    HiveConf hiveConf = new HiveConf();
+    hiveConf.set(HiveConf.ConfVars.HIVE_JAR_DIRECTORY.varname, "/tmp");
+    TezSessionPoolManager poolManager = new TestTezSessionPoolManager();
+
+    TezSessionState sessionState = poolManager.getSession(null, hiveConf, true, false);
+
+    LocalResource l1 = sessionState.createJarLocalResource(jarPath.toUri().toString());
+    LocalResource l2 = sessionState.createJarLocalResource(symlinkPath.toUri().toString());
+
+    // local resources point to the same original resource
+    Assert.assertEquals(l1.getResource().toPath().toUri(), l2.getResource().toPath().toUri());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolving symlinks before considering local files to be transformed to yarn LocalResource.

### Why are the changes needed?
Because localizing the same hive-exec jar more then once is a needless burden on HDFS and runtime.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
very same as on https://github.com/apache/hive/pull/4741
cluster test worked as expected, unit tests worked as expected also