### PR TITLE
HIVE-27837: Backport of HIVE-25093 and HIVE-25268

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/Date.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/Date.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.common.type;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -99,6 +100,10 @@ public class Date implements Comparable<Date> {
 
   public long toEpochMilli() {
     return localDate.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
+  }
+
+  public long toEpochMilli(ZoneId id) {
+    return localDate.atStartOfDay().atZone(id).toInstant().toEpochMilli();
   }
 
   public void setYear(int year) {

--- a/common/src/java/org/apache/hadoop/hive/common/type/Timestamp.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/Timestamp.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.common.type;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -75,8 +76,7 @@ public class Timestamp implements Comparable<Timestamp> {
 
   private LocalDateTime localDateTime;
 
-  /* Private constructor */
-  private Timestamp(LocalDateTime localDateTime) {
+  public Timestamp(LocalDateTime localDateTime) {
     this.localDateTime = localDateTime != null ? localDateTime : EPOCH;
   }
 
@@ -135,6 +135,10 @@ public class Timestamp implements Comparable<Timestamp> {
     return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
   }
 
+  public long toEpochMilli(ZoneId id) {
+    return localDateTime.atZone(id).toInstant().toEpochMilli();
+  }
+
   public void setTimeInMillis(long epochMilli) {
     localDateTime = LocalDateTime.ofInstant(
         Instant.ofEpochMilli(epochMilli), ZoneOffset.UTC);
@@ -178,6 +182,11 @@ public class Timestamp implements Comparable<Timestamp> {
   public static Timestamp ofEpochMilli(long epochMilli) {
     return new Timestamp(LocalDateTime
         .ofInstant(Instant.ofEpochMilli(epochMilli), ZoneOffset.UTC));
+  }
+
+  public static Timestamp ofEpochMilli(long epochMilli, ZoneId id) {
+    return new Timestamp(LocalDateTime
+        .ofInstant(Instant.ofEpochMilli(epochMilli), id));
   }
 
   public static Timestamp ofEpochMilli(long epochMilli, int nanos) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -17,16 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.udf.generic;
 
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveGrouping.DATE_GROUP;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveGrouping.STRING_GROUP;
-
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-
-import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Description;
@@ -34,13 +24,21 @@ import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.hive.ql.util.DateTimeMath;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters.Converter;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.io.Text;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveGrouping.DATE_GROUP;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveGrouping.STRING_GROUP;
 
 /**
  * GenericUDFDateFormat.
@@ -51,18 +49,17 @@ import org.apache.hadoop.io.Text;
  */
 @Description(name = "date_format", value = "_FUNC_(date/timestamp/string, fmt) - converts a date/timestamp/string "
     + "to a value of string in the format specified by the date format fmt.",
-    extended = "Supported formats are SimpleDateFormat formats - "
-        + "https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html. "
+    extended = "Supported formats are DateTimeFormatter formats - "
+        + "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html. "
         + "Second argument fmt should be constant.\n"
         + "Example: > SELECT _FUNC_('2015-04-08', 'y');\n '2015'")
 public class GenericUDFDateFormat extends GenericUDF {
-  private transient Converter[] tsConverters = new Converter[2];
-  private transient PrimitiveCategory[] tsInputTypes = new PrimitiveCategory[2];
-  private transient Converter[] dtConverters = new Converter[2];
-  private transient PrimitiveCategory[] dtInputTypes = new PrimitiveCategory[2];
-  private final java.util.Date date = new java.util.Date();
+  private final transient Converter[] tsConverters = new Converter[2];
+  private final transient PrimitiveCategory[] tsInputTypes = new PrimitiveCategory[2];
+
   private final Text output = new Text();
-  private transient SimpleDateFormat formatter;
+  private transient ZoneId timeZone;
+  private transient DateTimeFormatter formatter;
 
   @Override
   public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
@@ -74,30 +71,28 @@ public class GenericUDFDateFormat extends GenericUDF {
     // the function should support both short date and full timestamp format
     // time part of the timestamp should not be skipped
     checkArgGroups(arguments, 0, tsInputTypes, STRING_GROUP, DATE_GROUP);
-    checkArgGroups(arguments, 0, dtInputTypes, STRING_GROUP, DATE_GROUP);
-
     checkArgGroups(arguments, 1, tsInputTypes, STRING_GROUP);
 
     obtainTimestampConverter(arguments, 0, tsInputTypes, tsConverters);
-    obtainDateConverter(arguments, 0, dtInputTypes, dtConverters);
 
     if (arguments[1] instanceof ConstantObjectInspector) {
       String fmtStr = getConstantStringValue(arguments, 1);
       if (fmtStr != null) {
         try {
-          formatter = new SimpleDateFormat(fmtStr);
-          formatter.setCalendar(DateTimeMath.getTimeZonedProlepticGregorianCalendar());
+          if (timeZone == null) {
+            timeZone = SessionState.get() == null ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
+                .getLocalTimeZone();
+          }
+          formatter = DateTimeFormatter.ofPattern(fmtStr);
         } catch (IllegalArgumentException e) {
           // ignore
         }
       }
     } else {
-      throw new UDFArgumentTypeException(1, getFuncName() + " only takes constant as "
-          + getArgOrder(1) + " argument");
+      throw new UDFArgumentTypeException(1, getFuncName() + " only takes constant as " + getArgOrder(1) + " argument");
     }
 
-    ObjectInspector outputOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
-    return outputOI;
+    return PrimitiveObjectInspectorFactory.writableStringObjectInspector;
   }
 
   @Override
@@ -106,25 +101,18 @@ public class GenericUDFDateFormat extends GenericUDF {
       return null;
     }
 
-    ZoneId id = (SessionState.get() == null) ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
-        .getLocalTimeZone();
     // the function should support both short date and full timestamp format
     // time part of the timestamp should not be skipped
     Timestamp ts = getTimestampValue(arguments, 0, tsConverters);
+
     if (ts == null) {
-      Date d = getDateValue(arguments, 0, dtInputTypes, dtConverters);
-      if (d == null) {
-        return null;
-      }
-      ts = Timestamp.ofEpochMilli(d.toEpochMilli(id), id);
-    }
-
-
-    date.setTime(ts.toEpochMilli(id));
-    String res = formatter.format(date);
-    if (res == null) {
       return null;
     }
+
+    Instant instant = Instant.ofEpochSecond(ts.toEpochSecond(), ts.getNanos());
+    ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
+    String res = formatter.format(zonedDateTime.withZoneSameLocal(timeZone));
+
     output.set(res);
     return output;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
@@ -21,9 +21,12 @@ import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hive.common.util.DateUtils;
 
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -595,6 +598,24 @@ public class DateTimeMath {
   public static Calendar getProlepticGregorianCalendarUTC() {
     GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC".intern()));
     calendar.setGregorianChange(new java.util.Date(Long.MIN_VALUE));
+    return calendar;
+  }
+
+  /**
+   * TODO - this is a temporary fix for handling Julian calendar dates.
+   * Returns a Gregorian calendar that can be used from year 0+ instead of default 1582.10.15.
+   * This is desirable for some UDFs that work on dates which normally would use Julian calendar.
+   * Julian calendar only works with UTC time zone only.
+   * @return the calendar
+   */
+  public static Calendar getTimeZonedProlepticGregorianCalendar() {
+    ZoneId id = SessionState.get() == null ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
+        .getLocalTimeZone();
+    GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone(id));
+
+    if (id.getId().equals("UTC"))
+      calendar.setGregorianChange(new java.util.Date(Long.MIN_VALUE));
+
     return calendar;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
@@ -601,21 +601,4 @@ public class DateTimeMath {
     return calendar;
   }
 
-  /**
-   * TODO - this is a temporary fix for handling Julian calendar dates.
-   * Returns a Gregorian calendar that can be used from year 0+ instead of default 1582.10.15.
-   * This is desirable for some UDFs that work on dates which normally would use Julian calendar.
-   * Julian calendar only works with UTC time zone only.
-   * @return the calendar
-   */
-  public static Calendar getTimeZonedProlepticGregorianCalendar() {
-    ZoneId id = SessionState.get() == null ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
-        .getLocalTimeZone();
-    GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone(id));
-
-    if (id.getId().equals("UTC"))
-      calendar.setGregorianChange(new java.util.Date(Long.MIN_VALUE));
-
-    return calendar;
-  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
@@ -30,6 +30,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestGenericUDFDateFormat extends TestCase {
@@ -121,6 +124,22 @@ public class TestGenericUDFDateFormat extends TestCase {
     runAndVerifyTs("2015-04-12 10:30:45", fmtText, "Sunday", udf);
   }
 
+  @Test
+  public void testDateFormatTsWithTimeZone() throws HiveException {
+    GenericUDFDateFormat udf = new GenericUDFDateFormat();
+    ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableTimestampObjectInspector;
+    Text fmtText = new Text("yyyy-MM-dd HH:mm:ss.SSS z");
+    ObjectInspector valueOI1 = PrimitiveObjectInspectorFactory
+        .getPrimitiveWritableConstantObjectInspector(TypeInfoFactory.stringTypeInfo, fmtText);
+    ObjectInspector[] arguments = { valueOI0, valueOI1 };
+
+    udf.initialize(arguments);
+
+    runAndVerifyTs("2015-04-08 10:30:45", fmtText, "2015-04-08 10:30:45.000 PDT", udf);
+
+  }
+
+  @Test
   public void testNullFmt() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
@@ -149,6 +168,7 @@ public class TestGenericUDFDateFormat extends TestCase {
 
 
   @Test
+  @Ignore
   public void testJulianDates() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.udf.generic;
 
-import junit.framework.TestCase;
+
 
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.Timestamp;
@@ -35,8 +35,12 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class TestGenericUDFDateFormat extends TestCase {
+/**
+ * TestGenericUDFDateFormat.
+ */
+public class TestGenericUDFDateFormat {
 
+  @Test
   public void testDateFormatStr() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
@@ -68,6 +72,7 @@ public class TestGenericUDFDateFormat extends TestCase {
     runAndVerifyStr("2015-04-12 10", fmtText, "Sunday", udf);
   }
 
+  @Test
   public void testWrongDateStr() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
@@ -83,6 +88,7 @@ public class TestGenericUDFDateFormat extends TestCase {
     runAndVerifyStr(null, fmtText, null, udf);
   }
 
+  @Test
   public void testDateFormatDate() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableDateObjectInspector;
@@ -103,6 +109,7 @@ public class TestGenericUDFDateFormat extends TestCase {
     runAndVerifyDate("2015-04-12", fmtText, "Sunday", udf);
   }
 
+  @Test
   public void testDateFormatTs() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableTimestampObjectInspector;
@@ -153,10 +160,11 @@ public class TestGenericUDFDateFormat extends TestCase {
     runAndVerifyStr("2015-04-05", fmtText, null, udf);
   }
 
+  @Test
   public void testWrongFmt() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
-    Text fmtText = new Text("Q");
+    Text fmtText = new Text("B");
     ObjectInspector valueOI1 = PrimitiveObjectInspectorFactory
         .getPrimitiveWritableConstantObjectInspector(TypeInfoFactory.stringTypeInfo, fmtText);
     ObjectInspector[] arguments = { valueOI0, valueOI1 };
@@ -168,7 +176,6 @@ public class TestGenericUDFDateFormat extends TestCase {
 
 
   @Test
-  @Ignore
   public void testJulianDates() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
@@ -178,6 +185,19 @@ public class TestGenericUDFDateFormat extends TestCase {
     ObjectInspector[] arguments = { valueOI0, valueOI1 };
     udf.initialize(arguments);
     runAndVerifyStr("1001-01-05", fmtText, "05---01--1001", udf);
+  }
+
+  @Test
+  public void testTimestampPriorTo1900() throws HiveException {
+    GenericUDFDateFormat udf = new GenericUDFDateFormat();
+    ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+    Text fmtText = new Text("yyyy-MM-dd HH:mm:ss.SSS z");
+    ObjectInspector valueOI1 = PrimitiveObjectInspectorFactory
+        .getPrimitiveWritableConstantObjectInspector(TypeInfoFactory.stringTypeInfo, fmtText);
+    ObjectInspector[] arguments = { valueOI0, valueOI1 };
+    udf.initialize(arguments);
+    runAndVerifyStr("1400-01-14 01:01:10.123", fmtText, "1400-01-14 01:01:10.123 PST", udf);
+    runAndVerifyStr("1800-01-14 01:01:10.123", fmtText, "1800-01-14 01:01:10.123 PST", udf);
   }
 
   private void runAndVerifyStr(String str, Text fmtText, String expResult, GenericUDF udf)

--- a/ql/src/test/queries/clientpositive/udf_date_format.q
+++ b/ql/src/test/queries/clientpositive/udf_date_format.q
@@ -1,6 +1,8 @@
 DESCRIBE FUNCTION date_format;
 DESC FUNCTION EXTENDED date_format;
 
+set hive.local.time.zone=Africa/Johannesburg;
+
 explain select date_format('2015-04-08', 'EEEE');
 
 --string date
@@ -16,6 +18,7 @@ date_format('2015-04-08', 'D'),
 date_format('2015-04-08', 'd'),
 date_format(cast(null as string), 'dd');
 
+set hive.local.time.zone=Europe/Berlin;
 
 --string timestamp
 select
@@ -29,6 +32,7 @@ date_format('2015-04-08T10:30:45', 'dd'),
 date_format('2015-04-08 10', 'dd'),
 date_format(cast(null as string), 'dd');
 
+set hive.local.time.zone=Australia/Sydney;
 
 --date
 select
@@ -42,6 +46,8 @@ date_format(cast('2015-04-08' as date), 'W'),
 date_format(cast('2015-04-08' as date), 'D'),
 date_format(cast('2015-04-08' as date), 'd'),
 date_format(cast(null as date), 'dd');
+
+set hive.local.time.zone=Asia/Bangkok;
 
 --timestamp
 select
@@ -58,3 +64,17 @@ date_format(cast(null as timestamp), 'HH');
 select
 date_format('2015-04-08', ''),
 date_format('2015-04-08', 'Q');
+
+-- with time zone
+set hive.local.time.zone=Asia/Bangkok;
+select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
+
+set hive.local.time.zone=Australia/Sydney;
+select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
+
+set hive.local.time.zone=Europe/Berlin;
+select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
+
+--julian date
+set hive.local.time.zone=UTC;
+select date_format("1001-01-05","dd---MM--yyyy");

--- a/ql/src/test/queries/clientpositive/udf_date_format.q
+++ b/ql/src/test/queries/clientpositive/udf_date_format.q
@@ -63,7 +63,7 @@ date_format(cast(null as timestamp), 'HH');
 -- wrong fmt
 select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q');
+date_format('2015-04-08', 'B');
 
 -- with time zone
 set hive.local.time.zone=Asia/Bangkok;
@@ -78,3 +78,16 @@ select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
 --julian date
 set hive.local.time.zone=UTC;
 select date_format("1001-01-05","dd---MM--yyyy");
+
+--dates prior to 1900
+set hive.local.time.zone=Asia/Bangkok;
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+
+set hive.local.time.zone=Europe/Berlin;
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+
+set hive.local.time.zone=Africa/Johannesburg;
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');

--- a/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
@@ -8,7 +8,7 @@ PREHOOK: type: DESCFUNCTION
 POSTHOOK: query: DESC FUNCTION EXTENDED date_format
 POSTHOOK: type: DESCFUNCTION
 date_format(date/timestamp/string, fmt) - converts a date/timestamp/string to a value of string in the format specified by the date format fmt.
-Supported formats are SimpleDateFormat formats - https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html. Second argument fmt should be constant.
+Supported formats are DateTimeFormatter formats - https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html. Second argument fmt should be constant.
 Example: > SELECT date_format('2015-04-08', 'y');
  '2015'
 Function class:org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat
@@ -92,7 +92,7 @@ date_format(cast(null as string), 'dd')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-10	30	45	09 PM	08	123	08	08	NULL
+10	30	45	09 PM	08	1	08	08	NULL
 PREHOOK: query: select
 date_format(cast('2015-04-08' as date), 'EEEE'),
 date_format(cast('2015-04-08' as date), 'G'),
@@ -149,13 +149,13 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 10	30	45	10 AM	08	123	123	NULL
 PREHOOK: query: select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q')
+date_format('2015-04-08', 'B')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 POSTHOOK: query: select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q')
+date_format('2015-04-08', 'B')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
@@ -196,3 +196,57 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 05---01--1001
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:01:10.123 ICT
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:01:10.123 ICT
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:01:10.123 CET
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:01:10.123 CET
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:01:10.123 SAST
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:01:10.123 SAST

--- a/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
@@ -1,0 +1,198 @@
+PREHOOK: query: DESCRIBE FUNCTION date_format
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION date_format
+POSTHOOK: type: DESCFUNCTION
+date_format(date/timestamp/string, fmt) - converts a date/timestamp/string to a value of string in the format specified by the date format fmt.
+PREHOOK: query: DESC FUNCTION EXTENDED date_format
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESC FUNCTION EXTENDED date_format
+POSTHOOK: type: DESCFUNCTION
+date_format(date/timestamp/string, fmt) - converts a date/timestamp/string to a value of string in the format specified by the date format fmt.
+Supported formats are SimpleDateFormat formats - https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html. Second argument fmt should be constant.
+Example: > SELECT date_format('2015-04-08', 'y');
+ '2015'
+Function class:org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat
+Function type:BUILTIN
+PREHOOK: query: explain select date_format('2015-04-08', 'EEEE')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: explain select date_format('2015-04-08', 'EEEE')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: _dummy_table
+          Row Limit Per Split: 1
+          Select Operator
+            expressions: 'Wednesday' (type: string)
+            outputColumnNames: _col0
+            ListSink
+
+PREHOOK: query: select
+date_format('2015-04-08', 'E'),
+date_format('2015-04-08', 'G'),
+date_format('2015-04-08', 'y'),
+date_format('2015-04-08', 'Y'),
+date_format('2015-04-08', 'MMM'),
+date_format('2015-04-08', 'w'),
+date_format('2015-04-08', 'W'),
+date_format('2015-04-08', 'D'),
+date_format('2015-04-08', 'd'),
+date_format(cast(null as string), 'dd')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+date_format('2015-04-08', 'E'),
+date_format('2015-04-08', 'G'),
+date_format('2015-04-08', 'y'),
+date_format('2015-04-08', 'Y'),
+date_format('2015-04-08', 'MMM'),
+date_format('2015-04-08', 'w'),
+date_format('2015-04-08', 'W'),
+date_format('2015-04-08', 'D'),
+date_format('2015-04-08', 'd'),
+date_format(cast(null as string), 'dd')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Wed	AD	2015	2015	Apr	15	2	98	8	NULL
+PREHOOK: query: select
+date_format('2015-04-08 10:30:45', 'HH'),
+date_format('2015-04-08 10:30:45', 'mm'),
+date_format('2015-04-08 10:30:45', 'ss'),
+date_format('2015-04-08 21:30:45', 'hh a'),
+date_format('2015-04-08 10:30', 'dd'),
+date_format('2015-04-08 10:30:45.123', 'S'),
+date_format('2015-04-08T10:30:45', 'dd'),
+date_format('2015-04-08 10', 'dd'),
+date_format(cast(null as string), 'dd')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+date_format('2015-04-08 10:30:45', 'HH'),
+date_format('2015-04-08 10:30:45', 'mm'),
+date_format('2015-04-08 10:30:45', 'ss'),
+date_format('2015-04-08 21:30:45', 'hh a'),
+date_format('2015-04-08 10:30', 'dd'),
+date_format('2015-04-08 10:30:45.123', 'S'),
+date_format('2015-04-08T10:30:45', 'dd'),
+date_format('2015-04-08 10', 'dd'),
+date_format(cast(null as string), 'dd')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+10	30	45	09 PM	08	123	08	08	NULL
+PREHOOK: query: select
+date_format(cast('2015-04-08' as date), 'EEEE'),
+date_format(cast('2015-04-08' as date), 'G'),
+date_format(cast('2015-04-08' as date), 'yyyy'),
+date_format(cast('2015-04-08' as date), 'YY'),
+date_format(cast('2015-04-08' as date), 'MMM'),
+date_format(cast('2015-04-08' as date), 'w'),
+date_format(cast('2015-04-08' as date), 'W'),
+date_format(cast('2015-04-08' as date), 'D'),
+date_format(cast('2015-04-08' as date), 'd'),
+date_format(cast(null as date), 'dd')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+date_format(cast('2015-04-08' as date), 'EEEE'),
+date_format(cast('2015-04-08' as date), 'G'),
+date_format(cast('2015-04-08' as date), 'yyyy'),
+date_format(cast('2015-04-08' as date), 'YY'),
+date_format(cast('2015-04-08' as date), 'MMM'),
+date_format(cast('2015-04-08' as date), 'w'),
+date_format(cast('2015-04-08' as date), 'W'),
+date_format(cast('2015-04-08' as date), 'D'),
+date_format(cast('2015-04-08' as date), 'd'),
+date_format(cast(null as date), 'dd')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Wednesday	AD	2015	15	Apr	15	2	98	8	NULL
+PREHOOK: query: select
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'HH'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'mm'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'ss'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'hh a'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'dd'),
+date_format(cast('2015-04-08 10:30:45.123' as timestamp), 'SSS'),
+date_format(cast('2015-04-08 10:30:45.123456789' as timestamp), 'SSS'),
+date_format(cast(null as timestamp), 'HH')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'HH'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'mm'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'ss'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'hh a'),
+date_format(cast('2015-04-08 10:30:45' as timestamp), 'dd'),
+date_format(cast('2015-04-08 10:30:45.123' as timestamp), 'SSS'),
+date_format(cast('2015-04-08 10:30:45.123456789' as timestamp), 'SSS'),
+date_format(cast(null as timestamp), 'HH')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+10	30	45	10 AM	08	123	123	NULL
+PREHOOK: query: select
+date_format('2015-04-08', ''),
+date_format('2015-04-08', 'Q')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+date_format('2015-04-08', ''),
+date_format('2015-04-08', 'Q')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+	NULL
+PREHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+2015-04-08 10:30:45.000 ICT
+PREHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+2015-04-08 10:30:45.000 AEST
+PREHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+2015-04-08 10:30:45.000 CEST
+PREHOOK: query: select date_format("1001-01-05","dd---MM--yyyy")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format("1001-01-05","dd---MM--yyyy")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+05---01--1001


### PR DESCRIPTION
### What changes were proposed in this pull request?
Backport of HIVE-25093: date_format() UDF is returning output in UTC time zone only
Backport of HIVE-25268: date_format udf returns wrong results for dates prior to 1900

Jira link - https://issues.apache.org/jira/browse/HIVE-27837