### PR TITLE
HIVE-27817: Disable ssl hostname verification for 127.0.0.1

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
@@ -142,7 +142,11 @@ public class HiveAuthUtils {
       throws TTransportException {
     SSLSocket sslSocket = (SSLSocket) tSSLSocket.getSocket();
     SSLParameters sslParams = sslSocket.getSSLParameters();
-    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    if (sslSocket.getLocalAddress().getHostAddress().equals("127.0.0.1")) {
+      sslParams.setEndpointIdentificationAlgorithm(null);
+    } else {
+      sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    }
     sslSocket.setSSLParameters(sslParams);
     TSocket tSocket = new TSocket(sslSocket);
     return configureThriftMaxMessageSize(tSocket, maxMessageSize);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables ssl hostname verification for 127.0.0.1.


### Why are the changes needed?

We need to setup production tunnel because we can't connect to production environment directly:
```shell
sh -fN -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -L 127.0.0.1:10001:hiveserver2.prod.company.com:10001 bastion.company.com

JDBC url: jdbc:hive2://127.0.0.1:10001/default;ssl=true
```

But it will throw exception after HIVE-15025:
```
Exception in thread "main" java.sql.SQLException: Could not open client transport with JDBC Uri: jdbc:hive2://localhost:10001/default;ssl=true: javax.net.ssl.SSLHandshakeException: No subject alternative DNS name matching localhost found.
	at org.apache.hive.jdbc.HiveConnection.<init>(HiveConnection.java:224)
	at org.apache.hive.jdbc.HiveDriver.connect(HiveDriver.java:107)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
	at org.apache.spark.sql.TestJDBC$.main(TestJDBC.scala:47)
	at org.apache.spark.sql.TestJDBC.main(TestJDBC.scala)
Caused by: org.apache.hive.org.apache.thrift.transport.TTransportException: javax.net.ssl.SSLHandshakeException: No subject alternative DNS name matching localhost found.
	at org.apache.hive.org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:161)
	at org.apache.hive.org.apache.thrift.transport.TSaslTransport.sendSaslMessage(TSaslTransport.java:166)
	at org.apache.hive.org.apache.thrift.transport.TSaslClientTransport.handleSaslStartMessage(TSaslClientTransport.java:100)
	at org.apache.hive.org.apache.thrift.transport.TSaslTransport.open(TSaslTransport.java:271)
	at org.apache.hive.org.apache.thrift.transport.TSaslClientTransport.open(TSaslClientTransport.java:37)
	at org.apache.hive.jdbc.HiveConnection.openTransport(HiveConnection.java:311)
	at org.apache.hive.jdbc.HiveConnection.<init>(HiveConnection.java:196)
	... 5 more
```

This PR disables ssl hostname verification for 127.0.0.1 to workaround this issue.


### Does this PR introduce _any_ user-facing change?

No.

### Is the change a dependency upgrade?

No.


### How was this patch tested?

Manual test.