### PR TITLE
HIVE-27764: Add "WWW-Authenticate: Negotiate" header to the response when the client is unauthorized and Kerberos authentication is enabled

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -283,7 +283,8 @@ public class ThriftHttpServlet extends TServlet {
       }
       // Send a 401 to the client
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      if(isAuthTypeEnabled(request, HiveAuthConstants.AuthTypes.KERBEROS)) {
+      if (e instanceof HttpEmptyAuthenticationException &&
+          authType.isEnabled(HiveAuthConstants.AuthTypes.KERBEROS)) {
         response.addHeader(HttpAuthUtils.WWW_AUTHENTICATE, HttpAuthUtils.NEGOTIATE);
       } else {
         try {

--- a/service/src/test/org/apache/hive/service/cli/thrift/ThriftHttpServletTest.java
+++ b/service/src/test/org/apache/hive/service/cli/thrift/ThriftHttpServletTest.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.auth.HiveAuthConstants;
 import org.apache.hive.service.auth.HttpAuthUtils;
 import org.apache.hive.service.auth.ldap.HttpEmptyAuthenticationException;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,6 +73,39 @@ public class ThriftHttpServletTest {
     exceptionRule.expectMessage("Authorization header received " +
         "from the client is empty.");
     thriftHttpServlet.doKerberosAuth(httpServletRequest);
+  }
+
+  @Test
+  public void testWwwAuthenticateNegotiateHeaderAddedToTheResponse() throws Exception {
+    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
+    PrintWriter mockPrintWriter = Mockito.mock(PrintWriter.class);
+    Mockito.when(mockResponse.getWriter()).thenReturn(mockPrintWriter);
+
+    thriftHttpServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockResponse)
+      .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    Mockito.verify(mockPrintWriter)
+      .println("Authentication Error: Authorization header received from the client is empty.");
+    Mockito.verify(mockResponse)
+      .addHeader(HttpAuthUtils.WWW_AUTHENTICATE, HttpAuthUtils.NEGOTIATE);
+  }
+
+  @Test
+  public void testWwwAuthenticateNegotiateHeaderNotAddedToTheResponseWhenNotEmptyAuthorizationHeaderExists() throws Exception {
+    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(mockRequest.getHeader(HttpAuthUtils.AUTHORIZATION)).thenReturn("Authorization: Negotiate");
+    HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
+    PrintWriter mockPrintWriter = Mockito.mock(PrintWriter.class);
+    Mockito.when(mockResponse.getWriter()).thenReturn(mockPrintWriter);
+
+    thriftHttpServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockResponse)
+      .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    Mockito.verify(mockResponse, Mockito.times(0))
+      .addHeader(HttpAuthUtils.WWW_AUTHENTICATE, HttpAuthUtils.NEGOTIATE);
   }
 
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

[HIVE-27661](https://issues.apache.org/jira/browse/HIVE-27661) (#4666) refactored the authentication code a bit and also introduced a new bug: 
Before the modification, if the client was not authenticated and Kerberos authentication was enabled, a response header was included in the HTTP 401 response: `WWW-Authenticate: Negotiate`  
After the modification, this header is not included in the response, so [the reactive authentication flow implemented in the Knox gateway](https://github.com/apache/knox/blob/master/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/auth/SpnegoAuthInterceptor.java#L105-L113) does not work anymore.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change fixes an authentication problem that occurs when the hiveserver is behind a Knox gateway.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.


### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested with a new unit test and with manual tests in CDP Public Cloud env..