### PR TITLE
HIVE-27789: Iceberg: Add a way to expire snapshots with retain last.

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -864,6 +864,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
             expireSnapshotsSpec.getTimestampMillis(), deleteExecutorService);
       } else if (expireSnapshotsSpec.isExpireByIds()) {
         expireSnapshotByIds(icebergTable, expireSnapshotsSpec.getIdsToExpire(), deleteExecutorService);
+      } else if (expireSnapshotsSpec.isExpireByRetainLast()) {
+        expireSnapshotRetainLast(icebergTable, expireSnapshotsSpec.getNumRetainLast(), deleteExecutorService);
       } else {
         expireSnapshotOlderThanTimestamp(icebergTable, expireSnapshotsSpec.getTimestampMillis(), deleteExecutorService);
       }
@@ -872,6 +874,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         deleteExecutorService.shutdown();
       }
     }
+  }
+
+  private void expireSnapshotRetainLast(Table icebergTable, int numRetainLast, ExecutorService deleteExecutorService) {
+    ExpireSnapshots expireSnapshots = icebergTable.expireSnapshots();
+    expireSnapshots.retainLast(numRetainLast);
+    if (deleteExecutorService != null) {
+      expireSnapshots.executeDeleteWith(deleteExecutorService);
+    }
+    expireSnapshots.commit();
   }
 
   private void expireSnapshotByTimestampRange(Table icebergTable, Long fromTimestamp, Long toTimestamp,

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
@@ -485,6 +485,8 @@ alterStatementSuffixExecute
     -> ^(TOK_ALTERTABLE_EXECUTE KW_CHERRY_PICK $snapshotId)
     | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_BETWEEN (fromTimestamp=StringLiteral) KW_AND (toTimestamp=StringLiteral)
     -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $fromTimestamp $toTimestamp)
+    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS KW_RETAIN KW_LAST numToRetain=Number
+    -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS KW_RETAIN $numToRetain)
     ;
 
 alterStatementSuffixDropBranch

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
@@ -54,6 +54,7 @@ import static org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.ExecuteOpera
 import static org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.ExecuteOperationType.SET_CURRENT_SNAPSHOT;
 import static org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.RollbackSpec.RollbackType.TIME;
 import static org.apache.hadoop.hive.ql.parse.AlterTableExecuteSpec.RollbackSpec.RollbackType.VERSION;
+import static org.apache.hadoop.hive.ql.parse.HiveLexer.KW_RETAIN;
 
 /**
  * Analyzer for ALTER TABLE ... EXECUTE commands.
@@ -141,7 +142,12 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
         SessionState.get().getConf().getLocalTimeZone();
     ASTNode firstNode = (ASTNode) children.get(1);
     String firstNodeText = PlanUtils.stripQuotes(firstNode.getText().trim());
-    if (children.size() == 3) {
+    if (firstNode.getType() == KW_RETAIN) {
+      ASTNode numRetainLastNode = (ASTNode) children.get(2);
+      String numToRetainText = PlanUtils.stripQuotes(numRetainLastNode.getText());
+      int numToRetain = Integer.parseInt(numToRetainText);
+      spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT, new ExpireSnapshotsSpec(numToRetain));
+    } else if (children.size() == 3) {
       ASTNode secondNode = (ASTNode) children.get(2);
       String secondNodeText = PlanUtils.stripQuotes(secondNode.getText().trim());
       TimestampTZ fromTime = TimestampTZUtil.parse(firstNodeText, timeZone);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/AlterTableExecuteSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/AlterTableExecuteSpec.java
@@ -113,9 +113,12 @@ public class AlterTableExecuteSpec<T> {
 
     private long fromTimestampMillis = -1L;
 
+    private int numRetainLast = -1;
+
     public ExpireSnapshotsSpec(long timestampMillis) {
       this.timestampMillis = timestampMillis;
     }
+
 
     public ExpireSnapshotsSpec(String ids) {
       this.idsToExpire = ids.split(",");
@@ -124,6 +127,10 @@ public class AlterTableExecuteSpec<T> {
     public ExpireSnapshotsSpec(long fromTimestampMillis, long toTimestampMillis) {
       this.fromTimestampMillis = fromTimestampMillis;
       this.timestampMillis = toTimestampMillis;
+    }
+
+    public ExpireSnapshotsSpec(int numRetainLast) {
+      this.numRetainLast = numRetainLast;
     }
 
     public Long getTimestampMillis() {
@@ -138,12 +145,20 @@ public class AlterTableExecuteSpec<T> {
       return idsToExpire;
     }
 
+    public int getNumRetainLast() {
+      return numRetainLast;
+    }
+
     public boolean isExpireByIds() {
       return idsToExpire != null;
     }
 
     public boolean isExpireByTimestampRange() {
       return timestampMillis != -1 && fromTimestampMillis != -1;
+    }
+
+    public boolean isExpireByRetainLast() {
+      return numRetainLast != -1;
     }
 
     @Override
@@ -153,6 +168,8 @@ public class AlterTableExecuteSpec<T> {
         stringHelper.add("fromTimestampMillis", fromTimestampMillis).add("toTimestampMillis", timestampMillis);
       } else if (isExpireByIds()) {
         stringHelper.add("idsToExpire", Arrays.toString(idsToExpire));
+      } else if (isExpireByRetainLast()) {
+        stringHelper.add("numRetainLast", numRetainLast);
       } else {
         stringHelper.add("timestampMillis", timestampMillis);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/AlterTableExecuteSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/AlterTableExecuteSpec.java
@@ -119,7 +119,6 @@ public class AlterTableExecuteSpec<T> {
       this.timestampMillis = timestampMillis;
     }
 
-
     public ExpireSnapshotsSpec(String ids) {
       this.idsToExpire = ids.split(",");
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow iceberg table expiry with retain last

### Why are the changes needed?

Better usability

### Does this PR introduce _any_ user-facing change?

Yes, Iceberg snapshots can be expired using retain last

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT
