### PR TITLE
HIVE-27695: Intermittent OOM when running TestMiniTezCliDriver

### DIFF
--- a/data/conf/tez/tez-site.xml
+++ b/data/conf/tez/tez-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>tez.am.resource.memory.mb</name>
-    <value>128</value>
+    <value>512</value>
   </property>
   <property>
     <name>tez.task.resource.memory.mb</name>

--- a/ql/src/test/queries/clientpositive/hybridgrace_hashjoin_2.q
+++ b/ql/src/test/queries/clientpositive/hybridgrace_hashjoin_2.q
@@ -1,7 +1,6 @@
 --! qt:dataset:srcpart
 --! qt:dataset:src1
 --! qt:dataset:src
---! qt:disabled:HIVE-26820 Disable hybridgrace_hashjoin_2.q flaky test
 set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 -- Hybrid Grace Hash Join


### PR DESCRIPTION
### What changes were proposed in this pull request?
Increase max heap space for Tez Application master to 512MB.

### Why are the changes needed?
java.lang.OutOfMemoryError: GC overhead limit exceeded is thrown by the Tez Application Master (AM) cause the current heap size (128MB) is not enough to accommodate the needs of multiple Tez containers running. Each running container requires roughly 10MB of memory in the AM. The AM accumulates/manipulates multiple configuration objects (some of them retaining as much as 1MB of heap) per container. The heap gradually becomes full and GC is spending a lot of CPU time to clean things up without really making much progress since containers are reused and heap cannot shrink.

Extended analysis and justification under HIVE-27695.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
```
mvn test -Dtest=TestMiniTezCliDriver
```
Running all tests for `TestMiniTezCliDriver` without the changes here leads to OOM 95% of the time.