### PR TITLE
HIVE-27798: Corrected wrong hive-site.xml

### DIFF
--- a/packaging/src/docker/conf/hive-site.xml
+++ b/packaging/src/docker/conf/hive-site.xml
@@ -53,7 +53,7 @@
         <value>tez</value>
     </property>
     <property>
-        <name>metastore.warehouse.dir</name>
+        <name>hive.metastore.warehouse.dir</name>
         <value>/opt/hive/data/warehouse</value>
     </property>
     <property>


### PR DESCRIPTION
hive.metastore.warehouse.dir, this configuration item is configured incorrectly, causing the configuration item to not take effect.

bug image:
![image](https://github.com/apache/hive/assets/38107489/823918b0-8cb6-474b-83f4-870f2de46370)
![image](https://github.com/apache/hive/assets/38107489/f2a28ee6-16b2-44fb-8ad2-a4736fb21104)

fix image：
![image](https://github.com/apache/hive/assets/38107489/c18174b5-3f2f-4679-b55f-ea8708f5998e)
![image](https://github.com/apache/hive/assets/38107489/45bd5973-8bab-489f-9304-d1bc40a36661)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
I changed the `packaging/src/docker/conf/hive-site.xml` file.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
I discovered this bug when I was using it. Since there is no default directory for non-root users in the container, error messages appear when creating databases and data tables without permission. I corrected hive.metastore.warehouse.dir configuration. This error has been resolved.

The correct related configuration items are in the picture below.
![image](https://github.com/apache/hive/assets/38107489/880ced5c-fd72-43b6-abc0-da1735a0bfb1)

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Now there will be no errors when creating databases and tables in docker containers, and the data and directories will appear in the specified directory.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
UT

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
