### PR TITLE
HIVE-27812: Backport of HIVE-24138. Llap external client flow is broken due to netty shading

### DIFF
--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -195,7 +195,11 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
-      <version>${hadoop.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -383,6 +387,12 @@
           </exclusion>
       </exclusions>
    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-it-util</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-it-druid</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,10 @@
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-core</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
             <exclusion>
               <groupId>io.netty</groupId>
               <artifactId>netty-all</artifactId>
@@ -776,6 +780,10 @@
             <groupId>commmons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
            <exclusion>
              <groupId>io.netty</groupId>
              <artifactId>netty-all</artifactId>
@@ -794,6 +802,10 @@
           <exclusion>
             <groupId>commmons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
           </exclusion>
            <exclusion>
              <groupId>io.netty</groupId>


### PR DESCRIPTION
This is a backport of [HIVE-24138](https://issues.apache.org/jira/browse/HIVE-24138) : Llap external client flow is broken due to netty shading
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27812](https://issues.apache.org/jira/browse/HIVE-27812)