### PR TITLE
Backport of HIVE-22336: Updates should be pushed to the Metastore backend DB before creating the notification event

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -9840,6 +9840,7 @@ public class ObjectStore implements RawStore, Configurable {
     boolean commited = false;
     Query query = null;
     try {
+      pm.flush();
       openTransaction();
       lockForUpdate();
       query = pm.newQuery(MNotificationNextId.class);


### PR DESCRIPTION
This is a backport of [HIVE-22336](https://issues.apache.org/jira/browse/HIVE-22336) : Updates should be pushed to the Metastore backend DB before creating the notification event
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27822](https://issues.apache.org/jira/browse/HIVE-27822)