### PR TITLE
HIVE-27755: Quote identifiers in SQL emitted by SchemaTool for MySQL

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/HiveSchemaHelper.java
@@ -455,6 +455,11 @@ public class HiveSchemaHelper {
     }
 
     @Override
+    public boolean needsQuotedIdentifier() {
+      return true;
+    }
+
+    @Override
     public boolean isNonExecCommand(String dbCommand) {
       return super.isNonExecCommand(dbCommand) ||
           (dbCommand.startsWith("/*") && dbCommand.endsWith("*/")) ||

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/tools/schematool/MetastoreSchemaTool.java
@@ -345,6 +345,10 @@ public class MetastoreSchemaTool {
 
   // Quote if the database requires it
   protected String quote(String stmt) {
+    return quote(stmt, needsQuotedIdentifier, quoteCharacter);
+  }
+
+  public static String quote(String stmt, boolean needsQuotedIdentifier, String quoteCharacter) {
     stmt = stmt.replace("<q>", needsQuotedIdentifier ? quoteCharacter : "");
     stmt = stmt.replace("<qa>", quoteCharacter);
     return stmt;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Quote identifiers for MySQL as it is done for Postgres.

### Why are the changes needed?
The main motivation behind this change is to avoid unexpected query failures when/if the MySQL database decides to turn some identifier names we are using internally to reserved keywords. This is a rather likely scenario considering that recently a MySQL fork (https://docs.percona.com/percona-server/8.0/flexibility/sequence_table.html) turned SEQUENCE_TABLE into a reserved keyword.

### Does this PR introduce _any_ user-facing change?
Yes, it can avoid SchemaTool failures when metastore is deployed against DBMS such as Percona and possibly newer versions of MySQL/MariaDB.

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
cd standalone-metastore/metastore-server
mvn test -Dtest=TestMysql -Dtest.groups=""
mvn test -Dtest=TestSchemaToolForMetastore#*Mysql* -Dtest.groups="" (using the patch in #4754)
```
Additional manual tests as described in HIVE-27755.