### PR TITLE
HIVE-27840: Backport of HIVE-21729: Arrow serializer sometimes shifts timestamp by one second

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
@@ -882,8 +882,11 @@ public class Serializer {
     final TimestampColumnVector timestampColumnVector = (TimestampColumnVector) hiveVector;
     // Time = second + sub-second
     final long secondInMillis = timestampColumnVector.getTime(j);
-    final long secondInMicros = (secondInMillis - secondInMillis % MILLIS_PER_SECOND) * MICROS_PER_MILLIS;
-    final long subSecondInMicros = timestampColumnVector.getNanos(j) / NS_PER_MICROS;
+    final long nanos = timestampColumnVector.getNanos(j);
+    // nanos should be subtracted from total time(secondInMillis) to obtain micros
+    // Divide nanos by 1000_000 to bring it to millisecond precision and then perform the subtraction
+    final long secondInMicros = (secondInMillis - nanos / NS_PER_MILLIS) * MICROS_PER_MILLIS;
+    final long subSecondInMicros = nanos / NS_PER_MICROS;
     if ((secondInMillis > 0 && secondInMicros < 0) || (secondInMillis < 0 && secondInMicros > 0)) {
       // If the timestamp cannot be represented in long microsecond, set it as a null value
       timeStampMicroTZVector.setNull(i);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestArrowColumnarBatchSerDe.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestArrowColumnarBatchSerDe.java
@@ -518,6 +518,45 @@ public class TestArrowColumnarBatchSerDe {
     initAndSerializeAndDeserialize(schema, rows);
   }
 
+
+  @Test
+  public void testTimestampNanosPrecisionUpTo6Digits() throws SerDeException {
+    String[][] schema = {
+        {"timestamp1", "timestamp"},
+    };
+    //Nanos precise upto 6 digits
+    Object[][] tsRows = new Object[][]{
+        {new TimestampWritableV2(Timestamp.valueOf("1800-04-01 09:01:10.123999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("2050-04-01 09:01:10.999999"))},
+        null
+    };
+    initAndSerializeAndDeserialize(schema, tsRows);
+  }
+
+  @Test
+  public void testPositiveNegativeTSWithNanos() throws SerDeException {
+    String[][] schema = {
+        {"timestamp1", "timestamp"},
+    };
+
+    Object[][] tsRows = new Object[][]{
+        {new TimestampWritableV2(Timestamp.valueOf("1963-04-01 09:01:10.123"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1800-04-01 09:01:10.123999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1750-04-01 09:01:10.123999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1700-04-01 09:01:10.999999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("2050-04-01 09:01:10.999999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1991-06-05 09:01:10.999999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1992-11-04 09:01:10.999999"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1970-01-01 00:00:00"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1964-01-01 00:00:04.78"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1950-01-01 09:23:03.21"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1956-01-01 10:09:03.00"))},
+        {new TimestampWritableV2(Timestamp.valueOf("1947-08-27 10:25:36.26"))},
+        null
+    };
+    initAndSerializeAndDeserialize(schema, tsRows);
+  }
+
   @Test
   public void testPrimitiveDecimal() throws SerDeException {
     String[][] schema = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Backport of HIVE-21729: Arrow serializer sometimes shifts timestamp by one second

Jira - https://issues.apache.org/jira/browse/HIVE-27840