### PR TITLE
sort the fields after implementation-dependent operations and reorder…

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
@@ -557,6 +558,7 @@ public final class ObjectInspectorUtils {
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, Comparator.comparing(Field::getName));
     ArrayList<Field> af = new ArrayList<Field>();
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
@@ -76,7 +76,7 @@ public class TestObjectInspectorUtils {
           .getStandardObjectInspector(oi1);
       List<? extends StructField> fields = soi.getAllStructFieldRefs();
       assertEquals(10, fields.size());
-      assertEquals(fields.get(0), soi.getStructFieldRef("aint"));
+      assertEquals(fields.get(0), soi.getStructFieldRef("astring"));
 
       // null
       for (int i = 0; i < fields.size(); i++) {
@@ -87,22 +87,23 @@ public class TestObjectInspectorUtils {
       Complex cc = new Complex();
       cc.setAint(1);
       cc.setAString("test");
-      List<Integer> c2 = Arrays.asList(new Integer[] {1, 2, 3});
-      cc.setLint(c2);
       List<String> c3 = Arrays.asList(new String[] {"one", "two"});
       cc.setLString(c3);
-      List<IntString> c4 = new ArrayList<IntString>();
-      cc.setLintString(c4);
+      List<Integer> c4 = Arrays.asList(new Integer[] {1, 2, 3});
+      cc.setLint(c4);
+      List<IntString> c5 = new ArrayList<IntString>();
+      cc.setLintString(c5);
       cc.setMStringString(null);
       // standard object
       Object c = ObjectInspectorUtils.copyToStandardObject(cc, oi1);
 
-      assertEquals(1, soi.getStructFieldData(c, fields.get(0)));
-      assertEquals("test", soi.getStructFieldData(c, fields.get(1)));
-      assertEquals(c2, soi.getStructFieldData(c, fields.get(2)));
+      assertEquals("test", soi.getStructFieldData(c, fields.get(0)));
+      assertEquals(1, soi.getStructFieldData(c, fields.get(1)));
       assertEquals(c3, soi.getStructFieldData(c, fields.get(3)));
       assertEquals(c4, soi.getStructFieldData(c, fields.get(4)));
-      assertNull(soi.getStructFieldData(c, fields.get(5)));
+      assertEquals(c5, soi.getStructFieldData(c, fields.get(5)));
+      assertNull(soi.getStructFieldData(c, fields.get(6)));
+
       ArrayList<Object> cfields = new ArrayList<Object>();
       for (int i = 0; i < 10; i++) {
         cfields.add(soi.getStructFieldData(c, fields.get(i)));
@@ -110,28 +111,28 @@ public class TestObjectInspectorUtils {
       assertEquals(cfields, soi.getStructFieldsDataAsList(c));
 
       // sub fields
-      assertEquals(PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-          fields.get(0).getFieldObjectInspector());
       assertEquals(PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+          fields.get(0).getFieldObjectInspector());
+      assertEquals(PrimitiveObjectInspectorFactory.javaIntObjectInspector,
           fields.get(1).getFieldObjectInspector());
-      assertEquals(
-          ObjectInspectorFactory
-          .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector),
-          fields.get(2).getFieldObjectInspector());
       assertEquals(
           ObjectInspectorFactory
               .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
           fields.get(3).getFieldObjectInspector());
+      assertEquals(
+          ObjectInspectorFactory
+          .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector),
+          fields.get(4).getFieldObjectInspector());
       assertEquals(ObjectInspectorUtils
           .getStandardObjectInspector(ObjectInspectorFactory
           .getStandardListObjectInspector(ObjectInspectorFactory
           .getReflectionObjectInspector(IntString.class,
           ObjectInspectorFactory.ObjectInspectorOptions.THRIFT))),
-          fields.get(4).getFieldObjectInspector());
+          fields.get(5).getFieldObjectInspector());
       assertEquals(ObjectInspectorFactory.getStandardMapObjectInspector(
           PrimitiveObjectInspectorFactory.javaStringObjectInspector,
           PrimitiveObjectInspectorFactory.javaStringObjectInspector), fields
-          .get(5).getFieldObjectInspector());
+          .get(6).getFieldObjectInspector());
     } catch (Throwable e) {
       e.printStackTrace();
       throw e;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We found the flaky behavior in `serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java` with an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations.

In the method `getDeclaredNonStaticFields`,  it will call the implementation-dependent operations:

https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L559

The returned elements from `getDeclaredFields` are not in a particular order, which would make the assertions in the test `org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils` fail.

https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java#L79

The error message from NonDex is as follows.
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.84 s <<< FAILURE! - in org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils
[ERROR] org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils  Time elapsed: 0.83 s  <<< FAILURE!
java.lang.AssertionError: expected:<0:unionfield3> but was:<5:aint>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils(TestObjectInspectorUtils.java:79)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the test `serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java`, it will make assertions on the returned values of `soi.getAllStructFieldRefs`.
https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java#L75-L78

The function `getAllStructFieldRefs ` will return the `fields` which is defined below.
https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ReflectionStructObjectInspector.java#L192-L195

The `fields` is set as below.
https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ReflectionStructObjectInspector.java#L163-L178

The problem is `ObjectInspectorUtils#getDeclaredNonStaticFields` will call `getDeclaredFields();` which is an implementation-dependent operation.
https://github.com/apache/hive/blob/1843105f27f0b3550f70f71e2bf44830c79a6c69/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L559

As a result, we sorted the return value from `getDeclaredFields` to make the behavior consistent.
https://github.com/apache/hive/blob/6c40557a23cb346b119d5d30b695b926936ef5de/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L561
At the same time, after sorting the fields, we need to adjust the assertion sequences with some renamed variables.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```

Run the unit test using NonDex with the following command.
```
mvn -pl serde edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils#testObjectInspectorUtils -Drat.skip=true
```

Please let me know if you have any concerns.