### PR TITLE
HIVE-27809: Backport of HIVE-21715: Adding a new partition specified by location (which is empty) leads to Exceptions

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -395,6 +395,7 @@ minillaplocal.shared.query.files=alter_merge_2_orc.q,\
   vectorized_timestamp_ints_casts.q
 
 minillap.query.files=acid_bucket_pruning.q,\
+  add_part_with_loc.q,\
   bucket5.q,\
   bucket6.q,\
   dynamic_semijoin_user_level.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -2324,4 +2324,46 @@ public class AcidUtils {
     }
     return lockComponents;
   }
+
+  /**
+   * Safety check to make sure a file take from one acid table is not added into another acid table
+   * since the ROW__IDs embedded as part a write to one table won't make sense in different
+   * table/cluster.
+   */
+  public static void validateAcidFiles(Table table, FileStatus[] srcs, FileSystem fs) throws SemanticException {
+    if (!AcidUtils.isFullAcidTable(table)) {
+      return;
+    }
+    validateAcidFiles(srcs, fs);
+  }
+
+  private static void validateAcidFiles(FileStatus[] srcs, FileSystem fs) throws SemanticException {
+    try {
+      if (srcs == null) {
+        return;
+      }
+      for (FileStatus oneSrc : srcs) {
+        if (!AcidUtils.MetaDataFile.isRawFormatFile(oneSrc.getPath(), fs)) {
+          throw new SemanticException(ErrorMsg.LOAD_DATA_ACID_FILE, oneSrc.getPath().toString());
+        }
+      }
+    } catch (IOException ex) {
+      throw new SemanticException(ex);
+    }
+  }
+
+  /**
+   * Safety check to make sure the given location is not the location of acid table and
+   * all it's files  will be not added into another acid table
+   */
+  public static void validateAcidPartitionLocation(String location, Configuration conf) throws SemanticException {
+    try {
+      URI uri = new URI(location);
+      FileSystem fs = FileSystem.get(uri, conf);
+      FileStatus[] fileStatuses = LoadSemanticAnalyzer.matchFilesOrDir(fs, new Path(uri));
+      validateAcidFiles(fileStatuses, fs);
+    } catch (IOException | URISyntaxException ex) {
+      throw new SemanticException(ErrorMsg.INVALID_PATH.getMsg(ex.getMessage()), ex);
+    }
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
@@ -177,13 +177,17 @@ public final class HiveFileFormatUtils {
   }
 
   /**
-   * checks if files are in same format as the given input format.
+   * Checks if files are in same format as the given input format.
+   *
+   * Note: an empty set of files is considered compliant.
    */
   @SuppressWarnings("unchecked")
   public static boolean checkInputFormat(FileSystem fs, HiveConf conf,
       Class<? extends InputFormat> inputFormatCls, List<FileStatus> files)
       throws HiveException {
-    if (files.isEmpty()) return false;
+    if (files.isEmpty()) {
+      return true;
+    }
     Class<? extends InputFormatChecker> checkerCls = FileChecker.getInstance()
         .getInputFormatCheckerClass(inputFormatCls);
     if (checkerCls == null

--- a/ql/src/test/queries/clientpositive/add_part_with_loc.q
+++ b/ql/src/test/queries/clientpositive/add_part_with_loc.q
@@ -1,0 +1,23 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.exec.dynamic.partition.mode=nonstrict;
+set hive.exec.dynamic.partition=true;
+set hive.vectorized.execution.enabled=true;
+
+
+set hive.fileformat.check=true;
+
+create table supply (id int, part string, quantity int) partitioned by (day int)
+	stored as orc
+	location 'hdfs:///tmp/a1'
+	TBLPROPERTIES ('transactional'='true')
+;
+
+
+explain alter table supply add partition (day=20110102) location 
+	'hdfs:///tmp/a2';
+
+alter table supply add partition (day=20110103) location 
+	'hdfs:///tmp/a3';
+
+

--- a/ql/src/test/results/clientpositive/llap/add_part_with_loc.q.out
+++ b/ql/src/test/results/clientpositive/llap/add_part_with_loc.q.out
@@ -1,0 +1,59 @@
+PREHOOK: query: create table supply (id int, part string, quantity int) partitioned by (day int)
+	stored as orc
+	location 'hdfs://### HDFS PATH ###'
+	TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Input: hdfs://### HDFS PATH ###
+PREHOOK: Output: database:default
+PREHOOK: Output: default@supply
+POSTHOOK: query: create table supply (id int, part string, quantity int) partitioned by (day int)
+	stored as orc
+	location 'hdfs://### HDFS PATH ###'
+	TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Input: hdfs://### HDFS PATH ###
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@supply
+PREHOOK: query: explain alter table supply add partition (day=20110102) location 
+	'hdfs://### HDFS PATH ###'
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Input: hdfs://### HDFS PATH ###
+PREHOOK: Output: default@supply
+POSTHOOK: query: explain alter table supply add partition (day=20110102) location 
+	'hdfs://### HDFS PATH ###'
+POSTHOOK: type: ALTERTABLE_ADDPARTS
+POSTHOOK: Input: hdfs://### HDFS PATH ###
+POSTHOOK: Output: default@supply
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+  Stage-1 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-0
+      Add Partition Operator:
+#### A masked pattern was here ####
+          Spec: {day=20110102}
+
+  Stage: Stage-1
+    Move Operator
+      tables:
+          partition:
+            day 20110102
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.supply
+
+PREHOOK: query: alter table supply add partition (day=20110103) location 
+	'hdfs://### HDFS PATH ###'
+PREHOOK: type: ALTERTABLE_ADDPARTS
+PREHOOK: Input: hdfs://### HDFS PATH ###
+PREHOOK: Output: default@supply
+POSTHOOK: query: alter table supply add partition (day=20110103) location 
+	'hdfs://### HDFS PATH ###'
+POSTHOOK: type: ALTERTABLE_ADDPARTS
+POSTHOOK: Input: hdfs://### HDFS PATH ###
+POSTHOOK: Output: default@supply
+POSTHOOK: Output: default@supply@day=20110103


### PR DESCRIPTION
This is a backport of [HIVE-21715](https://issues.apache.org/jira/browse/HIVE-21715) : Adding a new partition specified by location (which is empty) leads to Exceptions
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27809](https://issues.apache.org/jira/browse/HIVE-27809)