### PR TITLE
HIVE-XXXXX: Update entrypoint.sh to remove `IS_RESUME` flag

### DIFF
--- a/packaging/src/docker/README.md
+++ b/packaging/src/docker/README.md
@@ -87,7 +87,6 @@ Launch the HiveServer2 with an embedded Metastore,
    ```shell
     docker run -d -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 \
          --env SERVICE_OPTS="-Dhive.metastore.uris=thrift://metastore:9083" \
-         --env IS_RESUME="true" \
          --name hiveserver2-standalone apache/hive:${HIVE_VERSION}
    ```
   To save the data between container restarts, you can start the HiveServer2 with a Volume,
@@ -95,7 +94,6 @@ Launch the HiveServer2 with an embedded Metastore,
    docker run -d -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 \
       --env SERVICE_OPTS="-Dhive.metastore.uris=thrift://metastore:9083" \
       --mount source=warehouse,target=/opt/hive/data/warehouse \
-      --env IS_RESUME="true" \
       --name hiveserver2 apache/hive:${HIVE_VERSION}
    ```
   

--- a/packaging/src/docker/docker-compose.yml
+++ b/packaging/src/docker/docker-compose.yml
@@ -42,7 +42,6 @@ services:
     environment:
       HIVE_SERVER2_THRIFT_PORT: 10000
       SERVICE_OPTS: '-Xmx1G -Dhive.metastore.uris=thrift://metastore:9083'
-      IS_RESUME: 'true'
       SERVICE_NAME: 'hiveserver2'
     ports:
       - '10000:10000'


### PR DESCRIPTION
I submitted a request for an account to the Apache Software Foundation, but I have not yet received access, and I am unable to create Jira tickets. I apologize for the inconvenience. In the meantime, I have gone ahead and created a pull request

You might have a specific reason for preparing the IS_RESUME flag, and if you do, please kindly share it with me 🙇‍♂️ 

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Update entrypoint.sh to remove `IS_RESUME` flag


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's annoying that we need to go through two steps, first setting IS_RESUME to false and then to true.

During my testing, I observed that the schematool can handle multiple runs without any issues, even if it encounters the error message 'Error: ERROR: relation "BUCKETING_COLS" already exists.' Given this, I propose updating the logic to eliminate the need for the IS_RESUME flag and ensure that the schematool runs smoothly every time."


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. IS_RESUME flag will be ignored.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I have verified that it works on my local PC.