### PR TITLE
HIVE-27509: query-executors fail to start: java.lang.NoSuchFieldError…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -404,6 +404,7 @@ public class HiveConf extends Configuration {
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_ALLOCATOR_DIRECT.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_USE_LRFU.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_LAMBDA.varname);
+    llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_HOTBUFFERS_PERCENTAGE.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_LRFU_BP_WRAPPER_SIZE.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_CACHE_ALLOW_SYNTHETIC_FILEID.varname);
     llapDaemonVarsSetLocal.add(ConfVars.LLAP_IO_USE_FILEID_PATH.varname);

--- a/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
+++ b/common/src/test/org/apache/hadoop/hive/conf/TestHiveConf.java
@@ -31,6 +31,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 
@@ -95,6 +97,142 @@ public class TestHiveConf {
 
     // Test HiveConf property variable substitution in hive-site.xml
     checkHiveConf("test.var.hiveconf.property", ConfVars.DEFAULTPARTITIONNAME.getDefaultValue());
+
+    // Test if all the LLAP conf vars are defined in LLAP daemon conf vars
+    Set<String> llapConfSet = getLLAPConfVars();
+    for (String varName : llapConfSet) {
+      Assert.assertTrue(HiveConf.getLlapDaemonConfVars().contains(varName));
+    }
+  }
+
+  private Set<String> getLLAPConfVars() {
+    Set<String> llapVarsExclusionSet = getLLAPVarsExclusionSet();
+    Set<String> llapConfSet = new HashSet<>();
+    for(ConfVars var: ConfVars.values()) {
+      if (var.name().startsWith("LLAP_") && !llapVarsExclusionSet.contains(var.varname)) {
+        llapConfSet.add(var.varname);
+      }
+    }
+    return llapConfSet;
+  }
+
+  /**
+   * Add those conf vars to this exclusion set which are not part of LLAP Daemon Conf vars
+   */
+  private Set<String> getLLAPVarsExclusionSet() {
+    Set<String> llapExclusionSet = new HashSet<>();
+    llapExclusionSet.add(ConfVars.LLAP_IO_CACHE_ONLY.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ROW_WRAPPER_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ACID_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_TRACE_SIZE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_TRACE_ALWAYS_DUMP.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_NONVECTOR_WRAPPER_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_PREALLOCATE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_MAPPED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_MAPPED_PATH.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_DISCARD_METHOD.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_DEFRAG_HEADROOM.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ALLOCATOR_MAX_FORCE_EVICTED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TRACK_CACHE_USAGE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_CACHE_DEFAULT_FS_FILE_ID.varname);
+    llapExclusionSet.add(ConfVars.LLAP_CACHE_ENABLE_ORC_GAP_CACHE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_CACHE_HYDRATION_STRATEGY_CLASS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_CACHE_HYDRATION_SAVE_DIR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_FORMATS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_ALLOC_SIZE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_VECTOR_SERDE_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_VECTOR_SERDE_ASYNC_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_SLICE_ROW_COUNT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_SLICE_LRR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_VRB_QUEUE_LIMIT_MAX.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_VRB_QUEUE_LIMIT_MIN.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_CVB_BUFFERED_SIZE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_PROACTIVE_EVICTION_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_PROACTIVE_EVICTION_SWEEP_INTERVAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_PROACTIVE_EVICTION_INSTANT_DEALLOC.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_CACHE_DELETEDELTAS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_SHARE_OBJECT_POOLS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_ALLOW_UBER.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_ENFORCE_TREE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_ENFORCE_VECTORIZED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_ENFORCE_STATS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_MAX_INPUT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_AUTO_MAX_OUTPUT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_SKIP_COMPILE_UDF_CHECK.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXECUTION_MODE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ETL_SKIP_FORMAT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_OBJECT_CACHE_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_IO_ENCODE_THREADPOOL_MULTIPLIER.varname);
+    llapExclusionSet.add(ConfVars.LLAP_USE_KERBEROS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_WEBUI_SPNEGO_KEYTAB_FILE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_WEBUI_SPNEGO_PRINCIPAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_FS_KERBEROS_PRINCIPAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_FS_KERBEROS_KEYTAB_FILE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ZKSM_ZK_SESSION_TIMEOUT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ZK_REGISTRY_USER.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ZK_REGISTRY_NAMESPACE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_PLUGIN_ACL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_PLUGIN_ACL_DENY.varname);
+    llapExclusionSet.add(ConfVars.LLAP_REMOTE_TOKEN_REQUIRES_SIGNING.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DELEGATION_TOKEN_RENEW_INTERVAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_PLUGIN_RPC_PORT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_PLUGIN_RPC_NUM_HANDLERS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_HDFS_PACKAGE_DIR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_QUEUE_NAME.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_NM_ADDRESS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_EXEC_USE_FQDN.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_TASK_SCHEDULER_TIMEOUT_SECONDS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_MAPJOIN_MEMORY_OVERSUBSCRIBE_FACTOR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_MEMORY_OVERSUBSCRIPTION_MAX_EXECUTORS_PER_QUERY.varname);
+    llapExclusionSet.add(ConfVars.LLAP_MAPJOIN_MEMORY_MONITOR_CHECK_INTERVAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_AM_REPORTER_MAX_THREADS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_COMMUNICATOR_NUM_THREADS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_PLUGIN_CLIENT_NUM_THREADS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_AM_COLLECT_DAEMON_METRICS_MS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_AM_COLLECT_DAEMON_METRICS_LISTENER.varname);
+    llapExclusionSet.add(ConfVars.LLAP_NODEHEALTHCHECKS_MINTASKS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_NODEHEALTHCHECKS_MININTERVALDURATION.varname);
+    llapExclusionSet.add(ConfVars.LLAP_NODEHEALTHCHECKS_TASKTIMERATIO.varname);
+    llapExclusionSet.add(ConfVars.LLAP_NODEHEALTHCHECKS_EXECUTORRATIO.varname);
+    llapExclusionSet.add(ConfVars.LLAP_NODEHEALTHCHECKS_MAXNODES.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_AM_REGISTRY_NAME.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_AM_REGISTRY_PRINCIPAL.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_AM_REGISTRY_KEYTAB_FILE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_NODE_REENABLE_MIN_TIMEOUT_MS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_NODE_REENABLE_MAX_TIMEOUT_MS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_NODE_DISABLE_BACK_OFF_FACTOR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_PREEMPT_INDEPENDENT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_NUM_SCHEDULABLE_TASKS_PER_NODE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_SCHEDULER_LOCALITY_DELAY.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_METRICS_TIMED_WINDOW_AVERAGE_DATA_POINTS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_METRICS_TIMED_WINDOW_AVERAGE_WINDOW_LENGTH.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_METRICS_SIMPLE_AVERAGE_DATA_POINTS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_COMMUNICATOR_CONNECTION_TIMEOUT_MS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_COMMUNICATOR_LISTENER_THREAD_COUNT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_MAX_CONCURRENT_REQUESTS_PER_NODE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_COMMUNICATOR_CONNECTION_SLEEP_BETWEEN_RETRIES_MS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_UMBILICAL_SERVER_PORT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_WEB_XFRAME_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_WEB_XFRAME_VALUE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_CLIENT_CONSISTENT_SPLITS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_SPLIT_LOCATION_PROVIDER_CLASS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_OUTPUT_SERVICE_PORT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_OUTPUT_STREAM_TIMEOUT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_OUTPUT_SERVICE_SEND_BUFFER_SIZE.varname);
+    llapExclusionSet.add(ConfVars.LLAP_DAEMON_OUTPUT_SERVICE_MAX_PENDING_WRITES.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_SPLITS_TEMP_TABLE_STORAGE_FORMAT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_USE_HYBRID_CALENDAR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_CLOUD_DEPLOYMENT_SETUP_ENABLED.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_CLOUD_RPC_PORT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_CLOUD_OUTPUT_SERVICE_PORT.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_CLOUD_JWT_SHARED_SECRET_PROVIDER.varname);
+    llapExclusionSet.add(ConfVars.LLAP_EXTERNAL_CLIENT_CLOUD_JWT_SHARED_SECRET.varname);
+    llapExclusionSet.add(ConfVars.LLAP_ENABLE_GRACE_JOIN_IN_LLAP.varname);
+    llapExclusionSet.add(ConfVars.LLAP_HS2_ENABLE_COORDINATOR.varname);
+    llapExclusionSet.add(ConfVars.LLAP_COLLECT_LOCK_METRICS.varname);
+    llapExclusionSet.add(ConfVars.LLAP_TASK_TIME_SUMMARY.varname);
+    return llapExclusionSet;
   }
 
   @Test


### PR DESCRIPTION
…: LLAP_LRFU_HOTBUFFERS_PERCENTAGE

### What changes were proposed in this pull request?
This is a bug fix.


### Why are the changes needed?
LLAP_LRFU_HOTBUFFERS_PERCENTAGE was not added as part of llapDaemonVarsSetLocal


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Unit test
