### PR TITLE
HIVE-27774: Remove PowerMock - finishing touches

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/jdbc-handler/pom.xml
+++ b/jdbc-handler/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/llap-client/pom.xml
+++ b/llap-client/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.8.3</orc.version>
     <mockito-core.version>3.4.4</mockito-core.version>
-    <powermock.version>2.0.2</powermock.version>
+    <mockito-inline.version>4.11.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
     <netty.version>4.1.77.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -809,7 +809,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito-inline.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Remove powermock.version
For mockito-inline, create a version property and use it. 

### What changes were proposed in this pull request?
Remove powermock.version
For mockito-inline, create a version property and use it. 

### Why are the changes needed?
To get rid of all the remainings of PowerMock

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Precommit tests