### PR TITLE
HIVE-27810: Backport of HIVE-22593: Dynamically partitioned MM (insert-only ACID) tables don'…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2414,10 +2414,11 @@ private void constructOneLBLocationMap(FileStatus fSta,
     final SessionState parentSession = SessionState.get();
 
     final List<Future<Void>> futures = Lists.newLinkedList();
+    // for each dynamically created DP directory, construct a full partition spec
+    // and load the partition based on that
+    boolean isTxnTable = AcidUtils.isTransactionalTable(tbl);
+    final Map<Long, RawStore> rawStoreMap = new ConcurrentHashMap<>();
     try {
-      // for each dynamically created DP directory, construct a full partition spec
-      // and load the partition based on that
-      final Map<Long, RawStore> rawStoreMap = new ConcurrentHashMap<>();
       for(final Path partPath : validPartitions) {
         // generate a full partition specification
         final LinkedHashMap<String, String> fullPartSpec = Maps.newLinkedHashMap(partSpec);
@@ -2489,7 +2490,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
     }
 
     try {
-      if (isAcid) {
+      if (isTxnTable) {
         List<String> partNames = new ArrayList<>(partitionsMap.size());
         for (Partition p : partitionsMap.values()) {
           partNames.add(p.getName());

--- a/ql/src/test/queries/clientpositive/mm_all.q
+++ b/ql/src/test/queries/clientpositive/mm_all.q
@@ -2,6 +2,7 @@
 --! qt:dataset:src
 
 -- MASK_LINEAGE
+-- SORT_QUERY_RESULTS
 
 set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;

--- a/ql/src/test/queries/clientpositive/mm_buckets.q
+++ b/ql/src/test/queries/clientpositive/mm_buckets.q
@@ -25,12 +25,12 @@ clustered by (key) into 2 buckets
 tblproperties("transactional"="true", "transactional_properties"="insert_only");
 insert into table bucket0_mm select key, key from intermediate_n2;
 select * from bucket0_mm order by key, id;
-select * from bucket0_mm tablesample (bucket 1 out of 2) s;
-select * from bucket0_mm tablesample (bucket 2 out of 2) s;
+select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id;
+select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id;
 insert into table bucket0_mm select key, key from intermediate_n2;
 select * from bucket0_mm order by key, id;
-select * from bucket0_mm tablesample (bucket 1 out of 2) s;
-select * from bucket0_mm tablesample (bucket 2 out of 2) s;
+select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id;
+select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id;
 drop table bucket0_mm;
 
 

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -3429,6 +3429,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.part_mm
+          Write Type: INSERT
           micromanaged table: true
 
 PREHOOK: query: insert into table part_mm partition(key_mm=455) select key from src order by value desc limit 3
@@ -3646,6 +3647,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
               name: default.tbl1_n1
+          Write Type: INSERT
           micromanaged table: true
 
 PREHOOK: query: insert into tbl1_n1 values('a', 69)
@@ -3778,6 +3780,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
               serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
               name: default.tbl1_n1
+          Write Type: INSERT
           micromanaged table: true
 
 PREHOOK: query: drop table tbl1_n1

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -6109,6 +6109,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.part_mm_n1
+          Write Type: INSERT
           micromanaged table: true
 
   Stage: Stage-3

--- a/ql/src/test/results/clientpositive/llap/insert_only_empty_query.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_only_empty_query.q.out
@@ -1,0 +1,210 @@
+PREHOOK: query: create table src_emptybucket_partitioned_1 (name string, age int, gpa decimal(3,2))
+                               partitioned by(year int)
+                               clustered by (age)
+                               sorted by (age)
+                               into 100 buckets
+                               stored as orc tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@src_emptybucket_partitioned_1
+POSTHOOK: query: create table src_emptybucket_partitioned_1 (name string, age int, gpa decimal(3,2))
+                               partitioned by(year int)
+                               clustered by (age)
+                               sorted by (age)
+                               into 100 buckets
+                               stored as orc tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@src_emptybucket_partitioned_1
+PREHOOK: query: create table source_table(name string, age int, gpa decimal(3,2))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@source_table
+POSTHOOK: query: create table source_table(name string, age int, gpa decimal(3,2))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@source_table
+PREHOOK: query: insert into source_table values("name", 56, 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@source_table
+POSTHOOK: query: insert into source_table values("name", 56, 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@source_table
+POSTHOOK: Lineage: source_table.age SCRIPT []
+POSTHOOK: Lineage: source_table.gpa SCRIPT []
+POSTHOOK: Lineage: source_table.name SCRIPT []
+PREHOOK: query: explain insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+POSTHOOK: query: explain insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: source_table
+                  Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: name (type: string), age (type: int), gpa (type: decimal(3,2))
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                    Limit
+                      Number of rows: 0
+                      Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: int)
+                        null sort order: a
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: int)
+                        Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string), _col2 (type: decimal(3,2))
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: string), KEY.reducesinkkey0 (type: int), VALUE._col1 (type: decimal(3,2))
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.src_emptybucket_partitioned_1
+                  Write Type: INSERT
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: int), _col2 (type: decimal(3,2)), UDFToInteger('2015') (type: int)
+                  outputColumnNames: name, age, gpa, year
+                  Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: compute_stats(name, 'hll'), compute_stats(age, 'hll'), compute_stats(gpa, 'hll')
+                    keys: year (type: int)
+                    minReductionHashAggr: 0.0
+                    mode: hash
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 1500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 1500 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: struct<columntype:string,maxlength:bigint,sumlength:bigint,count:bigint,countnulls:bigint,bitvector:binary>), _col2 (type: struct<columntype:string,min:bigint,max:bigint,countnulls:bigint,bitvector:binary>), _col3 (type: struct<columntype:string,min:decimal(3,2),max:decimal(3,2),countnulls:bigint,bitvector:binary>)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: compute_stats(VALUE._col0), compute_stats(VALUE._col1), compute_stats(VALUE._col2)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 1 Data size: 1532 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: struct<columntype:string,maxlength:bigint,avglength:double,countnulls:bigint,numdistinctvalues:bigint,ndvbitvector:binary>), _col2 (type: struct<columntype:string,min:bigint,max:bigint,countnulls:bigint,numdistinctvalues:bigint,ndvbitvector:binary>), _col3 (type: struct<columntype:string,min:decimal(3,2),max:decimal(3,2),countnulls:bigint,numdistinctvalues:bigint,ndvbitvector:binary>), _col0 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 1 Data size: 1532 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 1532 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            year 2015
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.src_emptybucket_partitioned_1
+          Write Type: INSERT
+          micromanaged table: true
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: name, age, gpa
+          Column Types: string, int, decimal(3,2)
+          Table: default.src_emptybucket_partitioned_1
+
+PREHOOK: query: insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+POSTHOOK: query: insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).age SIMPLE [(source_table)source_table.FieldSchema(name:age, type:int, comment:null), ]
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).gpa SIMPLE [(source_table)source_table.FieldSchema(name:gpa, type:decimal(3,2), comment:null), ]
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).name SIMPLE [(source_table)source_table.FieldSchema(name:name, type:string, comment:null), ]
+PREHOOK: query: insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@source_table
+PREHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+POSTHOOK: query: insert into table src_emptybucket_partitioned_1 partition(year=2015) select * from source_table limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@source_table
+POSTHOOK: Output: default@src_emptybucket_partitioned_1@year=2015
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).age SIMPLE [(source_table)source_table.FieldSchema(name:age, type:int, comment:null), ]
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).gpa SIMPLE [(source_table)source_table.FieldSchema(name:gpa, type:decimal(3,2), comment:null), ]
+POSTHOOK: Lineage: src_emptybucket_partitioned_1 PARTITION(year=2015).name SIMPLE [(source_table)source_table.FieldSchema(name:name, type:string, comment:null), ]
+PREHOOK: query: select * from src_emptybucket_partitioned_1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_emptybucket_partitioned_1
+PREHOOK: Input: default@src_emptybucket_partitioned_1@year=2015
+#### A masked pattern was here ####
+POSTHOOK: query: select * from src_emptybucket_partitioned_1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_emptybucket_partitioned_1
+POSTHOOK: Input: default@src_emptybucket_partitioned_1@year=2015
+#### A masked pattern was here ####
+name	56	4.00	2015
+PREHOOK: query: drop table src_emptybucket_partitioned_1
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@src_emptybucket_partitioned_1
+PREHOOK: Output: default@src_emptybucket_partitioned_1
+POSTHOOK: query: drop table src_emptybucket_partitioned_1
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@src_emptybucket_partitioned_1
+POSTHOOK: Output: default@src_emptybucket_partitioned_1
+PREHOOK: query: drop table source_table
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@source_table
+PREHOOK: Output: default@source_table
+POSTHOOK: query: drop table source_table
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@source_table
+POSTHOOK: Output: default@source_table

--- a/ql/src/test/results/clientpositive/llap/mm_all.q.out
+++ b/ql/src/test/results/clientpositive/llap/mm_all.q.out
@@ -148,6 +148,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.part_mm_n0
+          Write Type: INSERT
           micromanaged table: true
 
   Stage: Stage-3
@@ -221,18 +222,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 10	455
 10	455
 10	456
-97	455
-97	455
-97	456
-98	455
-98	455
-98	456
 100	455
 100	455
 100	456
 103	455
 103	455
 103	456
+97	455
+97	455
+97	456
+98	455
+98	455
+98	456
 PREHOOK: query: select * from part_mm_n0 order by key, key_mm
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_mm_n0
@@ -251,18 +252,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 10	455
 10	455
 10	456
-97	455
-97	455
-97	456
-98	455
-98	455
-98	456
 100	455
 100	455
 100	456
 103	455
 103	455
 103	456
+97	455
+97	455
+97	456
+98	455
+98	455
+98	456
 PREHOOK: query: truncate table part_mm_n0
 PREHOOK: type: TRUNCATETABLE
 PREHOOK: Output: default@part_mm_n0@key_mm=455
@@ -328,10 +329,10 @@ POSTHOOK: Input: default@simple_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
 10
-97
-98
 100
 103
+97
+98
 PREHOOK: query: insert into table simple_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -359,14 +360,14 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
 10
 10
-97
-97
-98
-98
 100
 100
 103
 103
+97
+97
+98
+98
 PREHOOK: query: truncate table simple_mm
 PREHOOK: type: TRUNCATETABLE
 PREHOOK: Output: default@simple_mm
@@ -450,10 +451,10 @@ POSTHOOK: Input: default@dp_mm@key1=123/key2=98
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	123	0
 10	123	10
-97	123	97
-98	123	98
 100	123	100
 103	123	103
+97	123	97
+98	123	98
 PREHOOK: query: drop table dp_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@dp_mm
@@ -504,15 +505,15 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
 1
 10
+100
+101
+103
+104
 11
 97
 98
 98
 99
-100
-101
-103
-104
 PREHOOK: query: insert into table union_mm 
 select p from
 (
@@ -556,20 +557,8 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
 1
 1
-2
 10
 10
-11
-11
-12
-97
-97
-98
-98
-98
-99
-99
-99
 100
 100
 100
@@ -581,6 +570,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 104
 104
 105
+11
+11
+12
+2
+97
+97
+98
+98
+98
+99
+99
+99
 PREHOOK: query: insert into table union_mm
 SELECT p FROM
 (
@@ -640,27 +641,9 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 1
 1
 1
-2
-2
 10
 10
 10
-11
-11
-11
-12
-12
-97
-97
-97
-98
-98
-98
-98
-99
-99
-99
-99
 100
 100
 100
@@ -678,6 +661,24 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 104
 105
 105
+11
+11
+11
+12
+12
+2
+2
+97
+97
+97
+98
+98
+98
+98
+99
+99
+99
+99
 PREHOOK: query: drop table union_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@union_mm
@@ -770,15 +771,15 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	0
 1	1
 10	10
+100	100
+101	101
+103	103
+104	104
 11	11
 97	97
 98	98
 98	98
 99	99
-100	100
-101	101
-103	103
-104	104
 PREHOOK: query: drop table partunion_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@partunion_mm
@@ -826,10 +827,10 @@ POSTHOOK: Input: default@skew_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	0	0
 10	10	10
-97	97	97
-98	98	98
 100	100	100
 103	103	103
+97	97	97
+98	98	98
 PREHOOK: query: drop table skew_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@skew_mm
@@ -950,15 +951,15 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	0	0	0
 1	2	3	4
 10	10	10	10
+100	100	100	100
+101	102	103	104
+103	103	103	103
+104	105	106	107
 11	12	13	14
 97	97	97	97
 98	98	98	98
 98	99	100	101
 99	100	101	102
-100	100	100	100
-101	102	103	104
-103	103	103	103
-104	105	106	107
 PREHOOK: query: drop table skew_dp_union_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@skew_dp_union_mm
@@ -998,12 +999,12 @@ POSTHOOK: query: select * from merge0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge0_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98
-97
-100
-103
 0
 10
+100
+103
+97
+98
 PREHOOK: query: insert into table merge0_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1027,18 +1028,18 @@ POSTHOOK: query: select * from merge0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge0_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98
-97
-100
-103
+0
 0
 10
-98
-97
+10
+100
 100
 103
-0
-10
+103
+97
+97
+98
+98
 PREHOOK: query: drop table merge0_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge0_mm
@@ -1078,12 +1079,12 @@ POSTHOOK: query: select * from merge2_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge2_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98
-97
-100
-103
 0
 10
+100
+103
+97
+98
 PREHOOK: query: insert into table merge2_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1107,18 +1108,18 @@ POSTHOOK: query: select * from merge2_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge2_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98
-97
-100
-103
+0
 0
 10
-98
-97
+10
+100
 100
 103
-0
-10
+103
+97
+97
+98
+98
 PREHOOK: query: drop table merge2_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge2_mm
@@ -1182,10 +1183,10 @@ POSTHOOK: Input: default@merge1_mm@key=98
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	0
 10	10
-97	97
-98	98
 100	100
 103	103
+97	97
+98	98
 PREHOOK: query: insert into table merge1_mm partition (key) select key, key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1235,14 +1236,14 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	0
 10	10
 10	10
-97	97
-97	97
-98	98
-98	98
 100	100
 100	100
 103	103
 103	103
+97	97
+97	97
+98	98
+98	98
 PREHOOK: query: drop table merge1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge1_mm
@@ -1281,12 +1282,12 @@ POSTHOOK: query: select * from ctas0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ctas0_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98	455
-97	455
-100	457
-103	457
 0	456
 10	456
+100	457
+103	457
+97	455
+98	455
 PREHOOK: query: drop table ctas0_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@ctas0_mm
@@ -1327,18 +1328,18 @@ POSTHOOK: query: select * from ctas1_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ctas1_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98	455
-97	455
-100	457
-103	457
+0	456
 0	456
 10	456
-98	455
-97	455
+10	456
+100	457
 100	457
 103	457
-0	456
-10	456
+103	457
+97	455
+97	455
+98	455
+98	455
 PREHOOK: query: drop table ctas1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@ctas1_mm
@@ -1405,10 +1406,10 @@ POSTHOOK: Input: default@multi0_1_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
+97	455
+98	455
 PREHOOK: query: select * from multi0_2_mm order by key, key2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@multi0_2_mm
@@ -1457,8 +1458,6 @@ POSTHOOK: Input: default@multi0_1_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
 455	97
@@ -1467,6 +1466,8 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 456	10
 457	100
 457	103
+97	455
+98	455
 PREHOOK: query: select * from multi0_2_mm order by key, key2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@multi0_2_mm
@@ -1477,10 +1478,10 @@ POSTHOOK: Input: default@multi0_2_mm
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
+97	455
+98	455
 PREHOOK: query: drop table multi0_1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@multi0_1_mm
@@ -1547,8 +1548,6 @@ POSTHOOK: Input: default@multi1_mm@p=2
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	456	2
 10	456	2
-97	455	2
-98	455	2
 100	457	2
 103	457	2
 455	97	1
@@ -1557,6 +1556,8 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 456	10	1
 457	100	1
 457	103	1
+97	455	2
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p=2) select p, key
 insert overwrite table multi1_mm partition(p=1) select key, p
@@ -1597,10 +1598,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 0	456	2
 10	456	1
 10	456	2
-97	455	1
-97	455	2
-98	455	1
-98	455	2
 100	457	1
 100	457	2
 103	457	1
@@ -1611,6 +1608,10 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 456	10	2
 457	100	2
 457	103	2
+97	455	1
+97	455	2
+98	455	1
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p) select p, key, p
 insert into table multi1_mm partition(p=1) select key, p
@@ -1667,12 +1668,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 10	456	1
 10	456	1
 10	456	2
-97	455	1
-97	455	1
-97	455	2
-98	455	1
-98	455	1
-98	455	2
 100	457	1
 100	457	1
 100	457	2
@@ -1691,6 +1686,12 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 457	100	457
 457	103	2
 457	103	457
+97	455	1
+97	455	1
+97	455	2
+98	455	1
+98	455	1
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p) select p, key, 1
 insert into table multi1_mm partition(p=1) select key, p
@@ -1740,14 +1741,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 10	456	1
 10	456	1
 10	456	2
-97	455	1
-97	455	1
-97	455	1
-97	455	2
-98	455	1
-98	455	1
-98	455	1
-98	455	2
 100	457	1
 100	457	1
 100	457	1
@@ -1774,6 +1767,14 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 457	103	1
 457	103	2
 457	103	457
+97	455	1
+97	455	1
+97	455	1
+97	455	2
+98	455	1
+98	455	1
+98	455	1
+98	455	2
 PREHOOK: query: drop table multi1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@multi1_mm
@@ -2120,12 +2121,12 @@ POSTHOOK: query: SELECT * FROM temp1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@temp1
 POSTHOOK: Output: hdfs://### HDFS PATH ###
-98
-97
-100
-103
 0
 10
+100
+103
+97
+98
 PREHOOK: query: drop table intermediate_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@intermediate_n0

--- a/ql/src/test/results/clientpositive/llap/mm_dp.q.out
+++ b/ql/src/test/results/clientpositive/llap/mm_dp.q.out
@@ -1,0 +1,4698 @@
+PREHOOK: query: drop table dp_mm
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table dp_mm
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: drop table intermediate_n0
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table intermediate_n0
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table intermediate_n0(key int, val string, r int) partitioned by (p int) stored as orc tblproperties("transactional"="false")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@intermediate_n0
+POSTHOOK: query: create table intermediate_n0(key int, val string, r int) partitioned by (p int) stored as orc tblproperties("transactional"="false")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@intermediate_n0
+PREHOOK: query: insert into table intermediate_n0 partition(p='455') select *, cast(rand(12345) * 30 as int) from src where key < 200
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=455
+POSTHOOK: query: insert into table intermediate_n0 partition(p='455') select *, cast(rand(12345) * 30 as int) from src where key < 200
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=455
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='456') select *, cast(rand(12345) * 30 as int) from src where key >= 200
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=456
+POSTHOOK: query: insert into table intermediate_n0 partition(p='456') select *, cast(rand(12345) * 30 as int) from src where key >= 200
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=456
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='457') select *, cast(rand(12345) * 30 as int) from src where key < 200
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=457
+POSTHOOK: query: insert into table intermediate_n0 partition(p='457') select *, cast(rand(12345) * 30 as int) from src where key < 200
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=457
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='457') select *, cast(rand(12345) * 30 as int) from src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=457
+POSTHOOK: query: insert into table intermediate_n0 partition(p='457') select *, cast(rand(12345) * 30 as int) from src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=457
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='458') select *, cast(rand(12345) * 30 as int) from src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=458
+POSTHOOK: query: insert into table intermediate_n0 partition(p='458') select *, cast(rand(12345) * 30 as int) from src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=458
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='458') select *, cast(rand(12345) * 30 as int) from src where key >= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=458
+POSTHOOK: query: insert into table intermediate_n0 partition(p='458') select *, cast(rand(12345) * 30 as int) from src where key >= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=458
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: insert into table intermediate_n0 partition(p='459') select *, cast(rand(12345) * 30 as int) from src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: default@intermediate_n0@p=459
+POSTHOOK: query: insert into table intermediate_n0 partition(p='459') select *, cast(rand(12345) * 30 as int) from src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: default@intermediate_n0@p=459
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: CREATE TABLE dp_mm(key int, p int, r int) PARTITIONED BY (val string)
+CLUSTERED BY (r) SORTED BY (r) INTO 3 BUCKETS
+STORED AS ORC  tblproperties("transactional"="true", "transactional_properties"="insert_only")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dp_mm
+POSTHOOK: query: CREATE TABLE dp_mm(key int, p int, r int) PARTITIONED BY (val string)
+CLUSTERED BY (r) SORTED BY (r) INTO 3 BUCKETS
+STORED AS ORC  tblproperties("transactional"="true", "transactional_properties"="insert_only")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dp_mm
+PREHOOK: query: explain 
+insert overwrite table dp_mm partition (val) select key, p, r, val from intermediate_n0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@intermediate_n0
+PREHOOK: Input: default@intermediate_n0@p=455
+PREHOOK: Input: default@intermediate_n0@p=456
+PREHOOK: Input: default@intermediate_n0@p=457
+PREHOOK: Input: default@intermediate_n0@p=458
+PREHOOK: Input: default@intermediate_n0@p=459
+PREHOOK: Output: default@dp_mm
+POSTHOOK: query: explain 
+insert overwrite table dp_mm partition (val) select key, p, r, val from intermediate_n0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@intermediate_n0
+POSTHOOK: Input: default@intermediate_n0@p=455
+POSTHOOK: Input: default@intermediate_n0@p=456
+POSTHOOK: Input: default@intermediate_n0@p=457
+POSTHOOK: Input: default@intermediate_n0@p=458
+POSTHOOK: Input: default@intermediate_n0@p=459
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: intermediate_n0
+                  Statistics: Num rows: 2605 Data size: 268315 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: int), p (type: int), r (type: int), val (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2605 Data size: 268315 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col3 (type: string), _bucket_number (type: string), _col2 (type: int)
+                      sort order: +++
+                      Map-reduce partition columns: _col3 (type: string)
+                      Statistics: Num rows: 2605 Data size: 268315 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), KEY._col2 (type: int), KEY._col3 (type: string), KEY._bucket_number (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _bucket_number
+                Statistics: Num rows: 2605 Data size: 747635 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Dp Sort State: PARTITION_BUCKET_SORTED
+                  Statistics: Num rows: 2605 Data size: 747635 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.dp_mm
+                  Write Type: INSERT
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            val 
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.dp_mm
+          Write Type: INSERT
+          micromanaged table: true
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: key, p, r
+          Column Types: int, int, int
+          Table: default.dp_mm
+
+PREHOOK: query: insert overwrite table dp_mm partition (val) select key, p, r, val from intermediate_n0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@intermediate_n0
+PREHOOK: Input: default@intermediate_n0@p=455
+PREHOOK: Input: default@intermediate_n0@p=456
+PREHOOK: Input: default@intermediate_n0@p=457
+PREHOOK: Input: default@intermediate_n0@p=458
+PREHOOK: Input: default@intermediate_n0@p=459
+PREHOOK: Output: default@dp_mm
+POSTHOOK: query: insert overwrite table dp_mm partition (val) select key, p, r, val from intermediate_n0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@intermediate_n0
+POSTHOOK: Input: default@intermediate_n0@p=455
+POSTHOOK: Input: default@intermediate_n0@p=456
+POSTHOOK: Input: default@intermediate_n0@p=457
+POSTHOOK: Input: default@intermediate_n0@p=458
+POSTHOOK: Input: default@intermediate_n0@p=459
+POSTHOOK: Output: default@dp_mm@val=val_0
+POSTHOOK: Output: default@dp_mm@val=val_10
+POSTHOOK: Output: default@dp_mm@val=val_100
+POSTHOOK: Output: default@dp_mm@val=val_103
+POSTHOOK: Output: default@dp_mm@val=val_104
+POSTHOOK: Output: default@dp_mm@val=val_105
+POSTHOOK: Output: default@dp_mm@val=val_11
+POSTHOOK: Output: default@dp_mm@val=val_111
+POSTHOOK: Output: default@dp_mm@val=val_113
+POSTHOOK: Output: default@dp_mm@val=val_114
+POSTHOOK: Output: default@dp_mm@val=val_116
+POSTHOOK: Output: default@dp_mm@val=val_118
+POSTHOOK: Output: default@dp_mm@val=val_119
+POSTHOOK: Output: default@dp_mm@val=val_12
+POSTHOOK: Output: default@dp_mm@val=val_120
+POSTHOOK: Output: default@dp_mm@val=val_125
+POSTHOOK: Output: default@dp_mm@val=val_126
+POSTHOOK: Output: default@dp_mm@val=val_128
+POSTHOOK: Output: default@dp_mm@val=val_129
+POSTHOOK: Output: default@dp_mm@val=val_131
+POSTHOOK: Output: default@dp_mm@val=val_133
+POSTHOOK: Output: default@dp_mm@val=val_134
+POSTHOOK: Output: default@dp_mm@val=val_136
+POSTHOOK: Output: default@dp_mm@val=val_137
+POSTHOOK: Output: default@dp_mm@val=val_138
+POSTHOOK: Output: default@dp_mm@val=val_143
+POSTHOOK: Output: default@dp_mm@val=val_145
+POSTHOOK: Output: default@dp_mm@val=val_146
+POSTHOOK: Output: default@dp_mm@val=val_149
+POSTHOOK: Output: default@dp_mm@val=val_15
+POSTHOOK: Output: default@dp_mm@val=val_150
+POSTHOOK: Output: default@dp_mm@val=val_152
+POSTHOOK: Output: default@dp_mm@val=val_153
+POSTHOOK: Output: default@dp_mm@val=val_155
+POSTHOOK: Output: default@dp_mm@val=val_156
+POSTHOOK: Output: default@dp_mm@val=val_157
+POSTHOOK: Output: default@dp_mm@val=val_158
+POSTHOOK: Output: default@dp_mm@val=val_160
+POSTHOOK: Output: default@dp_mm@val=val_162
+POSTHOOK: Output: default@dp_mm@val=val_163
+POSTHOOK: Output: default@dp_mm@val=val_164
+POSTHOOK: Output: default@dp_mm@val=val_165
+POSTHOOK: Output: default@dp_mm@val=val_166
+POSTHOOK: Output: default@dp_mm@val=val_167
+POSTHOOK: Output: default@dp_mm@val=val_168
+POSTHOOK: Output: default@dp_mm@val=val_169
+POSTHOOK: Output: default@dp_mm@val=val_17
+POSTHOOK: Output: default@dp_mm@val=val_170
+POSTHOOK: Output: default@dp_mm@val=val_172
+POSTHOOK: Output: default@dp_mm@val=val_174
+POSTHOOK: Output: default@dp_mm@val=val_175
+POSTHOOK: Output: default@dp_mm@val=val_176
+POSTHOOK: Output: default@dp_mm@val=val_177
+POSTHOOK: Output: default@dp_mm@val=val_178
+POSTHOOK: Output: default@dp_mm@val=val_179
+POSTHOOK: Output: default@dp_mm@val=val_18
+POSTHOOK: Output: default@dp_mm@val=val_180
+POSTHOOK: Output: default@dp_mm@val=val_181
+POSTHOOK: Output: default@dp_mm@val=val_183
+POSTHOOK: Output: default@dp_mm@val=val_186
+POSTHOOK: Output: default@dp_mm@val=val_187
+POSTHOOK: Output: default@dp_mm@val=val_189
+POSTHOOK: Output: default@dp_mm@val=val_19
+POSTHOOK: Output: default@dp_mm@val=val_190
+POSTHOOK: Output: default@dp_mm@val=val_191
+POSTHOOK: Output: default@dp_mm@val=val_192
+POSTHOOK: Output: default@dp_mm@val=val_193
+POSTHOOK: Output: default@dp_mm@val=val_194
+POSTHOOK: Output: default@dp_mm@val=val_195
+POSTHOOK: Output: default@dp_mm@val=val_196
+POSTHOOK: Output: default@dp_mm@val=val_197
+POSTHOOK: Output: default@dp_mm@val=val_199
+POSTHOOK: Output: default@dp_mm@val=val_2
+POSTHOOK: Output: default@dp_mm@val=val_20
+POSTHOOK: Output: default@dp_mm@val=val_200
+POSTHOOK: Output: default@dp_mm@val=val_201
+POSTHOOK: Output: default@dp_mm@val=val_202
+POSTHOOK: Output: default@dp_mm@val=val_203
+POSTHOOK: Output: default@dp_mm@val=val_205
+POSTHOOK: Output: default@dp_mm@val=val_207
+POSTHOOK: Output: default@dp_mm@val=val_208
+POSTHOOK: Output: default@dp_mm@val=val_209
+POSTHOOK: Output: default@dp_mm@val=val_213
+POSTHOOK: Output: default@dp_mm@val=val_214
+POSTHOOK: Output: default@dp_mm@val=val_216
+POSTHOOK: Output: default@dp_mm@val=val_217
+POSTHOOK: Output: default@dp_mm@val=val_218
+POSTHOOK: Output: default@dp_mm@val=val_219
+POSTHOOK: Output: default@dp_mm@val=val_221
+POSTHOOK: Output: default@dp_mm@val=val_222
+POSTHOOK: Output: default@dp_mm@val=val_223
+POSTHOOK: Output: default@dp_mm@val=val_224
+POSTHOOK: Output: default@dp_mm@val=val_226
+POSTHOOK: Output: default@dp_mm@val=val_228
+POSTHOOK: Output: default@dp_mm@val=val_229
+POSTHOOK: Output: default@dp_mm@val=val_230
+POSTHOOK: Output: default@dp_mm@val=val_233
+POSTHOOK: Output: default@dp_mm@val=val_235
+POSTHOOK: Output: default@dp_mm@val=val_237
+POSTHOOK: Output: default@dp_mm@val=val_238
+POSTHOOK: Output: default@dp_mm@val=val_239
+POSTHOOK: Output: default@dp_mm@val=val_24
+POSTHOOK: Output: default@dp_mm@val=val_241
+POSTHOOK: Output: default@dp_mm@val=val_242
+POSTHOOK: Output: default@dp_mm@val=val_244
+POSTHOOK: Output: default@dp_mm@val=val_247
+POSTHOOK: Output: default@dp_mm@val=val_248
+POSTHOOK: Output: default@dp_mm@val=val_249
+POSTHOOK: Output: default@dp_mm@val=val_252
+POSTHOOK: Output: default@dp_mm@val=val_255
+POSTHOOK: Output: default@dp_mm@val=val_256
+POSTHOOK: Output: default@dp_mm@val=val_257
+POSTHOOK: Output: default@dp_mm@val=val_258
+POSTHOOK: Output: default@dp_mm@val=val_26
+POSTHOOK: Output: default@dp_mm@val=val_260
+POSTHOOK: Output: default@dp_mm@val=val_262
+POSTHOOK: Output: default@dp_mm@val=val_263
+POSTHOOK: Output: default@dp_mm@val=val_265
+POSTHOOK: Output: default@dp_mm@val=val_266
+POSTHOOK: Output: default@dp_mm@val=val_27
+POSTHOOK: Output: default@dp_mm@val=val_272
+POSTHOOK: Output: default@dp_mm@val=val_273
+POSTHOOK: Output: default@dp_mm@val=val_274
+POSTHOOK: Output: default@dp_mm@val=val_275
+POSTHOOK: Output: default@dp_mm@val=val_277
+POSTHOOK: Output: default@dp_mm@val=val_278
+POSTHOOK: Output: default@dp_mm@val=val_28
+POSTHOOK: Output: default@dp_mm@val=val_280
+POSTHOOK: Output: default@dp_mm@val=val_281
+POSTHOOK: Output: default@dp_mm@val=val_282
+POSTHOOK: Output: default@dp_mm@val=val_283
+POSTHOOK: Output: default@dp_mm@val=val_284
+POSTHOOK: Output: default@dp_mm@val=val_285
+POSTHOOK: Output: default@dp_mm@val=val_286
+POSTHOOK: Output: default@dp_mm@val=val_287
+POSTHOOK: Output: default@dp_mm@val=val_288
+POSTHOOK: Output: default@dp_mm@val=val_289
+POSTHOOK: Output: default@dp_mm@val=val_291
+POSTHOOK: Output: default@dp_mm@val=val_292
+POSTHOOK: Output: default@dp_mm@val=val_296
+POSTHOOK: Output: default@dp_mm@val=val_298
+POSTHOOK: Output: default@dp_mm@val=val_30
+POSTHOOK: Output: default@dp_mm@val=val_302
+POSTHOOK: Output: default@dp_mm@val=val_305
+POSTHOOK: Output: default@dp_mm@val=val_306
+POSTHOOK: Output: default@dp_mm@val=val_307
+POSTHOOK: Output: default@dp_mm@val=val_308
+POSTHOOK: Output: default@dp_mm@val=val_309
+POSTHOOK: Output: default@dp_mm@val=val_310
+POSTHOOK: Output: default@dp_mm@val=val_311
+POSTHOOK: Output: default@dp_mm@val=val_315
+POSTHOOK: Output: default@dp_mm@val=val_316
+POSTHOOK: Output: default@dp_mm@val=val_317
+POSTHOOK: Output: default@dp_mm@val=val_318
+POSTHOOK: Output: default@dp_mm@val=val_321
+POSTHOOK: Output: default@dp_mm@val=val_322
+POSTHOOK: Output: default@dp_mm@val=val_323
+POSTHOOK: Output: default@dp_mm@val=val_325
+POSTHOOK: Output: default@dp_mm@val=val_327
+POSTHOOK: Output: default@dp_mm@val=val_33
+POSTHOOK: Output: default@dp_mm@val=val_331
+POSTHOOK: Output: default@dp_mm@val=val_332
+POSTHOOK: Output: default@dp_mm@val=val_333
+POSTHOOK: Output: default@dp_mm@val=val_335
+POSTHOOK: Output: default@dp_mm@val=val_336
+POSTHOOK: Output: default@dp_mm@val=val_338
+POSTHOOK: Output: default@dp_mm@val=val_339
+POSTHOOK: Output: default@dp_mm@val=val_34
+POSTHOOK: Output: default@dp_mm@val=val_341
+POSTHOOK: Output: default@dp_mm@val=val_342
+POSTHOOK: Output: default@dp_mm@val=val_344
+POSTHOOK: Output: default@dp_mm@val=val_345
+POSTHOOK: Output: default@dp_mm@val=val_348
+POSTHOOK: Output: default@dp_mm@val=val_35
+POSTHOOK: Output: default@dp_mm@val=val_351
+POSTHOOK: Output: default@dp_mm@val=val_353
+POSTHOOK: Output: default@dp_mm@val=val_356
+POSTHOOK: Output: default@dp_mm@val=val_360
+POSTHOOK: Output: default@dp_mm@val=val_362
+POSTHOOK: Output: default@dp_mm@val=val_364
+POSTHOOK: Output: default@dp_mm@val=val_365
+POSTHOOK: Output: default@dp_mm@val=val_366
+POSTHOOK: Output: default@dp_mm@val=val_367
+POSTHOOK: Output: default@dp_mm@val=val_368
+POSTHOOK: Output: default@dp_mm@val=val_369
+POSTHOOK: Output: default@dp_mm@val=val_37
+POSTHOOK: Output: default@dp_mm@val=val_373
+POSTHOOK: Output: default@dp_mm@val=val_374
+POSTHOOK: Output: default@dp_mm@val=val_375
+POSTHOOK: Output: default@dp_mm@val=val_377
+POSTHOOK: Output: default@dp_mm@val=val_378
+POSTHOOK: Output: default@dp_mm@val=val_379
+POSTHOOK: Output: default@dp_mm@val=val_382
+POSTHOOK: Output: default@dp_mm@val=val_384
+POSTHOOK: Output: default@dp_mm@val=val_386
+POSTHOOK: Output: default@dp_mm@val=val_389
+POSTHOOK: Output: default@dp_mm@val=val_392
+POSTHOOK: Output: default@dp_mm@val=val_393
+POSTHOOK: Output: default@dp_mm@val=val_394
+POSTHOOK: Output: default@dp_mm@val=val_395
+POSTHOOK: Output: default@dp_mm@val=val_396
+POSTHOOK: Output: default@dp_mm@val=val_397
+POSTHOOK: Output: default@dp_mm@val=val_399
+POSTHOOK: Output: default@dp_mm@val=val_4
+POSTHOOK: Output: default@dp_mm@val=val_400
+POSTHOOK: Output: default@dp_mm@val=val_401
+POSTHOOK: Output: default@dp_mm@val=val_402
+POSTHOOK: Output: default@dp_mm@val=val_403
+POSTHOOK: Output: default@dp_mm@val=val_404
+POSTHOOK: Output: default@dp_mm@val=val_406
+POSTHOOK: Output: default@dp_mm@val=val_407
+POSTHOOK: Output: default@dp_mm@val=val_409
+POSTHOOK: Output: default@dp_mm@val=val_41
+POSTHOOK: Output: default@dp_mm@val=val_411
+POSTHOOK: Output: default@dp_mm@val=val_413
+POSTHOOK: Output: default@dp_mm@val=val_414
+POSTHOOK: Output: default@dp_mm@val=val_417
+POSTHOOK: Output: default@dp_mm@val=val_418
+POSTHOOK: Output: default@dp_mm@val=val_419
+POSTHOOK: Output: default@dp_mm@val=val_42
+POSTHOOK: Output: default@dp_mm@val=val_421
+POSTHOOK: Output: default@dp_mm@val=val_424
+POSTHOOK: Output: default@dp_mm@val=val_427
+POSTHOOK: Output: default@dp_mm@val=val_429
+POSTHOOK: Output: default@dp_mm@val=val_43
+POSTHOOK: Output: default@dp_mm@val=val_430
+POSTHOOK: Output: default@dp_mm@val=val_431
+POSTHOOK: Output: default@dp_mm@val=val_432
+POSTHOOK: Output: default@dp_mm@val=val_435
+POSTHOOK: Output: default@dp_mm@val=val_436
+POSTHOOK: Output: default@dp_mm@val=val_437
+POSTHOOK: Output: default@dp_mm@val=val_438
+POSTHOOK: Output: default@dp_mm@val=val_439
+POSTHOOK: Output: default@dp_mm@val=val_44
+POSTHOOK: Output: default@dp_mm@val=val_443
+POSTHOOK: Output: default@dp_mm@val=val_444
+POSTHOOK: Output: default@dp_mm@val=val_446
+POSTHOOK: Output: default@dp_mm@val=val_448
+POSTHOOK: Output: default@dp_mm@val=val_449
+POSTHOOK: Output: default@dp_mm@val=val_452
+POSTHOOK: Output: default@dp_mm@val=val_453
+POSTHOOK: Output: default@dp_mm@val=val_454
+POSTHOOK: Output: default@dp_mm@val=val_455
+POSTHOOK: Output: default@dp_mm@val=val_457
+POSTHOOK: Output: default@dp_mm@val=val_458
+POSTHOOK: Output: default@dp_mm@val=val_459
+POSTHOOK: Output: default@dp_mm@val=val_460
+POSTHOOK: Output: default@dp_mm@val=val_462
+POSTHOOK: Output: default@dp_mm@val=val_463
+POSTHOOK: Output: default@dp_mm@val=val_466
+POSTHOOK: Output: default@dp_mm@val=val_467
+POSTHOOK: Output: default@dp_mm@val=val_468
+POSTHOOK: Output: default@dp_mm@val=val_469
+POSTHOOK: Output: default@dp_mm@val=val_47
+POSTHOOK: Output: default@dp_mm@val=val_470
+POSTHOOK: Output: default@dp_mm@val=val_472
+POSTHOOK: Output: default@dp_mm@val=val_475
+POSTHOOK: Output: default@dp_mm@val=val_477
+POSTHOOK: Output: default@dp_mm@val=val_478
+POSTHOOK: Output: default@dp_mm@val=val_479
+POSTHOOK: Output: default@dp_mm@val=val_480
+POSTHOOK: Output: default@dp_mm@val=val_481
+POSTHOOK: Output: default@dp_mm@val=val_482
+POSTHOOK: Output: default@dp_mm@val=val_483
+POSTHOOK: Output: default@dp_mm@val=val_484
+POSTHOOK: Output: default@dp_mm@val=val_485
+POSTHOOK: Output: default@dp_mm@val=val_487
+POSTHOOK: Output: default@dp_mm@val=val_489
+POSTHOOK: Output: default@dp_mm@val=val_490
+POSTHOOK: Output: default@dp_mm@val=val_491
+POSTHOOK: Output: default@dp_mm@val=val_492
+POSTHOOK: Output: default@dp_mm@val=val_493
+POSTHOOK: Output: default@dp_mm@val=val_494
+POSTHOOK: Output: default@dp_mm@val=val_495
+POSTHOOK: Output: default@dp_mm@val=val_496
+POSTHOOK: Output: default@dp_mm@val=val_497
+POSTHOOK: Output: default@dp_mm@val=val_498
+POSTHOOK: Output: default@dp_mm@val=val_5
+POSTHOOK: Output: default@dp_mm@val=val_51
+POSTHOOK: Output: default@dp_mm@val=val_53
+POSTHOOK: Output: default@dp_mm@val=val_54
+POSTHOOK: Output: default@dp_mm@val=val_57
+POSTHOOK: Output: default@dp_mm@val=val_58
+POSTHOOK: Output: default@dp_mm@val=val_64
+POSTHOOK: Output: default@dp_mm@val=val_65
+POSTHOOK: Output: default@dp_mm@val=val_66
+POSTHOOK: Output: default@dp_mm@val=val_67
+POSTHOOK: Output: default@dp_mm@val=val_69
+POSTHOOK: Output: default@dp_mm@val=val_70
+POSTHOOK: Output: default@dp_mm@val=val_72
+POSTHOOK: Output: default@dp_mm@val=val_74
+POSTHOOK: Output: default@dp_mm@val=val_76
+POSTHOOK: Output: default@dp_mm@val=val_77
+POSTHOOK: Output: default@dp_mm@val=val_78
+POSTHOOK: Output: default@dp_mm@val=val_8
+POSTHOOK: Output: default@dp_mm@val=val_80
+POSTHOOK: Output: default@dp_mm@val=val_82
+POSTHOOK: Output: default@dp_mm@val=val_83
+POSTHOOK: Output: default@dp_mm@val=val_84
+POSTHOOK: Output: default@dp_mm@val=val_85
+POSTHOOK: Output: default@dp_mm@val=val_86
+POSTHOOK: Output: default@dp_mm@val=val_87
+POSTHOOK: Output: default@dp_mm@val=val_9
+POSTHOOK: Output: default@dp_mm@val=val_90
+POSTHOOK: Output: default@dp_mm@val=val_92
+POSTHOOK: Output: default@dp_mm@val=val_95
+POSTHOOK: Output: default@dp_mm@val=val_96
+POSTHOOK: Output: default@dp_mm@val=val_97
+POSTHOOK: Output: default@dp_mm@val=val_98
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+POSTHOOK: Lineage: ###Masked###
+PREHOOK: query: select * from dp_mm order by key, p, r, val
+PREHOOK: type: QUERY
+PREHOOK: Input: default@dp_mm
+PREHOOK: Input: default@dp_mm@val=val_0
+PREHOOK: Input: default@dp_mm@val=val_10
+PREHOOK: Input: default@dp_mm@val=val_100
+PREHOOK: Input: default@dp_mm@val=val_103
+PREHOOK: Input: default@dp_mm@val=val_104
+PREHOOK: Input: default@dp_mm@val=val_105
+PREHOOK: Input: default@dp_mm@val=val_11
+PREHOOK: Input: default@dp_mm@val=val_111
+PREHOOK: Input: default@dp_mm@val=val_113
+PREHOOK: Input: default@dp_mm@val=val_114
+PREHOOK: Input: default@dp_mm@val=val_116
+PREHOOK: Input: default@dp_mm@val=val_118
+PREHOOK: Input: default@dp_mm@val=val_119
+PREHOOK: Input: default@dp_mm@val=val_12
+PREHOOK: Input: default@dp_mm@val=val_120
+PREHOOK: Input: default@dp_mm@val=val_125
+PREHOOK: Input: default@dp_mm@val=val_126
+PREHOOK: Input: default@dp_mm@val=val_128
+PREHOOK: Input: default@dp_mm@val=val_129
+PREHOOK: Input: default@dp_mm@val=val_131
+PREHOOK: Input: default@dp_mm@val=val_133
+PREHOOK: Input: default@dp_mm@val=val_134
+PREHOOK: Input: default@dp_mm@val=val_136
+PREHOOK: Input: default@dp_mm@val=val_137
+PREHOOK: Input: default@dp_mm@val=val_138
+PREHOOK: Input: default@dp_mm@val=val_143
+PREHOOK: Input: default@dp_mm@val=val_145
+PREHOOK: Input: default@dp_mm@val=val_146
+PREHOOK: Input: default@dp_mm@val=val_149
+PREHOOK: Input: default@dp_mm@val=val_15
+PREHOOK: Input: default@dp_mm@val=val_150
+PREHOOK: Input: default@dp_mm@val=val_152
+PREHOOK: Input: default@dp_mm@val=val_153
+PREHOOK: Input: default@dp_mm@val=val_155
+PREHOOK: Input: default@dp_mm@val=val_156
+PREHOOK: Input: default@dp_mm@val=val_157
+PREHOOK: Input: default@dp_mm@val=val_158
+PREHOOK: Input: default@dp_mm@val=val_160
+PREHOOK: Input: default@dp_mm@val=val_162
+PREHOOK: Input: default@dp_mm@val=val_163
+PREHOOK: Input: default@dp_mm@val=val_164
+PREHOOK: Input: default@dp_mm@val=val_165
+PREHOOK: Input: default@dp_mm@val=val_166
+PREHOOK: Input: default@dp_mm@val=val_167
+PREHOOK: Input: default@dp_mm@val=val_168
+PREHOOK: Input: default@dp_mm@val=val_169
+PREHOOK: Input: default@dp_mm@val=val_17
+PREHOOK: Input: default@dp_mm@val=val_170
+PREHOOK: Input: default@dp_mm@val=val_172
+PREHOOK: Input: default@dp_mm@val=val_174
+PREHOOK: Input: default@dp_mm@val=val_175
+PREHOOK: Input: default@dp_mm@val=val_176
+PREHOOK: Input: default@dp_mm@val=val_177
+PREHOOK: Input: default@dp_mm@val=val_178
+PREHOOK: Input: default@dp_mm@val=val_179
+PREHOOK: Input: default@dp_mm@val=val_18
+PREHOOK: Input: default@dp_mm@val=val_180
+PREHOOK: Input: default@dp_mm@val=val_181
+PREHOOK: Input: default@dp_mm@val=val_183
+PREHOOK: Input: default@dp_mm@val=val_186
+PREHOOK: Input: default@dp_mm@val=val_187
+PREHOOK: Input: default@dp_mm@val=val_189
+PREHOOK: Input: default@dp_mm@val=val_19
+PREHOOK: Input: default@dp_mm@val=val_190
+PREHOOK: Input: default@dp_mm@val=val_191
+PREHOOK: Input: default@dp_mm@val=val_192
+PREHOOK: Input: default@dp_mm@val=val_193
+PREHOOK: Input: default@dp_mm@val=val_194
+PREHOOK: Input: default@dp_mm@val=val_195
+PREHOOK: Input: default@dp_mm@val=val_196
+PREHOOK: Input: default@dp_mm@val=val_197
+PREHOOK: Input: default@dp_mm@val=val_199
+PREHOOK: Input: default@dp_mm@val=val_2
+PREHOOK: Input: default@dp_mm@val=val_20
+PREHOOK: Input: default@dp_mm@val=val_200
+PREHOOK: Input: default@dp_mm@val=val_201
+PREHOOK: Input: default@dp_mm@val=val_202
+PREHOOK: Input: default@dp_mm@val=val_203
+PREHOOK: Input: default@dp_mm@val=val_205
+PREHOOK: Input: default@dp_mm@val=val_207
+PREHOOK: Input: default@dp_mm@val=val_208
+PREHOOK: Input: default@dp_mm@val=val_209
+PREHOOK: Input: default@dp_mm@val=val_213
+PREHOOK: Input: default@dp_mm@val=val_214
+PREHOOK: Input: default@dp_mm@val=val_216
+PREHOOK: Input: default@dp_mm@val=val_217
+PREHOOK: Input: default@dp_mm@val=val_218
+PREHOOK: Input: default@dp_mm@val=val_219
+PREHOOK: Input: default@dp_mm@val=val_221
+PREHOOK: Input: default@dp_mm@val=val_222
+PREHOOK: Input: default@dp_mm@val=val_223
+PREHOOK: Input: default@dp_mm@val=val_224
+PREHOOK: Input: default@dp_mm@val=val_226
+PREHOOK: Input: default@dp_mm@val=val_228
+PREHOOK: Input: default@dp_mm@val=val_229
+PREHOOK: Input: default@dp_mm@val=val_230
+PREHOOK: Input: default@dp_mm@val=val_233
+PREHOOK: Input: default@dp_mm@val=val_235
+PREHOOK: Input: default@dp_mm@val=val_237
+PREHOOK: Input: default@dp_mm@val=val_238
+PREHOOK: Input: default@dp_mm@val=val_239
+PREHOOK: Input: default@dp_mm@val=val_24
+PREHOOK: Input: default@dp_mm@val=val_241
+PREHOOK: Input: default@dp_mm@val=val_242
+PREHOOK: Input: default@dp_mm@val=val_244
+PREHOOK: Input: default@dp_mm@val=val_247
+PREHOOK: Input: default@dp_mm@val=val_248
+PREHOOK: Input: default@dp_mm@val=val_249
+PREHOOK: Input: default@dp_mm@val=val_252
+PREHOOK: Input: default@dp_mm@val=val_255
+PREHOOK: Input: default@dp_mm@val=val_256
+PREHOOK: Input: default@dp_mm@val=val_257
+PREHOOK: Input: default@dp_mm@val=val_258
+PREHOOK: Input: default@dp_mm@val=val_26
+PREHOOK: Input: default@dp_mm@val=val_260
+PREHOOK: Input: default@dp_mm@val=val_262
+PREHOOK: Input: default@dp_mm@val=val_263
+PREHOOK: Input: default@dp_mm@val=val_265
+PREHOOK: Input: default@dp_mm@val=val_266
+PREHOOK: Input: default@dp_mm@val=val_27
+PREHOOK: Input: default@dp_mm@val=val_272
+PREHOOK: Input: default@dp_mm@val=val_273
+PREHOOK: Input: default@dp_mm@val=val_274
+PREHOOK: Input: default@dp_mm@val=val_275
+PREHOOK: Input: default@dp_mm@val=val_277
+PREHOOK: Input: default@dp_mm@val=val_278
+PREHOOK: Input: default@dp_mm@val=val_28
+PREHOOK: Input: default@dp_mm@val=val_280
+PREHOOK: Input: default@dp_mm@val=val_281
+PREHOOK: Input: default@dp_mm@val=val_282
+PREHOOK: Input: default@dp_mm@val=val_283
+PREHOOK: Input: default@dp_mm@val=val_284
+PREHOOK: Input: default@dp_mm@val=val_285
+PREHOOK: Input: default@dp_mm@val=val_286
+PREHOOK: Input: default@dp_mm@val=val_287
+PREHOOK: Input: default@dp_mm@val=val_288
+PREHOOK: Input: default@dp_mm@val=val_289
+PREHOOK: Input: default@dp_mm@val=val_291
+PREHOOK: Input: default@dp_mm@val=val_292
+PREHOOK: Input: default@dp_mm@val=val_296
+PREHOOK: Input: default@dp_mm@val=val_298
+PREHOOK: Input: default@dp_mm@val=val_30
+PREHOOK: Input: default@dp_mm@val=val_302
+PREHOOK: Input: default@dp_mm@val=val_305
+PREHOOK: Input: default@dp_mm@val=val_306
+PREHOOK: Input: default@dp_mm@val=val_307
+PREHOOK: Input: default@dp_mm@val=val_308
+PREHOOK: Input: default@dp_mm@val=val_309
+PREHOOK: Input: default@dp_mm@val=val_310
+PREHOOK: Input: default@dp_mm@val=val_311
+PREHOOK: Input: default@dp_mm@val=val_315
+PREHOOK: Input: default@dp_mm@val=val_316
+PREHOOK: Input: default@dp_mm@val=val_317
+PREHOOK: Input: default@dp_mm@val=val_318
+PREHOOK: Input: default@dp_mm@val=val_321
+PREHOOK: Input: default@dp_mm@val=val_322
+PREHOOK: Input: default@dp_mm@val=val_323
+PREHOOK: Input: default@dp_mm@val=val_325
+PREHOOK: Input: default@dp_mm@val=val_327
+PREHOOK: Input: default@dp_mm@val=val_33
+PREHOOK: Input: default@dp_mm@val=val_331
+PREHOOK: Input: default@dp_mm@val=val_332
+PREHOOK: Input: default@dp_mm@val=val_333
+PREHOOK: Input: default@dp_mm@val=val_335
+PREHOOK: Input: default@dp_mm@val=val_336
+PREHOOK: Input: default@dp_mm@val=val_338
+PREHOOK: Input: default@dp_mm@val=val_339
+PREHOOK: Input: default@dp_mm@val=val_34
+PREHOOK: Input: default@dp_mm@val=val_341
+PREHOOK: Input: default@dp_mm@val=val_342
+PREHOOK: Input: default@dp_mm@val=val_344
+PREHOOK: Input: default@dp_mm@val=val_345
+PREHOOK: Input: default@dp_mm@val=val_348
+PREHOOK: Input: default@dp_mm@val=val_35
+PREHOOK: Input: default@dp_mm@val=val_351
+PREHOOK: Input: default@dp_mm@val=val_353
+PREHOOK: Input: default@dp_mm@val=val_356
+PREHOOK: Input: default@dp_mm@val=val_360
+PREHOOK: Input: default@dp_mm@val=val_362
+PREHOOK: Input: default@dp_mm@val=val_364
+PREHOOK: Input: default@dp_mm@val=val_365
+PREHOOK: Input: default@dp_mm@val=val_366
+PREHOOK: Input: default@dp_mm@val=val_367
+PREHOOK: Input: default@dp_mm@val=val_368
+PREHOOK: Input: default@dp_mm@val=val_369
+PREHOOK: Input: default@dp_mm@val=val_37
+PREHOOK: Input: default@dp_mm@val=val_373
+PREHOOK: Input: default@dp_mm@val=val_374
+PREHOOK: Input: default@dp_mm@val=val_375
+PREHOOK: Input: default@dp_mm@val=val_377
+PREHOOK: Input: default@dp_mm@val=val_378
+PREHOOK: Input: default@dp_mm@val=val_379
+PREHOOK: Input: default@dp_mm@val=val_382
+PREHOOK: Input: default@dp_mm@val=val_384
+PREHOOK: Input: default@dp_mm@val=val_386
+PREHOOK: Input: default@dp_mm@val=val_389
+PREHOOK: Input: default@dp_mm@val=val_392
+PREHOOK: Input: default@dp_mm@val=val_393
+PREHOOK: Input: default@dp_mm@val=val_394
+PREHOOK: Input: default@dp_mm@val=val_395
+PREHOOK: Input: default@dp_mm@val=val_396
+PREHOOK: Input: default@dp_mm@val=val_397
+PREHOOK: Input: default@dp_mm@val=val_399
+PREHOOK: Input: default@dp_mm@val=val_4
+PREHOOK: Input: default@dp_mm@val=val_400
+PREHOOK: Input: default@dp_mm@val=val_401
+PREHOOK: Input: default@dp_mm@val=val_402
+PREHOOK: Input: default@dp_mm@val=val_403
+PREHOOK: Input: default@dp_mm@val=val_404
+PREHOOK: Input: default@dp_mm@val=val_406
+PREHOOK: Input: default@dp_mm@val=val_407
+PREHOOK: Input: default@dp_mm@val=val_409
+PREHOOK: Input: default@dp_mm@val=val_41
+PREHOOK: Input: default@dp_mm@val=val_411
+PREHOOK: Input: default@dp_mm@val=val_413
+PREHOOK: Input: default@dp_mm@val=val_414
+PREHOOK: Input: default@dp_mm@val=val_417
+PREHOOK: Input: default@dp_mm@val=val_418
+PREHOOK: Input: default@dp_mm@val=val_419
+PREHOOK: Input: default@dp_mm@val=val_42
+PREHOOK: Input: default@dp_mm@val=val_421
+PREHOOK: Input: default@dp_mm@val=val_424
+PREHOOK: Input: default@dp_mm@val=val_427
+PREHOOK: Input: default@dp_mm@val=val_429
+PREHOOK: Input: default@dp_mm@val=val_43
+PREHOOK: Input: default@dp_mm@val=val_430
+PREHOOK: Input: default@dp_mm@val=val_431
+PREHOOK: Input: default@dp_mm@val=val_432
+PREHOOK: Input: default@dp_mm@val=val_435
+PREHOOK: Input: default@dp_mm@val=val_436
+PREHOOK: Input: default@dp_mm@val=val_437
+PREHOOK: Input: default@dp_mm@val=val_438
+PREHOOK: Input: default@dp_mm@val=val_439
+PREHOOK: Input: default@dp_mm@val=val_44
+PREHOOK: Input: default@dp_mm@val=val_443
+PREHOOK: Input: default@dp_mm@val=val_444
+PREHOOK: Input: default@dp_mm@val=val_446
+PREHOOK: Input: default@dp_mm@val=val_448
+PREHOOK: Input: default@dp_mm@val=val_449
+PREHOOK: Input: default@dp_mm@val=val_452
+PREHOOK: Input: default@dp_mm@val=val_453
+PREHOOK: Input: default@dp_mm@val=val_454
+PREHOOK: Input: default@dp_mm@val=val_455
+PREHOOK: Input: default@dp_mm@val=val_457
+PREHOOK: Input: default@dp_mm@val=val_458
+PREHOOK: Input: default@dp_mm@val=val_459
+PREHOOK: Input: default@dp_mm@val=val_460
+PREHOOK: Input: default@dp_mm@val=val_462
+PREHOOK: Input: default@dp_mm@val=val_463
+PREHOOK: Input: default@dp_mm@val=val_466
+PREHOOK: Input: default@dp_mm@val=val_467
+PREHOOK: Input: default@dp_mm@val=val_468
+PREHOOK: Input: default@dp_mm@val=val_469
+PREHOOK: Input: default@dp_mm@val=val_47
+PREHOOK: Input: default@dp_mm@val=val_470
+PREHOOK: Input: default@dp_mm@val=val_472
+PREHOOK: Input: default@dp_mm@val=val_475
+PREHOOK: Input: default@dp_mm@val=val_477
+PREHOOK: Input: default@dp_mm@val=val_478
+PREHOOK: Input: default@dp_mm@val=val_479
+PREHOOK: Input: default@dp_mm@val=val_480
+PREHOOK: Input: default@dp_mm@val=val_481
+PREHOOK: Input: default@dp_mm@val=val_482
+PREHOOK: Input: default@dp_mm@val=val_483
+PREHOOK: Input: default@dp_mm@val=val_484
+PREHOOK: Input: default@dp_mm@val=val_485
+PREHOOK: Input: default@dp_mm@val=val_487
+PREHOOK: Input: default@dp_mm@val=val_489
+PREHOOK: Input: default@dp_mm@val=val_490
+PREHOOK: Input: default@dp_mm@val=val_491
+PREHOOK: Input: default@dp_mm@val=val_492
+PREHOOK: Input: default@dp_mm@val=val_493
+PREHOOK: Input: default@dp_mm@val=val_494
+PREHOOK: Input: default@dp_mm@val=val_495
+PREHOOK: Input: default@dp_mm@val=val_496
+PREHOOK: Input: default@dp_mm@val=val_497
+PREHOOK: Input: default@dp_mm@val=val_498
+PREHOOK: Input: default@dp_mm@val=val_5
+PREHOOK: Input: default@dp_mm@val=val_51
+PREHOOK: Input: default@dp_mm@val=val_53
+PREHOOK: Input: default@dp_mm@val=val_54
+PREHOOK: Input: default@dp_mm@val=val_57
+PREHOOK: Input: default@dp_mm@val=val_58
+PREHOOK: Input: default@dp_mm@val=val_64
+PREHOOK: Input: default@dp_mm@val=val_65
+PREHOOK: Input: default@dp_mm@val=val_66
+PREHOOK: Input: default@dp_mm@val=val_67
+PREHOOK: Input: default@dp_mm@val=val_69
+PREHOOK: Input: default@dp_mm@val=val_70
+PREHOOK: Input: default@dp_mm@val=val_72
+PREHOOK: Input: default@dp_mm@val=val_74
+PREHOOK: Input: default@dp_mm@val=val_76
+PREHOOK: Input: default@dp_mm@val=val_77
+PREHOOK: Input: default@dp_mm@val=val_78
+PREHOOK: Input: default@dp_mm@val=val_8
+PREHOOK: Input: default@dp_mm@val=val_80
+PREHOOK: Input: default@dp_mm@val=val_82
+PREHOOK: Input: default@dp_mm@val=val_83
+PREHOOK: Input: default@dp_mm@val=val_84
+PREHOOK: Input: default@dp_mm@val=val_85
+PREHOOK: Input: default@dp_mm@val=val_86
+PREHOOK: Input: default@dp_mm@val=val_87
+PREHOOK: Input: default@dp_mm@val=val_9
+PREHOOK: Input: default@dp_mm@val=val_90
+PREHOOK: Input: default@dp_mm@val=val_92
+PREHOOK: Input: default@dp_mm@val=val_95
+PREHOOK: Input: default@dp_mm@val=val_96
+PREHOOK: Input: default@dp_mm@val=val_97
+PREHOOK: Input: default@dp_mm@val=val_98
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from dp_mm order by key, p, r, val
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@dp_mm
+POSTHOOK: Input: default@dp_mm@val=val_0
+POSTHOOK: Input: default@dp_mm@val=val_10
+POSTHOOK: Input: default@dp_mm@val=val_100
+POSTHOOK: Input: default@dp_mm@val=val_103
+POSTHOOK: Input: default@dp_mm@val=val_104
+POSTHOOK: Input: default@dp_mm@val=val_105
+POSTHOOK: Input: default@dp_mm@val=val_11
+POSTHOOK: Input: default@dp_mm@val=val_111
+POSTHOOK: Input: default@dp_mm@val=val_113
+POSTHOOK: Input: default@dp_mm@val=val_114
+POSTHOOK: Input: default@dp_mm@val=val_116
+POSTHOOK: Input: default@dp_mm@val=val_118
+POSTHOOK: Input: default@dp_mm@val=val_119
+POSTHOOK: Input: default@dp_mm@val=val_12
+POSTHOOK: Input: default@dp_mm@val=val_120
+POSTHOOK: Input: default@dp_mm@val=val_125
+POSTHOOK: Input: default@dp_mm@val=val_126
+POSTHOOK: Input: default@dp_mm@val=val_128
+POSTHOOK: Input: default@dp_mm@val=val_129
+POSTHOOK: Input: default@dp_mm@val=val_131
+POSTHOOK: Input: default@dp_mm@val=val_133
+POSTHOOK: Input: default@dp_mm@val=val_134
+POSTHOOK: Input: default@dp_mm@val=val_136
+POSTHOOK: Input: default@dp_mm@val=val_137
+POSTHOOK: Input: default@dp_mm@val=val_138
+POSTHOOK: Input: default@dp_mm@val=val_143
+POSTHOOK: Input: default@dp_mm@val=val_145
+POSTHOOK: Input: default@dp_mm@val=val_146
+POSTHOOK: Input: default@dp_mm@val=val_149
+POSTHOOK: Input: default@dp_mm@val=val_15
+POSTHOOK: Input: default@dp_mm@val=val_150
+POSTHOOK: Input: default@dp_mm@val=val_152
+POSTHOOK: Input: default@dp_mm@val=val_153
+POSTHOOK: Input: default@dp_mm@val=val_155
+POSTHOOK: Input: default@dp_mm@val=val_156
+POSTHOOK: Input: default@dp_mm@val=val_157
+POSTHOOK: Input: default@dp_mm@val=val_158
+POSTHOOK: Input: default@dp_mm@val=val_160
+POSTHOOK: Input: default@dp_mm@val=val_162
+POSTHOOK: Input: default@dp_mm@val=val_163
+POSTHOOK: Input: default@dp_mm@val=val_164
+POSTHOOK: Input: default@dp_mm@val=val_165
+POSTHOOK: Input: default@dp_mm@val=val_166
+POSTHOOK: Input: default@dp_mm@val=val_167
+POSTHOOK: Input: default@dp_mm@val=val_168
+POSTHOOK: Input: default@dp_mm@val=val_169
+POSTHOOK: Input: default@dp_mm@val=val_17
+POSTHOOK: Input: default@dp_mm@val=val_170
+POSTHOOK: Input: default@dp_mm@val=val_172
+POSTHOOK: Input: default@dp_mm@val=val_174
+POSTHOOK: Input: default@dp_mm@val=val_175
+POSTHOOK: Input: default@dp_mm@val=val_176
+POSTHOOK: Input: default@dp_mm@val=val_177
+POSTHOOK: Input: default@dp_mm@val=val_178
+POSTHOOK: Input: default@dp_mm@val=val_179
+POSTHOOK: Input: default@dp_mm@val=val_18
+POSTHOOK: Input: default@dp_mm@val=val_180
+POSTHOOK: Input: default@dp_mm@val=val_181
+POSTHOOK: Input: default@dp_mm@val=val_183
+POSTHOOK: Input: default@dp_mm@val=val_186
+POSTHOOK: Input: default@dp_mm@val=val_187
+POSTHOOK: Input: default@dp_mm@val=val_189
+POSTHOOK: Input: default@dp_mm@val=val_19
+POSTHOOK: Input: default@dp_mm@val=val_190
+POSTHOOK: Input: default@dp_mm@val=val_191
+POSTHOOK: Input: default@dp_mm@val=val_192
+POSTHOOK: Input: default@dp_mm@val=val_193
+POSTHOOK: Input: default@dp_mm@val=val_194
+POSTHOOK: Input: default@dp_mm@val=val_195
+POSTHOOK: Input: default@dp_mm@val=val_196
+POSTHOOK: Input: default@dp_mm@val=val_197
+POSTHOOK: Input: default@dp_mm@val=val_199
+POSTHOOK: Input: default@dp_mm@val=val_2
+POSTHOOK: Input: default@dp_mm@val=val_20
+POSTHOOK: Input: default@dp_mm@val=val_200
+POSTHOOK: Input: default@dp_mm@val=val_201
+POSTHOOK: Input: default@dp_mm@val=val_202
+POSTHOOK: Input: default@dp_mm@val=val_203
+POSTHOOK: Input: default@dp_mm@val=val_205
+POSTHOOK: Input: default@dp_mm@val=val_207
+POSTHOOK: Input: default@dp_mm@val=val_208
+POSTHOOK: Input: default@dp_mm@val=val_209
+POSTHOOK: Input: default@dp_mm@val=val_213
+POSTHOOK: Input: default@dp_mm@val=val_214
+POSTHOOK: Input: default@dp_mm@val=val_216
+POSTHOOK: Input: default@dp_mm@val=val_217
+POSTHOOK: Input: default@dp_mm@val=val_218
+POSTHOOK: Input: default@dp_mm@val=val_219
+POSTHOOK: Input: default@dp_mm@val=val_221
+POSTHOOK: Input: default@dp_mm@val=val_222
+POSTHOOK: Input: default@dp_mm@val=val_223
+POSTHOOK: Input: default@dp_mm@val=val_224
+POSTHOOK: Input: default@dp_mm@val=val_226
+POSTHOOK: Input: default@dp_mm@val=val_228
+POSTHOOK: Input: default@dp_mm@val=val_229
+POSTHOOK: Input: default@dp_mm@val=val_230
+POSTHOOK: Input: default@dp_mm@val=val_233
+POSTHOOK: Input: default@dp_mm@val=val_235
+POSTHOOK: Input: default@dp_mm@val=val_237
+POSTHOOK: Input: default@dp_mm@val=val_238
+POSTHOOK: Input: default@dp_mm@val=val_239
+POSTHOOK: Input: default@dp_mm@val=val_24
+POSTHOOK: Input: default@dp_mm@val=val_241
+POSTHOOK: Input: default@dp_mm@val=val_242
+POSTHOOK: Input: default@dp_mm@val=val_244
+POSTHOOK: Input: default@dp_mm@val=val_247
+POSTHOOK: Input: default@dp_mm@val=val_248
+POSTHOOK: Input: default@dp_mm@val=val_249
+POSTHOOK: Input: default@dp_mm@val=val_252
+POSTHOOK: Input: default@dp_mm@val=val_255
+POSTHOOK: Input: default@dp_mm@val=val_256
+POSTHOOK: Input: default@dp_mm@val=val_257
+POSTHOOK: Input: default@dp_mm@val=val_258
+POSTHOOK: Input: default@dp_mm@val=val_26
+POSTHOOK: Input: default@dp_mm@val=val_260
+POSTHOOK: Input: default@dp_mm@val=val_262
+POSTHOOK: Input: default@dp_mm@val=val_263
+POSTHOOK: Input: default@dp_mm@val=val_265
+POSTHOOK: Input: default@dp_mm@val=val_266
+POSTHOOK: Input: default@dp_mm@val=val_27
+POSTHOOK: Input: default@dp_mm@val=val_272
+POSTHOOK: Input: default@dp_mm@val=val_273
+POSTHOOK: Input: default@dp_mm@val=val_274
+POSTHOOK: Input: default@dp_mm@val=val_275
+POSTHOOK: Input: default@dp_mm@val=val_277
+POSTHOOK: Input: default@dp_mm@val=val_278
+POSTHOOK: Input: default@dp_mm@val=val_28
+POSTHOOK: Input: default@dp_mm@val=val_280
+POSTHOOK: Input: default@dp_mm@val=val_281
+POSTHOOK: Input: default@dp_mm@val=val_282
+POSTHOOK: Input: default@dp_mm@val=val_283
+POSTHOOK: Input: default@dp_mm@val=val_284
+POSTHOOK: Input: default@dp_mm@val=val_285
+POSTHOOK: Input: default@dp_mm@val=val_286
+POSTHOOK: Input: default@dp_mm@val=val_287
+POSTHOOK: Input: default@dp_mm@val=val_288
+POSTHOOK: Input: default@dp_mm@val=val_289
+POSTHOOK: Input: default@dp_mm@val=val_291
+POSTHOOK: Input: default@dp_mm@val=val_292
+POSTHOOK: Input: default@dp_mm@val=val_296
+POSTHOOK: Input: default@dp_mm@val=val_298
+POSTHOOK: Input: default@dp_mm@val=val_30
+POSTHOOK: Input: default@dp_mm@val=val_302
+POSTHOOK: Input: default@dp_mm@val=val_305
+POSTHOOK: Input: default@dp_mm@val=val_306
+POSTHOOK: Input: default@dp_mm@val=val_307
+POSTHOOK: Input: default@dp_mm@val=val_308
+POSTHOOK: Input: default@dp_mm@val=val_309
+POSTHOOK: Input: default@dp_mm@val=val_310
+POSTHOOK: Input: default@dp_mm@val=val_311
+POSTHOOK: Input: default@dp_mm@val=val_315
+POSTHOOK: Input: default@dp_mm@val=val_316
+POSTHOOK: Input: default@dp_mm@val=val_317
+POSTHOOK: Input: default@dp_mm@val=val_318
+POSTHOOK: Input: default@dp_mm@val=val_321
+POSTHOOK: Input: default@dp_mm@val=val_322
+POSTHOOK: Input: default@dp_mm@val=val_323
+POSTHOOK: Input: default@dp_mm@val=val_325
+POSTHOOK: Input: default@dp_mm@val=val_327
+POSTHOOK: Input: default@dp_mm@val=val_33
+POSTHOOK: Input: default@dp_mm@val=val_331
+POSTHOOK: Input: default@dp_mm@val=val_332
+POSTHOOK: Input: default@dp_mm@val=val_333
+POSTHOOK: Input: default@dp_mm@val=val_335
+POSTHOOK: Input: default@dp_mm@val=val_336
+POSTHOOK: Input: default@dp_mm@val=val_338
+POSTHOOK: Input: default@dp_mm@val=val_339
+POSTHOOK: Input: default@dp_mm@val=val_34
+POSTHOOK: Input: default@dp_mm@val=val_341
+POSTHOOK: Input: default@dp_mm@val=val_342
+POSTHOOK: Input: default@dp_mm@val=val_344
+POSTHOOK: Input: default@dp_mm@val=val_345
+POSTHOOK: Input: default@dp_mm@val=val_348
+POSTHOOK: Input: default@dp_mm@val=val_35
+POSTHOOK: Input: default@dp_mm@val=val_351
+POSTHOOK: Input: default@dp_mm@val=val_353
+POSTHOOK: Input: default@dp_mm@val=val_356
+POSTHOOK: Input: default@dp_mm@val=val_360
+POSTHOOK: Input: default@dp_mm@val=val_362
+POSTHOOK: Input: default@dp_mm@val=val_364
+POSTHOOK: Input: default@dp_mm@val=val_365
+POSTHOOK: Input: default@dp_mm@val=val_366
+POSTHOOK: Input: default@dp_mm@val=val_367
+POSTHOOK: Input: default@dp_mm@val=val_368
+POSTHOOK: Input: default@dp_mm@val=val_369
+POSTHOOK: Input: default@dp_mm@val=val_37
+POSTHOOK: Input: default@dp_mm@val=val_373
+POSTHOOK: Input: default@dp_mm@val=val_374
+POSTHOOK: Input: default@dp_mm@val=val_375
+POSTHOOK: Input: default@dp_mm@val=val_377
+POSTHOOK: Input: default@dp_mm@val=val_378
+POSTHOOK: Input: default@dp_mm@val=val_379
+POSTHOOK: Input: default@dp_mm@val=val_382
+POSTHOOK: Input: default@dp_mm@val=val_384
+POSTHOOK: Input: default@dp_mm@val=val_386
+POSTHOOK: Input: default@dp_mm@val=val_389
+POSTHOOK: Input: default@dp_mm@val=val_392
+POSTHOOK: Input: default@dp_mm@val=val_393
+POSTHOOK: Input: default@dp_mm@val=val_394
+POSTHOOK: Input: default@dp_mm@val=val_395
+POSTHOOK: Input: default@dp_mm@val=val_396
+POSTHOOK: Input: default@dp_mm@val=val_397
+POSTHOOK: Input: default@dp_mm@val=val_399
+POSTHOOK: Input: default@dp_mm@val=val_4
+POSTHOOK: Input: default@dp_mm@val=val_400
+POSTHOOK: Input: default@dp_mm@val=val_401
+POSTHOOK: Input: default@dp_mm@val=val_402
+POSTHOOK: Input: default@dp_mm@val=val_403
+POSTHOOK: Input: default@dp_mm@val=val_404
+POSTHOOK: Input: default@dp_mm@val=val_406
+POSTHOOK: Input: default@dp_mm@val=val_407
+POSTHOOK: Input: default@dp_mm@val=val_409
+POSTHOOK: Input: default@dp_mm@val=val_41
+POSTHOOK: Input: default@dp_mm@val=val_411
+POSTHOOK: Input: default@dp_mm@val=val_413
+POSTHOOK: Input: default@dp_mm@val=val_414
+POSTHOOK: Input: default@dp_mm@val=val_417
+POSTHOOK: Input: default@dp_mm@val=val_418
+POSTHOOK: Input: default@dp_mm@val=val_419
+POSTHOOK: Input: default@dp_mm@val=val_42
+POSTHOOK: Input: default@dp_mm@val=val_421
+POSTHOOK: Input: default@dp_mm@val=val_424
+POSTHOOK: Input: default@dp_mm@val=val_427
+POSTHOOK: Input: default@dp_mm@val=val_429
+POSTHOOK: Input: default@dp_mm@val=val_43
+POSTHOOK: Input: default@dp_mm@val=val_430
+POSTHOOK: Input: default@dp_mm@val=val_431
+POSTHOOK: Input: default@dp_mm@val=val_432
+POSTHOOK: Input: default@dp_mm@val=val_435
+POSTHOOK: Input: default@dp_mm@val=val_436
+POSTHOOK: Input: default@dp_mm@val=val_437
+POSTHOOK: Input: default@dp_mm@val=val_438
+POSTHOOK: Input: default@dp_mm@val=val_439
+POSTHOOK: Input: default@dp_mm@val=val_44
+POSTHOOK: Input: default@dp_mm@val=val_443
+POSTHOOK: Input: default@dp_mm@val=val_444
+POSTHOOK: Input: default@dp_mm@val=val_446
+POSTHOOK: Input: default@dp_mm@val=val_448
+POSTHOOK: Input: default@dp_mm@val=val_449
+POSTHOOK: Input: default@dp_mm@val=val_452
+POSTHOOK: Input: default@dp_mm@val=val_453
+POSTHOOK: Input: default@dp_mm@val=val_454
+POSTHOOK: Input: default@dp_mm@val=val_455
+POSTHOOK: Input: default@dp_mm@val=val_457
+POSTHOOK: Input: default@dp_mm@val=val_458
+POSTHOOK: Input: default@dp_mm@val=val_459
+POSTHOOK: Input: default@dp_mm@val=val_460
+POSTHOOK: Input: default@dp_mm@val=val_462
+POSTHOOK: Input: default@dp_mm@val=val_463
+POSTHOOK: Input: default@dp_mm@val=val_466
+POSTHOOK: Input: default@dp_mm@val=val_467
+POSTHOOK: Input: default@dp_mm@val=val_468
+POSTHOOK: Input: default@dp_mm@val=val_469
+POSTHOOK: Input: default@dp_mm@val=val_47
+POSTHOOK: Input: default@dp_mm@val=val_470
+POSTHOOK: Input: default@dp_mm@val=val_472
+POSTHOOK: Input: default@dp_mm@val=val_475
+POSTHOOK: Input: default@dp_mm@val=val_477
+POSTHOOK: Input: default@dp_mm@val=val_478
+POSTHOOK: Input: default@dp_mm@val=val_479
+POSTHOOK: Input: default@dp_mm@val=val_480
+POSTHOOK: Input: default@dp_mm@val=val_481
+POSTHOOK: Input: default@dp_mm@val=val_482
+POSTHOOK: Input: default@dp_mm@val=val_483
+POSTHOOK: Input: default@dp_mm@val=val_484
+POSTHOOK: Input: default@dp_mm@val=val_485
+POSTHOOK: Input: default@dp_mm@val=val_487
+POSTHOOK: Input: default@dp_mm@val=val_489
+POSTHOOK: Input: default@dp_mm@val=val_490
+POSTHOOK: Input: default@dp_mm@val=val_491
+POSTHOOK: Input: default@dp_mm@val=val_492
+POSTHOOK: Input: default@dp_mm@val=val_493
+POSTHOOK: Input: default@dp_mm@val=val_494
+POSTHOOK: Input: default@dp_mm@val=val_495
+POSTHOOK: Input: default@dp_mm@val=val_496
+POSTHOOK: Input: default@dp_mm@val=val_497
+POSTHOOK: Input: default@dp_mm@val=val_498
+POSTHOOK: Input: default@dp_mm@val=val_5
+POSTHOOK: Input: default@dp_mm@val=val_51
+POSTHOOK: Input: default@dp_mm@val=val_53
+POSTHOOK: Input: default@dp_mm@val=val_54
+POSTHOOK: Input: default@dp_mm@val=val_57
+POSTHOOK: Input: default@dp_mm@val=val_58
+POSTHOOK: Input: default@dp_mm@val=val_64
+POSTHOOK: Input: default@dp_mm@val=val_65
+POSTHOOK: Input: default@dp_mm@val=val_66
+POSTHOOK: Input: default@dp_mm@val=val_67
+POSTHOOK: Input: default@dp_mm@val=val_69
+POSTHOOK: Input: default@dp_mm@val=val_70
+POSTHOOK: Input: default@dp_mm@val=val_72
+POSTHOOK: Input: default@dp_mm@val=val_74
+POSTHOOK: Input: default@dp_mm@val=val_76
+POSTHOOK: Input: default@dp_mm@val=val_77
+POSTHOOK: Input: default@dp_mm@val=val_78
+POSTHOOK: Input: default@dp_mm@val=val_8
+POSTHOOK: Input: default@dp_mm@val=val_80
+POSTHOOK: Input: default@dp_mm@val=val_82
+POSTHOOK: Input: default@dp_mm@val=val_83
+POSTHOOK: Input: default@dp_mm@val=val_84
+POSTHOOK: Input: default@dp_mm@val=val_85
+POSTHOOK: Input: default@dp_mm@val=val_86
+POSTHOOK: Input: default@dp_mm@val=val_87
+POSTHOOK: Input: default@dp_mm@val=val_9
+POSTHOOK: Input: default@dp_mm@val=val_90
+POSTHOOK: Input: default@dp_mm@val=val_92
+POSTHOOK: Input: default@dp_mm@val=val_95
+POSTHOOK: Input: default@dp_mm@val=val_96
+POSTHOOK: Input: default@dp_mm@val=val_97
+POSTHOOK: Input: default@dp_mm@val=val_98
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0	455	3	val_0
+0	455	10	val_0
+0	455	23	val_0
+0	457	3	val_0
+0	457	10	val_0
+0	457	14	val_0
+0	457	17	val_0
+0	457	23	val_0
+0	457	28	val_0
+0	458	14	val_0
+0	458	17	val_0
+0	458	28	val_0
+0	459	14	val_0
+0	459	17	val_0
+0	459	28	val_0
+2	455	10	val_2
+2	457	5	val_2
+2	457	10	val_2
+2	458	5	val_2
+2	459	5	val_2
+4	455	4	val_4
+4	457	4	val_4
+4	457	24	val_4
+4	458	24	val_4
+4	459	24	val_4
+5	455	9	val_5
+5	455	13	val_5
+5	455	28	val_5
+5	457	3	val_5
+5	457	9	val_5
+5	457	13	val_5
+5	457	28	val_5
+5	457	28	val_5
+5	457	28	val_5
+5	458	3	val_5
+5	458	28	val_5
+5	458	28	val_5
+5	459	3	val_5
+5	459	28	val_5
+5	459	28	val_5
+8	455	23	val_8
+8	457	6	val_8
+8	457	23	val_8
+8	458	6	val_8
+8	459	6	val_8
+9	455	27	val_9
+9	457	9	val_9
+9	457	27	val_9
+9	458	9	val_9
+9	459	9	val_9
+10	455	4	val_10
+10	457	4	val_10
+10	457	9	val_10
+10	458	9	val_10
+10	459	9	val_10
+11	455	9	val_11
+11	457	9	val_11
+11	457	14	val_11
+11	458	14	val_11
+11	459	14	val_11
+12	455	9	val_12
+12	455	27	val_12
+12	457	9	val_12
+12	457	13	val_12
+12	457	23	val_12
+12	457	27	val_12
+12	458	13	val_12
+12	458	23	val_12
+12	459	13	val_12
+12	459	23	val_12
+15	455	9	val_15
+15	455	24	val_15
+15	457	9	val_15
+15	457	17	val_15
+15	457	19	val_15
+15	457	24	val_15
+15	458	17	val_15
+15	458	19	val_15
+15	459	17	val_15
+15	459	19	val_15
+17	455	13	val_17
+17	457	1	val_17
+17	457	13	val_17
+17	458	1	val_17
+17	459	1	val_17
+18	455	10	val_18
+18	455	24	val_18
+18	457	10	val_18
+18	457	14	val_18
+18	457	24	val_18
+18	457	24	val_18
+18	458	14	val_18
+18	458	24	val_18
+18	459	14	val_18
+18	459	24	val_18
+19	455	19	val_19
+19	457	19	val_19
+19	457	24	val_19
+19	458	24	val_19
+19	459	24	val_19
+20	455	24	val_20
+20	457	9	val_20
+20	457	24	val_20
+20	458	9	val_20
+20	459	9	val_20
+24	455	4	val_24
+24	455	28	val_24
+24	457	1	val_24
+24	457	4	val_24
+24	457	6	val_24
+24	457	28	val_24
+24	458	1	val_24
+24	458	6	val_24
+24	459	1	val_24
+24	459	6	val_24
+26	455	7	val_26
+26	455	23	val_26
+26	457	5	val_26
+26	457	7	val_26
+26	457	19	val_26
+26	457	23	val_26
+26	458	5	val_26
+26	458	19	val_26
+26	459	5	val_26
+26	459	19	val_26
+27	455	27	val_27
+27	457	9	val_27
+27	457	27	val_27
+27	458	9	val_27
+27	459	9	val_27
+28	455	23	val_28
+28	457	5	val_28
+28	457	23	val_28
+28	458	5	val_28
+28	459	5	val_28
+30	455	28	val_30
+30	457	20	val_30
+30	457	28	val_30
+30	458	20	val_30
+30	459	20	val_30
+33	455	20	val_33
+33	457	17	val_33
+33	457	20	val_33
+33	458	17	val_33
+33	459	17	val_33
+34	455	27	val_34
+34	457	24	val_34
+34	457	27	val_34
+34	458	24	val_34
+34	459	24	val_34
+35	455	13	val_35
+35	455	23	val_35
+35	455	24	val_35
+35	457	5	val_35
+35	457	7	val_35
+35	457	9	val_35
+35	457	13	val_35
+35	457	23	val_35
+35	457	24	val_35
+35	458	5	val_35
+35	458	7	val_35
+35	458	9	val_35
+35	459	5	val_35
+35	459	7	val_35
+35	459	9	val_35
+37	455	1	val_37
+37	455	28	val_37
+37	457	1	val_37
+37	457	7	val_37
+37	457	11	val_37
+37	457	28	val_37
+37	458	7	val_37
+37	458	11	val_37
+37	459	7	val_37
+37	459	11	val_37
+41	455	19	val_41
+41	457	19	val_41
+41	457	20	val_41
+41	458	20	val_41
+41	459	20	val_41
+42	455	9	val_42
+42	455	14	val_42
+42	457	9	val_42
+42	457	14	val_42
+42	457	17	val_42
+42	457	19	val_42
+42	458	17	val_42
+42	458	19	val_42
+42	459	17	val_42
+42	459	19	val_42
+43	455	23	val_43
+43	457	23	val_43
+43	457	27	val_43
+43	458	27	val_43
+43	459	27	val_43
+44	455	4	val_44
+44	457	4	val_44
+44	457	11	val_44
+44	458	11	val_44
+44	459	11	val_44
+47	455	13	val_47
+47	457	13	val_47
+47	457	28	val_47
+47	458	28	val_47
+47	459	28	val_47
+51	455	4	val_51
+51	455	27	val_51
+51	457	4	val_51
+51	457	9	val_51
+51	457	17	val_51
+51	457	27	val_51
+51	458	9	val_51
+51	458	17	val_51
+51	459	9	val_51
+51	459	17	val_51
+53	455	24	val_53
+53	457	2	val_53
+53	457	24	val_53
+53	458	2	val_53
+53	459	2	val_53
+54	455	20	val_54
+54	457	1	val_54
+54	457	20	val_54
+54	458	1	val_54
+54	459	1	val_54
+57	455	1	val_57
+57	457	1	val_57
+57	457	28	val_57
+57	458	28	val_57
+57	459	28	val_57
+58	455	1	val_58
+58	455	4	val_58
+58	457	1	val_58
+58	457	1	val_58
+58	457	2	val_58
+58	457	4	val_58
+58	458	1	val_58
+58	458	2	val_58
+58	459	1	val_58
+58	459	2	val_58
+64	455	1	val_64
+64	457	1	val_64
+64	457	6	val_64
+64	458	6	val_64
+64	459	6	val_64
+65	455	3	val_65
+65	457	3	val_65
+65	457	24	val_65
+65	458	24	val_65
+65	459	24	val_65
+66	455	13	val_66
+66	457	10	val_66
+66	457	13	val_66
+66	458	10	val_66
+66	459	10	val_66
+67	455	1	val_67
+67	455	10	val_67
+67	457	1	val_67
+67	457	10	val_67
+67	457	24	val_67
+67	457	28	val_67
+67	458	24	val_67
+67	458	28	val_67
+67	459	24	val_67
+67	459	28	val_67
+69	455	9	val_69
+69	457	1	val_69
+69	457	9	val_69
+69	458	1	val_69
+69	459	1	val_69
+70	455	19	val_70
+70	455	27	val_70
+70	455	28	val_70
+70	457	4	val_70
+70	457	5	val_70
+70	457	7	val_70
+70	457	19	val_70
+70	457	27	val_70
+70	457	28	val_70
+70	458	4	val_70
+70	458	5	val_70
+70	458	7	val_70
+70	459	4	val_70
+70	459	5	val_70
+70	459	7	val_70
+72	455	10	val_72
+72	455	19	val_72
+72	457	1	val_72
+72	457	10	val_72
+72	457	19	val_72
+72	457	23	val_72
+72	458	1	val_72
+72	458	23	val_72
+72	459	1	val_72
+72	459	23	val_72
+74	455	14	val_74
+74	457	6	val_74
+74	457	14	val_74
+74	458	6	val_74
+74	459	6	val_74
+76	455	13	val_76
+76	455	24	val_76
+76	457	9	val_76
+76	457	11	val_76
+76	457	13	val_76
+76	457	24	val_76
+76	458	9	val_76
+76	458	11	val_76
+76	459	9	val_76
+76	459	11	val_76
+77	455	16	val_77
+77	457	16	val_77
+77	457	28	val_77
+77	458	28	val_77
+77	459	28	val_77
+78	455	10	val_78
+78	457	10	val_78
+78	457	14	val_78
+78	458	14	val_78
+78	459	14	val_78
+80	455	19	val_80
+80	457	19	val_80
+80	457	25	val_80
+80	458	25	val_80
+80	459	25	val_80
+82	455	14	val_82
+82	457	11	val_82
+82	457	14	val_82
+82	458	11	val_82
+82	459	11	val_82
+83	455	9	val_83
+83	455	27	val_83
+83	457	9	val_83
+83	457	10	val_83
+83	457	27	val_83
+83	457	28	val_83
+83	458	10	val_83
+83	458	28	val_83
+83	459	10	val_83
+83	459	28	val_83
+84	455	4	val_84
+84	455	19	val_84
+84	457	4	val_84
+84	457	5	val_84
+84	457	19	val_84
+84	457	28	val_84
+84	458	5	val_84
+84	458	28	val_84
+84	459	5	val_84
+84	459	28	val_84
+85	455	2	val_85
+85	457	2	val_85
+85	457	15	val_85
+85	458	15	val_85
+85	459	15	val_85
+86	455	10	val_86
+86	457	10	val_86
+86	457	27	val_86
+86	458	27	val_86
+86	459	27	val_86
+87	455	28	val_87
+87	457	24	val_87
+87	457	28	val_87
+87	458	24	val_87
+87	459	24	val_87
+90	455	9	val_90
+90	455	10	val_90
+90	455	13	val_90
+90	457	9	val_90
+90	457	10	val_90
+90	457	13	val_90
+90	457	17	val_90
+90	457	27	val_90
+90	457	28	val_90
+90	458	17	val_90
+90	458	27	val_90
+90	458	28	val_90
+90	459	17	val_90
+90	459	27	val_90
+90	459	28	val_90
+92	455	7	val_92
+92	457	4	val_92
+92	457	7	val_92
+92	458	4	val_92
+92	459	4	val_92
+95	455	1	val_95
+95	455	14	val_95
+95	457	1	val_95
+95	457	5	val_95
+95	457	14	val_95
+95	457	28	val_95
+95	458	5	val_95
+95	458	28	val_95
+95	459	5	val_95
+95	459	28	val_95
+96	455	9	val_96
+96	457	9	val_96
+96	457	13	val_96
+96	458	13	val_96
+96	459	13	val_96
+97	455	19	val_97
+97	455	27	val_97
+97	457	2	val_97
+97	457	2	val_97
+97	457	19	val_97
+97	457	27	val_97
+97	458	2	val_97
+97	458	2	val_97
+97	459	2	val_97
+97	459	2	val_97
+98	455	9	val_98
+98	455	14	val_98
+98	457	4	val_98
+98	457	9	val_98
+98	457	14	val_98
+98	457	25	val_98
+98	458	4	val_98
+98	458	25	val_98
+98	459	4	val_98
+98	459	25	val_98
+100	455	10	val_100
+100	455	10	val_100
+100	457	10	val_100
+100	457	10	val_100
+100	457	27	val_100
+100	457	27	val_100
+100	458	27	val_100
+100	458	27	val_100
+100	458	27	val_100
+100	458	27	val_100
+100	459	27	val_100
+100	459	27	val_100
+103	455	2	val_103
+103	455	27	val_103
+103	457	2	val_103
+103	457	14	val_103
+103	457	14	val_103
+103	457	27	val_103
+103	458	1	val_103
+103	458	14	val_103
+103	458	14	val_103
+103	458	25	val_103
+103	459	14	val_103
+103	459	14	val_103
+104	455	23	val_104
+104	455	28	val_104
+104	457	3	val_104
+104	457	6	val_104
+104	457	23	val_104
+104	457	28	val_104
+104	458	3	val_104
+104	458	6	val_104
+104	458	6	val_104
+104	458	20	val_104
+104	459	3	val_104
+104	459	6	val_104
+105	455	14	val_105
+105	457	5	val_105
+105	457	14	val_105
+105	458	3	val_105
+105	458	5	val_105
+105	459	5	val_105
+111	455	10	val_111
+111	457	10	val_111
+111	457	23	val_111
+111	458	19	val_111
+111	458	23	val_111
+111	459	23	val_111
+113	455	10	val_113
+113	455	19	val_113
+113	457	3	val_113
+113	457	10	val_113
+113	457	19	val_113
+113	457	27	val_113
+113	458	1	val_113
+113	458	3	val_113
+113	458	25	val_113
+113	458	27	val_113
+113	459	3	val_113
+113	459	27	val_113
+114	455	20	val_114
+114	457	0	val_114
+114	457	20	val_114
+114	458	0	val_114
+114	458	5	val_114
+114	459	0	val_114
+116	455	10	val_116
+116	457	10	val_116
+116	457	10	val_116
+116	458	10	val_116
+116	458	10	val_116
+116	459	10	val_116
+118	455	7	val_118
+118	455	10	val_118
+118	457	4	val_118
+118	457	7	val_118
+118	457	10	val_118
+118	457	10	val_118
+118	458	4	val_118
+118	458	10	val_118
+118	458	10	val_118
+118	458	19	val_118
+118	459	4	val_118
+118	459	10	val_118
+119	455	7	val_119
+119	455	24	val_119
+119	455	27	val_119
+119	457	5	val_119
+119	457	7	val_119
+119	457	17	val_119
+119	457	24	val_119
+119	457	27	val_119
+119	457	28	val_119
+119	458	1	val_119
+119	458	5	val_119
+119	458	17	val_119
+119	458	23	val_119
+119	458	25	val_119
+119	458	28	val_119
+119	459	5	val_119
+119	459	17	val_119
+119	459	28	val_119
+120	455	10	val_120
+120	455	13	val_120
+120	457	10	val_120
+120	457	13	val_120
+120	457	24	val_120
+120	457	27	val_120
+120	458	24	val_120
+120	458	27	val_120
+120	458	27	val_120
+120	458	28	val_120
+120	459	24	val_120
+120	459	27	val_120
+125	455	1	val_125
+125	455	9	val_125
+125	457	1	val_125
+125	457	7	val_125
+125	457	9	val_125
+125	457	20	val_125
+125	458	7	val_125
+125	458	10	val_125
+125	458	14	val_125
+125	458	20	val_125
+125	459	7	val_125
+125	459	20	val_125
+126	455	14	val_126
+126	457	3	val_126
+126	457	14	val_126
+126	458	3	val_126
+126	458	6	val_126
+126	459	3	val_126
+128	455	7	val_128
+128	455	19	val_128
+128	455	28	val_128
+128	457	2	val_128
+128	457	2	val_128
+128	457	7	val_128
+128	457	14	val_128
+128	457	19	val_128
+128	457	28	val_128
+128	458	1	val_128
+128	458	2	val_128
+128	458	2	val_128
+128	458	9	val_128
+128	458	14	val_128
+128	458	17	val_128
+128	459	2	val_128
+128	459	2	val_128
+128	459	14	val_128
+129	455	9	val_129
+129	455	10	val_129
+129	457	9	val_129
+129	457	10	val_129
+129	457	27	val_129
+129	457	27	val_129
+129	458	6	val_129
+129	458	27	val_129
+129	458	27	val_129
+129	458	27	val_129
+129	459	27	val_129
+129	459	27	val_129
+131	455	19	val_131
+131	457	14	val_131
+131	457	19	val_131
+131	458	1	val_131
+131	458	14	val_131
+131	459	14	val_131
+133	455	13	val_133
+133	457	6	val_133
+133	457	13	val_133
+133	458	6	val_133
+133	458	11	val_133
+133	459	6	val_133
+134	455	27	val_134
+134	455	28	val_134
+134	457	15	val_134
+134	457	27	val_134
+134	457	27	val_134
+134	457	28	val_134
+134	458	2	val_134
+134	458	15	val_134
+134	458	27	val_134
+134	458	27	val_134
+134	459	15	val_134
+134	459	27	val_134
+136	455	7	val_136
+136	457	5	val_136
+136	457	7	val_136
+136	458	5	val_136
+136	458	28	val_136
+136	459	5	val_136
+137	455	10	val_137
+137	455	27	val_137
+137	457	9	val_137
+137	457	10	val_137
+137	457	14	val_137
+137	457	27	val_137
+137	458	6	val_137
+137	458	9	val_137
+137	458	9	val_137
+137	458	14	val_137
+137	459	9	val_137
+137	459	14	val_137
+138	455	10	val_138
+138	455	13	val_138
+138	455	23	val_138
+138	455	24	val_138
+138	457	3	val_138
+138	457	5	val_138
+138	457	7	val_138
+138	457	10	val_138
+138	457	11	val_138
+138	457	13	val_138
+138	457	23	val_138
+138	457	24	val_138
+138	458	2	val_138
+138	458	3	val_138
+138	458	5	val_138
+138	458	6	val_138
+138	458	7	val_138
+138	458	7	val_138
+138	458	10	val_138
+138	458	11	val_138
+138	459	3	val_138
+138	459	5	val_138
+138	459	7	val_138
+138	459	11	val_138
+143	455	10	val_143
+143	457	10	val_143
+143	457	27	val_143
+143	458	27	val_143
+143	458	27	val_143
+143	459	27	val_143
+145	455	28	val_145
+145	457	6	val_145
+145	457	28	val_145
+145	458	5	val_145
+145	458	6	val_145
+145	459	6	val_145
+146	455	4	val_146
+146	455	24	val_146
+146	457	3	val_146
+146	457	4	val_146
+146	457	13	val_146
+146	457	24	val_146
+146	458	3	val_146
+146	458	10	val_146
+146	458	13	val_146
+146	458	27	val_146
+146	459	3	val_146
+146	459	13	val_146
+149	455	4	val_149
+149	455	24	val_149
+149	457	2	val_149
+149	457	4	val_149
+149	457	24	val_149
+149	457	24	val_149
+149	458	2	val_149
+149	458	9	val_149
+149	458	24	val_149
+149	458	28	val_149
+149	459	2	val_149
+149	459	24	val_149
+150	455	10	val_150
+150	457	10	val_150
+150	457	14	val_150
+150	458	14	val_150
+150	458	28	val_150
+150	459	14	val_150
+152	455	1	val_152
+152	455	23	val_152
+152	457	1	val_152
+152	457	1	val_152
+152	457	20	val_152
+152	457	23	val_152
+152	458	1	val_152
+152	458	3	val_152
+152	458	16	val_152
+152	458	20	val_152
+152	459	1	val_152
+152	459	20	val_152
+153	455	20	val_153
+153	457	15	val_153
+153	457	20	val_153
+153	458	15	val_153
+153	458	17	val_153
+153	459	15	val_153
+155	455	4	val_155
+155	457	4	val_155
+155	457	17	val_155
+155	458	3	val_155
+155	458	17	val_155
+155	459	17	val_155
+156	455	28	val_156
+156	457	2	val_156
+156	457	28	val_156
+156	458	2	val_156
+156	458	9	val_156
+156	459	2	val_156
+157	455	9	val_157
+157	457	9	val_157
+157	457	10	val_157
+157	458	7	val_157
+157	458	10	val_157
+157	459	10	val_157
+158	455	20	val_158
+158	457	2	val_158
+158	457	20	val_158
+158	458	2	val_158
+158	458	4	val_158
+158	459	2	val_158
+160	455	27	val_160
+160	457	10	val_160
+160	457	27	val_160
+160	458	10	val_160
+160	458	10	val_160
+160	459	10	val_160
+162	455	9	val_162
+162	457	2	val_162
+162	457	9	val_162
+162	458	2	val_162
+162	458	2	val_162
+162	459	2	val_162
+163	455	1	val_163
+163	457	1	val_163
+163	457	1	val_163
+163	458	1	val_163
+163	458	1	val_163
+163	459	1	val_163
+164	455	7	val_164
+164	455	24	val_164
+164	457	7	val_164
+164	457	10	val_164
+164	457	24	val_164
+164	457	28	val_164
+164	458	4	val_164
+164	458	10	val_164
+164	458	20	val_164
+164	458	28	val_164
+164	459	10	val_164
+164	459	28	val_164
+165	455	10	val_165
+165	455	24	val_165
+165	457	4	val_165
+165	457	7	val_165
+165	457	10	val_165
+165	457	24	val_165
+165	458	4	val_165
+165	458	7	val_165
+165	458	13	val_165
+165	458	24	val_165
+165	459	4	val_165
+165	459	7	val_165
+166	455	9	val_166
+166	457	9	val_166
+166	457	17	val_166
+166	458	6	val_166
+166	458	17	val_166
+166	459	17	val_166
+167	455	2	val_167
+167	455	7	val_167
+167	455	7	val_167
+167	457	2	val_167
+167	457	7	val_167
+167	457	7	val_167
+167	457	11	val_167
+167	457	24	val_167
+167	457	28	val_167
+167	458	1	val_167
+167	458	1	val_167
+167	458	11	val_167
+167	458	11	val_167
+167	458	24	val_167
+167	458	28	val_167
+167	459	11	val_167
+167	459	24	val_167
+167	459	28	val_167
+168	455	20	val_168
+168	457	15	val_168
+168	457	20	val_168
+168	458	15	val_168
+168	458	17	val_168
+168	459	15	val_168
+169	455	10	val_169
+169	455	20	val_169
+169	455	27	val_169
+169	455	28	val_169
+169	457	2	val_169
+169	457	3	val_169
+169	457	9	val_169
+169	457	10	val_169
+169	457	11	val_169
+169	457	20	val_169
+169	457	27	val_169
+169	457	28	val_169
+169	458	2	val_169
+169	458	3	val_169
+169	458	3	val_169
+169	458	9	val_169
+169	458	9	val_169
+169	458	9	val_169
+169	458	11	val_169
+169	458	25	val_169
+169	459	2	val_169
+169	459	3	val_169
+169	459	9	val_169
+169	459	11	val_169
+170	455	27	val_170
+170	457	24	val_170
+170	457	27	val_170
+170	458	24	val_170
+170	458	24	val_170
+170	459	24	val_170
+172	455	10	val_172
+172	455	24	val_172
+172	457	10	val_172
+172	457	14	val_172
+172	457	20	val_172
+172	457	24	val_172
+172	458	7	val_172
+172	458	11	val_172
+172	458	14	val_172
+172	458	20	val_172
+172	459	14	val_172
+172	459	20	val_172
+174	455	10	val_174
+174	455	24	val_174
+174	457	10	val_174
+174	457	10	val_174
+174	457	24	val_174
+174	457	24	val_174
+174	458	10	val_174
+174	458	10	val_174
+174	458	24	val_174
+174	458	24	val_174
+174	459	10	val_174
+174	459	24	val_174
+175	455	1	val_175
+175	455	19	val_175
+175	457	1	val_175
+175	457	4	val_175
+175	457	14	val_175
+175	457	19	val_175
+175	458	4	val_175
+175	458	6	val_175
+175	458	6	val_175
+175	458	14	val_175
+175	459	4	val_175
+175	459	14	val_175
+176	455	9	val_176
+176	455	16	val_176
+176	457	4	val_176
+176	457	9	val_176
+176	457	16	val_176
+176	457	28	val_176
+176	458	4	val_176
+176	458	17	val_176
+176	458	20	val_176
+176	458	28	val_176
+176	459	4	val_176
+176	459	28	val_176
+177	455	23	val_177
+177	457	4	val_177
+177	457	23	val_177
+177	458	1	val_177
+177	458	4	val_177
+177	459	4	val_177
+178	455	24	val_178
+178	457	24	val_178
+178	457	28	val_178
+178	458	28	val_178
+178	458	28	val_178
+178	459	28	val_178
+179	455	1	val_179
+179	455	5	val_179
+179	457	0	val_179
+179	457	1	val_179
+179	457	5	val_179
+179	457	11	val_179
+179	458	0	val_179
+179	458	11	val_179
+179	458	17	val_179
+179	458	25	val_179
+179	459	0	val_179
+179	459	11	val_179
+180	455	24	val_180
+180	457	19	val_180
+180	457	24	val_180
+180	458	13	val_180
+180	458	19	val_180
+180	459	19	val_180
+181	455	7	val_181
+181	457	1	val_181
+181	457	7	val_181
+181	458	1	val_181
+181	458	23	val_181
+181	459	1	val_181
+183	455	13	val_183
+183	457	13	val_183
+183	457	20	val_183
+183	458	14	val_183
+183	458	20	val_183
+183	459	20	val_183
+186	455	9	val_186
+186	457	9	val_186
+186	457	23	val_186
+186	458	4	val_186
+186	458	23	val_186
+186	459	23	val_186
+187	455	10	val_187
+187	455	14	val_187
+187	455	20	val_187
+187	457	4	val_187
+187	457	6	val_187
+187	457	10	val_187
+187	457	14	val_187
+187	457	16	val_187
+187	457	20	val_187
+187	458	4	val_187
+187	458	6	val_187
+187	458	7	val_187
+187	458	10	val_187
+187	458	16	val_187
+187	458	20	val_187
+187	459	4	val_187
+187	459	6	val_187
+187	459	16	val_187
+189	455	4	val_189
+189	457	1	val_189
+189	457	4	val_189
+189	458	1	val_189
+189	458	4	val_189
+189	459	1	val_189
+190	455	9	val_190
+190	457	9	val_190
+190	457	15	val_190
+190	458	15	val_190
+190	458	17	val_190
+190	459	15	val_190
+191	455	24	val_191
+191	455	24	val_191
+191	457	7	val_191
+191	457	23	val_191
+191	457	24	val_191
+191	457	24	val_191
+191	458	4	val_191
+191	458	7	val_191
+191	458	7	val_191
+191	458	23	val_191
+191	459	7	val_191
+191	459	23	val_191
+192	455	24	val_192
+192	457	24	val_192
+192	457	25	val_192
+192	458	25	val_192
+192	458	28	val_192
+192	459	25	val_192
+193	455	7	val_193
+193	455	23	val_193
+193	455	27	val_193
+193	457	1	val_193
+193	457	6	val_193
+193	457	7	val_193
+193	457	23	val_193
+193	457	24	val_193
+193	457	27	val_193
+193	458	1	val_193
+193	458	4	val_193
+193	458	6	val_193
+193	458	7	val_193
+193	458	24	val_193
+193	458	27	val_193
+193	459	1	val_193
+193	459	6	val_193
+193	459	24	val_193
+194	455	24	val_194
+194	457	11	val_194
+194	457	24	val_194
+194	458	5	val_194
+194	458	11	val_194
+194	459	11	val_194
+195	455	10	val_195
+195	455	24	val_195
+195	457	6	val_195
+195	457	10	val_195
+195	457	13	val_195
+195	457	24	val_195
+195	458	6	val_195
+195	458	6	val_195
+195	458	13	val_195
+195	458	13	val_195
+195	459	6	val_195
+195	459	13	val_195
+196	455	24	val_196
+196	457	7	val_196
+196	457	24	val_196
+196	458	2	val_196
+196	458	7	val_196
+196	459	7	val_196
+197	455	2	val_197
+197	455	9	val_197
+197	457	2	val_197
+197	457	6	val_197
+197	457	9	val_197
+197	457	15	val_197
+197	458	6	val_197
+197	458	7	val_197
+197	458	11	val_197
+197	458	15	val_197
+197	459	6	val_197
+197	459	15	val_197
+199	455	14	val_199
+199	455	27	val_199
+199	455	27	val_199
+199	457	9	val_199
+199	457	14	val_199
+199	457	23	val_199
+199	457	24	val_199
+199	457	27	val_199
+199	457	27	val_199
+199	458	2	val_199
+199	458	9	val_199
+199	458	9	val_199
+199	458	23	val_199
+199	458	23	val_199
+199	458	24	val_199
+199	459	9	val_199
+199	459	23	val_199
+199	459	24	val_199
+200	456	5	val_200
+200	456	28	val_200
+200	457	14	val_200
+200	457	27	val_200
+200	458	4	val_200
+200	458	6	val_200
+200	458	14	val_200
+200	458	27	val_200
+200	459	14	val_200
+200	459	27	val_200
+201	456	13	val_201
+201	457	4	val_201
+201	458	4	val_201
+201	458	13	val_201
+201	459	4	val_201
+202	456	1	val_202
+202	457	27	val_202
+202	458	9	val_202
+202	458	27	val_202
+202	459	27	val_202
+203	456	1	val_203
+203	456	27	val_203
+203	457	11	val_203
+203	457	24	val_203
+203	458	11	val_203
+203	458	17	val_203
+203	458	24	val_203
+203	458	27	val_203
+203	459	11	val_203
+203	459	24	val_203
+205	456	1	val_205
+205	456	10	val_205
+205	457	1	val_205
+205	457	15	val_205
+205	458	1	val_205
+205	458	15	val_205
+205	458	15	val_205
+205	458	23	val_205
+205	459	1	val_205
+205	459	15	val_205
+207	456	9	val_207
+207	456	19	val_207
+207	457	4	val_207
+207	457	10	val_207
+207	458	4	val_207
+207	458	4	val_207
+207	458	10	val_207
+207	458	10	val_207
+207	459	4	val_207
+207	459	10	val_207
+208	456	16	val_208
+208	456	19	val_208
+208	456	23	val_208
+208	457	1	val_208
+208	457	6	val_208
+208	457	10	val_208
+208	458	1	val_208
+208	458	1	val_208
+208	458	1	val_208
+208	458	6	val_208
+208	458	7	val_208
+208	458	10	val_208
+208	459	1	val_208
+208	459	6	val_208
+208	459	10	val_208
+209	456	3	val_209
+209	456	9	val_209
+209	457	1	val_209
+209	457	3	val_209
+209	458	1	val_209
+209	458	3	val_209
+209	458	3	val_209
+209	458	25	val_209
+209	459	1	val_209
+209	459	3	val_209
+213	456	1	val_213
+213	456	2	val_213
+213	457	16	val_213
+213	457	27	val_213
+213	458	6	val_213
+213	458	16	val_213
+213	458	20	val_213
+213	458	27	val_213
+213	459	16	val_213
+213	459	27	val_213
+214	456	16	val_214
+214	457	1	val_214
+214	458	1	val_214
+214	458	20	val_214
+214	459	1	val_214
+216	456	3	val_216
+216	456	16	val_216
+216	457	2	val_216
+216	457	2	val_216
+216	458	2	val_216
+216	458	2	val_216
+216	458	4	val_216
+216	458	11	val_216
+216	459	2	val_216
+216	459	2	val_216
+217	456	9	val_217
+217	456	19	val_217
+217	457	23	val_217
+217	457	28	val_217
+217	458	2	val_217
+217	458	19	val_217
+217	458	23	val_217
+217	458	28	val_217
+217	459	23	val_217
+217	459	28	val_217
+218	456	1	val_218
+218	457	3	val_218
+218	458	3	val_218
+218	458	27	val_218
+218	459	3	val_218
+219	456	6	val_219
+219	456	20	val_219
+219	457	15	val_219
+219	457	28	val_219
+219	458	11	val_219
+219	458	15	val_219
+219	458	17	val_219
+219	458	28	val_219
+219	459	15	val_219
+219	459	28	val_219
+221	456	7	val_221
+221	456	9	val_221
+221	457	15	val_221
+221	457	19	val_221
+221	458	13	val_221
+221	458	14	val_221
+221	458	15	val_221
+221	458	19	val_221
+221	459	15	val_221
+221	459	19	val_221
+222	456	2	val_222
+222	457	1	val_222
+222	458	1	val_222
+222	458	1	val_222
+222	459	1	val_222
+223	456	4	val_223
+223	456	10	val_223
+223	457	27	val_223
+223	457	27	val_223
+223	458	24	val_223
+223	458	27	val_223
+223	458	27	val_223
+223	458	27	val_223
+223	459	27	val_223
+223	459	27	val_223
+224	456	23	val_224
+224	456	23	val_224
+224	457	2	val_224
+224	457	20	val_224
+224	458	2	val_224
+224	458	14	val_224
+224	458	20	val_224
+224	458	24	val_224
+224	459	2	val_224
+224	459	20	val_224
+226	456	28	val_226
+226	457	1	val_226
+226	458	1	val_226
+226	458	6	val_226
+226	459	1	val_226
+228	456	24	val_228
+228	457	28	val_228
+228	458	10	val_228
+228	458	28	val_228
+228	459	28	val_228
+229	456	11	val_229
+229	456	14	val_229
+229	457	2	val_229
+229	457	14	val_229
+229	458	2	val_229
+229	458	11	val_229
+229	458	14	val_229
+229	458	27	val_229
+229	459	2	val_229
+229	459	14	val_229
+230	456	2	val_230
+230	456	7	val_230
+230	456	10	val_230
+230	456	13	val_230
+230	456	13	val_230
+230	457	3	val_230
+230	457	4	val_230
+230	457	11	val_230
+230	457	28	val_230
+230	457	28	val_230
+230	458	3	val_230
+230	458	4	val_230
+230	458	4	val_230
+230	458	4	val_230
+230	458	4	val_230
+230	458	5	val_230
+230	458	7	val_230
+230	458	11	val_230
+230	458	28	val_230
+230	458	28	val_230
+230	459	3	val_230
+230	459	4	val_230
+230	459	11	val_230
+230	459	28	val_230
+230	459	28	val_230
+233	456	10	val_233
+233	456	28	val_233
+233	457	10	val_233
+233	457	25	val_233
+233	458	6	val_233
+233	458	10	val_233
+233	458	10	val_233
+233	458	25	val_233
+233	459	10	val_233
+233	459	25	val_233
+235	456	16	val_235
+235	457	6	val_235
+235	458	5	val_235
+235	458	6	val_235
+235	459	6	val_235
+237	456	9	val_237
+237	456	20	val_237
+237	457	9	val_237
+237	457	27	val_237
+237	458	1	val_237
+237	458	9	val_237
+237	458	9	val_237
+237	458	27	val_237
+237	459	9	val_237
+237	459	27	val_237
+238	456	10	val_238
+238	456	24	val_238
+238	457	10	val_238
+238	457	10	val_238
+238	458	10	val_238
+238	458	10	val_238
+238	458	10	val_238
+238	458	10	val_238
+238	459	10	val_238
+238	459	10	val_238
+239	456	1	val_239
+239	456	10	val_239
+239	457	17	val_239
+239	457	24	val_239
+239	458	11	val_239
+239	458	11	val_239
+239	458	17	val_239
+239	458	24	val_239
+239	459	17	val_239
+239	459	24	val_239
+241	456	9	val_241
+241	457	7	val_241
+241	458	7	val_241
+241	458	7	val_241
+241	459	7	val_241
+242	456	14	val_242
+242	456	16	val_242
+242	457	5	val_242
+242	457	11	val_242
+242	458	5	val_242
+242	458	7	val_242
+242	458	10	val_242
+242	458	11	val_242
+242	459	5	val_242
+242	459	11	val_242
+244	456	19	val_244
+244	457	1	val_244
+244	458	1	val_244
+244	458	23	val_244
+244	459	1	val_244
+247	456	24	val_247
+247	457	20	val_247
+247	458	20	val_247
+247	458	20	val_247
+247	459	20	val_247
+248	456	25	val_248
+248	457	15	val_248
+248	458	11	val_248
+248	458	15	val_248
+248	459	15	val_248
+249	456	20	val_249
+249	457	2	val_249
+249	458	2	val_249
+249	458	2	val_249
+249	459	2	val_249
+252	456	20	val_252
+252	457	5	val_252
+252	458	3	val_252
+252	458	5	val_252
+252	459	5	val_252
+255	456	9	val_255
+255	456	16	val_255
+255	457	11	val_255
+255	457	13	val_255
+255	458	7	val_255
+255	458	7	val_255
+255	458	11	val_255
+255	458	13	val_255
+255	459	11	val_255
+255	459	13	val_255
+256	456	6	val_256
+256	456	27	val_256
+256	457	2	val_256
+256	457	24	val_256
+256	458	2	val_256
+256	458	24	val_256
+256	458	24	val_256
+256	458	27	val_256
+256	459	2	val_256
+256	459	24	val_256
+257	456	6	val_257
+257	457	15	val_257
+257	458	15	val_257
+257	458	17	val_257
+257	459	15	val_257
+258	456	10	val_258
+258	457	10	val_258
+258	458	10	val_258
+258	458	10	val_258
+258	459	10	val_258
+260	456	19	val_260
+260	457	14	val_260
+260	458	14	val_260
+260	458	28	val_260
+260	459	14	val_260
+262	456	24	val_262
+262	457	9	val_262
+262	458	9	val_262
+262	458	24	val_262
+262	459	9	val_262
+263	456	24	val_263
+263	457	9	val_263
+263	458	9	val_263
+263	458	9	val_263
+263	459	9	val_263
+265	456	13	val_265
+265	456	27	val_265
+265	457	16	val_265
+265	457	28	val_265
+265	458	16	val_265
+265	458	16	val_265
+265	458	19	val_265
+265	458	28	val_265
+265	459	16	val_265
+265	459	28	val_265
+266	456	16	val_266
+266	457	7	val_266
+266	458	7	val_266
+266	458	7	val_266
+266	459	7	val_266
+272	456	14	val_272
+272	456	27	val_272
+272	457	1	val_272
+272	457	16	val_272
+272	458	1	val_272
+272	458	3	val_272
+272	458	16	val_272
+272	458	27	val_272
+272	459	1	val_272
+272	459	16	val_272
+273	456	4	val_273
+273	456	4	val_273
+273	456	19	val_273
+273	457	9	val_273
+273	457	9	val_273
+273	457	27	val_273
+273	458	1	val_273
+273	458	1	val_273
+273	458	9	val_273
+273	458	9	val_273
+273	458	24	val_273
+273	458	27	val_273
+273	459	9	val_273
+273	459	9	val_273
+273	459	27	val_273
+274	456	7	val_274
+274	457	14	val_274
+274	458	3	val_274
+274	458	14	val_274
+274	459	14	val_274
+275	456	24	val_275
+275	457	24	val_275
+275	458	24	val_275
+275	458	24	val_275
+275	459	24	val_275
+277	456	10	val_277
+277	456	13	val_277
+277	456	13	val_277
+277	456	16	val_277
+277	457	1	val_277
+277	457	19	val_277
+277	457	20	val_277
+277	457	27	val_277
+277	458	1	val_277
+277	458	6	val_277
+277	458	19	val_277
+277	458	19	val_277
+277	458	20	val_277
+277	458	27	val_277
+277	458	28	val_277
+277	458	28	val_277
+277	459	1	val_277
+277	459	19	val_277
+277	459	20	val_277
+277	459	27	val_277
+278	456	7	val_278
+278	456	28	val_278
+278	457	15	val_278
+278	457	19	val_278
+278	458	3	val_278
+278	458	10	val_278
+278	458	15	val_278
+278	458	19	val_278
+278	459	15	val_278
+278	459	19	val_278
+280	456	7	val_280
+280	456	27	val_280
+280	457	14	val_280
+280	457	28	val_280
+280	458	4	val_280
+280	458	14	val_280
+280	458	16	val_280
+280	458	28	val_280
+280	459	14	val_280
+280	459	28	val_280
+281	456	2	val_281
+281	456	23	val_281
+281	457	4	val_281
+281	457	27	val_281
+281	458	1	val_281
+281	458	4	val_281
+281	458	9	val_281
+281	458	27	val_281
+281	459	4	val_281
+281	459	27	val_281
+282	456	9	val_282
+282	456	27	val_282
+282	457	9	val_282
+282	457	11	val_282
+282	458	5	val_282
+282	458	9	val_282
+282	458	9	val_282
+282	458	11	val_282
+282	459	9	val_282
+282	459	11	val_282
+283	456	10	val_283
+283	457	20	val_283
+283	458	3	val_283
+283	458	20	val_283
+283	459	20	val_283
+284	456	10	val_284
+284	457	4	val_284
+284	458	4	val_284
+284	458	19	val_284
+284	459	4	val_284
+285	456	13	val_285
+285	457	28	val_285
+285	458	23	val_285
+285	458	28	val_285
+285	459	28	val_285
+286	456	20	val_286
+286	457	11	val_286
+286	458	5	val_286
+286	458	11	val_286
+286	459	11	val_286
+287	456	25	val_287
+287	457	14	val_287
+287	458	14	val_287
+287	458	14	val_287
+287	459	14	val_287
+288	456	1	val_288
+288	456	13	val_288
+288	457	4	val_288
+288	457	20	val_288
+288	458	4	val_288
+288	458	16	val_288
+288	458	19	val_288
+288	458	20	val_288
+288	459	4	val_288
+288	459	20	val_288
+289	456	5	val_289
+289	457	14	val_289
+289	458	11	val_289
+289	458	14	val_289
+289	459	14	val_289
+291	456	10	val_291
+291	457	1	val_291
+291	458	1	val_291
+291	458	28	val_291
+291	459	1	val_291
+292	456	1	val_292
+292	457	15	val_292
+292	458	15	val_292
+292	458	17	val_292
+292	459	15	val_292
+296	456	16	val_296
+296	457	17	val_296
+296	458	6	val_296
+296	458	17	val_296
+296	459	17	val_296
+298	456	1	val_298
+298	456	27	val_298
+298	456	27	val_298
+298	457	9	val_298
+298	457	24	val_298
+298	457	24	val_298
+298	458	9	val_298
+298	458	24	val_298
+298	458	24	val_298
+298	458	24	val_298
+298	458	24	val_298
+298	458	24	val_298
+298	459	9	val_298
+298	459	24	val_298
+298	459	24	val_298
+302	456	4	val_302
+302	457	14	val_302
+302	458	5	val_302
+302	458	14	val_302
+302	459	14	val_302
+305	456	6	val_305
+305	457	14	val_305
+305	458	14	val_305
+305	458	17	val_305
+305	459	14	val_305
+306	456	4	val_306
+306	457	10	val_306
+306	458	10	val_306
+306	458	24	val_306
+306	459	10	val_306
+307	456	7	val_307
+307	456	20	val_307
+307	457	1	val_307
+307	457	25	val_307
+307	458	1	val_307
+307	458	4	val_307
+307	458	25	val_307
+307	458	28	val_307
+307	459	1	val_307
+307	459	25	val_307
+308	456	28	val_308
+308	457	28	val_308
+308	458	10	val_308
+308	458	28	val_308
+308	459	28	val_308
+309	456	10	val_309
+309	456	28	val_309
+309	457	16	val_309
+309	457	28	val_309
+309	458	9	val_309
+309	458	16	val_309
+309	458	28	val_309
+309	458	28	val_309
+309	459	16	val_309
+309	459	28	val_309
+310	456	23	val_310
+310	457	24	val_310
+310	458	24	val_310
+310	458	24	val_310
+310	459	24	val_310
+311	456	11	val_311
+311	456	27	val_311
+311	456	27	val_311
+311	457	5	val_311
+311	457	24	val_311
+311	457	27	val_311
+311	458	5	val_311
+311	458	24	val_311
+311	458	27	val_311
+311	458	27	val_311
+311	458	27	val_311
+311	458	27	val_311
+311	459	5	val_311
+311	459	24	val_311
+311	459	27	val_311
+315	456	24	val_315
+315	457	3	val_315
+315	458	3	val_315
+315	458	10	val_315
+315	459	3	val_315
+316	456	3	val_316
+316	456	6	val_316
+316	456	24	val_316
+316	457	10	val_316
+316	457	15	val_316
+316	457	27	val_316
+316	458	1	val_316
+316	458	2	val_316
+316	458	10	val_316
+316	458	15	val_316
+316	458	20	val_316
+316	458	27	val_316
+316	459	10	val_316
+316	459	15	val_316
+316	459	27	val_316
+317	456	1	val_317
+317	456	28	val_317
+317	457	14	val_317
+317	457	17	val_317
+317	458	4	val_317
+317	458	14	val_317
+317	458	14	val_317
+317	458	17	val_317
+317	459	14	val_317
+317	459	17	val_317
+318	456	20	val_318
+318	456	20	val_318
+318	456	27	val_318
+318	457	1	val_318
+318	457	3	val_318
+318	457	14	val_318
+318	458	1	val_318
+318	458	1	val_318
+318	458	3	val_318
+318	458	6	val_318
+318	458	14	val_318
+318	458	17	val_318
+318	459	1	val_318
+318	459	3	val_318
+318	459	14	val_318
+321	456	3	val_321
+321	456	7	val_321
+321	457	4	val_321
+321	457	4	val_321
+321	458	4	val_321
+321	458	4	val_321
+321	458	19	val_321
+321	458	20	val_321
+321	459	4	val_321
+321	459	4	val_321
+322	456	20	val_322
+322	456	24	val_322
+322	457	9	val_322
+322	457	14	val_322
+322	458	9	val_322
+322	458	9	val_322
+322	458	14	val_322
+322	458	17	val_322
+322	459	9	val_322
+322	459	14	val_322
+323	456	9	val_323
+323	457	10	val_323
+323	458	10	val_323
+323	458	10	val_323
+323	459	10	val_323
+325	456	7	val_325
+325	456	7	val_325
+325	457	13	val_325
+325	457	25	val_325
+325	458	13	val_325
+325	458	13	val_325
+325	458	25	val_325
+325	458	25	val_325
+325	459	13	val_325
+325	459	25	val_325
+327	456	9	val_327
+327	456	10	val_327
+327	456	24	val_327
+327	457	6	val_327
+327	457	23	val_327
+327	457	28	val_327
+327	458	6	val_327
+327	458	19	val_327
+327	458	20	val_327
+327	458	23	val_327
+327	458	27	val_327
+327	458	28	val_327
+327	459	6	val_327
+327	459	23	val_327
+327	459	28	val_327
+331	456	2	val_331
+331	456	10	val_331
+331	457	1	val_331
+331	457	6	val_331
+331	458	1	val_331
+331	458	6	val_331
+331	458	28	val_331
+331	458	28	val_331
+331	459	1	val_331
+331	459	6	val_331
+332	456	10	val_332
+332	457	10	val_332
+332	458	10	val_332
+332	458	10	val_332
+332	459	10	val_332
+333	456	1	val_333
+333	456	7	val_333
+333	457	9	val_333
+333	457	13	val_333
+333	458	9	val_333
+333	458	9	val_333
+333	458	10	val_333
+333	458	13	val_333
+333	459	9	val_333
+333	459	13	val_333
+335	456	28	val_335
+335	457	1	val_335
+335	458	1	val_335
+335	458	1	val_335
+335	459	1	val_335
+336	456	25	val_336
+336	457	15	val_336
+336	458	3	val_336
+336	458	15	val_336
+336	459	15	val_336
+338	456	11	val_338
+338	457	14	val_338
+338	458	2	val_338
+338	458	14	val_338
+338	459	14	val_338
+339	456	6	val_339
+339	457	14	val_339
+339	458	11	val_339
+339	458	14	val_339
+339	459	14	val_339
+341	456	24	val_341
+341	457	7	val_341
+341	458	7	val_341
+341	458	9	val_341
+341	459	7	val_341
+342	456	27	val_342
+342	456	28	val_342
+342	457	1	val_342
+342	457	4	val_342
+342	458	1	val_342
+342	458	1	val_342
+342	458	4	val_342
+342	458	5	val_342
+342	459	1	val_342
+342	459	4	val_342
+344	456	5	val_344
+344	456	28	val_344
+344	457	10	val_344
+344	457	15	val_344
+344	458	4	val_344
+344	458	10	val_344
+344	458	15	val_344
+344	458	20	val_344
+344	459	10	val_344
+344	459	15	val_344
+345	456	10	val_345
+345	457	10	val_345
+345	458	10	val_345
+345	458	10	val_345
+345	459	10	val_345
+348	456	3	val_348
+348	456	9	val_348
+348	456	9	val_348
+348	456	19	val_348
+348	456	20	val_348
+348	457	1	val_348
+348	457	4	val_348
+348	457	6	val_348
+348	457	7	val_348
+348	457	7	val_348
+348	458	1	val_348
+348	458	3	val_348
+348	458	4	val_348
+348	458	6	val_348
+348	458	7	val_348
+348	458	7	val_348
+348	458	9	val_348
+348	458	16	val_348
+348	458	20	val_348
+348	458	28	val_348
+348	459	1	val_348
+348	459	4	val_348
+348	459	6	val_348
+348	459	7	val_348
+348	459	7	val_348
+351	456	2	val_351
+351	457	25	val_351
+351	458	5	val_351
+351	458	25	val_351
+351	459	25	val_351
+353	456	1	val_353
+353	456	2	val_353
+353	457	7	val_353
+353	457	10	val_353
+353	458	5	val_353
+353	458	7	val_353
+353	458	9	val_353
+353	458	10	val_353
+353	459	7	val_353
+353	459	10	val_353
+356	456	4	val_356
+356	457	2	val_356
+356	458	2	val_356
+356	458	24	val_356
+356	459	2	val_356
+360	456	6	val_360
+360	457	5	val_360
+360	458	5	val_360
+360	458	17	val_360
+360	459	5	val_360
+362	456	10	val_362
+362	457	4	val_362
+362	458	4	val_362
+362	458	19	val_362
+362	459	4	val_362
+364	456	7	val_364
+364	457	14	val_364
+364	458	14	val_364
+364	458	14	val_364
+364	459	14	val_364
+365	456	2	val_365
+365	457	5	val_365
+365	458	5	val_365
+365	458	5	val_365
+365	459	5	val_365
+366	456	7	val_366
+366	457	11	val_366
+366	458	11	val_366
+366	458	11	val_366
+366	459	11	val_366
+367	456	5	val_367
+367	456	28	val_367
+367	457	5	val_367
+367	457	6	val_367
+367	458	5	val_367
+367	458	6	val_367
+367	458	6	val_367
+367	458	6	val_367
+367	459	5	val_367
+367	459	6	val_367
+368	456	2	val_368
+368	457	11	val_368
+368	458	11	val_368
+368	458	20	val_368
+368	459	11	val_368
+369	456	9	val_369
+369	456	16	val_369
+369	456	28	val_369
+369	457	7	val_369
+369	457	17	val_369
+369	457	27	val_369
+369	458	2	val_369
+369	458	4	val_369
+369	458	7	val_369
+369	458	14	val_369
+369	458	17	val_369
+369	458	27	val_369
+369	459	7	val_369
+369	459	17	val_369
+369	459	27	val_369
+373	456	24	val_373
+373	457	2	val_373
+373	458	2	val_373
+373	458	20	val_373
+373	459	2	val_373
+374	456	9	val_374
+374	457	7	val_374
+374	458	7	val_374
+374	458	16	val_374
+374	459	7	val_374
+375	456	20	val_375
+375	457	17	val_375
+375	458	3	val_375
+375	458	17	val_375
+375	459	17	val_375
+377	456	20	val_377
+377	457	16	val_377
+377	458	16	val_377
+377	458	16	val_377
+377	459	16	val_377
+378	456	24	val_378
+378	457	13	val_378
+378	458	10	val_378
+378	458	13	val_378
+378	459	13	val_378
+379	456	1	val_379
+379	457	15	val_379
+379	458	15	val_379
+379	458	15	val_379
+379	459	15	val_379
+382	456	9	val_382
+382	456	28	val_382
+382	457	3	val_382
+382	457	28	val_382
+382	458	2	val_382
+382	458	3	val_382
+382	458	20	val_382
+382	458	28	val_382
+382	459	3	val_382
+382	459	28	val_382
+384	456	4	val_384
+384	456	11	val_384
+384	456	23	val_384
+384	457	14	val_384
+384	457	20	val_384
+384	457	27	val_384
+384	458	5	val_384
+384	458	14	val_384
+384	458	17	val_384
+384	458	20	val_384
+384	458	24	val_384
+384	458	27	val_384
+384	459	14	val_384
+384	459	20	val_384
+384	459	27	val_384
+386	456	24	val_386
+386	457	20	val_386
+386	458	2	val_386
+386	458	20	val_386
+386	459	20	val_386
+389	456	1	val_389
+389	457	3	val_389
+389	458	3	val_389
+389	458	20	val_389
+389	459	3	val_389
+392	456	20	val_392
+392	457	20	val_392
+392	458	16	val_392
+392	458	20	val_392
+392	459	20	val_392
+393	456	6	val_393
+393	457	14	val_393
+393	458	14	val_393
+393	458	17	val_393
+393	459	14	val_393
+394	456	24	val_394
+394	457	24	val_394
+394	458	24	val_394
+394	458	24	val_394
+394	459	24	val_394
+395	456	6	val_395
+395	456	10	val_395
+395	457	24	val_395
+395	457	27	val_395
+395	458	1	val_395
+395	458	24	val_395
+395	458	24	val_395
+395	458	27	val_395
+395	459	24	val_395
+395	459	27	val_395
+396	456	1	val_396
+396	456	10	val_396
+396	456	20	val_396
+396	457	9	val_396
+396	457	14	val_396
+396	457	19	val_396
+396	458	6	val_396
+396	458	9	val_396
+396	458	9	val_396
+396	458	10	val_396
+396	458	14	val_396
+396	458	19	val_396
+396	459	9	val_396
+396	459	14	val_396
+396	459	19	val_396
+397	456	20	val_397
+397	456	27	val_397
+397	457	3	val_397
+397	457	7	val_397
+397	458	3	val_397
+397	458	3	val_397
+397	458	7	val_397
+397	458	16	val_397
+397	459	3	val_397
+397	459	7	val_397
+399	456	23	val_399
+399	456	28	val_399
+399	457	14	val_399
+399	457	16	val_399
+399	458	14	val_399
+399	458	14	val_399
+399	458	14	val_399
+399	458	16	val_399
+399	459	14	val_399
+399	459	16	val_399
+400	456	3	val_400
+400	457	17	val_400
+400	458	6	val_400
+400	458	17	val_400
+400	459	17	val_400
+401	456	1	val_401
+401	456	2	val_401
+401	456	4	val_401
+401	456	10	val_401
+401	456	19	val_401
+401	457	11	val_401
+401	457	14	val_401
+401	457	19	val_401
+401	457	24	val_401
+401	457	25	val_401
+401	458	2	val_401
+401	458	5	val_401
+401	458	11	val_401
+401	458	13	val_401
+401	458	14	val_401
+401	458	17	val_401
+401	458	19	val_401
+401	458	23	val_401
+401	458	24	val_401
+401	458	25	val_401
+401	459	11	val_401
+401	459	14	val_401
+401	459	19	val_401
+401	459	24	val_401
+401	459	25	val_401
+402	456	7	val_402
+402	457	11	val_402
+402	458	11	val_402
+402	458	11	val_402
+402	459	11	val_402
+403	456	16	val_403
+403	456	20	val_403
+403	456	28	val_403
+403	457	14	val_403
+403	457	14	val_403
+403	457	17	val_403
+403	458	4	val_403
+403	458	11	val_403
+403	458	11	val_403
+403	458	14	val_403
+403	458	14	val_403
+403	458	17	val_403
+403	459	14	val_403
+403	459	14	val_403
+403	459	17	val_403
+404	456	4	val_404
+404	456	13	val_404
+404	457	9	val_404
+404	457	20	val_404
+404	458	1	val_404
+404	458	9	val_404
+404	458	20	val_404
+404	458	24	val_404
+404	459	9	val_404
+404	459	20	val_404
+406	456	5	val_406
+406	456	6	val_406
+406	456	24	val_406
+406	456	25	val_406
+406	457	11	val_406
+406	457	24	val_406
+406	457	28	val_406
+406	457	28	val_406
+406	458	10	val_406
+406	458	11	val_406
+406	458	11	val_406
+406	458	24	val_406
+406	458	25	val_406
+406	458	27	val_406
+406	458	28	val_406
+406	458	28	val_406
+406	459	11	val_406
+406	459	24	val_406
+406	459	28	val_406
+406	459	28	val_406
+407	456	25	val_407
+407	457	17	val_407
+407	458	14	val_407
+407	458	17	val_407
+407	459	17	val_407
+409	456	10	val_409
+409	456	11	val_409
+409	456	24	val_409
+409	457	10	val_409
+409	457	14	val_409
+409	457	17	val_409
+409	458	9	val_409
+409	458	10	val_409
+409	458	14	val_409
+409	458	14	val_409
+409	458	17	val_409
+409	458	25	val_409
+409	459	10	val_409
+409	459	14	val_409
+409	459	17	val_409
+411	456	10	val_411
+411	457	25	val_411
+411	458	25	val_411
+411	458	28	val_411
+411	459	25	val_411
+413	456	10	val_413
+413	456	28	val_413
+413	457	5	val_413
+413	457	13	val_413
+413	458	5	val_413
+413	458	13	val_413
+413	458	13	val_413
+413	458	17	val_413
+413	459	5	val_413
+413	459	13	val_413
+414	456	27	val_414
+414	456	28	val_414
+414	457	6	val_414
+414	457	11	val_414
+414	458	6	val_414
+414	458	7	val_414
+414	458	11	val_414
+414	458	11	val_414
+414	459	6	val_414
+414	459	11	val_414
+417	456	4	val_417
+417	456	5	val_417
+417	456	14	val_417
+417	457	15	val_417
+417	457	27	val_417
+417	457	27	val_417
+417	458	4	val_417
+417	458	15	val_417
+417	458	27	val_417
+417	458	27	val_417
+417	458	27	val_417
+417	458	27	val_417
+417	459	15	val_417
+417	459	27	val_417
+417	459	27	val_417
+418	456	24	val_418
+418	457	10	val_418
+418	458	10	val_418
+418	458	10	val_418
+418	459	10	val_418
+419	456	9	val_419
+419	457	13	val_419
+419	458	13	val_419
+419	458	13	val_419
+419	459	13	val_419
+421	456	6	val_421
+421	457	14	val_421
+421	458	11	val_421
+421	458	14	val_421
+421	459	14	val_421
+424	456	7	val_424
+424	456	14	val_424
+424	457	2	val_424
+424	457	10	val_424
+424	458	2	val_424
+424	458	7	val_424
+424	458	10	val_424
+424	458	27	val_424
+424	459	2	val_424
+424	459	10	val_424
+427	456	10	val_427
+427	457	20	val_427
+427	458	20	val_427
+427	458	23	val_427
+427	459	20	val_427
+429	456	14	val_429
+429	456	27	val_429
+429	457	5	val_429
+429	457	24	val_429
+429	458	2	val_429
+429	458	5	val_429
+429	458	24	val_429
+429	458	24	val_429
+429	459	5	val_429
+429	459	24	val_429
+430	456	3	val_430
+430	456	7	val_430
+430	456	10	val_430
+430	457	2	val_430
+430	457	5	val_430
+430	457	23	val_430
+430	458	1	val_430
+430	458	1	val_430
+430	458	2	val_430
+430	458	4	val_430
+430	458	5	val_430
+430	458	23	val_430
+430	459	2	val_430
+430	459	5	val_430
+430	459	23	val_430
+431	456	4	val_431
+431	456	5	val_431
+431	456	24	val_431
+431	457	1	val_431
+431	457	17	val_431
+431	457	27	val_431
+431	458	1	val_431
+431	458	6	val_431
+431	458	9	val_431
+431	458	17	val_431
+431	458	23	val_431
+431	458	27	val_431
+431	459	1	val_431
+431	459	17	val_431
+431	459	27	val_431
+432	456	28	val_432
+432	457	20	val_432
+432	458	14	val_432
+432	458	20	val_432
+432	459	20	val_432
+435	456	10	val_435
+435	457	14	val_435
+435	458	14	val_435
+435	458	23	val_435
+435	459	14	val_435
+436	456	19	val_436
+436	457	10	val_436
+436	458	10	val_436
+436	458	14	val_436
+436	459	10	val_436
+437	456	14	val_437
+437	457	1	val_437
+437	458	1	val_437
+437	458	16	val_437
+437	459	1	val_437
+438	456	3	val_438
+438	456	3	val_438
+438	456	4	val_438
+438	457	3	val_438
+438	457	14	val_438
+438	457	24	val_438
+438	458	3	val_438
+438	458	6	val_438
+438	458	14	val_438
+438	458	14	val_438
+438	458	24	val_438
+438	458	28	val_438
+438	459	3	val_438
+438	459	14	val_438
+438	459	24	val_438
+439	456	1	val_439
+439	456	3	val_439
+439	457	2	val_439
+439	457	20	val_439
+439	458	2	val_439
+439	458	3	val_439
+439	458	20	val_439
+439	458	20	val_439
+439	459	2	val_439
+439	459	20	val_439
+443	456	24	val_443
+443	457	7	val_443
+443	458	7	val_443
+443	458	7	val_443
+443	459	7	val_443
+444	456	10	val_444
+444	457	10	val_444
+444	458	10	val_444
+444	458	10	val_444
+444	459	10	val_444
+446	456	10	val_446
+446	457	10	val_446
+446	458	10	val_446
+446	458	10	val_446
+446	459	10	val_446
+448	456	14	val_448
+448	457	20	val_448
+448	458	2	val_448
+448	458	20	val_448
+448	459	20	val_448
+449	456	28	val_449
+449	457	16	val_449
+449	458	16	val_449
+449	458	20	val_449
+449	459	16	val_449
+452	456	3	val_452
+452	457	6	val_452
+452	458	6	val_452
+452	458	20	val_452
+452	459	6	val_452
+453	456	14	val_453
+453	457	7	val_453
+453	458	7	val_453
+453	458	16	val_453
+453	459	7	val_453
+454	456	7	val_454
+454	456	10	val_454
+454	456	23	val_454
+454	457	3	val_454
+454	457	10	val_454
+454	457	24	val_454
+454	458	1	val_454
+454	458	3	val_454
+454	458	10	val_454
+454	458	10	val_454
+454	458	24	val_454
+454	458	28	val_454
+454	459	3	val_454
+454	459	10	val_454
+454	459	24	val_454
+455	456	25	val_455
+455	457	27	val_455
+455	458	14	val_455
+455	458	27	val_455
+455	459	27	val_455
+457	456	14	val_457
+457	457	6	val_457
+457	458	6	val_457
+457	458	28	val_457
+457	459	6	val_457
+458	456	7	val_458
+458	456	19	val_458
+458	457	19	val_458
+458	457	24	val_458
+458	458	1	val_458
+458	458	13	val_458
+458	458	19	val_458
+458	458	24	val_458
+458	459	19	val_458
+458	459	24	val_458
+459	456	27	val_459
+459	456	27	val_459
+459	457	3	val_459
+459	457	27	val_459
+459	458	1	val_459
+459	458	3	val_459
+459	458	27	val_459
+459	458	27	val_459
+459	459	3	val_459
+459	459	27	val_459
+460	456	14	val_460
+460	457	27	val_460
+460	458	27	val_460
+460	458	27	val_460
+460	459	27	val_460
+462	456	3	val_462
+462	456	3	val_462
+462	457	6	val_462
+462	457	14	val_462
+462	458	1	val_462
+462	458	6	val_462
+462	458	14	val_462
+462	458	28	val_462
+462	459	6	val_462
+462	459	14	val_462
+463	456	20	val_463
+463	456	28	val_463
+463	457	3	val_463
+463	457	3	val_463
+463	458	1	val_463
+463	458	2	val_463
+463	458	3	val_463
+463	458	3	val_463
+463	459	3	val_463
+463	459	3	val_463
+466	456	4	val_466
+466	456	5	val_466
+466	456	27	val_466
+466	457	17	val_466
+466	457	20	val_466
+466	457	28	val_466
+466	458	3	val_466
+466	458	17	val_466
+466	458	20	val_466
+466	458	25	val_466
+466	458	28	val_466
+466	458	28	val_466
+466	459	17	val_466
+466	459	20	val_466
+466	459	28	val_466
+467	456	23	val_467
+467	457	9	val_467
+467	458	9	val_467
+467	458	24	val_467
+467	459	9	val_467
+468	456	1	val_468
+468	456	4	val_468
+468	456	20	val_468
+468	456	23	val_468
+468	457	1	val_468
+468	457	3	val_468
+468	457	24	val_468
+468	457	25	val_468
+468	458	1	val_468
+468	458	1	val_468
+468	458	3	val_468
+468	458	14	val_468
+468	458	24	val_468
+468	458	25	val_468
+468	458	27	val_468
+468	458	28	val_468
+468	459	1	val_468
+468	459	3	val_468
+468	459	24	val_468
+468	459	25	val_468
+469	456	1	val_469
+469	456	4	val_469
+469	456	9	val_469
+469	456	9	val_469
+469	456	20	val_469
+469	457	1	val_469
+469	457	6	val_469
+469	457	16	val_469
+469	457	16	val_469
+469	457	16	val_469
+469	458	1	val_469
+469	458	3	val_469
+469	458	6	val_469
+469	458	10	val_469
+469	458	16	val_469
+469	458	16	val_469
+469	458	16	val_469
+469	458	20	val_469
+469	458	27	val_469
+469	458	28	val_469
+469	459	1	val_469
+469	459	6	val_469
+469	459	16	val_469
+469	459	16	val_469
+469	459	16	val_469
+470	456	2	val_470
+470	457	11	val_470
+470	458	11	val_470
+470	458	11	val_470
+470	459	11	val_470
+472	456	27	val_472
+472	457	24	val_472
+472	458	24	val_472
+472	458	24	val_472
+472	459	24	val_472
+475	456	20	val_475
+475	457	4	val_475
+475	458	4	val_475
+475	458	4	val_475
+475	459	4	val_475
+477	456	10	val_477
+477	457	4	val_477
+477	458	4	val_477
+477	458	20	val_477
+477	459	4	val_477
+478	456	19	val_478
+478	456	28	val_478
+478	457	14	val_478
+478	457	23	val_478
+478	458	1	val_478
+478	458	14	val_478
+478	458	23	val_478
+478	458	23	val_478
+478	459	14	val_478
+478	459	23	val_478
+479	456	11	val_479
+479	457	28	val_479
+479	458	14	val_479
+479	458	28	val_479
+479	459	28	val_479
+480	456	7	val_480
+480	456	10	val_480
+480	456	27	val_480
+480	457	3	val_480
+480	457	13	val_480
+480	457	20	val_480
+480	458	3	val_480
+480	458	3	val_480
+480	458	3	val_480
+480	458	10	val_480
+480	458	13	val_480
+480	458	20	val_480
+480	459	3	val_480
+480	459	13	val_480
+480	459	20	val_480
+481	456	24	val_481
+481	457	1	val_481
+481	458	1	val_481
+481	458	3	val_481
+481	459	1	val_481
+482	456	7	val_482
+482	457	7	val_482
+482	458	7	val_482
+482	458	7	val_482
+482	459	7	val_482
+483	456	1	val_483
+483	457	27	val_483
+483	458	1	val_483
+483	458	27	val_483
+483	459	27	val_483
+484	456	10	val_484
+484	457	23	val_484
+484	458	13	val_484
+484	458	23	val_484
+484	459	23	val_484
+485	456	6	val_485
+485	457	14	val_485
+485	458	14	val_485
+485	458	14	val_485
+485	459	14	val_485
+487	456	9	val_487
+487	457	10	val_487
+487	458	7	val_487
+487	458	10	val_487
+487	459	10	val_487
+489	456	9	val_489
+489	456	13	val_489
+489	456	27	val_489
+489	456	28	val_489
+489	457	1	val_489
+489	457	7	val_489
+489	457	10	val_489
+489	457	27	val_489
+489	458	1	val_489
+489	458	7	val_489
+489	458	9	val_489
+489	458	10	val_489
+489	458	10	val_489
+489	458	14	val_489
+489	458	27	val_489
+489	458	28	val_489
+489	459	1	val_489
+489	459	7	val_489
+489	459	10	val_489
+489	459	27	val_489
+490	456	5	val_490
+490	457	15	val_490
+490	458	11	val_490
+490	458	15	val_490
+490	459	15	val_490
+491	456	7	val_491
+491	457	17	val_491
+491	458	4	val_491
+491	458	17	val_491
+491	459	17	val_491
+492	456	10	val_492
+492	456	23	val_492
+492	457	10	val_492
+492	457	10	val_492
+492	458	10	val_492
+492	458	10	val_492
+492	458	10	val_492
+492	458	14	val_492
+492	459	10	val_492
+492	459	10	val_492
+493	456	24	val_493
+493	457	20	val_493
+493	458	20	val_493
+493	458	20	val_493
+493	459	20	val_493
+494	456	13	val_494
+494	457	19	val_494
+494	458	19	val_494
+494	458	19	val_494
+494	459	19	val_494
+495	456	27	val_495
+495	457	25	val_495
+495	458	7	val_495
+495	458	25	val_495
+495	459	25	val_495
+496	456	7	val_496
+496	457	15	val_496
+496	458	3	val_496
+496	458	15	val_496
+496	459	15	val_496
+497	456	5	val_497
+497	457	17	val_497
+497	458	17	val_497
+497	458	25	val_497
+497	459	17	val_497
+498	456	1	val_498
+498	456	9	val_498
+498	456	9	val_498
+498	457	5	val_498
+498	457	7	val_498
+498	457	10	val_498
+498	458	5	val_498
+498	458	7	val_498
+498	458	7	val_498
+498	458	7	val_498
+498	458	10	val_498
+498	458	27	val_498
+498	459	5	val_498
+498	459	7	val_498
+498	459	10	val_498
+PREHOOK: query: drop table dp_mm
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@dp_mm
+PREHOOK: Output: default@dp_mm
+POSTHOOK: query: drop table dp_mm
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@dp_mm
+POSTHOOK: Output: default@dp_mm
+PREHOOK: query: drop table intermediate_n0
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@intermediate_n0
+PREHOOK: Output: default@intermediate_n0
+POSTHOOK: query: drop table intermediate_n0
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@intermediate_n0
+POSTHOOK: Output: default@intermediate_n0

--- a/ql/src/test/results/clientpositive/mm_all.q.out
+++ b/ql/src/test/results/clientpositive/mm_all.q.out
@@ -145,6 +145,7 @@ STAGE PLANS:
               output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
               serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
               name: default.part_mm_n0
+          Write Type: INSERT
           micromanaged table: true
 
   Stage: Stage-2
@@ -235,18 +236,18 @@ POSTHOOK: Input: default@part_mm_n0@key_mm=456
 10	455
 10	455
 10	456
-97	455
-97	455
-97	456
-98	455
-98	455
-98	456
 100	455
 100	455
 100	456
 103	455
 103	455
 103	456
+97	455
+97	455
+97	456
+98	455
+98	455
+98	456
 PREHOOK: query: select * from part_mm_n0 order by key, key_mm
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_mm_n0
@@ -265,18 +266,18 @@ POSTHOOK: Input: default@part_mm_n0@key_mm=456
 10	455
 10	455
 10	456
-97	455
-97	455
-97	456
-98	455
-98	455
-98	456
 100	455
 100	455
 100	456
 103	455
 103	455
 103	456
+97	455
+97	455
+97	456
+98	455
+98	455
+98	456
 PREHOOK: query: truncate table part_mm_n0
 PREHOOK: type: TRUNCATETABLE
 PREHOOK: Output: default@part_mm_n0@key_mm=455
@@ -342,10 +343,10 @@ POSTHOOK: Input: default@simple_mm
 #### A masked pattern was here ####
 0
 10
-97
-98
 100
 103
+97
+98
 PREHOOK: query: insert into table simple_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -373,14 +374,14 @@ POSTHOOK: Input: default@simple_mm
 0
 10
 10
-97
-97
-98
-98
 100
 100
 103
 103
+97
+97
+98
+98
 PREHOOK: query: truncate table simple_mm
 PREHOOK: type: TRUNCATETABLE
 PREHOOK: Output: default@simple_mm
@@ -464,10 +465,10 @@ POSTHOOK: Input: default@dp_mm@key1=123/key2=98
 #### A masked pattern was here ####
 0	123	0
 10	123	10
-97	123	97
-98	123	98
 100	123	100
 103	123	103
+97	123	97
+98	123	98
 PREHOOK: query: drop table dp_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@dp_mm
@@ -518,15 +519,15 @@ POSTHOOK: Input: default@union_mm
 0
 1
 10
+100
+101
+103
+104
 11
 97
 98
 98
 99
-100
-101
-103
-104
 PREHOOK: query: insert into table union_mm 
 select p from
 (
@@ -570,20 +571,8 @@ POSTHOOK: Input: default@union_mm
 0
 1
 1
-2
 10
 10
-11
-11
-12
-97
-97
-98
-98
-98
-99
-99
-99
 100
 100
 100
@@ -595,6 +584,18 @@ POSTHOOK: Input: default@union_mm
 104
 104
 105
+11
+11
+12
+2
+97
+97
+98
+98
+98
+99
+99
+99
 PREHOOK: query: insert into table union_mm
 SELECT p FROM
 (
@@ -654,27 +655,9 @@ POSTHOOK: Input: default@union_mm
 1
 1
 1
-2
-2
 10
 10
 10
-11
-11
-11
-12
-12
-97
-97
-97
-98
-98
-98
-98
-99
-99
-99
-99
 100
 100
 100
@@ -692,6 +675,24 @@ POSTHOOK: Input: default@union_mm
 104
 105
 105
+11
+11
+11
+12
+12
+2
+2
+97
+97
+97
+98
+98
+98
+98
+99
+99
+99
+99
 PREHOOK: query: drop table union_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@union_mm
@@ -784,15 +785,15 @@ POSTHOOK: Input: default@partunion_mm@key=99
 0	0
 1	1
 10	10
+100	100
+101	101
+103	103
+104	104
 11	11
 97	97
 98	98
 98	98
 99	99
-100	100
-101	101
-103	103
-104	104
 PREHOOK: query: drop table partunion_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@partunion_mm
@@ -840,10 +841,10 @@ POSTHOOK: Input: default@skew_mm
 #### A masked pattern was here ####
 0	0	0
 10	10	10
-97	97	97
-98	98	98
 100	100	100
 103	103	103
+97	97	97
+98	98	98
 PREHOOK: query: drop table skew_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@skew_mm
@@ -964,15 +965,15 @@ POSTHOOK: Input: default@skew_dp_union_mm@k3=98
 0	0	0	0
 1	2	3	4
 10	10	10	10
+100	100	100	100
+101	102	103	104
+103	103	103	103
+104	105	106	107
 11	12	13	14
 97	97	97	97
 98	98	98	98
 98	99	100	101
 99	100	101	102
-100	100	100	100
-101	102	103	104
-103	103	103	103
-104	105	106	107
 PREHOOK: query: drop table skew_dp_union_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@skew_dp_union_mm
@@ -1012,12 +1013,12 @@ POSTHOOK: query: select * from merge0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge0_mm
 #### A masked pattern was here ####
-98
-97
 0
 10
 100
 103
+97
+98
 PREHOOK: query: insert into table merge0_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1041,18 +1042,18 @@ POSTHOOK: query: select * from merge0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge0_mm
 #### A masked pattern was here ####
-98
-97
+0
 0
 10
-100
-103
-98
-97
-0
 10
 100
+100
 103
+103
+97
+97
+98
+98
 PREHOOK: query: drop table merge0_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge0_mm
@@ -1092,12 +1093,12 @@ POSTHOOK: query: select * from merge2_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge2_mm
 #### A masked pattern was here ####
-98
-97
 0
 10
 100
 103
+97
+98
 PREHOOK: query: insert into table merge2_mm select key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1121,18 +1122,18 @@ POSTHOOK: query: select * from merge2_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@merge2_mm
 #### A masked pattern was here ####
-98
-97
+0
 0
 10
-100
-103
-98
-97
-0
 10
 100
+100
 103
+103
+97
+97
+98
+98
 PREHOOK: query: drop table merge2_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge2_mm
@@ -1196,10 +1197,10 @@ POSTHOOK: Input: default@merge1_mm@key=98
 #### A masked pattern was here ####
 0	0
 10	10
-97	97
-98	98
 100	100
 103	103
+97	97
+98	98
 PREHOOK: query: insert into table merge1_mm partition (key) select key, key from intermediate_n0
 PREHOOK: type: QUERY
 PREHOOK: Input: default@intermediate_n0
@@ -1249,14 +1250,14 @@ POSTHOOK: Input: default@merge1_mm@key=98
 0	0
 10	10
 10	10
-97	97
-97	97
-98	98
-98	98
 100	100
 100	100
 103	103
 103	103
+97	97
+97	97
+98	98
+98	98
 PREHOOK: query: drop table merge1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@merge1_mm
@@ -1295,12 +1296,12 @@ POSTHOOK: query: select * from ctas0_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ctas0_mm
 #### A masked pattern was here ####
-98	455
-97	455
 0	456
 10	456
 100	457
 103	457
+97	455
+98	455
 PREHOOK: query: drop table ctas0_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@ctas0_mm
@@ -1341,10 +1342,6 @@ POSTHOOK: query: select * from ctas1_mm
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@ctas1_mm
 #### A masked pattern was here ####
-98	455
-98	455
-97	455
-97	455
 0	456
 0	456
 10	456
@@ -1353,6 +1350,10 @@ POSTHOOK: Input: default@ctas1_mm
 100	457
 103	457
 103	457
+97	455
+97	455
+98	455
+98	455
 PREHOOK: query: drop table ctas1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@ctas1_mm
@@ -1419,10 +1420,10 @@ POSTHOOK: Input: default@multi0_1_mm
 #### A masked pattern was here ####
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
+97	455
+98	455
 PREHOOK: query: select * from multi0_2_mm order by key, key2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@multi0_2_mm
@@ -1471,8 +1472,6 @@ POSTHOOK: Input: default@multi0_1_mm
 #### A masked pattern was here ####
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
 455	97
@@ -1481,6 +1480,8 @@ POSTHOOK: Input: default@multi0_1_mm
 456	10
 457	100
 457	103
+97	455
+98	455
 PREHOOK: query: select * from multi0_2_mm order by key, key2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@multi0_2_mm
@@ -1491,10 +1492,10 @@ POSTHOOK: Input: default@multi0_2_mm
 #### A masked pattern was here ####
 0	456
 10	456
-97	455
-98	455
 100	457
 103	457
+97	455
+98	455
 PREHOOK: query: drop table multi0_1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@multi0_1_mm
@@ -1561,8 +1562,6 @@ POSTHOOK: Input: default@multi1_mm@p=2
 #### A masked pattern was here ####
 0	456	2
 10	456	2
-97	455	2
-98	455	2
 100	457	2
 103	457	2
 455	97	1
@@ -1571,6 +1570,8 @@ POSTHOOK: Input: default@multi1_mm@p=2
 456	10	1
 457	100	1
 457	103	1
+97	455	2
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p=2) select p, key
 insert overwrite table multi1_mm partition(p=1) select key, p
@@ -1611,10 +1612,6 @@ POSTHOOK: Input: default@multi1_mm@p=2
 0	456	2
 10	456	1
 10	456	2
-97	455	1
-97	455	2
-98	455	1
-98	455	2
 100	457	1
 100	457	2
 103	457	1
@@ -1625,6 +1622,10 @@ POSTHOOK: Input: default@multi1_mm@p=2
 456	10	2
 457	100	2
 457	103	2
+97	455	1
+97	455	2
+98	455	1
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p) select p, key, p
 insert into table multi1_mm partition(p=1) select key, p
@@ -1681,12 +1682,6 @@ POSTHOOK: Input: default@multi1_mm@p=457
 10	456	1
 10	456	1
 10	456	2
-97	455	1
-97	455	1
-97	455	2
-98	455	1
-98	455	1
-98	455	2
 100	457	1
 100	457	1
 100	457	2
@@ -1705,6 +1700,12 @@ POSTHOOK: Input: default@multi1_mm@p=457
 457	100	457
 457	103	2
 457	103	457
+97	455	1
+97	455	1
+97	455	2
+98	455	1
+98	455	1
+98	455	2
 PREHOOK: query: from intermediate_n0
 insert into table multi1_mm partition(p) select p, key, 1
 insert into table multi1_mm partition(p=1) select key, p
@@ -1754,14 +1755,6 @@ POSTHOOK: Input: default@multi1_mm@p=457
 10	456	1
 10	456	1
 10	456	2
-97	455	1
-97	455	1
-97	455	1
-97	455	2
-98	455	1
-98	455	1
-98	455	1
-98	455	2
 100	457	1
 100	457	1
 100	457	1
@@ -1788,6 +1781,14 @@ POSTHOOK: Input: default@multi1_mm@p=457
 457	103	1
 457	103	2
 457	103	457
+97	455	1
+97	455	1
+97	455	1
+97	455	2
+98	455	1
+98	455	1
+98	455	1
+98	455	2
 PREHOOK: query: drop table multi1_mm
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@multi1_mm
@@ -1841,7 +1842,7 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
 	bucketing_version   	2                   
-	numFiles            	1                   
+	numFiles            	3                   
 	numRows             	6                   
 	rawDataSize         	13                  
 	totalSize           	19                  
@@ -1892,7 +1893,7 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"key\":\"true\"}}
 	bucketing_version   	2                   
-	numFiles            	2                   
+	numFiles            	6                   
 	numRows             	12                  
 	rawDataSize         	26                  
 	totalSize           	38                  
@@ -2134,12 +2135,12 @@ POSTHOOK: query: SELECT * FROM temp1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@temp1
 #### A masked pattern was here ####
-98
-97
 0
 10
 100
 103
+97
+98
 PREHOOK: query: drop table intermediate_n0
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@intermediate_n0

--- a/ql/src/test/results/clientpositive/mm_buckets.q.out
+++ b/ql/src/test/results/clientpositive/mm_buckets.q.out
@@ -83,27 +83,27 @@ POSTHOOK: Input: default@bucket0_mm
 98	98
 100	100
 103	103
-PREHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s
+PREHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-POSTHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s
+POSTHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
 10	10
-98	98
 97	97
-PREHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s
+98	98
+PREHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-POSTHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s
+POSTHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-100	100
 0	0
+100	100
 103	103
 PREHOOK: query: insert into table bucket0_mm select key, key from intermediate_n2
 PREHOOK: type: QUERY
@@ -141,32 +141,32 @@ POSTHOOK: Input: default@bucket0_mm
 100	100
 103	103
 103	103
-PREHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s
+PREHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-POSTHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s
+POSTHOOK: query: select * from bucket0_mm tablesample (bucket 1 out of 2) s order by key, id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
 10	10
-98	98
 10	10
+97	97
+97	97
 98	98
-97	97
-97	97
-PREHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s
+98	98
+PREHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-POSTHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s
+POSTHOOK: query: select * from bucket0_mm tablesample (bucket 2 out of 2) s order by key, id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@bucket0_mm
 #### A masked pattern was here ####
-100	100
+0	0
 0	0
 100	100
-0	0
+100	100
 103	103
 103	103
 PREHOOK: query: drop table bucket0_mm


### PR DESCRIPTION
This is a backport of [HIVE-22593](https://issues.apache.org/jira/browse/HIVE-22593) : Dynamically partitioned MM (insert-only ACID) tables don't compact automatically
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27810](https://issues.apache.org/jira/browse/HIVE-27810)