### PR TITLE
HIVE-27780: Implement direct SQL for get_all_functions

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3086,7 +3086,7 @@ class MetaStoreDirectSql {
     final int dbNameIndex = 2;
     final int funcClassNameIndex = 3;
     final int funcOwnerNameIndex = 4;
-    final int funcOwerTypeIndex = 5;
+    final int funcOwnerTypeIndex = 5;
     final int funcCreateTimeIndex = 6;
     final int funcTypeIndex = 7;
 
@@ -3118,7 +3118,7 @@ class MetaStoreDirectSql {
         String dbName = MetastoreDirectSqlUtils.extractSqlString(function[dbNameIndex]);
         String funcClassName = MetastoreDirectSqlUtils.extractSqlString(function[funcClassNameIndex]);
         String funcOwnerName = MetastoreDirectSqlUtils.extractSqlString(function[funcOwnerNameIndex]);
-        String funcOwerType = MetastoreDirectSqlUtils.extractSqlString(function[funcOwerTypeIndex]);
+        String funcOwnerType = MetastoreDirectSqlUtils.extractSqlString(function[funcOwnerTypeIndex]);
         int funcCreateTime = MetastoreDirectSqlUtils.extractSqlInt(function[funcCreateTimeIndex]);
         int funcType = MetastoreDirectSqlUtils.extractSqlInt(function[funcTypeIndex]);
 
@@ -3128,7 +3128,7 @@ class MetaStoreDirectSql {
         func.setCatName(catName);
         func.setClassName(funcClassName);
         func.setOwnerName(funcOwnerName);
-        func.setOwnerType(PrincipalType.valueOf(funcOwerType));
+        func.setOwnerType(PrincipalType.valueOf(funcOwnerType));
         func.setCreateTime(funcCreateTime);
         func.setFunctionType(FunctionType.findByValue(funcType));
         func.setResourceUris(new ArrayList<>());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -68,6 +68,8 @@ import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DatabaseType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.FunctionType;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsFilterSpec;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -92,6 +94,7 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.model.MConstraint;
 import org.apache.hadoop.hive.metastore.model.MCreationMetadata;
 import org.apache.hadoop.hive.metastore.model.MDatabase;
+import org.apache.hadoop.hive.metastore.model.MFunction;
 import org.apache.hadoop.hive.metastore.model.MNotificationLog;
 import org.apache.hadoop.hive.metastore.model.MNotificationNextId;
 import org.apache.hadoop.hive.metastore.model.MPartition;
@@ -182,7 +185,7 @@ class MetaStoreDirectSql {
       SDS, SERDES, SKEWED_STRING_LIST_VALUES, SKEWED_VALUES, BUCKETING_COLS, SKEWED_COL_NAMES,
       SKEWED_COL_VALUE_LOC_MAP, COLUMNS_V2, PARTITION_KEYS, SERDE_PARAMS, PART_COL_STATS, KEY_CONSTRAINTS,
       TAB_COL_STATS, PARTITION_KEY_VALS, PART_PRIVS, PART_COL_PRIVS, SKEWED_STRING_LIST, CDS,
-      TBL_COL_PRIVS;
+      TBL_COL_PRIVS, FUNCS, FUNC_RU;
 
   public MetaStoreDirectSql(PersistenceManager pm, Configuration conf, String schema) {
     this.pm = pm;
@@ -3063,5 +3066,101 @@ class MetaStoreDirectSql {
     }
     long csId = updateStat.getNextCSIdForMPartitionColumnStatistics(numStats);
     return updateStat.updatePartitionColumnStatistics(partColStatsMap, tbl, csId, validWriteIds, writeId, listeners);
+  }
+
+  public List<Function> getFunctions(String catName) throws MetaException {
+    List<Long> funcIds = getFunctionIds();
+    // Get full objects. For Oracle/etc. do it in batches.
+    return Batchable.runBatched(batchSize, funcIds, new Batchable<Long, Function>() {
+      @Override
+      public List<Function> run(List<Long> input) throws MetaException {
+        return getFunctionsFromFunctionIds(input, catName);
+      }
+    });
+  }
+
+  private List<Function> getFunctionsFromFunctionIds(List<Long> funcIdList, String catName) throws MetaException {
+    String funcIds = getIdListForIn(funcIdList);
+    final int funcIdIndex = 0;
+    final int funcNameIndex = 1;
+    final int dbNameIndex = 2;
+    final int funcClassNameIndex = 3;
+    final int funcOwnerNameIndex = 4;
+    final int funcOwerTypeIndex = 5;
+    final int funcCreateTimeIndex = 6;
+    final int funcTypeIndex = 7;
+
+    String queryText = "SELECT " +
+        FUNCS + ".\"FUNC_ID\", " +
+        FUNCS + ".\"FUNC_NAME\", " +
+        DBS + ".\"NAME\", " +
+        FUNCS + ".\"CLASS_NAME\", " +
+        FUNCS + ".\"OWNER_NAME\", " +
+        FUNCS + ".\"OWNER_TYPE\", " +
+        FUNCS + ".\"CREATE_TIME\", " +
+        FUNCS + ".\"FUNC_TYPE\"" +
+        " FROM " + FUNCS +
+        " LEFT JOIN " + DBS + " ON " + FUNCS + ".\"DB_ID\" = " + DBS + ".\"DB_ID\"" +
+        " where " + FUNCS +".\"FUNC_ID\" in (" + funcIds + ") order by " + FUNCS + ".\"FUNC_NAME\" asc";
+
+    List<Function> results = new ArrayList<>();
+    TreeMap<Long, Function> funcs = new TreeMap<>();
+    final boolean doTrace = LOG.isDebugEnabled();
+    long start = doTrace ? System.nanoTime() : 0;
+    try (QueryWrapper query = new QueryWrapper(pm.newQuery("javax.jdo.query.SQL", queryText))) {
+      List<Object[]> queryResult = executeWithArray(query.getInnerQuery(), null, queryText);
+      long end = doTrace ? System.nanoTime() : 0;
+      MetastoreDirectSqlUtils.timingTrace(doTrace, queryText, start, end);
+
+      for (Object[] function : queryResult) {
+        Long funcId = MetastoreDirectSqlUtils.extractSqlLong(function[funcIdIndex]);
+        String funcName = MetastoreDirectSqlUtils.extractSqlString(function[funcNameIndex]);
+        String dbName = MetastoreDirectSqlUtils.extractSqlString(function[dbNameIndex]);
+        String funcClassName = MetastoreDirectSqlUtils.extractSqlString(function[funcClassNameIndex]);
+        String funcOwnerName = MetastoreDirectSqlUtils.extractSqlString(function[funcOwnerNameIndex]);
+        String funcOwerType = MetastoreDirectSqlUtils.extractSqlString(function[funcOwerTypeIndex]);
+        int funcCreateTime = MetastoreDirectSqlUtils.extractSqlInt(function[funcCreateTimeIndex]);
+        int funcType = MetastoreDirectSqlUtils.extractSqlInt(function[funcTypeIndex]);
+
+        Function func = new Function();
+        func.setFunctionName(funcName);
+        func.setDbName(dbName);
+        func.setCatName(catName);
+        func.setClassName(funcClassName);
+        func.setOwnerName(funcOwnerName);
+        func.setOwnerType(PrincipalType.valueOf(funcOwerType));
+        func.setCreateTime(funcCreateTime);
+        func.setFunctionType(FunctionType.findByValue(funcType));
+        func.setResourceUris(new ArrayList<>());
+
+        results.add(func);
+        funcs.put(funcId, func);
+      }
+    }
+    MetastoreDirectSqlUtils.setFunctionResourceUris(FUNC_RU, pm, funcIds, funcs);
+    return results;
+  }
+
+  private List<Long> getFunctionIds() throws MetaException {
+    boolean doTrace = LOG.isDebugEnabled();
+
+    String queryText = "select " + FUNCS + ".\"FUNC_ID\" from " + FUNCS;
+
+    long start = doTrace ? System.nanoTime() : 0;
+    try (QueryWrapper query = new QueryWrapper(pm.newQuery("javax.jdo.query.SQL", queryText))) {
+      List<Object> sqlResult = executeWithArray(query.getInnerQuery(), null, queryText);
+      long queryTime = doTrace ? System.nanoTime() : 0;
+      MetastoreDirectSqlUtils.timingTrace(doTrace, queryText, start, queryTime);
+      final List<Long> result;
+      if (sqlResult.isEmpty()) {
+        result = Collections.emptyList();
+      } else {
+        result = new ArrayList<>(sqlResult.size());
+        for (Object fields : sqlResult) {
+          result.add(MetastoreDirectSqlUtils.extractSqlLong(fields));
+        }
+      }
+      return result;
+    }
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -19,17 +19,18 @@
 
 package org.apache.hadoop.hive.metastore;
 
-import com.google.common.base.Joiner;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.ResourceType;
+import org.apache.hadoop.hive.metastore.api.ResourceUri;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.SkewedInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
-import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 /**
  * Helper utilities used by DirectSQL code in HiveMetastore.
@@ -512,6 +512,21 @@ class MetastoreDirectSqlUtils {
     for (SerDeInfo t : serdes.values()) {
       t.setParameters(MetaStoreServerUtils.trimMapNulls(t.getParameters(), convertMapNullsToEmptyStrings));
     }
+  }
+
+  static void setFunctionResourceUris(String FUNC_RU, PersistenceManager pm, String funcIds,
+      TreeMap<Long, Function> functions)
+      throws MetaException {
+    String queryText;
+    queryText = "select \"FUNC_ID\", \"RESOURCE_TYPE\", \"RESOURCE_URI\" from " +  FUNC_RU + ""
+        + " where \"FUNC_ID\" in (" + funcIds + ")"
+        + " order by \"FUNC_ID\" asc, \"INTEGER_IDX\" asc";
+    loopJoinOrderedResult(pm, functions, queryText, 0, new ApplyFunc<Function>() {
+      @Override
+      public void apply(Function t, Object[] fields) {
+        ResourceUri resourceUri = new ResourceUri(ResourceType.findByValue((int)fields[1]), (String) fields[2]);
+        t.getResourceUris().add(resourceUri);
+      }});
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -518,15 +518,13 @@ class MetastoreDirectSqlUtils {
       TreeMap<Long, Function> functions)
       throws MetaException {
     String queryText;
-    queryText = "select \"FUNC_ID\", \"RESOURCE_TYPE\", \"RESOURCE_URI\" from " +  FUNC_RU + ""
+    queryText = "select \"FUNC_ID\", \"RESOURCE_TYPE\", \"RESOURCE_URI\" from " +  FUNC_RU
         + " where \"FUNC_ID\" in (" + funcIds + ")"
         + " order by \"FUNC_ID\" asc, \"INTEGER_IDX\" asc";
-    loopJoinOrderedResult(pm, functions, queryText, 0, new ApplyFunc<Function>() {
-      @Override
-      public void apply(Function t, Object[] fields) {
-        ResourceUri resourceUri = new ResourceUri(ResourceType.findByValue((int)fields[1]), (String) fields[2]);
-        t.getResourceUris().add(resourceUri);
-      }});
+    loopJoinOrderedResult(pm, functions, queryText, 0, (t, fields) -> {
+      ResourceUri resourceUri = new ResourceUri(ResourceType.findByValue((int)fields[1]), (String) fields[2]);
+      t.getResourceUris().add(resourceUri);
+    });
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -11598,7 +11598,7 @@ public class ObjectStore implements RawStore, Configurable {
         try {
           return getAllFunctionsViaJDO(catalogName);
         } catch (Exception e) {
-          LOG.error("Failed to convert to funcs", e);
+          LOG.error("Failed to convert to functions", e);
           throw new MetaException(e.getMessage());
         }
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -11579,6 +11579,33 @@ public class ObjectStore implements RawStore, Configurable {
 
   @Override
   public List<Function> getAllFunctions(String catName) throws MetaException {
+    try {
+      return getFunctionsInternal(catName);
+    } catch (NoSuchObjectException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected List<Function> getFunctionsInternal(String catalogName)
+      throws MetaException, NoSuchObjectException {
+    return new GetListHelper<Function>(catalogName, "", "", true, true) {
+      @Override
+      protected List<Function> getSqlResult(GetHelper<List<Function>> ctx) throws MetaException {
+        return directSql.getFunctions(catalogName);
+      }
+      @Override
+      protected List<Function> getJdoResult(GetHelper<List<Function>> ctx) throws MetaException {
+        try {
+          return getAllFunctionsViaJDO(catalogName);
+        } catch (Exception e) {
+          LOG.error("Failed to convert to funcs", e);
+          throw new MetaException(e.getMessage());
+        }
+      }
+    }.run(false);
+  }
+
+  private List<Function> getAllFunctionsViaJDO (String catName) {
     boolean commited = false;
     Query query = null;
     try {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestFunctions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestFunctions.java
@@ -377,12 +377,20 @@ public class TestFunctions extends MetaStoreClientTest {
     for(Function function : allFunctions) {
       if (function.getDbName().equals(OTHER_DATABASE)) {
         Assert.assertEquals("Comparing functions", testFunctions[3], function);
+        Assert.assertEquals("Checking function's resourceUris",
+            testFunctions[3].getResourceUris().toString(), function.getResourceUris().toString());
       } else if (function.getFunctionName().equals("test_function_hidden_1")) {
         Assert.assertEquals("Comparing functions", testFunctions[2], function);
+        Assert.assertEquals("Checking function's resourceUris",
+            testFunctions[2].getResourceUris().toString(), function.getResourceUris().toString());
       } else if (function.getFunctionName().equals("test_function_to_find_2")) {
         Assert.assertEquals("Comparing functions", testFunctions[1], function);
+        Assert.assertEquals("Checking function's resourceUris",
+            testFunctions[1].getResourceUris().toString(), function.getResourceUris().toString());
       } else {
         Assert.assertEquals("Comparing functions", testFunctions[0], function);
+        Assert.assertEquals("Checking function's resourceUris",
+            testFunctions[0].getResourceUris().toString(), function.getResourceUris().toString());
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Implement direct SQL for get_all_functions

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We have a special Hive cluster which has many udfs, and we often use `Hive::getAllFunctions()` to retrieve all udf functions, but the `getAllFunctions ` often return results slowly(10s~30s). This is because the query of  ` HMSHandler::get_all_functions`  is automatically generated by JDO/DataNucleus and the query will  join `DBS `and `FUNCS `& `FUN_RU`, and the query will be slowly when having many udf functions.

In addition, when we open a Hive session, a new `Hive` object will be initialized, and all functions will be fetched. That is to say, the  ` HMSHandler::get_all_functions`  is often invoked, and we need optimize it using direct SQL.

https://github.com/apache/hive/blob/dec006e81e657bc6edb0d57d31076f04e1f088c5/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L562-L568

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. If direct SQL way failled, it would fall back to JDO.
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT