### PR TITLE
HIVE-27802: Simplify TestTezSessionState.testSymlinkedLocalFilesAreLocalizedOnce

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezSessionState.java
@@ -28,22 +28,6 @@ import org.junit.Test;
 
 public class TestTezSessionState {
 
-  private class TestTezSessionPoolManager extends TezSessionPoolManager {
-    public TestTezSessionPoolManager() {
-      super();
-    }
-
-    @Override
-    public void setupPool(HiveConf conf) throws Exception {
-      super.setupPool(conf);
-    }
-
-    @Override
-    public TezSessionPoolSession createSession(String sessionId, HiveConf conf) {
-      return new SampleTezSessionState(sessionId, this, conf);
-    }
-  }
-
   @Test
   public void testSymlinkedLocalFilesAreLocalizedOnce() throws Exception {
     Path jarPath = Files.createTempFile("jar", "");
@@ -57,9 +41,8 @@ public class TestTezSessionState {
 
     HiveConf hiveConf = new HiveConf();
     hiveConf.set(HiveConf.ConfVars.HIVE_JAR_DIRECTORY.varname, "/tmp");
-    TezSessionPoolManager poolManager = new TestTezSessionPoolManager();
 
-    TezSessionState sessionState = poolManager.getSession(null, hiveConf, true, false);
+    TezSessionState sessionState = new TezSessionState(DagUtils.getInstance(), hiveConf);
 
     LocalResource l1 = sessionState.createJarLocalResource(jarPath.toUri().toString());
     LocalResource l2 = sessionState.createJarLocalResource(symlinkPath.toUri().toString());


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
