### PR TITLE
HIVE-27745 : Create a test which validates Schematool sanity

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/tools/schematool/TestSchemaToolForMetastore.java
@@ -30,9 +30,12 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.dbcp2.DelegatingConnection;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrTokenizer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaException;
@@ -41,6 +44,7 @@ import org.apache.hadoop.hive.metastore.MetaStoreSchemaInfoFactory;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.metastore.utils.MetastoreVersionInfo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -465,6 +469,18 @@ public class TestSchemaToolForMetastore {
     execute(new SchemaToolTaskInit(), "-initSchemaTo 1.2.0");
     execute(new SchemaToolTaskUpgrade(), "-upgradeSchema");
     validateMetastoreDbPropertiesTable();
+  }
+
+  @Test
+  public void testValidateHiveShortVersion() {
+    String hiveShortVersion = MetastoreVersionInfo.getShortVersion();
+    String hiveVersion = MetastoreVersionInfo.getVersion();
+    Assert.assertEquals(hiveVersion, StringUtils.join(hiveShortVersion, "-SNAPSHOT"));
+    Assert.assertTrue(hiveVersion.startsWith(hiveShortVersion));
+    String fileName = Stream.of("src/test/resources/sql/postgres/upgrade-3.1.3000-to-" , hiveShortVersion ,".postgres.sql").
+            collect(Collectors.joining());
+    File file = new File(fileName);
+    Assert.assertTrue(file.exists());
   }
 
   private File generateTestScript(String [] stmts) throws IOException {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
After every release, stream gets updated with newer hive-version and related short-version. This test makes sure hive short version is part of hiveversion in order to avoid errors in initSchema and upgradeSchema command at later stage.
Please check comment section of check https://github.com/apache/hive/pull/4750


### Why are the changes needed?
If update sync between hive-short version and hive-version gets missed during newer release, initSchema and upgradeSchema commands fail at later stage.


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
With unit test
