### PR TITLE
HIVE-27773 get_valid_write_ids is being called multiple times for a single query

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -372,7 +372,7 @@ class DriverTxnHandler {
       txnWriteIds = new ValidTxnWriteIdList(driverContext.getCompactorTxnId());
       txnWriteIds.addTableValidWriteIdList(driverContext.getCompactionWriteIds());
     } else {
-      txnWriteIds = driverContext.getTxnManager().getValidWriteIds(txnTables, txnString);
+      txnWriteIds = driverContext.getTxnManager().getValidWriteIds(txnTables, txnString, false);
     }
     if (driverContext.getTxnType() == TxnType.READ_ONLY && !getTables(false, true).isEmpty()) {
       throw new IllegalStateException(String.format(

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -1626,7 +1626,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
     }
     String fullTableName = AcidUtils.getFullTableName(dbName, tblName);
     ValidWriteIdList validWriteIds = getTxnMgr()
-            .getValidWriteIds(Collections.singletonList(fullTableName), validTxnString)
+            .getValidWriteIds(Collections.singletonList(fullTableName), validTxnString, false)
             .getTableValidWriteIdList(fullTableName);
     return ((validWriteIds != null) ? validWriteIds.toString() : null);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -2411,7 +2411,7 @@ public class AcidUtils {
           return null;
         }
         if (validWriteIdList == null) {
-          validWriteIdList = getTableValidWriteIdListWithTxnList(conf, dbName, tblName);
+          validWriteIdList = getTableValidWriteIdListWithTxnList(conf, dbName, tblName, false);
         }
         if (validWriteIdList == null) {
           throw new AssertionError("Cannot find valid write ID list for " + tblName);
@@ -2433,7 +2433,7 @@ public class AcidUtils {
    * @throws LockException
    */
   public static ValidWriteIdList getTableValidWriteIdListWithTxnList(
-      Configuration conf, String dbName, String tableName) throws LockException {
+      Configuration conf, String dbName, String tableName, boolean useWriteIdCache) throws LockException {
     HiveTxnManager sessionTxnMgr = SessionState.get().getTxnMgr();
     if (sessionTxnMgr == null) {
       return null;
@@ -2446,7 +2446,7 @@ public class AcidUtils {
     String fullTableName = getFullTableName(dbName, tableName);
     tablesInput.add(fullTableName);
 
-    validTxnWriteIdList = sessionTxnMgr.getValidWriteIds(tablesInput, validTxnList);
+    validTxnWriteIdList = sessionTxnMgr.getValidWriteIds(tablesInput, validTxnList, useWriteIdCache);
     return validTxnWriteIdList != null ?
         validTxnWriteIdList.getTableValidWriteIdList(fullTableName) : null;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
@@ -294,7 +294,7 @@ class DummyTxnManager extends HiveTxnManagerImpl {
 
   @Override
   public ValidTxnWriteIdList getValidWriteIds(List<String> tableList,
-                                              String validTxnList) throws LockException {
+                                              String validTxnList, boolean useWriteIdCache) throws LockException {
     return new ValidTxnWriteIdList(getCurrentTxnId());
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
@@ -208,7 +208,7 @@ public interface HiveTxnManager {
    * @return list of valid table write Ids.
    * @throws LockException
    */
-  ValidTxnWriteIdList getValidWriteIds(List<String> tableList, String validTxnList) throws LockException;
+  ValidTxnWriteIdList getValidWriteIds(List<String> tableList, String validTxnList, boolean useWriteIdCache) throws LockException;
 
   /**
    * Get the name for currently installed transaction manager.

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1728,7 +1728,7 @@ public class Hive {
         long txnId = SessionState.get() != null && SessionState.get().getTxnMgr() != null ?
             SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
         if (txnId > 0) {
-          validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName);
+          validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName, true);
         }
         request.setValidWriteIdList(validWriteIdList != null ? validWriteIdList.toString() : null);
       }
@@ -1795,7 +1795,7 @@ public class Hive {
     HiveTxnManager txnMgr = sessionState != null? sessionState.getTxnMgr() : null;
     long txnId = txnMgr != null ? txnMgr.getCurrentTxnId() : 0;
     if (txnId > 0) {
-      validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName);
+      validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName, true);
     } else {
       String fullTableName = getFullTableName(dbName, tableName);
       validWriteIdList = new ValidReaderWriteIdList(fullTableName, new long[0], new BitSet(), Long.MAX_VALUE);
@@ -2531,7 +2531,7 @@ public class Hive {
     TableSnapshot tableSnapshot = null;
     if ((writeId != null) && (writeId > 0)) {
       ValidWriteIdList writeIds = AcidUtils.getTableValidWriteIdListWithTxnList(
-              conf, tbl.getDbName(), tbl.getTableName());
+              conf, tbl.getDbName(), tbl.getTableName(), false);
       tableSnapshot = new TableSnapshot(writeId, writeIds.writeToString());
     } else {
       // Make sure we pass in the names, so we can get the correct snapshot for rename table.

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -2517,7 +2517,7 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
       }
       final String fullTableName = TableName.getDbTable(dbName, tblName);
       final ValidTxnWriteIdList validTxnWriteIdList = SessionState.get().getTxnMgr()
-          .getValidWriteIds(ImmutableList.of(fullTableName), validTxnsList);
+          .getValidWriteIds(ImmutableList.of(fullTableName), validTxnsList, true);
       ValidWriteIdList writeIdList = validTxnWriteIdList.getTableValidWriteIdList(fullTableName);
       return (writeIdList != null) ? writeIdList.toString() : null;
     } catch (Exception e) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
@@ -129,7 +129,7 @@ public class HiveMaterializedViewUtils {
     List<String> tablesUsedNames = tablesUsed.stream()
         .map(tableName -> TableName.getDbTable(tableName.getDb(), tableName.getTable()))
         .collect(Collectors.toList());
-    ValidTxnWriteIdList currentTxnWriteIds = txnMgr.getValidWriteIds(tablesUsedNames, validTxnsList);
+    ValidTxnWriteIdList currentTxnWriteIds = txnMgr.getValidWriteIds(tablesUsedNames, validTxnsList, true);
     if (currentTxnWriteIds == null) {
       LOG.debug("Materialized view " + materializedViewTable.getFullyQualifiedName() +
               " ignored for rewriting as we could not obtain current txn ids");
@@ -274,7 +274,7 @@ public class HiveMaterializedViewUtils {
       }
     }.go(materialization.queryRel);
     ValidTxnWriteIdList currentTxnList =
-        SessionState.get().getTxnMgr().getValidWriteIds(tablesUsed, validTxnsList);
+        SessionState.get().getTxnMgr().getValidWriteIds(tablesUsed, validTxnsList, true);
     // Augment
     final RexBuilder rexBuilder = materialization.queryRel.getCluster().getRexBuilder();
     return applyRule(

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
@@ -104,7 +104,7 @@ public class CacheTableHelper {
     }
     String validTxnList = conf.get(ValidTxnList.VALID_TXNS_KEY);
     try {
-      txnMgr.getValidWriteIds(fullTableNamesList, validTxnList);
+      txnMgr.getValidWriteIds(fullTableNamesList, validTxnList, true);
     } catch (Exception e) {
       LOG.info("Population of valid write id list cache failed, will be done later in query.");
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -15709,7 +15709,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (transactionalTables.size() > 0) {
       try {
         String txnString = conf.get(ValidTxnList.VALID_TXNS_KEY);
-        return getTxnMgr().getValidWriteIds(transactionalTables, txnString);
+        return getTxnMgr().getValidWriteIds(transactionalTables, txnString, true);
       } catch (Exception err) {
         String msg = "Error while getting the txnWriteIdList for tables " + transactionalTables
                 + " and validTxnList " + conf.get(ValidTxnList.VALID_TXNS_KEY);

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -3274,7 +3274,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     long testTxnId = txnMgr2.openTxn(ctx, "u2");
     Assert.assertTrue("Invalid txn ID", testTxnId > underHwmOpenTxnId);
     String testValidTxns = txnMgr2.getValidTxns().toString();
-    ValidWriteIdList testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns)
+    ValidWriteIdList testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns, true)
             .getTableValidWriteIdList("temp.t7");
     Assert.assertEquals(baseWriteId, testValidWriteIds.getHighWatermark());
     Assert.assertTrue("Invalid write ID list", testValidWriteIds.isWriteIdValid(baseWriteId));
@@ -3291,7 +3291,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     Assert.assertEquals(3, underHwmOpenWriteId);
 
     // Verify the ValidWriteIdList with one open txn on this table. Write ID of open txn should be invalid.
-    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns)
+    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns, false)
         .getTableValidWriteIdList("temp.t7");
     Assert.assertEquals(underHwmOpenWriteId, testValidWriteIds.getHighWatermark());
     Assert.assertTrue("Invalid write ID list", testValidWriteIds.isWriteIdValid(baseWriteId));
@@ -3301,7 +3301,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     // Commit the txn under HWM.
     // Verify the writeId of this committed txn should be invalid for test txn.
     txnMgr1.commitTxn();
-    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns)
+    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns, true)
         .getTableValidWriteIdList("temp.t7");
     Assert.assertEquals(underHwmOpenWriteId, testValidWriteIds.getHighWatermark());
     Assert.assertTrue("Invalid write ID list", testValidWriteIds.isWriteIdValid(baseWriteId));
@@ -3314,7 +3314,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     long testWriteId = txnMgr2.getTableWriteId("temp", "T7");
     Assert.assertEquals(4, testWriteId);
 
-    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns)
+    testValidWriteIds = txnMgr2.getValidWriteIds(Collections.singletonList("temp.t7"), testValidTxns, false)
         .getTableValidWriteIdList("temp.t7");
     Assert.assertEquals(testWriteId, testValidWriteIds.getHighWatermark());
     Assert.assertTrue("Invalid write ID list", testValidWriteIds.isWriteIdValid(baseWriteId));

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestTxnManager.java
@@ -60,7 +60,7 @@ class TestTxnManager extends DummyTxnManager {
 
   @Override
   public ValidTxnWriteIdList getValidWriteIds(List<String> tableList,
-                                              String validTxnList) throws LockException {
+                                              String validTxnList, boolean useWriteIdCache) throws LockException {
     // Format : <txnId>$<table_name>:<hwm>:<minOpenWriteId>:<open_writeids>:<abort_writeids>
     return new ValidTxnWriteIdList(getCurrentTxnId() + DOLLAR.toString() + "db.table" + COLON +
         getCurrentTxnId() + COLON +


### PR DESCRIPTION

### What changes were proposed in this pull request?
get_valid_write_ids gets called multiple times for the same transaction list and set of tables for a query. Subsequent calls can make use of the cached result and thereby reducing the time spent in metastore calls.


### Why are the changes needed?
This is needed for performance improvement of query compilation


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Tested locally using the log to determine if this is making use of the cache
