### PR TITLE
HIVE-27852: Backport of HIVE-27324: Hive query with NOT IN condition is giving incorrect results

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -75,6 +75,7 @@ minillap.shared.query.files=insert_into1.q,\
   mapreduce2.q,\
   mm_all.q,\
   mm_cttas.q,\
+  notInTest.q,\
   orc_merge1.q,\
   orc_merge10.q,\
   orc_merge2.q,\

--- a/ql/src/test/queries/clientpositive/notInTest.q
+++ b/ql/src/test/queries/clientpositive/notInTest.q
@@ -1,0 +1,93 @@
+create table t3 (id int,name string, age int);
+insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45);
+
+create table t4 (id int,name string, age int);
+insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23);
+
+create table t5 (id int,name string, ages int);
+insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23);
+
+set hive.cbo.enable = false;
+
+select * from t3
+where age in (select distinct(age) age from t4)
+order by age ;
+
+select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age ;
+
+
+select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age ;
+
+
+select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age ;
+
+select count(*) from t3
+where age not in (23,22, null );
+
+explain select * from t3
+        where age not in (select distinct(age) age from t4);
+
+explain select * from t3
+where age not in (select distinct(ages) ages from t5 );
+
+explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null);
+
+select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10);
+
+
+
+explain select id, name, age
+from t3 b where b.age not in
+(select min(age)
+ from (select id, age from t3) a
+ where age < 10 and b.age = a.age)
+ order by name;
+
+set hive.cbo.enable = true;
+
+select * from t3
+where age in (select distinct(age) age from t4)
+order by age ;
+
+select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age ;
+
+select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age ;
+
+
+select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age ;
+
+select count(*) from t3
+where age not in (23,22, null );
+
+explain select * from t3
+        where age not in (select distinct(age) age from t4);
+
+explain select * from t3
+where age not in (select distinct(ages) ages from t5 );
+
+explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null);
+
+select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10);
+
+ explain select id, name, age
+         from t3 b where b.age not in
+         (select min(age)
+          from (select id, age from t3) a
+          where age < 10 and b.age = a.age)
+          order by name;

--- a/ql/src/test/results/clientpositive/llap/create_view_disable_cbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_view_disable_cbo.q.out
@@ -1,0 +1,114 @@
+PREHOOK: query: CREATE DATABASE IF NOT EXISTS cdh_82023_repro_db
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: query: CREATE DATABASE IF NOT EXISTS cdh_82023_repro_db
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:cdh_82023_repro_db
+PREHOOK: query: CREATE TABLE IF NOT EXISTS `cdh_82023_repro_db`.`data` (
+  `text` string
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: cdh_82023_repro_db@data
+PREHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: query: CREATE TABLE IF NOT EXISTS `cdh_82023_repro_db`.`data` (
+  `text` string
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: cdh_82023_repro_db@data
+POSTHOOK: Output: database:cdh_82023_repro_db
+PREHOOK: query: CREATE VIEW IF NOT EXISTS `cdh_82023_repro_db`.`background` AS
+SELECT
+  *
+FROM
+  `cdh_82023_repro_db`.`data` `xouter`
+WHERE
+  `xouter`.`text` NOT IN (
+    SELECT
+      UPPER(`xinner`.`text`)
+    FROM
+      `cdh_82023_repro_db`.`data` `xinner`
+    GROUP BY
+      UPPER(`xinner`.`text`)
+  )
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: cdh_82023_repro_db@data
+PREHOOK: Output: cdh_82023_repro_db@background
+PREHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: query: CREATE VIEW IF NOT EXISTS `cdh_82023_repro_db`.`background` AS
+SELECT
+  *
+FROM
+  `cdh_82023_repro_db`.`data` `xouter`
+WHERE
+  `xouter`.`text` NOT IN (
+    SELECT
+      UPPER(`xinner`.`text`)
+    FROM
+      `cdh_82023_repro_db`.`data` `xinner`
+    GROUP BY
+      UPPER(`xinner`.`text`)
+  )
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: cdh_82023_repro_db@data
+POSTHOOK: Output: cdh_82023_repro_db@background
+POSTHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: Lineage: background.text EXPRESSION [(data)xouter.FieldSchema(name:text, type:string, comment:null), ]
+Warning: Shuffle Join MERGEJOIN[45][tables = [xouter, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: SELECT * FROM `cdh_82023_repro_db`.`background`
+PREHOOK: type: QUERY
+PREHOOK: Input: cdh_82023_repro_db@background
+PREHOOK: Input: cdh_82023_repro_db@data
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM `cdh_82023_repro_db`.`background`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: cdh_82023_repro_db@background
+POSTHOOK: Input: cdh_82023_repro_db@data
+#### A masked pattern was here ####
+PREHOOK: query: CREATE VIEW IF NOT EXISTS `cdh_82023_repro_db`.`foreground`AS
+SELECT
+  *
+FROM
+  `cdh_82023_repro_db`.`background`
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: cdh_82023_repro_db@background
+PREHOOK: Input: cdh_82023_repro_db@data
+PREHOOK: Output: cdh_82023_repro_db@foreground
+PREHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: query: CREATE VIEW IF NOT EXISTS `cdh_82023_repro_db`.`foreground`AS
+SELECT
+  *
+FROM
+  `cdh_82023_repro_db`.`background`
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: cdh_82023_repro_db@background
+POSTHOOK: Input: cdh_82023_repro_db@data
+POSTHOOK: Output: cdh_82023_repro_db@foreground
+POSTHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: Lineage: foreground.text EXPRESSION [(data)xouter.FieldSchema(name:text, type:string, comment:null), ]
+Warning: Shuffle Join MERGEJOIN[46][tables = [xouter, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: SELECT * FROM `cdh_82023_repro_db`.`foreground`
+PREHOOK: type: QUERY
+PREHOOK: Input: cdh_82023_repro_db@background
+PREHOOK: Input: cdh_82023_repro_db@data
+PREHOOK: Input: cdh_82023_repro_db@foreground
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM `cdh_82023_repro_db`.`foreground`
+POSTHOOK: type: QUERY
+POSTHOOK: Input: cdh_82023_repro_db@background
+POSTHOOK: Input: cdh_82023_repro_db@data
+POSTHOOK: Input: cdh_82023_repro_db@foreground
+#### A masked pattern was here ####
+PREHOOK: query: DROP DATABASE IF EXISTS `cdh_82023_repro_db` CASCADE
+PREHOOK: type: DROPDATABASE
+PREHOOK: Input: database:cdh_82023_repro_db
+PREHOOK: Output: cdh_82023_repro_db@background
+PREHOOK: Output: cdh_82023_repro_db@data
+PREHOOK: Output: cdh_82023_repro_db@foreground
+PREHOOK: Output: database:cdh_82023_repro_db
+POSTHOOK: query: DROP DATABASE IF EXISTS `cdh_82023_repro_db` CASCADE
+POSTHOOK: type: DROPDATABASE
+POSTHOOK: Input: database:cdh_82023_repro_db
+POSTHOOK: Output: cdh_82023_repro_db@background
+POSTHOOK: Output: cdh_82023_repro_db@data
+POSTHOOK: Output: cdh_82023_repro_db@foreground
+POSTHOOK: Output: database:cdh_82023_repro_db

--- a/ql/src/test/results/clientpositive/llap/notInTest.q.out
+++ b/ql/src/test/results/clientpositive/llap/notInTest.q.out
@@ -1,0 +1,1825 @@
+PREHOOK: query: create table t3 (id int,name string, age int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t3
+POSTHOOK: query: create table t3 (id int,name string, age int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t3
+PREHOOK: query: insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t3
+POSTHOOK: query: insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t3
+POSTHOOK: Lineage: t3.age SCRIPT []
+POSTHOOK: Lineage: t3.id SCRIPT []
+POSTHOOK: Lineage: t3.name SCRIPT []
+PREHOOK: query: create table t4 (id int,name string, age int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t4
+POSTHOOK: query: create table t4 (id int,name string, age int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t4
+PREHOOK: query: insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t4
+POSTHOOK: query: insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t4
+POSTHOOK: Lineage: t4.age SCRIPT []
+POSTHOOK: Lineage: t4.id SCRIPT []
+POSTHOOK: Lineage: t4.name SCRIPT []
+PREHOOK: query: create table t5 (id int,name string, ages int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t5
+POSTHOOK: query: create table t5 (id int,name string, ages int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t5
+PREHOOK: query: insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t5
+POSTHOOK: query: insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t5
+POSTHOOK: Lineage: t5.ages SCRIPT []
+POSTHOOK: Lineage: t5.id SCRIPT []
+POSTHOOK: Lineage: t5.name SCRIPT []
+PREHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+6	Ramya	5
+1	Sagar	23
+3	Surya	23
+5	Scott	23
+7		23
+8		23
+4	Raman	45
+14	hela	45
+Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join MERGEJOIN[48][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+Warning: Shuffle Join MERGEJOIN[44][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  filterExpr: age is not null (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: id (type: int), name (type: string), age (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t4
+                  filterExpr: (age is not null or age is null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.57142854
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: null (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: null (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: null (type: int)
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col7
+                Statistics: Num rows: 17 Data size: 1652 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col7 is null (type: boolean)
+                  Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: null (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: count()
+                    minReductionHashAggr: 0.4
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[44][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  filterExpr: age is not null (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: id (type: int), name (type: string), age (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t5
+                  filterExpr: (ages is not null or ages is null) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ages is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: ages (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ages is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: null (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: null (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: null (type: int)
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col7
+                Statistics: Num rows: 17 Data size: 1648 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col7 is null (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: null (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: count()
+                    minReductionHashAggr: 0.4
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  filterExpr: age is not null (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: id (type: int), name (type: string), age (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t5
+                  filterExpr: (ages is not null or (ages is not null and ages is null)) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ages is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: ages (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ages is not null and ages is null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: null (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: null (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: null (type: int)
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col7
+                Statistics: Num rows: 17 Data size: 1648 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col7 is null (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: null (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: count()
+                    minReductionHashAggr: 0.4
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[50][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2
+Warning: Shuffle Join MERGEJOIN[52][tables = [b, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain select id, name, age
+from t3 b where b.age not in
+(select min(age)
+ from (select id, age from t3) a
+ where age < 10 and b.age = a.age)
+ order by name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select id, name, age
+from t3 b where b.age not in
+(select min(age)
+ from (select id, age from t3) a
+ where age < 10 and b.age = a.age)
+ order by name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: (age is not null or (age < 10)) (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: id (type: int), name (type: string), age (type: int)
+                  Filter Operator
+                    predicate: (age < 10) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: age (type: int)
+                      outputColumnNames: _col1
+                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(_col1)
+                        keys: _col1 (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int), _col2 (type: int)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col2 (type: int), _col2 (type: int)
+                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int), _col2 (type: int)
+                  1 _col0 (type: int), _col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col7
+                Statistics: Num rows: 16 Data size: 1552 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col7 is null (type: boolean)
+                  Statistics: Num rows: 13 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col2 (type: int)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col1 is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: int), _col0 (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: int)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col1 is null or _col0 is null) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+6	Ramya	5
+1	Sagar	23
+3	Surya	23
+5	Scott	23
+7		23
+8		23
+4	Raman	45
+14	hela	45
+Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join MERGEJOIN[42][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: id (type: int), name (type: string), age (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t4
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.57142854
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: age (type: int)
+                    outputColumnNames: age
+                    Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.57142854
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4
+                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
+                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
+                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), true (type: boolean)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: boolean)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  minReductionHashAggr: 0.6666666
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: id (type: int), name (type: string), age (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t5
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ages is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: ages (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: ages (type: int)
+                    outputColumnNames: ages
+                    Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: ages (type: int)
+                      minReductionHashAggr: 0.57142854
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4
+                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
+                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
+                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), true (type: boolean)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: boolean)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  minReductionHashAggr: 0.6666666
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: id (type: int), name (type: string), age (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t5
+                  filterExpr: ages is not null (type: boolean)
+                  Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ages is not null (type: boolean)
+                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: ages (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4
+                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
+                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
+                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), true (type: boolean)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: boolean)
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  minReductionHashAggr: 0.6666666
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[44][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2
+PREHOOK: query: explain select id, name, age
+         from t3 b where b.age not in
+         (select min(age)
+          from (select id, age from t3) a
+          where age < 10 and b.age = a.age)
+          order by name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain select id, name, age
+         from t3 b where b.age not in
+         (select min(age)
+          from (select id, age from t3) a
+          where age < 10 and b.age = a.age)
+          order by name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: id (type: int), name (type: string), age (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: string)
+                  Filter Operator
+                    predicate: (age < 10) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(age)
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
+                    Group By Operator
+                      aggregations: min(age)
+                      keys: age (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4
+                Statistics: Num rows: 17 Data size: 1664 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: if(_col4 is null, sq_count_check(0L, true), sq_count_check(_col4, true)) (type: boolean)
+                  Statistics: Num rows: 8 Data size: 784 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5
+                Statistics: Num rows: 8 Data size: 896 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 8 Data size: 896 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col4 (type: bigint), _col5 (type: bigint)
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
+                Statistics: Num rows: 8 Data size: 916 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col4 is null or (_col4 = 0L) or (_col6 is not null or _col2 is null or (_col5 < _col4)) is not true) (type: boolean)
+                  Statistics: Num rows: 8 Data size: 916 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col2 (type: int)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  keys: _col0 (type: int)
+                  mode: complete
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col1)
+                  keys: _col0 (type: int)
+                  mode: complete
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 2 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 2 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: bigint), _col2 (type: bigint)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = _col1) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: true (type: boolean), _col0 (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: boolean)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/notInTest.q.out
+++ b/ql/src/test/results/clientpositive/llap/notInTest.q.out
@@ -77,7 +77,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 8		23
 4	Raman	45
 14	hela	45
-Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[41][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(age) age from t4  )
 order by age
@@ -97,7 +97,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 12	fed	18
 11	nick	19
 10	Sam	22
-Warning: Shuffle Join MERGEJOIN[48][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[43][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
 order by age
@@ -117,7 +117,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 12	fed	18
 11	nick	19
 10	Sam	22
-Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[41][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(ages) ages from t5 )
 order by age
@@ -143,7 +143,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t3
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-Warning: Shuffle Join MERGEJOIN[44][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[39][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
         where age not in (select distinct(age) age from t4)
 PREHOOK: type: QUERY
@@ -166,7 +166,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
         Reducer 6 <- Map 4 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
@@ -176,36 +176,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t3
-                  filterExpr: age is not null (type: boolean)
                   Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: age is not null (type: boolean)
                     Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: id (type: int), name (type: string), age (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t4
-                  filterExpr: (age is not null or age is null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: age is not null (type: boolean)
                     Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: age (type: int)
-                      minReductionHashAggr: 0.57142854
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -216,18 +211,16 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: null (type: int)
-                        minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: null (type: int)
-                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: null (type: int)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -241,7 +234,6 @@ STAGE PLANS:
                 Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col2 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col2 (type: int)
                   Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
@@ -255,18 +247,18 @@ STAGE PLANS:
                 keys:
                   0 _col2 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col7
-                Statistics: Num rows: 17 Data size: 1652 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col6
+                Statistics: Num rows: 13 Data size: 1268 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col7 is null (type: boolean)
-                  Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 9 Data size: 880 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 9 Data size: 880 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 9 Data size: 880 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -281,7 +273,6 @@ STAGE PLANS:
                 Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -297,12 +288,10 @@ STAGE PLANS:
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: count()
-                    minReductionHashAggr: 0.4
                     mode: hash
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
@@ -321,12 +310,10 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: 0L (type: bigint)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
 
@@ -336,7 +323,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[44][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[39][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
 where age not in (select distinct(ages) ages from t5 )
 PREHOOK: type: QUERY
@@ -359,7 +346,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
         Reducer 6 <- Map 4 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
@@ -369,36 +356,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t3
-                  filterExpr: age is not null (type: boolean)
                   Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: age is not null (type: boolean)
                     Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: id (type: int), name (type: string), age (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t5
-                  filterExpr: (ages is not null or ages is null) (type: boolean)
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ages is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: ages (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -409,18 +391,16 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: null (type: int)
-                        minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: null (type: int)
-                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: null (type: int)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -434,7 +414,6 @@ STAGE PLANS:
                 Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col2 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col2 (type: int)
                   Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
@@ -448,18 +427,18 @@ STAGE PLANS:
                 keys:
                   0 _col2 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col7
-                Statistics: Num rows: 17 Data size: 1648 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col6
+                Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col7 is null (type: boolean)
-                  Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -474,7 +453,6 @@ STAGE PLANS:
                 Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -490,12 +468,10 @@ STAGE PLANS:
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: count()
-                    minReductionHashAggr: 0.4
                     mode: hash
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
@@ -514,12 +490,10 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: 0L (type: bigint)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
 
@@ -529,7 +503,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[46][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[41][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
         where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
 PREHOOK: type: QUERY
@@ -552,7 +526,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
         Reducer 6 <- Map 4 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
@@ -562,36 +536,31 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t3
-                  filterExpr: age is not null (type: boolean)
                   Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: age is not null (type: boolean)
                     Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: id (type: int), name (type: string), age (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t5
-                  filterExpr: (ages is not null or (ages is not null and ages is null)) (type: boolean)
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ages is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: ages (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -602,18 +571,16 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         keys: null (type: int)
-                        minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: null (type: int)
-                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: null (type: int)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -627,7 +594,6 @@ STAGE PLANS:
                 Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col2 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col2 (type: int)
                   Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
@@ -641,18 +607,18 @@ STAGE PLANS:
                 keys:
                   0 _col2 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col7
-                Statistics: Num rows: 17 Data size: 1648 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col6
+                Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col7 is null (type: boolean)
-                  Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 14 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -667,7 +633,6 @@ STAGE PLANS:
                 Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col0 (type: int)
-                  null sort order: z
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -683,12 +648,10 @@ STAGE PLANS:
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     aggregations: count()
-                    minReductionHashAggr: 0.4
                     mode: hash
                     outputColumnNames: _col0
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
@@ -707,12 +670,10 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: 0L (type: bigint)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
 
@@ -722,7 +683,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[50][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[45][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Reducer 7' is a cross product
 PREHOOK: query: select count(*) from t3
 where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
 PREHOOK: type: QUERY
@@ -734,7 +695,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@t3
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 2
-Warning: Shuffle Join MERGEJOIN[52][tables = [b, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+Warning: Shuffle Join MERGEJOIN[47][tables = [b, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select id, name, age
 from t3 b where b.age not in
 (select min(age)
@@ -762,50 +723,53 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: (age is not null or (age < 10)) (type: boolean)
                   Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: age is not null (type: boolean)
                     Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      null sort order: 
                       sort order: 
                       Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: id (type: int), name (type: string), age (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  Statistics: Num rows: 14 Data size: 56 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (age < 10) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: age (type: int)
                       outputColumnNames: _col1
-                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Group By Operator
                         aggregations: min(_col1)
                         keys: _col1 (type: int)
-                        minReductionHashAggr: 0.4
                         mode: hash
                         outputColumnNames: _col0, _col1
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -819,7 +783,6 @@ STAGE PLANS:
                 Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   key expressions: _col2 (type: int), _col2 (type: int)
-                  null sort order: zz
                   sort order: ++
                   Map-reduce partition columns: _col2 (type: int), _col2 (type: int)
                   Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
@@ -833,20 +796,19 @@ STAGE PLANS:
                 keys:
                   0 _col2 (type: int), _col2 (type: int)
                   1 _col0 (type: int), _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col7
-                Statistics: Num rows: 16 Data size: 1552 Basic stats: COMPLETE Column stats: COMPLETE
+                outputColumnNames: _col0, _col1, _col2, _col6
+                Statistics: Num rows: 13 Data size: 1264 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col7 is null (type: boolean)
-                  Statistics: Num rows: 13 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 10 Data size: 972 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 10 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: string)
-                      null sort order: z
                       sort order: +
-                      Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 10 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: int)
         Reducer 4 
             Execution mode: vectorized, llap
@@ -854,15 +816,15 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 10 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 13 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 10 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -880,27 +842,24 @@ STAGE PLANS:
                     Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int), _col1 (type: int)
-                      null sort order: zz
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col1 is null or _col0 is null) (type: boolean)
+                  predicate: (_col0 is null or _col1 is null) (type: boolean)
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: count()
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-        Reducer 6 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -915,12 +874,10 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: 0L (type: bigint)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
-                        null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
 
@@ -952,7 +909,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 8		23
 4	Raman	45
 14	hela	45
-Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(age) age from t4  )
 order by age
@@ -972,7 +929,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 12	fed	18
 11	nick	19
 10	Sam	22
-Warning: Shuffle Join MERGEJOIN[42][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[35][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
 order by age
@@ -992,7 +949,7 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 12	fed	18
 11	nick	19
 10	Sam	22
-Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select * from t3
 where age not in (select distinct(ages) ages from t5 )
 order by age
@@ -1010,17 +967,15 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 PREHOOK: query: select count(*) from t3
 where age not in (23,22, null )
 PREHOOK: type: QUERY
-PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Input: default@t3
 PREHOOK: Output: hdfs://### HDFS PATH ###
 POSTHOOK: query: select count(*) from t3
 where age not in (23,22, null )
 POSTHOOK: type: QUERY
-POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Input: default@t3
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[30][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
         where age not in (select distinct(age) age from t4)
 PREHOOK: type: QUERY
@@ -1042,11 +997,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1059,69 +1014,43 @@ STAGE PLANS:
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col2 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: int)
+                      sort order: 
                       Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: string)
+                      value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t4
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: age is not null (type: boolean)
-                    Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: age (type: int)
-                      minReductionHashAggr: 0.57142854
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: age (type: int)
                     outputColumnNames: age
                     Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: age (type: int)
-                      minReductionHashAggr: 0.57142854
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: age (type: int)
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col2 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col4
-                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1130,27 +1059,69 @@ STAGE PLANS:
                 keys:
                   0 
                   1 
-                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
-                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
-                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
-                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1164,43 +1135,10 @@ STAGE PLANS:
                   Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(), count(_col0)
-                  minReductionHashAggr: 0.6666666
-                  mode: hash
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0), count(VALUE._col1)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -1208,7 +1146,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[30][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
 where age not in (select distinct(ages) ages from t5 )
 PREHOOK: type: QUERY
@@ -1230,11 +1168,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1247,69 +1185,43 @@ STAGE PLANS:
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col2 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: int)
+                      sort order: 
                       Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: string)
+                      value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t5
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ages is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: ages (type: int)
-                      minReductionHashAggr: 0.4
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: ages (type: int)
                     outputColumnNames: ages
                     Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: ages (type: int)
-                      minReductionHashAggr: 0.57142854
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: ages (type: int)
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col2 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col4
-                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1318,27 +1230,69 @@ STAGE PLANS:
                 keys:
                   0 
                   1 
-                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
-                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
-                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
-                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1352,43 +1306,10 @@ STAGE PLANS:
                   Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(), count(_col0)
-                  minReductionHashAggr: 0.6666666
-                  mode: hash
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0), count(VALUE._col1)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -1396,7 +1317,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[40][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain select * from t3
         where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
 PREHOOK: type: QUERY
@@ -1418,10 +1339,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (ONE_TO_ONE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1434,54 +1356,37 @@ STAGE PLANS:
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
-                      key expressions: _col2 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col2 (type: int)
+                      sort order: 
                       Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: int), _col1 (type: string)
+                      value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Map 4 
             Map Operator Tree:
                 TableScan
                   alias: t5
-                  filterExpr: ages is not null (type: boolean)
                   Statistics: Num rows: 7 Data size: 28 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ages is not null (type: boolean)
                     Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: ages (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col2 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col4
-                Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 19 Data size: 1848 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col4 (type: boolean)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1490,27 +1395,69 @@ STAGE PLANS:
                 keys:
                   0 
                   1 
-                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
-                Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int), _col5 (type: bigint), _col6 (type: bigint), _col4 (type: boolean)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
-                  Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((_col3 = 0L) or (_col6 is null and (_col4 >= _col3) and _col2 is not null)) (type: boolean)
-                    Statistics: Num rows: 19 Data size: 2152 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                      File Output Operator
-                        compressed: false
-                        Statistics: Num rows: 19 Data size: 1824 Basic stats: COMPLETE Column stats: COMPLETE
-                        table:
-                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 14 Data size: 1568 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col2 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+                Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+                  Statistics: Num rows: 14 Data size: 1592 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(), count(_col0)
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1524,35 +1471,10 @@ STAGE PLANS:
                   Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-                Group By Operator
-                  aggregations: count(), count(_col0)
-                  minReductionHashAggr: 0.6666666
-                  mode: hash
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0), count(VALUE._col1)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -1560,7 +1482,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[44][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[37][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select count(*) from t3
 where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
 PREHOOK: type: QUERY
@@ -1599,13 +1521,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 1 (SIMPLE_EDGE)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (SIMPLE_EDGE)
+        Reducer 10 <- Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (ONE_TO_ONE_EDGE)
+        Reducer 3 <- Reducer 2 (ONE_TO_ONE_EDGE), Reducer 7 (ONE_TO_ONE_EDGE), Reducer 9 (ONE_TO_ONE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 5 (SIMPLE_EDGE)
+        Reducer 8 <- Map 5 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 10 (ONE_TO_ONE_EDGE), Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1619,36 +1542,38 @@ STAGE PLANS:
                     Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col2 (type: int)
-                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col2 (type: int)
                       Statistics: Num rows: 14 Data size: 1344 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: t3
+                  Statistics: Num rows: 14 Data size: 56 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (age < 10) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       keys: age (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: min(age)
                       keys: age (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1656,19 +1581,43 @@ STAGE PLANS:
                     Group By Operator
                       aggregations: min(age)
                       keys: age (type: int)
-                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
+                  Filter Operator
+                    predicate: age is not null (type: boolean)
+                    Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: age (type: int)
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
-            LLAP IO: all inputs
+            LLAP IO: no inputs
+        Reducer 10 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1679,20 +1628,19 @@ STAGE PLANS:
                   0 _col2 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col4
-                Statistics: Num rows: 17 Data size: 1664 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 14 Data size: 1376 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: if(_col4 is null, sq_count_check(0L, true), sq_count_check(_col4, true)) (type: boolean)
-                  Statistics: Num rows: 8 Data size: 784 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: (sq_count_check(CASE WHEN (_col4 is null) THEN (0) ELSE (_col4) END, true) > 0) (type: boolean)
+                  Statistics: Num rows: 4 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 4 Data size: 384 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col2 (type: int)
-                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col2 (type: int)
-                      Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 4 Data size: 384 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string)
         Reducer 3 
             Execution mode: llap
@@ -1700,52 +1648,35 @@ STAGE PLANS:
               Merge Join Operator
                 condition map:
                      Left Outer Join 0 to 1
+                     Left Outer Join 0 to 2
                 keys:
                   0 _col2 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col4, _col5
-                Statistics: Num rows: 8 Data size: 896 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: int)
-                  Statistics: Num rows: 8 Data size: 896 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col4 (type: bigint), _col5 (type: bigint)
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col2 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col6
-                Statistics: Num rows: 8 Data size: 916 Basic stats: COMPLETE Column stats: COMPLETE
+                  2 _col2 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col7
+                Statistics: Num rows: 2 Data size: 232 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col4 is null or (_col4 = 0L) or (_col6 is not null or _col2 is null or (_col5 < _col4)) is not true) (type: boolean)
-                  Statistics: Num rows: 8 Data size: 916 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: CASE WHEN ((_col4 = 0L)) THEN (true) WHEN (_col4 is null) THEN (true) WHEN (_col7 is not null) THEN (false) WHEN (_col2 is null) THEN (null) WHEN ((_col5 < _col4)) THEN (false) ELSE (true) END (type: boolean)
+                  Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: string)
-                      null sort order: z
                       sort order: +
-                      Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 8 Data size: 768 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -1766,7 +1697,6 @@ STAGE PLANS:
                   Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1788,7 +1718,6 @@ STAGE PLANS:
                   Statistics: Num rows: 2 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 2 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1802,20 +1731,40 @@ STAGE PLANS:
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
                 Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col0 = _col1) (type: boolean)
+                Select Operator
+                  expressions: _col1 (type: int)
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col1 is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int), true (type: boolean)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: boolean)
+        Reducer 9 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: true (type: boolean), _col0 (type: int)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: boolean)
+                  value expressions: _col1 (type: boolean)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
@@ -649,46 +649,46 @@ POSTHOOK: Input: default@cbo_/t3////
  1
  1
  1
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
 1
 1
 1
@@ -929,46 +929,46 @@ POSTHOOK: Input: default@cbo_/t3////
 1
 1
 1
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
 NULL
 NULL
 NULL
@@ -1025,10 +1025,10 @@ POSTHOOK: Input: default@cbo_/t3////
  1
  1
  1
- 1 
- 1 
- 1 
- 1 
+ 1
+ 1
+ 1
+ 1
 1
 1
 1
@@ -1101,10 +1101,10 @@ POSTHOOK: Input: default@cbo_/t3////
 1
 1
 1
-1 
-1 
-1 
-1 
+1
+1
+1
+1
 PREHOOK: query: select `c/b/o_t1`.c_int, `//cbo_t2`.c_int from `c/b/o_t1` left outer join  `//cbo_t2` on `c/b/o_t1`.key=`//cbo_t2`.key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@//cbo_t2
@@ -2565,14 +2565,14 @@ POSTHOOK: Input: default@cbo_/t3////
  1	1	 1	1	 1
  1	1	 1	1	 1
  1	1	 1	1	 1
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
- 1 	1	 1 	1	 1 
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
+ 1 	1	 1 	1	 1
 1	1	1	1	1
 1	1	1	1	1
 1	1	1	1	1
@@ -3077,14 +3077,14 @@ POSTHOOK: Input: default@cbo_/t3////
 1	1	1	1	1
 1	1	1	1	1
 1	1	1	1	1
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
-1 	1	1 	1	1 
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
+1 	1	1 	1	1
 PREHOOK: query: select b, `c/b/o_t1`.c, `//cbo_t2`.c_int, `cbo_/t3////`.c_int from (select key as a, c_int as b, `c/b/o_t1`.c_float as c from `c/b/o_t1`) `c/b/o_t1` join `//cbo_t2` on `c/b/o_t1`.a=`//cbo_t2`.key join `cbo_/t3////` on `c/b/o_t1`.a=`cbo_/t3////`.key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@//cbo_t2
@@ -15679,8 +15679,8 @@ POSTHOOK: Input: default@cbo_/t3////
 #### A masked pattern was here ####
 1.0	1	 1
 1.0	1	 1
-1.0	1	 1 
-1.0	1	 1 
+1.0	1	 1
+1.0	1	 1
 1.0	1	1
 1.0	1	1
 1.0	1	1
@@ -15693,8 +15693,8 @@ POSTHOOK: Input: default@cbo_/t3////
 1.0	1	1
 1.0	1	1
 1.0	1	1
-1.0	1	1 
-1.0	1	1 
+1.0	1	1
+1.0	1	1
 PREHOOK: query: select * from (select `cbo_/t3////`.c_int, `c/b/o_t1`.c, b from (select key as a, c_int as b, `c/b/o_t1`.c_float as c from `c/b/o_t1`  where (`c/b/o_t1`.c_int + 1 = 2) and (`c/b/o_t1`.c_int > 0 or `c/b/o_t1`.c_float >= 0)) `c/b/o_t1` left semi join (select `//cbo_t2`.key as p, `//cbo_t2`.c_int as q, c_float as r from `//cbo_t2`  where (`//cbo_t2`.c_int + 1 == 2) and (`//cbo_t2`.c_int > 0 or `//cbo_t2`.c_float >= 0)) `//cbo_t2` on `c/b/o_t1`.a=p left outer join `cbo_/t3////` on `c/b/o_t1`.a=key where (b + `cbo_/t3////`.c_int  == 2) and (b > 0 or c_int >= 0)) R where  (R.c_int + 1 = 2) and (R.b > 0 or c_int >= 0)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@//cbo_t2
@@ -16790,15 +16790,15 @@ POSTHOOK: Input: default@//cbo_t2
 POSTHOOK: Input: default@//cbo_t2@dt=2014
 POSTHOOK: Input: default@c/b/o_t1
 #### A masked pattern was here ####
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
-where not exists 
+where not exists
 
-  (select distinct a.key 
+  (select distinct a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value and a.value > 'val_2'
 
@@ -16806,15 +16806,15 @@ where not exists
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
-where not exists 
+where not exists
 
-  (select distinct a.key 
+  (select distinct a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value and a.value > 'val_2'
 
@@ -16941,17 +16941,17 @@ POSTHOOK: Input: default@src/_/cbo
 199	val_199
 199	val_199
 2	val_2
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 group by key, value
 
-having not exists 
+having not exists
 
-  (select a.key 
+  (select a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_12'
 
@@ -16959,17 +16959,17 @@ having not exists
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 group by key, value
 
-having not exists 
+having not exists
 
-  (select a.key 
+  (select a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_12'
 
@@ -16991,34 +16991,34 @@ POSTHOOK: Input: default@src/_/cbo
 118	val_118
 119	val_119
 12	val_12
-PREHOOK: query: create view cv1 as 
+PREHOOK: query: create view cv1 as
 
-select * 
+select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 where exists
 
-  (select a.key 
+  (select a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 PREHOOK: type: CREATEVIEW
 PREHOOK: Input: default@src/_/cbo
 PREHOOK: Output: database:default
 PREHOOK: Output: default@cv1
-POSTHOOK: query: create view cv1 as 
+POSTHOOK: query: create view cv1 as
 
-select * 
+select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 where exists
 
-  (select a.key 
+  (select a.key
 
-  from `src/_/cbo` a 
+  from `src/_/cbo` a
 
   where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 POSTHOOK: type: CREATEVIEW
@@ -17048,17 +17048,17 @@ POSTHOOK: Input: default@src/_/cbo
 97	val_97
 98	val_98
 98	val_98
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from (select * 
+from (select *
 
-      from `src/_/cbo` b 
+      from `src/_/cbo` b
 
-      where exists 
+      where exists
 
-          (select a.key 
+          (select a.key
 
-          from `src/_/cbo` a 
+          from `src/_/cbo` a
 
           where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 
@@ -17066,17 +17066,17 @@ from (select *
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from (select * 
+from (select *
 
-      from `src/_/cbo` b 
+      from `src/_/cbo` b
 
-      where exists 
+      where exists
 
-          (select a.key 
+          (select a.key
 
-          from `src/_/cbo` a 
+          from `src/_/cbo` a
 
           where b.value = a.value  and a.key = b.key and a.value > 'val_9')
 
@@ -17097,17 +17097,17 @@ POSTHOOK: Input: default@src/_/cbo
 98	val_98
 PREHOOK: query: select *
 
-from (select b.key, count(*) 
+from (select b.key, count(*)
 
-  from `src/_/cbo` b 
+  from `src/_/cbo` b
 
   group by b.key
 
-  having exists 
+  having exists
 
-    (select a.key 
+    (select a.key
 
-    from `src/_/cbo` a 
+    from `src/_/cbo` a
 
     where a.key = b.key and a.value > 'val_9'
 
@@ -17119,17 +17119,17 @@ PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
 POSTHOOK: query: select *
 
-from (select b.key, count(*) 
+from (select b.key, count(*)
 
-  from `src/_/cbo` b 
+  from `src/_/cbo` b
 
   group by b.key
 
-  having exists 
+  having exists
 
-    (select a.key 
+    (select a.key
 
-    from `src/_/cbo` a 
+    from `src/_/cbo` a
 
     where a.key = b.key and a.value > 'val_9'
 
@@ -17145,17 +17145,17 @@ POSTHOOK: Input: default@src/_/cbo
 96	1
 97	2
 98	2
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from `src/_/cbo` 
+from `src/_/cbo`
 
 where `src/_/cbo`.key in (select key from `src/_/cbo` s1 where s1.key > '9') order by key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from `src/_/cbo` 
+from `src/_/cbo`
 
 where `src/_/cbo`.key in (select key from `src/_/cbo` s1 where s1.key > '9') order by key
 POSTHOOK: type: QUERY
@@ -17172,15 +17172,15 @@ POSTHOOK: Input: default@src/_/cbo
 97	val_97
 98	val_98
 98	val_98
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 where b.key in
 
-        (select distinct a.key 
+        (select distinct a.key
 
-         from `src/_/cbo` a 
+         from `src/_/cbo` a
 
          where b.value = a.value and a.key > '9'
 
@@ -17188,15 +17188,15 @@ where b.key in
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from `src/_/cbo` b 
+from `src/_/cbo` b
 
 where b.key in
 
-        (select distinct a.key 
+        (select distinct a.key
 
-         from `src/_/cbo` a 
+         from `src/_/cbo` a
 
          where b.value = a.value and a.key > '9'
 
@@ -17215,9 +17215,9 @@ POSTHOOK: Input: default@src/_/cbo
 97	val_97
 98	val_98
 98	val_98
-PREHOOK: query: select p.p_partkey, li.l_suppkey 
+PREHOOK: query: select p.p_partkey, li.l_suppkey
 
-from (select distinct l_partkey as p_partkey from `line/item`) p join `line/item` li on p.p_partkey = li.l_partkey 
+from (select distinct l_partkey as p_partkey from `line/item`) p join `line/item` li on p.p_partkey = li.l_partkey
 
 where li.l_linenumber = 1 and
 
@@ -17227,9 +17227,9 @@ where li.l_linenumber = 1 and
 PREHOOK: type: QUERY
 PREHOOK: Input: default@line/item
 #### A masked pattern was here ####
-POSTHOOK: query: select p.p_partkey, li.l_suppkey 
+POSTHOOK: query: select p.p_partkey, li.l_suppkey
 
-from (select distinct l_partkey as p_partkey from `line/item`) p join `line/item` li on p.p_partkey = li.l_partkey 
+from (select distinct l_partkey as p_partkey from `line/item`) p join `line/item` li on p.p_partkey = li.l_partkey
 
 where li.l_linenumber = 1 and
 
@@ -17241,7 +17241,7 @@ POSTHOOK: Input: default@line/item
 #### A masked pattern was here ####
 108570	8571
 4297	1798
-PREHOOK: query: select key, value, count(*) 
+PREHOOK: query: select key, value, count(*)
 
 from `src/_/cbo` b
 
@@ -17253,7 +17253,7 @@ having count(*) in (select count(*) from `src/_/cbo` s1 where s1.key > '9' group
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select key, value, count(*) 
+POSTHOOK: query: select key, value, count(*)
 
 from `src/_/cbo` b
 
@@ -17279,25 +17279,25 @@ POSTHOOK: Input: default@src/_/cbo
 96	val_96	1
 97	val_97	2
 98	val_98	2
-PREHOOK: query: select p_mfgr, p_name, avg(p_size) 
+PREHOOK: query: select p_mfgr, p_name, avg(p_size)
 
-from `p/a/r/t` 
+from `p/a/r/t`
 
 group by p_mfgr, p_name
 
-having p_name in 
+having p_name in
 
   (select first_value(p_name) over(partition by p_mfgr order by p_size) from `p/a/r/t`) order by p_mfgr
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select p_mfgr, p_name, avg(p_size) 
+POSTHOOK: query: select p_mfgr, p_name, avg(p_size)
 
-from `p/a/r/t` 
+from `p/a/r/t`
 
 group by p_mfgr, p_name
 
-having p_name in 
+having p_name in
 
   (select first_value(p_name) over(partition by p_mfgr order by p_size) from `p/a/r/t`) order by p_mfgr
 POSTHOOK: type: QUERY
@@ -17308,13 +17308,13 @@ Manufacturer#2	almond aquamarine midnight light salmon	2.0
 Manufacturer#3	almond antique misty red olive	1.0
 Manufacturer#4	almond aquamarine yellow dodger mint	7.0
 Manufacturer#5	almond antique sky peru orange	2.0
-PREHOOK: query: select * 
+PREHOOK: query: select *
 
-from `src/_/cbo` 
+from `src/_/cbo`
 
-where `src/_/cbo`.key not in  
+where `src/_/cbo`.key not in
 
-  ( select key  from `src/_/cbo` s1 
+  ( select key  from `src/_/cbo` s1
 
     where s1.key > '2'
 
@@ -17322,13 +17322,13 @@ where `src/_/cbo`.key not in
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src/_/cbo
 #### A masked pattern was here ####
-POSTHOOK: query: select * 
+POSTHOOK: query: select *
 
-from `src/_/cbo` 
+from `src/_/cbo`
 
-where `src/_/cbo`.key not in  
+where `src/_/cbo`.key not in
 
-  ( select key  from `src/_/cbo` s1 
+  ( select key  from `src/_/cbo` s1
 
     where s1.key > '2'
 
@@ -17455,33 +17455,33 @@ POSTHOOK: Input: default@src/_/cbo
 199	val_199
 199	val_199
 2	val_2
-PREHOOK: query: select p_mfgr, b.p_name, p_size 
+PREHOOK: query: select p_mfgr, b.p_name, p_size
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
-where b.p_name not in 
+where b.p_name not in
 
-  (select p_name 
+  (select p_name
 
-  from (select p_mfgr, p_name, p_size as r from `p/a/r/t`) a 
+  from (select p_mfgr, p_name, p_size as r from `p/a/r/t`) a
 
-  where r < 10 and b.p_mfgr = a.p_mfgr 
+  where r < 10 and b.p_mfgr = a.p_mfgr
 
   ) order by p_mfgr,p_size
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select p_mfgr, b.p_name, p_size 
+POSTHOOK: query: select p_mfgr, b.p_name, p_size
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
-where b.p_name not in 
+where b.p_name not in
 
-  (select p_name 
+  (select p_name
 
-  from (select p_mfgr, p_name, p_size as r from `p/a/r/t`) a 
+  from (select p_mfgr, p_name, p_size as r from `p/a/r/t`) a
 
-  where r < 10 and b.p_mfgr = a.p_mfgr 
+  where r < 10 and b.p_mfgr = a.p_mfgr
 
   ) order by p_mfgr,p_size
 POSTHOOK: type: QUERY
@@ -17505,15 +17505,15 @@ Manufacturer#4	almond azure aquamarine papaya violet	12
 Manufacturer#5	almond antique blue firebrick mint	31
 Manufacturer#5	almond aquamarine dodger light gainsboro	46
 Manufacturer#5	almond azure blanched chiffon midnight	23
-PREHOOK: query: select p_name, p_size 
+PREHOOK: query: select p_name, p_size
 
-from 
+from
 
-`p/a/r/t` where `p/a/r/t`.p_size not in 
+`p/a/r/t` where `p/a/r/t`.p_size not in
 
-  (select avg(p_size) 
+  (select avg(p_size)
 
-  from (select p_size from `p/a/r/t`) a 
+  from (select p_size from `p/a/r/t`) a
 
   where p_size < 10
 
@@ -17521,15 +17521,15 @@ from
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select p_name, p_size 
+POSTHOOK: query: select p_name, p_size
 
-from 
+from
 
-`p/a/r/t` where `p/a/r/t`.p_size not in 
+`p/a/r/t` where `p/a/r/t`.p_size not in
 
-  (select avg(p_size) 
+  (select avg(p_size)
 
-  from (select p_size from `p/a/r/t`) a 
+  from (select p_size from `p/a/r/t`) a
 
   where p_size < 10
 
@@ -17563,13 +17563,13 @@ almond aquamarine sandy cyan gainsboro	18
 almond aquamarine yellow dodger mint	7
 almond azure aquamarine papaya violet	12
 almond azure blanched chiffon midnight	23
-PREHOOK: query: select p_mfgr, p_name, p_size 
+PREHOOK: query: select p_mfgr, p_name, p_size
 
-from `p/a/r/t` b where b.p_size not in 
+from `p/a/r/t` b where b.p_size not in
 
-  (select min(p_size) 
+  (select min(p_size)
 
-  from (select p_mfgr, p_size from `p/a/r/t`) a 
+  from (select p_mfgr, p_size from `p/a/r/t`) a
 
   where p_size < 10 and b.p_mfgr = a.p_mfgr
 
@@ -17577,13 +17577,13 @@ from `p/a/r/t` b where b.p_size not in
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select p_mfgr, p_name, p_size 
+POSTHOOK: query: select p_mfgr, p_name, p_size
 
-from `p/a/r/t` b where b.p_size not in 
+from `p/a/r/t` b where b.p_size not in
 
-  (select min(p_size) 
+  (select min(p_size)
 
-  from (select p_mfgr, p_size from `p/a/r/t`) a 
+  from (select p_mfgr, p_size from `p/a/r/t`) a
 
   where p_size < 10 and b.p_mfgr = a.p_mfgr
 
@@ -17611,25 +17611,25 @@ Manufacturer#5	almond antique blue firebrick mint	31
 Manufacturer#5	almond antique medium spring khaki	6
 Manufacturer#5	almond aquamarine dodger light gainsboro	46
 Manufacturer#5	almond azure blanched chiffon midnight	23
-PREHOOK: query: select li.l_partkey, count(*) 
+PREHOOK: query: select li.l_partkey, count(*)
 
-from `line/item` li 
+from `line/item` li
 
-where li.l_linenumber = 1 and 
+where li.l_linenumber = 1 and
 
-  li.l_orderkey not in (select l_orderkey from `line/item` where l_shipmode = 'AIR') 
+  li.l_orderkey not in (select l_orderkey from `line/item` where l_shipmode = 'AIR')
 
 group by li.l_partkey order by li.l_partkey
 PREHOOK: type: QUERY
 PREHOOK: Input: default@line/item
 #### A masked pattern was here ####
-POSTHOOK: query: select li.l_partkey, count(*) 
+POSTHOOK: query: select li.l_partkey, count(*)
 
-from `line/item` li 
+from `line/item` li
 
-where li.l_linenumber = 1 and 
+where li.l_linenumber = 1 and
 
-  li.l_orderkey not in (select l_orderkey from `line/item` where l_shipmode = 'AIR') 
+  li.l_orderkey not in (select l_orderkey from `line/item` where l_shipmode = 'AIR')
 
 group by li.l_partkey order by li.l_partkey
 POSTHOOK: type: QUERY
@@ -17651,17 +17651,17 @@ POSTHOOK: Input: default@line/item
 85951	1
 88035	1
 88362	1
-PREHOOK: query: select b.p_mfgr, min(p_retailprice) 
+PREHOOK: query: select b.p_mfgr, min(p_retailprice)
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
 group by b.p_mfgr
 
-having b.p_mfgr not in 
+having b.p_mfgr not in
 
-  (select p_mfgr 
+  (select p_mfgr
 
-  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from `p/a/r/t` group by p_mfgr) a 
+  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from `p/a/r/t` group by p_mfgr) a
 
   where min(p_retailprice) = l and r - l > 600
 
@@ -17671,17 +17671,17 @@ having b.p_mfgr not in
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select b.p_mfgr, min(p_retailprice) 
+POSTHOOK: query: select b.p_mfgr, min(p_retailprice)
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
 group by b.p_mfgr
 
-having b.p_mfgr not in 
+having b.p_mfgr not in
 
-  (select p_mfgr 
+  (select p_mfgr
 
-  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from `p/a/r/t` group by p_mfgr) a 
+  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from `p/a/r/t` group by p_mfgr) a
 
   where min(p_retailprice) = l and r - l > 600
 
@@ -17693,15 +17693,15 @@ POSTHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
 Manufacturer#1	1173.15
 Manufacturer#2	1690.68
-PREHOOK: query: select b.p_mfgr, min(p_retailprice) 
+PREHOOK: query: select b.p_mfgr, min(p_retailprice)
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
 group by b.p_mfgr
 
-having b.p_mfgr not in 
+having b.p_mfgr not in
 
-  (select p_mfgr 
+  (select p_mfgr
 
   from `p/a/r/t` a
 
@@ -17715,15 +17715,15 @@ having b.p_mfgr not in
 PREHOOK: type: QUERY
 PREHOOK: Input: default@p/a/r/t
 #### A masked pattern was here ####
-POSTHOOK: query: select b.p_mfgr, min(p_retailprice) 
+POSTHOOK: query: select b.p_mfgr, min(p_retailprice)
 
-from `p/a/r/t` b 
+from `p/a/r/t` b
 
 group by b.p_mfgr
 
-having b.p_mfgr not in 
+having b.p_mfgr not in
 
-  (select p_mfgr 
+  (select p_mfgr
 
   from `p/a/r/t` a
 
@@ -17934,12 +17934,12 @@ POSTHOOK: Input: default@cbo_/t3////
  1
  1
  1
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
 1
 1
 1
@@ -17965,12 +17965,12 @@ POSTHOOK: Input: default@cbo_/t3////
 1
 1
 1
-1 
-1 
-1 
-1 
-1 
-1 
+1
+1
+1
+1
+1
+1
 2
 2
 2
@@ -18034,42 +18034,42 @@ POSTHOOK: Input: default@cbo_/t3////
  1
  1
  1
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
- 1 
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
 1
 1
 1
@@ -18670,42 +18670,42 @@ POSTHOOK: Input: default@cbo_/t3////
 1
 1
 1
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
-1 
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
 2
 2
 2

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
@@ -1,0 +1,4770 @@
+PREHOOK: query: create database "db~!@@#$%^&*(),<>"
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: query: create database "db~!@@#$%^&*(),<>"
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: query: use "db~!@@#$%^&*(),<>"
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:db~!@@#$%^&*(),<>
+POSTHOOK: query: use "db~!@@#$%^&*(),<>"
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:db~!@@#$%^&*(),<>
+PREHOOK: query: create table "c/b/o_t1"(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: query: create table "c/b/o_t1"(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: query: create table "//cbo_t2"(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: query: create table "//cbo_t2"(key string, value string, c_int int, c_float float, c_boolean boolean)  partitioned by (dt string) row format delimited fields terminated by ',' STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: query: create table "cbo_/t3////"(key string, value string, c_int int, c_float float, c_boolean boolean)  row format delimited fields terminated by ',' STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: query: create table "cbo_/t3////"(key string, value string, c_int int, c_float float, c_boolean boolean)  row format delimited fields terminated by ',' STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+PREHOOK: query: load data local inpath '../../data/files/cbo_t1.txt' into table "c/b/o_t1" partition (dt='2014')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: query: load data local inpath '../../data/files/cbo_t1.txt' into table "c/b/o_t1" partition (dt='2014')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: query: load data local inpath '../../data/files/cbo_t2.txt' into table "//cbo_t2" partition (dt='2014')
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: query: load data local inpath '../../data/files/cbo_t2.txt' into table "//cbo_t2" partition (dt='2014')
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: query: load data local inpath '../../data/files/cbo_t3.txt' into table "cbo_/t3////"
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: query: load data local inpath '../../data/files/cbo_t3.txt' into table "cbo_/t3////"
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+PREHOOK: query: CREATE TABLE "p/a/r/t"(
+    p_partkey INT,
+    p_name STRING,
+    p_mfgr STRING,
+    p_brand STRING,
+    p_type STRING,
+    p_size INT,
+    p_container STRING,
+    p_retailprice DOUBLE,
+    p_comment STRING
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+POSTHOOK: query: CREATE TABLE "p/a/r/t"(
+    p_partkey INT,
+    p_name STRING,
+    p_mfgr STRING,
+    p_brand STRING,
+    p_type STRING,
+    p_size INT,
+    p_container STRING,
+    p_retailprice DOUBLE,
+    p_comment STRING
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/part.tbl.bz2' overwrite into table "p/a/r/t"
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/part.tbl.bz2' overwrite into table "p/a/r/t"
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+PREHOOK: query: CREATE TABLE "line/item" (L_ORDERKEY      INT,
+                                L_PARTKEY       INT,
+                                L_SUPPKEY       INT,
+                                L_LINENUMBER    INT,
+                                L_QUANTITY      DOUBLE,
+                                L_EXTENDEDPRICE DOUBLE,
+                                L_DISCOUNT      DOUBLE,
+                                L_TAX           DOUBLE,
+                                L_RETURNFLAG    STRING,
+                                L_LINESTATUS    STRING,
+                                l_shipdate      STRING,
+                                L_COMMITDATE    STRING,
+                                L_RECEIPTDATE   STRING,
+                                L_SHIPINSTRUCT  STRING,
+                                L_SHIPMODE      STRING,
+                                L_COMMENT       STRING)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY '|'
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@line/item
+POSTHOOK: query: CREATE TABLE "line/item" (L_ORDERKEY      INT,
+                                L_PARTKEY       INT,
+                                L_SUPPKEY       INT,
+                                L_LINENUMBER    INT,
+                                L_QUANTITY      DOUBLE,
+                                L_EXTENDEDPRICE DOUBLE,
+                                L_DISCOUNT      DOUBLE,
+                                L_TAX           DOUBLE,
+                                L_RETURNFLAG    STRING,
+                                L_LINESTATUS    STRING,
+                                l_shipdate      STRING,
+                                L_COMMITDATE    STRING,
+                                L_RECEIPTDATE   STRING,
+                                L_SHIPINSTRUCT  STRING,
+                                L_SHIPMODE      STRING,
+                                L_COMMENT       STRING)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY '|'
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@line/item
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/lineitem.tbl.bz2' OVERWRITE INTO TABLE "line/item"
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: db~!@@#$%^&*(),<>@line/item
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/tpch/tiny/lineitem.tbl.bz2' OVERWRITE INTO TABLE "line/item"
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: db~!@@#$%^&*(),<>@line/item
+PREHOOK: query: create table "src/_/cbo" as select * from default.src
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@src
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: query: create table "src/_/cbo" as select * from default.src
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@src
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
+POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
+PREHOOK: query: analyze table "c/b/o_t1" compute statistics for columns key, value, c_int, c_float, c_boolean
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "c/b/o_t1" compute statistics for columns key, value, c_int, c_float, c_boolean
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+PREHOOK: query: analyze table "//cbo_t2" compute statistics for columns key, value, c_int, c_float, c_boolean
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "//cbo_t2" compute statistics for columns key, value, c_int, c_float, c_boolean
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+#### A masked pattern was here ####
+PREHOOK: query: analyze table "cbo_/t3////" compute statistics for columns key, value, c_int, c_float, c_boolean
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "cbo_/t3////" compute statistics for columns key, value, c_int, c_float, c_boolean
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+PREHOOK: query: analyze table "src/_/cbo" compute statistics for columns
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "src/_/cbo" compute statistics for columns
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+PREHOOK: query: analyze table "p/a/r/t" compute statistics for columns
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+PREHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "p/a/r/t" compute statistics for columns
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+PREHOOK: query: analyze table "line/item" compute statistics for columns
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: db~!@@#$%^&*(),<>@line/item
+PREHOOK: Output: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table "line/item" compute statistics for columns
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: db~!@@#$%^&*(),<>@line/item
+POSTHOOK: Output: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+PREHOOK: query: select key, (c_int+1)+2 as x, sum(c_int) from "c/b/o_t1" group by c_float, "c/b/o_t1".c_int, key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: select key, (c_int+1)+2 as x, sum(c_int) from "c/b/o_t1" group by c_float, "c/b/o_t1".c_int, key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+ 1	4	2
+ 1 	4	2
+1	4	12
+1 	4	2
+NULL	NULL	NULL
+PREHOOK: query: explain select unionsrc.key FROM (select 'max' as key, max(c_int) as value from "cbo_/t3////" s1
+
+UNION  ALL
+
+    select 'min' as key,  min(c_int) as value from "cbo_/t3////" s2
+
+    UNION ALL
+
+        select 'avg' as key,  avg(c_int) as value from "cbo_/t3////" s3) unionsrc order by unionsrc.key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+POSTHOOK: query: explain select unionsrc.key FROM (select 'max' as key, max(c_int) as value from "cbo_/t3////" s1
+
+UNION  ALL
+
+    select 'min' as key,  min(c_int) as value from "cbo_/t3////" s2
+
+    UNION ALL
+
+        select 'avg' as key,  avg(c_int) as value from "cbo_/t3////" s3) unionsrc order by unionsrc.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: s1
+                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: c_int (type: int)
+                    outputColumnNames: c_int
+                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: max(c_int)
+                      minReductionHashAggr: 0.95
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: s2
+                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: c_int (type: int)
+                    outputColumnNames: c_int
+                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(c_int)
+                      minReductionHashAggr: 0.95
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 7 
+            Map Operator Tree:
+                TableScan
+                  alias: s3
+                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: c_int (type: int)
+                    outputColumnNames: c_int
+                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: avg(c_int)
+                      minReductionHashAggr: 0.95
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: struct<count:bigint,sum:double,input:int>)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'max' (type: string)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0
+                Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'min' (type: string)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: avg(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'avg' (type: string)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 3 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select "c/b/o_t1".key from "c/b/o_t1" join "cbo_/t3////"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+POSTHOOK: query: explain select "c/b/o_t1".key from "c/b/o_t1" join "cbo_/t3////"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Map 3 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  Statistics: Num rows: 20 Data size: 1615 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 20 Data size: 1615 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: key (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: cbo_/t3////
+                  Statistics: Num rows: 20 Data size: 262 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 20 Data size: 262 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0
+                Statistics: Num rows: 400 Data size: 33915 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 400 Data size: 33915 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select "c/b/o_t1".c_int, "//cbo_t2".c_int from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".key="//cbo_t2".key where ("c/b/o_t1".c_int + "//cbo_t2".c_int == 2) and ("c/b/o_t1".c_int > 0 or "//cbo_t2".c_float >= 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select "c/b/o_t1".c_int, "//cbo_t2".c_int from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".key="//cbo_t2".key where ("c/b/o_t1".c_int + "//cbo_t2".c_int == 2) and ("c/b/o_t1".c_int > 0 or "//cbo_t2".c_float >= 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1691 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 18 Data size: 1513 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 18 Data size: 1513 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: c_int (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: //cbo_t2
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 18 Data size: 1581 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 18 Data size: 1581 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: c_int (type: int), c_float (type: float)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 key (type: string)
+                outputColumnNames: _col2, _col12, _col13
+                Statistics: Num rows: 64 Data size: 756 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (((_col2 + _col12) = 2) and ((_col2 > 0) or (_col13 >= 0.0))) (type: boolean)
+                  Statistics: Num rows: 32 Data size: 384 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: int), _col12 (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 32 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 32 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select key, (c_int+1)+2 as x, sum(c_int) from "c/b/o_t1" group by c_float, "c/b/o_t1".c_int, key order by x limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select key, (c_int+1)+2 as x, sum(c_int) from "c/b/o_t1" group by c_float, "c/b/o_t1".c_int, key order by x limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), c_int (type: int), c_float (type: float)
+                    outputColumnNames: key, c_int, c_float
+                    Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(c_int)
+                      keys: c_float (type: float), c_int (type: int), key (type: string)
+                      minReductionHashAggr: 0.6
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 10 Data size: 1010 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: float), _col1 (type: int), _col2 (type: string)
+                        null sort order: zzz
+                        sort order: +++
+                        Map-reduce partition columns: _col0 (type: float), _col1 (type: int), _col2 (type: string)
+                        Statistics: Num rows: 10 Data size: 1010 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col3 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: float), KEY._col1 (type: int), KEY._col2 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 10 Data size: 1010 Basic stats: COMPLETE Column stats: COMPLETE
+                Top N Key Operator
+                  sort order: +
+                  keys: ((_col1 + 1) + 2) (type: int)
+                  null sort order: z
+                  Statistics: Num rows: 10 Data size: 1010 Basic stats: COMPLETE Column stats: COMPLETE
+                  top n: 1
+                  Select Operator
+                    expressions: _col2 (type: string), ((_col1 + 1) + 2) (type: int), _col3 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 10 Data size: 885 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 10 Data size: 885 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: string), _col2 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: string), KEY.reducesinkkey0 (type: int), VALUE._col1 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 10 Data size: 885 Basic stats: COMPLETE Column stats: COMPLETE
+                Limit
+                  Number of rows: 1
+                  Statistics: Num rows: 1 Data size: 97 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 97 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: 1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select "c/b/o_t1".c_int           from "c/b/o_t1" left semi join   "//cbo_t2" on "c/b/o_t1".key="//cbo_t2".key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select "c/b/o_t1".c_int           from "c/b/o_t1" left semi join   "//cbo_t2" on "c/b/o_t1".key="//cbo_t2".key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1691 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 18 Data size: 1513 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 18 Data size: 1513 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: c_int (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: //cbo_t2
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1615 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 18 Data size: 1445 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 18 Data size: 1445 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.6666666
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col2
+                Statistics: Num rows: 18 Data size: 68 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col2 (type: int)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 18 Data size: 68 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 18 Data size: 68 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from "c/b/o_t1" as "c/b/o_t1"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from "c/b/o_t1" as "c/b/o_t1"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: c/b/o_t1
+          Select Operator
+            expressions: key (type: string), value (type: string), c_int (type: int), c_float (type: float), c_boolean (type: boolean), dt (type: string)
+            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+            ListSink
+
+PREHOOK: query: explain select * from "c/b/o_t1" as "c/b/o_t1"  where "c/b/o_t1".c_int >= 0 and c_float+c_int >= 0 or c_float <= 100
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from "c/b/o_t1" as "c/b/o_t1"  where "c/b/o_t1".c_int >= 0 and c_float+c_int >= 0 or c_float <= 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: c/b/o_t1
+          filterExpr: (((c_int >= 0) and ((c_float + c_int) >= 0)) or (c_float <= 100.0)) (type: boolean)
+          Filter Operator
+            predicate: (((c_int >= 0) and ((c_float + c_int) >= 0)) or (c_float <= 100.0)) (type: boolean)
+            Select Operator
+              expressions: key (type: string), value (type: string), c_int (type: int), c_float (type: float), c_boolean (type: boolean), dt (type: string)
+              outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+              ListSink
+
+PREHOOK: query: explain select * from (select * from "c/b/o_t1" where "c/b/o_t1".c_int >= 0) as "c/b/o_t1"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from (select * from "c/b/o_t1" where "c/b/o_t1".c_int >= 0) as "c/b/o_t1"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: c/b/o_t1
+          filterExpr: (c_int >= 0) (type: boolean)
+          Filter Operator
+            predicate: (c_int >= 0) (type: boolean)
+            Select Operator
+              expressions: key (type: string), value (type: string), c_int (type: int), c_float (type: float), c_boolean (type: boolean), dt (type: string)
+              outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+              ListSink
+
+PREHOOK: query: explain select null from "cbo_/t3////"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+POSTHOOK: query: explain select null from "cbo_/t3////"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@cbo_/t3////
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: cbo_/t3////
+          Select Operator
+            expressions: null (type: void)
+            outputColumnNames: _col0
+            ListSink
+
+PREHOOK: query: explain select key from "c/b/o_t1" where c_int = -6  or c_int = +6
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select key from "c/b/o_t1" where c_int = -6  or c_int = +6
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: c/b/o_t1
+          filterExpr: (c_int) IN (-6, 6) (type: boolean)
+          Filter Operator
+            predicate: (c_int) IN (-6, 6) (type: boolean)
+            Select Operator
+              expressions: key (type: string)
+              outputColumnNames: _col0
+              ListSink
+
+PREHOOK: query: explain select count("c/b/o_t1".dt) from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".dt  = "//cbo_t2".dt  where "c/b/o_t1".dt = '2014'
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select count("c/b/o_t1".dt) from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".dt  = "//cbo_t2".dt  where "c/b/o_t1".dt = '2014'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  filterExpr: (dt = '2014') (type: boolean)
+                  Statistics: Num rows: 20 Data size: 2022 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: '2014' (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: '2014' (type: string)
+                    Statistics: Num rows: 20 Data size: 2022 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: '2014' (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 20 Data size: 1760 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: _col0 (type: string)
+                      minReductionHashAggr: 0.95
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                      Dynamic Partitioning Event Operator
+                        Target column: dt (string)
+                        Target Input: //cbo_t2
+                        Partition key expr: dt
+                        Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                        Target Vertex: Map 4
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: //cbo_t2
+                  filterExpr: (dt = '2014') (type: boolean)
+                  Statistics: Num rows: 20 Data size: 2022 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: '2014' (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: '2014' (type: string)
+                    Statistics: Num rows: 20 Data size: 2022 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 '2014' (type: string)
+                  1 '2014' (type: string)
+                Statistics: Num rows: 400 Data size: 3200 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: '2014' (type: string)
+                  outputColumnNames: _col5
+                  Statistics: Num rows: 400 Data size: 3200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: count(_col5)
+                    minReductionHashAggr: 0.99
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select "c/b/o_t1".value from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".key = "//cbo_t2".key where "c/b/o_t1".dt = '10' and "c/b/o_t1".c_boolean = true
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain select "c/b/o_t1".value from "c/b/o_t1" join "//cbo_t2" on "c/b/o_t1".key = "//cbo_t2".key where "c/b/o_t1".dt = '10' and "c/b/o_t1".c_boolean = true
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  filterExpr: (key is not null and (dt = '10') and (c_boolean = true)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 458 Basic stats: COMPLETE Column stats: PARTIAL
+                  Filter Operator
+                    predicate: (key is not null and (dt = '10') and (c_boolean = true)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 458 Basic stats: COMPLETE Column stats: PARTIAL
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 1 Data size: 458 Basic stats: COMPLETE Column stats: PARTIAL
+                      value expressions: value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: unknown
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: //cbo_t2
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 20 Data size: 1615 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 18 Data size: 1445 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 18 Data size: 1445 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 key (type: string)
+                outputColumnNames: _col1
+                Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: PARTIAL
+                Select Operator
+                  expressions: _col1 (type: string)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: PARTIAL
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 3 Data size: 552 Basic stats: COMPLETE Column stats: PARTIAL
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+where not exists
+
+  (select distinct a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value and a.value > 'val_2'
+
+  )
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+where not exists
+
+  (select distinct a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value and a.value > 'val_2'
+
+  )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: value (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: value (type: string)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: key (type: string)
+                  Filter Operator
+                    predicate: (value > 'val_2') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: string), value (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 value (type: string)
+                  1 _col1 (type: string)
+                outputColumnNames: _col0, _col1, _col7
+                Statistics: Num rows: 770 Data size: 161721 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col7 is null (type: boolean)
+                  Statistics: Num rows: 500 Data size: 105016 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 105016 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 500 Data size: 105016 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: string)
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: string)
+                    Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+group by key, value
+
+having not exists
+
+  (select a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value  and a.key = b.key and a.value > 'val_12'
+
+  )
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+group by key, value
+
+having not exists
+
+  (select a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value  and a.key = b.key and a.value > 'val_12'
+
+  )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string)
+                    outputColumnNames: key, value
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: string), value (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (value > 'val_12') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: value (type: string), key (type: string)
+                      outputColumnNames: _col1, _col2
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: string), _col2 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col1 (type: string), _col2 (type: string)
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string), _col0 (type: string)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col1 (type: string), _col0 (type: string)
+                  Statistics: Num rows: 316 Data size: 56248 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col1 (type: string), _col0 (type: string)
+                  1 _col1 (type: string), _col2 (type: string)
+                outputColumnNames: _col0, _col1, _col4
+                Statistics: Num rows: 482 Data size: 100325 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col4 is null (type: boolean)
+                  Statistics: Num rows: 316 Data size: 65818 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 316 Data size: 65818 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 316 Data size: 65818 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: create view cv1_n0 as
+
+select *
+
+from "src/_/cbo" b
+
+where exists
+
+  (select a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value  and a.key = b.key and a.value > 'val_9')
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@cv1_n0
+POSTHOOK: query: create view cv1_n0 as
+
+select *
+
+from "src/_/cbo" b
+
+where exists
+
+  (select a.key
+
+  from "src/_/cbo" a
+
+  where b.value = a.value  and a.key = b.key and a.value > 'val_9')
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cv1_n0
+POSTHOOK: Lineage: cv1_n0.key EXPRESSION [(src/_/cbo)b.FieldSchema(name:key, type:string, comment:null), ]
+POSTHOOK: Lineage: cv1_n0.value EXPRESSION [(src/_/cbo)b.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select * from cv1_n0
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@cv1_n0
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: select * from cv1_n0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@cv1_n0
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+90	val_90
+90	val_90
+90	val_90
+92	val_92
+95	val_95
+95	val_95
+96	val_96
+97	val_97
+97	val_97
+98	val_98
+98	val_98
+PREHOOK: query: explain select *
+
+from (select *
+
+      from "src/_/cbo" b
+
+      where exists
+
+          (select a.key
+
+          from "src/_/cbo" a
+
+          where b.value = a.value  and a.key = b.key and a.value > 'val_9')
+
+     ) a
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from (select *
+
+      from "src/_/cbo" b
+
+      where exists
+
+          (select a.key
+
+          from "src/_/cbo" a
+
+          where b.value = a.value  and a.key = b.key and a.value > 'val_9')
+
+     ) a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: (value is not null and key is not null) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (value is not null and key is not null) (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: value (type: string), key (type: string)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: value (type: string), key (type: string)
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: ((value > 'val_9') and key is not null) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((value > 'val_9') and key is not null) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: value (type: string), key (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string), _col1 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string), _col1 (type: string)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                          Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 value (type: string), key (type: string)
+                  1 _col0 (type: string), _col1 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from (select b.key, count(*)
+
+  from "src/_/cbo" b
+
+  group by b.key
+
+  having exists
+
+    (select a.key
+
+    from "src/_/cbo" a
+
+    where a.key = b.key and a.value > 'val_9'
+
+    )
+
+) a
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from (select b.key, count(*)
+
+  from "src/_/cbo" b
+
+  group by b.key
+
+  having exists
+
+    (select a.key
+
+    from "src/_/cbo" a
+
+    where a.key = b.key and a.value > 'val_9'
+
+    )
+
+) a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: (((value > 'val_9') and key is not null) or key is not null) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((value > 'val_9') and key is not null) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 166 Data size: 15770 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: bigint)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from "src/_/cbo"
+
+where "src/_/cbo".key in (select key from "src/_/cbo" s1 where s1.key > '9') order by key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from "src/_/cbo"
+
+where "src/_/cbo".key in (select key from "src/_/cbo" s1 where s1.key > '9') order by key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src/_/cbo
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: s1
+                  filterExpr: (key > '9') (type: boolean)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key > '9') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 105 Data size: 9135 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 105 Data size: 9135 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+where b.key in
+
+        (select distinct a.key
+
+         from "src/_/cbo" a
+
+         where b.value = a.value and a.key > '9'
+
+        ) order by b.key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from "src/_/cbo" b
+
+where b.key in
+
+        (select distinct a.key
+
+         from "src/_/cbo" a
+
+         where b.value = a.value and a.key > '9'
+
+        ) order by b.key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: ((key is not null and value is not null) or ((key > '9') and value is not null)) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key is not null and value is not null) (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string), value (type: string)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: key (type: string), value (type: string)
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((key > '9') and value is not null) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: string), value (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 key (type: string), value (type: string)
+                  1 _col0 (type: string), _col1 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 262 Data size: 46636 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  keys: _col0 (type: string), _col1 (type: string)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col1 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select p.p_partkey, li.l_suppkey
+
+from (select distinct l_partkey as p_partkey from "line/item") p join "line/item" li on p.p_partkey = li.l_partkey
+
+where li.l_linenumber = 1 and
+
+ li.l_orderkey in (select l_orderkey from "line/item" where l_shipmode = 'AIR' and l_linenumber = li.l_linenumber)
+
+ order by p.p_partkey
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+POSTHOOK: query: explain select p.p_partkey, li.l_suppkey
+
+from (select distinct l_partkey as p_partkey from "line/item") p join "line/item" li on p.p_partkey = li.l_partkey
+
+where li.l_linenumber = 1 and
+
+ li.l_orderkey in (select l_orderkey from "line/item" where l_shipmode = 'AIR' and l_linenumber = li.l_linenumber)
+
+ order by p.p_partkey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: line/item
+                  filterExpr: (((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) or l_partkey is not null or (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1))) (type: boolean)
+                  Statistics: Num rows: 100 Data size: 9600 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: l_orderkey (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: int), 1 (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), 1 (type: int)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), 1 (type: int)
+                          Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: l_partkey is not null (type: boolean)
+                    Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: l_partkey (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
+                    Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: l_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: l_partkey (type: int)
+                      Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: l_orderkey (type: int), l_suppkey (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col1 (type: int), 1 (type: int)
+                  1 _col0 (type: int), 1 (type: int)
+                outputColumnNames: _col0, _col3
+                Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col3 (type: int)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: int)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 l_partkey (type: int)
+                outputColumnNames: _col0, _col1, _col3
+                Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: int), 1 (type: int)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col1 (type: int), 1 (type: int)
+                  Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col3 (type: int)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select key, value, count(*)
+
+from "src/_/cbo" b
+
+where b.key in (select key from "src/_/cbo" where "src/_/cbo".key > '8')
+
+group by key, value
+
+having count(*) in (select count(*) from "src/_/cbo" s1 where s1.key > '9' group by s1.key ) order by key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select key, value, count(*)
+
+from "src/_/cbo" b
+
+where b.key in (select key from "src/_/cbo" where "src/_/cbo".key > '8')
+
+group by key, value
+
+having count(*) in (select count(*) from "src/_/cbo" s1 where s1.key > '9' group by s1.key ) order by key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: key (type: string)
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: src/_/cbo
+                  filterExpr: ((key > '8') or (key > '9')) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key > '8') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 105 Data size: 9135 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 105 Data size: 9135 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key > '9') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 105 Data size: 9975 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 105 Data size: 9975 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 key (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  keys: _col0 (type: string), _col1 (type: string)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col1 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                    Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col2 is not null (type: boolean)
+                  Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col2 (type: bigint)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col2 (type: bigint)
+                    Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: string), _col1 (type: string)
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col2 (type: bigint)
+                  1 _col0 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string), _col2 (type: bigint)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 102 Data size: 18972 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 105 Data size: 9975 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: bigint)
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 105 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col1 is not null (type: boolean)
+                    Statistics: Num rows: 105 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: bigint)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 105 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: bigint)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 105 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: bigint)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: bigint)
+                          Statistics: Num rows: 105 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select p_mfgr, p_name, avg(p_size)
+
+from "p/a/r/t"
+
+group by p_mfgr, p_name
+
+having p_name in
+
+  (select first_value(p_name) over(partition by p_mfgr order by p_size) from "p/a/r/t") order by p_mfgr
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select p_mfgr, p_name, avg(p_size)
+
+from "p/a/r/t"
+
+group by p_mfgr, p_name
+
+having p_name in
+
+  (select first_value(p_name) over(partition by p_mfgr order by p_size) from "p/a/r/t") order by p_mfgr
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: p/a/r/t
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: p_mfgr (type: string), p_size (type: int)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: p_mfgr (type: string)
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: p_name (type: string)
+                  Filter Operator
+                    predicate: p_name is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: avg(p_size)
+                      keys: p_mfgr (type: string), p_name (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 25 Data size: 7375 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 25 Data size: 7375 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col2 (type: struct<count:bigint,sum:double,input:int>)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string), KEY.reducesinkkey1 (type: int)
+                outputColumnNames: _col1, _col2, _col5
+                Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string, _col5: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col5 ASC NULLS LAST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: first_value_window_0
+                              arguments: _col1
+                              name: first_value
+                              window function: GenericUDAFFirstValueEvaluator
+                              window frame: RANGE PRECEDING(MAX)~CURRENT
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: first_value_window_0 is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: first_value_window_0 (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 26 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 26 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 26 Data size: 4784 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col1 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string), _col2 (type: double)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: double)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: avg(VALUE._col0)
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: string)
+                  Statistics: Num rows: 25 Data size: 5675 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string), _col2 (type: double)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select *
+
+from "src/_/cbo"
+
+where "src/_/cbo".key not in
+
+  ( select key  from "src/_/cbo" s1
+
+    where s1.key > '2'
+
+  ) order by key
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select *
+
+from "src/_/cbo"
+
+where "src/_/cbo".key not in
+
+  ( select key  from "src/_/cbo" s1
+
+    where s1.key > '2'
+
+  ) order by key
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src/_/cbo
+                  filterExpr: (key is not null or (key > '2') or ((key > '2') and key is null)) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: key (type: string), value (type: string)
+                  Filter Operator
+                    predicate: (key > '2') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((key > '2') and key is null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col6
+                Statistics: Num rows: 762 Data size: 158517 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 500 Data size: 104051 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 500 Data size: 104051 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 500 Data size: 104051 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select p_mfgr, b.p_name, p_size
+
+from "p/a/r/t" b
+
+where b.p_name not in
+
+  (select p_name
+
+  from (select p_mfgr, p_name, p_size as r from "p/a/r/t") a
+
+  where r < 10 and b.p_mfgr = a.p_mfgr
+
+  ) order by p_mfgr,p_size
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select p_mfgr, b.p_name, p_size
+
+from "p/a/r/t" b
+
+where b.p_name not in
+
+  (select p_name
+
+  from (select p_mfgr, p_name, p_size as r from "p/a/r/t") a
+
+  where r < 10 and b.p_mfgr = a.p_mfgr
+
+  ) order by p_mfgr,p_size
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: ((p_name is not null and p_mfgr is not null) or ((p_size < 10) and p_name is not null and p_mfgr is not null) or ((p_size < 10) and (p_name is null or p_mfgr is null))) (type: boolean)
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (p_name is not null and p_mfgr is not null) (type: boolean)
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
+                  Filter Operator
+                    predicate: ((p_size < 10) and p_name is not null and p_mfgr is not null) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 1115 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_name (type: string), p_mfgr (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 1095 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                        Statistics: Num rows: 5 Data size: 1095 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((p_size < 10) and (p_name is null or p_mfgr is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 223 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 223 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col1, _col2, _col5
+                Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col1 (type: string), _col2 (type: string)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col1 (type: string), _col2 (type: string)
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col5 (type: int)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col1 (type: string), _col2 (type: string)
+                  1 _col0 (type: string), _col1 (type: string)
+                outputColumnNames: _col1, _col2, _col5, _col13
+                Statistics: Num rows: 31 Data size: 7639 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col13 is null (type: boolean)
+                  Statistics: Num rows: 26 Data size: 6403 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col1 (type: string), _col5 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string), _col2 (type: int)
+                      null sort order: zz
+                      sort order: ++
+                      Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), KEY.reducesinkkey1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select p_name, p_size
+
+from
+
+"p/a/r/t" where "p/a/r/t".p_size not in
+
+  (select avg(p_size)
+
+  from (select p_size from "p/a/r/t") a
+
+  where p_size < 10
+
+  ) order by p_name
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select p_name, p_size
+
+from
+
+"p/a/r/t" where "p/a/r/t".p_size not in
+
+  (select avg(p_size)
+
+  from (select p_size from "p/a/r/t") a
+
+  where p_size < 10
+
+  ) order by p_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: p/a/r/t
+                  filterExpr: (UDFToDouble(p_size) is not null or (p_size < 10)) (type: boolean)
+                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: UDFToDouble(p_size) is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: p_name (type: string), p_size (type: int)
+                  Filter Operator
+                    predicate: (p_size < 10) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_size (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: avg(_col0)
+                        minReductionHashAggr: 0.8
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: struct<count:bigint,sum:double,input:int>)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col1, _col5
+                Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: UDFToDouble(_col5) (type: double)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: UDFToDouble(_col5) (type: double)
+                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string), _col5 (type: int)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 UDFToDouble(_col5) (type: double)
+                  1 _col0 (type: double)
+                outputColumnNames: _col1, _col5, _col13
+                Statistics: Num rows: 27 Data size: 3391 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col13 is null (type: boolean)
+                  Statistics: Num rows: 26 Data size: 3266 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: string), _col5 (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: avg(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col0 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: double)
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col0 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      mode: complete
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Filter Operator
+                        predicate: (_col0 = 0L) (type: boolean)
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Group By Operator
+                            keys: 0L (type: bigint)
+                            minReductionHashAggr: 0.4
+                            mode: hash
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              null sort order: 
+                              sort order: 
+                              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select p_mfgr, p_name, p_size
+
+from "p/a/r/t" b where b.p_size not in
+
+  (select min(p_size)
+
+  from (select p_mfgr, p_size from "p/a/r/t") a
+
+  where p_size < 10 and b.p_mfgr = a.p_mfgr
+
+  ) order by  p_name
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select p_mfgr, p_name, p_size
+
+from "p/a/r/t" b where b.p_size not in
+
+  (select min(p_size)
+
+  from (select p_mfgr, p_size from "p/a/r/t") a
+
+  where p_size < 10 and b.p_mfgr = a.p_mfgr
+
+  ) order by  p_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  filterExpr: ((p_size is not null and p_mfgr is not null) or ((p_size < 10) and p_mfgr is not null) or (p_size < 10)) (type: boolean)
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (p_size is not null and p_mfgr is not null) (type: boolean)
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
+                  Filter Operator
+                    predicate: ((p_size < 10) and p_mfgr is not null) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_mfgr (type: string), p_size (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(_col1)
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: int)
+                  Filter Operator
+                    predicate: (p_size < 10) (type: boolean)
+                    Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_mfgr (type: string), p_size (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(_col1)
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col1, _col2, _col5
+                Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col5 (type: int), _col2 (type: string)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col5 (type: int), _col2 (type: string)
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col5 (type: int), _col2 (type: string)
+                  1 _col0 (type: int), _col1 (type: string)
+                outputColumnNames: _col1, _col2, _col5, _col13
+                Statistics: Num rows: 32 Data size: 7164 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col13 is null (type: boolean)
+                  Statistics: Num rows: 26 Data size: 5822 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col1 (type: string), _col5 (type: int)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: string), _col2 (type: int)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col1 is not null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: int), _col0 (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: string)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
+                      Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col1 is null or _col0 is null) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 102 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 102 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select li.l_partkey, count(*)
+
+from "line/item" li
+
+where li.l_linenumber = 1 and
+
+  li.l_orderkey not in (select l_orderkey from "line/item" where l_shipmode = 'AIR')
+
+group by li.l_partkey order by li.l_partkey
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+POSTHOOK: query: explain select li.l_partkey, count(*)
+
+from "line/item" li
+
+where li.l_linenumber = 1 and
+
+  li.l_orderkey not in (select l_orderkey from "line/item" where l_shipmode = 'AIR')
+
+group by li.l_partkey order by li.l_partkey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@line/item
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: line/item
+                  filterExpr: (((l_shipmode = 'AIR') and l_orderkey is not null) or ((l_shipmode = 'AIR') and l_orderkey is null) or (l_orderkey is not null and (l_linenumber = 1))) (type: boolean)
+                  Statistics: Num rows: 100 Data size: 9200 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
+                    Statistics: Num rows: 14 Data size: 1288 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: l_orderkey (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 14 Data size: 56 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 14 Data size: 56 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((l_shipmode = 'AIR') and l_orderkey is null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+                  Filter Operator
+                    predicate: (l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
+                    Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: l_orderkey (type: int), l_partkey (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col1, _col20
+                Statistics: Num rows: 14 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col20 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: int)
+                    outputColumnNames: _col1
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: _col1 (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: bigint)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 6 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 14 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 14 Data size: 112 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: int)
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select b.p_mfgr, min(p_retailprice)
+
+from "p/a/r/t" b
+
+group by b.p_mfgr
+
+having b.p_mfgr not in
+
+  (select p_mfgr
+
+  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from "p/a/r/t" group by p_mfgr) a
+
+  where min(p_retailprice) = l and r - l > 600
+
+  )
+
+  order by b.p_mfgr
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select b.p_mfgr, min(p_retailprice)
+
+from "p/a/r/t" b
+
+group by b.p_mfgr
+
+having b.p_mfgr not in
+
+  (select p_mfgr
+
+  from (select p_mfgr, min(p_retailprice) l, max(p_retailprice) r, avg(p_retailprice) a from "p/a/r/t" group by p_mfgr) a
+
+  where min(p_retailprice) = l and r - l > 600
+
+  )
+
+  order by b.p_mfgr
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: p_mfgr (type: string), p_retailprice (type: double)
+                    outputColumnNames: p_mfgr, p_retailprice
+                    Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(p_retailprice)
+                      keys: p_mfgr (type: string)
+                      minReductionHashAggr: 0.8076923
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double)
+                    Group By Operator
+                      aggregations: min(p_retailprice), max(p_retailprice), avg(p_retailprice)
+                      keys: p_mfgr (type: string)
+                      minReductionHashAggr: 0.8076923
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 5 Data size: 970 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 970 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double), _col2 (type: double), _col3 (type: struct<count:bigint,sum:double,input:double>)
+                  Filter Operator
+                    predicate: p_mfgr is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(p_retailprice), max(p_retailprice), avg(p_retailprice)
+                      keys: p_mfgr (type: string)
+                      minReductionHashAggr: 0.8076923
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 5 Data size: 970 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 970 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double), _col2 (type: double), _col3 (type: struct<count:bigint,sum:double,input:double>)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string), _col1 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string), _col1 (type: double)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col0 (type: string), _col1 (type: double)
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: string), _col1 (type: double)
+                  1 _col0 (type: string), _col1 (type: double)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 6 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col2 is null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 726 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: double)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: double)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), avg(VALUE._col2)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 5 Data size: 610 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: double), _col2 (type: double)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 5 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (((_col2 - _col1) > 600) and (_col0 is null or _col1 is null)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 114 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 114 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), avg(VALUE._col2)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 5 Data size: 610 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: double), _col2 (type: double)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 5 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (((_col2 - _col1) > 600) and _col1 is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 114 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: string), _col1 (type: double)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: double)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: double)
+                        Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select b.p_mfgr, min(p_retailprice)
+
+from "p/a/r/t" b
+
+group by b.p_mfgr
+
+having b.p_mfgr not in
+
+  (select p_mfgr
+
+  from "p/a/r/t" a
+
+  group by p_mfgr
+
+  having max(p_retailprice) - min(p_retailprice) > 600
+
+  )
+
+  order by b.p_mfgr
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+POSTHOOK: query: explain select b.p_mfgr, min(p_retailprice)
+
+from "p/a/r/t" b
+
+group by b.p_mfgr
+
+having b.p_mfgr not in
+
+  (select p_mfgr
+
+  from "p/a/r/t" a
+
+  group by p_mfgr
+
+  having max(p_retailprice) - min(p_retailprice) > 600
+
+  )
+
+  order by b.p_mfgr
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@p/a/r/t
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: b
+                  Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: p_mfgr (type: string), p_retailprice (type: double)
+                    outputColumnNames: p_mfgr, p_retailprice
+                    Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(p_retailprice)
+                      keys: p_mfgr (type: string)
+                      minReductionHashAggr: 0.8076923
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double)
+                  Filter Operator
+                    predicate: p_mfgr is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2756 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: max(p_retailprice), min(p_retailprice)
+                      keys: p_mfgr (type: string)
+                      minReductionHashAggr: 0.8076923
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 5 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 5 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double), _col2 (type: double)
+                  Filter Operator
+                    predicate: p_mfgr is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_retailprice (type: double)
+                      outputColumnNames: p_retailprice
+                      Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: max(p_retailprice), min(p_retailprice)
+                        keys: null (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: null (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: null (type: string)
+                          Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: double), _col2 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string), _col1 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: double)
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 6 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col2 is null (type: boolean)
+                  Statistics: Num rows: 5 Data size: 726 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: double)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: double)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 5 Data size: 530 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0), min(VALUE._col1)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 5 Data size: 570 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: ((_col1 - _col2) > 600) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 114 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: string)
+                      Statistics: Num rows: 1 Data size: 98 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0), min(VALUE._col1)
+                keys: null (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: double), _col2 (type: double)
+                  outputColumnNames: _col1, _col2
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((_col1 - _col2) > 600) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select f,a,e,b from (select count(*) as a, count(c_int) as b, sum(c_int) as c, avg(c_int) as d, max(c_int) as e, min(c_int) as f from "c/b/o_t1") "c/b/o_t1"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select f,a,e,b from (select count(*) as a, count(c_int) as b, sum(c_int) as c, avg(c_int) as d, max(c_int) as e, min(c_int) as f from "c/b/o_t1") "c/b/o_t1"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: c_int (type: int)
+                    outputColumnNames: c_int
+                    Statistics: Num rows: 20 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count(), count(c_int), sum(c_int), avg(c_int), max(c_int), min(c_int)
+                      minReductionHashAggr: 0.95
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                      Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: struct<count:bigint,sum:double,input:int>), _col4 (type: int), _col5 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0), count(VALUE._col1), sum(VALUE._col2), avg(VALUE._col3), max(VALUE._col4), min(VALUE._col5)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 1 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col5 (type: int), _col0 (type: bigint), _col4 (type: int), _col1 (type: bigint)
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from (select * from "c/b/o_t1" order by key, c_boolean, value, dt)a union all select * from (select * from "//cbo_t2" order by key, c_boolean, value, dt)b
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from (select * from "c/b/o_t1" order by key, c_boolean, value, dt)a union all select * from (select * from "//cbo_t2" order by key, c_boolean, value, dt)b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string), c_int (type: int), c_float (type: float), c_boolean (type: boolean), dt (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                    Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string), _col4 (type: boolean), _col1 (type: string), _col5 (type: string)
+                      null sort order: zzzz
+                      sort order: ++++
+                      Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: int), _col3 (type: float)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: //cbo_t2
+                  Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: key (type: string), value (type: string), c_int (type: int), c_float (type: float), c_boolean (type: boolean), dt (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                    Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string), _col4 (type: boolean), _col1 (type: string), _col5 (type: string)
+                      null sort order: zzzz
+                      sort order: ++++
+                      Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: int), _col3 (type: float)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey2 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: float), KEY.reducesinkkey1 (type: boolean), KEY.reducesinkkey3 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 40 Data size: 14276 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey2 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: float), KEY.reducesinkkey1 (type: boolean), KEY.reducesinkkey3 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 20 Data size: 7138 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 40 Data size: 14276 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: create view v1_n7 as select c_int, value, c_boolean, dt from "c/b/o_t1"
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: query: create view v1_n7 as select c_int, value, c_boolean, dt from "c/b/o_t1"
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Lineage: v1_n7.c_boolean SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_boolean, type:boolean, comment:null), ]
+POSTHOOK: Lineage: v1_n7.c_int SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_int, type:int, comment:null), ]
+POSTHOOK: Lineage: v1_n7.dt SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:dt, type:string, comment:null), ]
+POSTHOOK: Lineage: v1_n7.value SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: create view v2_n2 as select c_int, value from "//cbo_t2"
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@v2_n2
+POSTHOOK: query: create view v2_n2 as select c_int, value from "//cbo_t2"
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v2_n2
+POSTHOOK: Lineage: v2_n2.c_int SIMPLE [(//cbo_t2)//cbo_t2.FieldSchema(name:c_int, type:int, comment:null), ]
+POSTHOOK: Lineage: v2_n2.value SIMPLE [(//cbo_t2)//cbo_t2.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select value from v1_n7 where c_boolean=false
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: select value from v1_n7 where c_boolean=false
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+1
+1
+PREHOOK: query: select max(c_int) from v1_n7 group by (c_boolean)
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: select max(c_int) from v1_n7 group by (c_boolean)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+1
+1
+NULL
+PREHOOK: query: select count(v1_n7.c_int)  from v1_n7 join "//cbo_t2" on v1_n7.c_int = "//cbo_t2".c_int
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: select count(v1_n7.c_int)  from v1_n7 join "//cbo_t2" on v1_n7.c_int = "//cbo_t2".c_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+234
+PREHOOK: query: select count(v1_n7.c_int)  from v1_n7 join v2_n2 on v1_n7.c_int = v2_n2.c_int
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db~!@@#$%^&*(),<>@v2_n2
+#### A masked pattern was here ####
+POSTHOOK: query: select count(v1_n7.c_int)  from v1_n7 join v2_n2 on v1_n7.c_int = v2_n2.c_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Input: db~!@@#$%^&*(),<>@//cbo_t2@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v2_n2
+#### A masked pattern was here ####
+234
+PREHOOK: query: select count(*) from v1_n7 a join v1_n7 b on a.value = b.value
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from v1_n7 a join v1_n7 b on a.value = b.value
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+156
+PREHOOK: query: create view v3_n0 as select v1_n7.value val from v1_n7 join "c/b/o_t1" on v1_n7.c_boolean = "c/b/o_t1".c_boolean
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@v3_n0
+POSTHOOK: query: create view v3_n0 as select v1_n7.value val from v1_n7 join "c/b/o_t1" on v1_n7.c_boolean = "c/b/o_t1".c_boolean
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v3_n0
+POSTHOOK: Lineage: v3_n0.val EXPRESSION [(c/b/o_t1)c/b/o_t1.FieldSchema(name:value, type:string, comment:null), ]
+PREHOOK: query: select count(val) from v3_n0 where val != '1'
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db~!@@#$%^&*(),<>@v3_n0
+#### A masked pattern was here ####
+POSTHOOK: query: select count(val) from v3_n0 where val != '1'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v3_n0
+#### A masked pattern was here ####
+96
+PREHOOK: query: with q1 as ( select key from "c/b/o_t1" where key = '1')
+
+select count(*) from q1
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: with q1 as ( select key from "c/b/o_t1" where key = '1')
+
+select count(*) from q1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+12
+PREHOOK: query: with q1 as ( select value from v1_n7 where c_boolean = false)
+
+select count(value) from q1
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: with q1 as ( select value from v1_n7 where c_boolean = false)
+
+select count(value) from q1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+2
+PREHOOK: query: create view v4_n0 as
+
+with q1 as ( select key,c_int from "c/b/o_t1"  where key = '1')
+
+select * from q1
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@v4_n0
+POSTHOOK: query: create view v4_n0 as
+
+with q1 as ( select key,c_int from "c/b/o_t1"  where key = '1')
+
+select * from q1
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v4_n0
+POSTHOOK: Lineage: v4_n0.c_int SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:c_int, type:int, comment:null), ]
+POSTHOOK: Lineage: v4_n0.key SIMPLE [(c/b/o_t1)c/b/o_t1.FieldSchema(name:key, type:string, comment:null), ]
+PREHOOK: query: with q1 as ( select c_int from q2 where c_boolean = false),
+
+q2 as ( select c_int,c_boolean from v1_n7  where value = '1')
+
+select sum(c_int) from (select c_int from q1) a
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+POSTHOOK: query: with q1 as ( select c_int from q2 where c_boolean = false),
+
+q2 as ( select c_int,c_boolean from v1_n7  where value = '1')
+
+select sum(c_int) from (select c_int from q1) a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+#### A masked pattern was here ####
+2
+PREHOOK: query: with q1 as ( select "c/b/o_t1".c_int c_int from q2 join "c/b/o_t1" where q2.c_int = "c/b/o_t1".c_int  and "c/b/o_t1".dt='2014'),
+
+q2 as ( select c_int,c_boolean from v1_n7  where value = '1' or dt = '14')
+
+select count(*) from q1 join q2 join v4_n0 on q1.c_int = q2.c_int and v4_n0.c_int = q2.c_int
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: Input: db~!@@#$%^&*(),<>@v4_n0
+#### A masked pattern was here ####
+POSTHOOK: query: with q1 as ( select "c/b/o_t1".c_int c_int from q2 join "c/b/o_t1" where q2.c_int = "c/b/o_t1".c_int  and "c/b/o_t1".dt='2014'),
+
+q2 as ( select c_int,c_boolean from v1_n7  where value = '1' or dt = '14')
+
+select count(*) from q1 join q2 join v4_n0 on q1.c_int = q2.c_int and v4_n0.c_int = q2.c_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v4_n0
+#### A masked pattern was here ####
+31104
+PREHOOK: query: drop view v1_n7
+PREHOOK: type: DROPVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: Output: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: query: drop view v1_n7
+POSTHOOK: type: DROPVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v1_n7
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v1_n7
+PREHOOK: query: drop view v2_n2
+PREHOOK: type: DROPVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@v2_n2
+PREHOOK: Output: db~!@@#$%^&*(),<>@v2_n2
+POSTHOOK: query: drop view v2_n2
+POSTHOOK: type: DROPVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v2_n2
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v2_n2
+PREHOOK: query: drop view v3_n0
+PREHOOK: type: DROPVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@v3_n0
+PREHOOK: Output: db~!@@#$%^&*(),<>@v3_n0
+POSTHOOK: query: drop view v3_n0
+POSTHOOK: type: DROPVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v3_n0
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v3_n0
+PREHOOK: query: drop view v4_n0
+PREHOOK: type: DROPVIEW
+PREHOOK: Input: db~!@@#$%^&*(),<>@v4_n0
+PREHOOK: Output: db~!@@#$%^&*(),<>@v4_n0
+POSTHOOK: query: drop view v4_n0
+POSTHOOK: type: DROPVIEW
+POSTHOOK: Input: db~!@@#$%^&*(),<>@v4_n0
+POSTHOOK: Output: db~!@@#$%^&*(),<>@v4_n0
+PREHOOK: query: explain select count(c_int) over(partition by c_float order by key), sum(c_float) over(partition by c_float order by key), max(c_int) over(partition by c_float order by key), min(c_int) over(partition by c_float order by key), row_number() over(partition by c_float order by key) as rn, rank() over(partition by c_float order by key), dense_rank() over(partition by c_float order by key), round(percent_rank() over(partition by c_float order by key), 2), lead(c_int, 2, c_int) over(partition by c_float order by key), lag(c_float, 2, c_float) over(partition by c_float order by key) from "c/b/o_t1" order by rn
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+POSTHOOK: query: explain select count(c_int) over(partition by c_float order by key), sum(c_float) over(partition by c_float order by key), max(c_int) over(partition by c_float order by key), min(c_int) over(partition by c_float order by key), row_number() over(partition by c_float order by key) as rn, rank() over(partition by c_float order by key), dense_rank() over(partition by c_float order by key), round(percent_rank() over(partition by c_float order by key), 2), lead(c_int, 2, c_int) over(partition by c_float order by key), lag(c_float, 2, c_float) over(partition by c_float order by key) from "c/b/o_t1" order by rn
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Input: db~!@@#$%^&*(),<>@c/b/o_t1@dt=2014
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: c/b/o_t1
+                  Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: c_float (type: float), key (type: string)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: c_float (type: float)
+                    Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: c_int (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey1 (type: string), VALUE._col1 (type: int), KEY.reducesinkkey0 (type: float)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string, _col2: int, _col3: float
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col0 ASC NULLS LAST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col2
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: RANGE PRECEDING(MAX)~CURRENT
+                            window function definition
+                              alias: sum_window_1
+                              arguments: _col3
+                              name: sum
+                              window function: GenericUDAFSumDouble
+                              window frame: RANGE PRECEDING(MAX)~CURRENT
+                            window function definition
+                              alias: max_window_2
+                              arguments: _col2
+                              name: max
+                              window function: GenericUDAFMaxEvaluator
+                              window frame: RANGE PRECEDING(MAX)~CURRENT
+                            window function definition
+                              alias: min_window_3
+                              arguments: _col2
+                              name: min
+                              window function: GenericUDAFMinEvaluator
+                              window frame: RANGE PRECEDING(MAX)~CURRENT
+                            window function definition
+                              alias: row_number_window_4
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: rank_window_5
+                              arguments: _col0
+                              name: rank
+                              window function: GenericUDAFRankEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: dense_rank_window_6
+                              arguments: _col0
+                              name: dense_rank
+                              window function: GenericUDAFDenseRankEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: percent_rank_window_7
+                              arguments: _col0
+                              name: percent_rank
+                              window function: GenericUDAFPercentRankEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_8
+                              arguments: _col2, 2, _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_9
+                              arguments: _col3, 2, _col3
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 20 Data size: 1767 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), sum_window_1 (type: double), max_window_2 (type: int), min_window_3 (type: int), row_number_window_4 (type: int), rank_window_5 (type: int), dense_rank_window_6 (type: int), round(percent_rank_window_7, 2) (type: double), lead_window_8 (type: int), lag_window_9 (type: float)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                    Statistics: Num rows: 20 Data size: 1040 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col4 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 20 Data size: 1040 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: bigint), _col1 (type: double), _col2 (type: int), _col3 (type: int), _col5 (type: int), _col6 (type: int), _col7 (type: double), _col8 (type: int), _col9 (type: float)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: double), VALUE._col2 (type: int), VALUE._col3 (type: int), KEY.reducesinkkey0 (type: int), VALUE._col4 (type: int), VALUE._col5 (type: int), VALUE._col6 (type: double), VALUE._col7 (type: int), VALUE._col8 (type: float)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 20 Data size: 1040 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 20 Data size: 1040 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: insert into table "src/_/cbo" select * from default.src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: query: insert into table "src/_/cbo" select * from default.src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
+POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
+PREHOOK: query: explain select * from "src/_/cbo" limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from "src/_/cbo" limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: 1
+      Processor Tree:
+        TableScan
+          alias: src/_/cbo
+          Limit
+            Number of rows: 1
+            Select Operator
+              expressions: key (type: string), value (type: string)
+              outputColumnNames: _col0, _col1
+              ListSink
+
+PREHOOK: query: insert overwrite table "src/_/cbo" select * from default.src
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: query: insert overwrite table "src/_/cbo" select * from default.src
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Lineage: src/_/cbo.key SIMPLE [(src)src.FieldSchema(name:key, type:string, comment:default), ]
+POSTHOOK: Lineage: src/_/cbo.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
+PREHOOK: query: explain select * from "src/_/cbo" limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from "src/_/cbo" limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@src/_/cbo
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: 1
+      Processor Tree:
+        TableScan
+          alias: src/_/cbo
+          Limit
+            Number of rows: 1
+            Select Operator
+              expressions: key (type: string), value (type: string)
+              outputColumnNames: _col0, _col1
+              ListSink
+
+PREHOOK: query: drop table "t//"
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: query: drop table "t//"
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: query: create table "t//" (col string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: query: create table "t//" (col string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@t//
+PREHOOK: query: insert into "t//" values(1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: query: insert into "t//" values(1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: Lineage: t//.col SCRIPT []
+PREHOOK: query: insert into "t//" values(null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: query: insert into "t//" values(null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: Lineage: t//.col SCRIPT []
+PREHOOK: query: analyze table "t//" compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@t//
+PREHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: query: analyze table "t//" compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@t//
+POSTHOOK: Output: db~!@@#$%^&*(),<>@t//
+PREHOOK: query: explain select * from "t//"
+PREHOOK: type: QUERY
+PREHOOK: Input: db~!@@#$%^&*(),<>@t//
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from "t//"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: db~!@@#$%^&*(),<>@t//
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: t//
+          Select Operator
+            expressions: col (type: string)
+            outputColumnNames: _col0
+            ListSink
+
+PREHOOK: query: drop database "db~!@@#$%^&*(),<>" cascade
+PREHOOK: type: DROPDATABASE
+PREHOOK: Input: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: database:db~!@@#$%^&*(),<>
+PREHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+PREHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+PREHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+PREHOOK: Output: db~!@@#$%^&*(),<>@cv1_n0
+PREHOOK: Output: db~!@@#$%^&*(),<>@line/item
+PREHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+PREHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+PREHOOK: Output: db~!@@#$%^&*(),<>@t//
+POSTHOOK: query: drop database "db~!@@#$%^&*(),<>" cascade
+POSTHOOK: type: DROPDATABASE
+POSTHOOK: Input: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: database:db~!@@#$%^&*(),<>
+POSTHOOK: Output: db~!@@#$%^&*(),<>@//cbo_t2
+POSTHOOK: Output: db~!@@#$%^&*(),<>@c/b/o_t1
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cbo_/t3////
+POSTHOOK: Output: db~!@@#$%^&*(),<>@cv1_n0
+POSTHOOK: Output: db~!@@#$%^&*(),<>@line/item
+POSTHOOK: Output: db~!@@#$%^&*(),<>@p/a/r/t
+POSTHOOK: Output: db~!@@#$%^&*(),<>@src/_/cbo
+POSTHOOK: Output: db~!@@#$%^&*(),<>@t//

--- a/ql/src/test/results/clientpositive/llap/subquery_unqual_corr_expr.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_unqual_corr_expr.q.out
@@ -1,0 +1,282 @@
+PREHOOK: query: explain 
+select * from src tablesample (10 rows) where lower(key) in (select key from src)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: explain 
+select * from src tablesample (10 rows) where lower(key) in (select key from src)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: lower(key) is not null (type: boolean)
+                  Row Limit Per Split: 10
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: lower(key) is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: lower(key) (type: string)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: lower(key) (type: string)
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: key (type: string), value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 316 Data size: 27492 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 lower(key) (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from src tablesample (10 rows) where lower(key) in (select key from src)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: select * from src tablesample (10 rows) where lower(key) in (select key from src)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+165	val_165
+238	val_238
+255	val_255
+27	val_27
+278	val_278
+311	val_311
+409	val_409
+484	val_484
+86	val_86
+98	val_98
+Warning: Shuffle Join MERGEJOIN[31][tables = [src, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain 
+select * from src tablesample (10 rows) where concat(key,value) not in (select key from src)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: explain 
+select * from src tablesample (10 rows) where concat(key,value) not in (select key from src)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: concat(key, value) is not null (type: boolean)
+                  Row Limit Per Split: 10
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: concat(key, value) is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: key (type: string), value (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: src
+                  filterExpr: (key is not null or key is null) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 87 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: concat(_col0, _col1) (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: concat(_col0, _col1) (type: string)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: string), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 concat(_col0, _col1) (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1, _col6
+                Statistics: Num rows: 684 Data size: 165339 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col6 is null (type: boolean)
+                  Statistics: Num rows: 184 Data size: 44584 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: string)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 184 Data size: 44584 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 184 Data size: 44584 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col0 = 0L) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: 0L (type: bigint)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join MERGEJOIN[31][tables = [src, sq_1_notin_nullcheck]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from src tablesample (10 rows) where concat(key,value) not in (select key from src)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+#### A masked pattern was here ####
+POSTHOOK: query: select * from src tablesample (10 rows) where concat(key,value) not in (select key from src)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+#### A masked pattern was here ####
+165	val_165
+238	val_238
+255	val_255
+278	val_278
+27	val_27
+311	val_311
+409	val_409
+484	val_484
+86	val_86
+98	val_98

--- a/ql/src/test/results/clientpositive/notInTest.q.out
+++ b/ql/src/test/results/clientpositive/notInTest.q.out
@@ -1,0 +1,2094 @@
+PREHOOK: query: create table t3 (id int,name string, age int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t3
+POSTHOOK: query: create table t3 (id int,name string, age int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t3
+PREHOOK: query: insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t3
+POSTHOOK: query: insert into t3 values(1,'Sagar',23),(2,'Sultan',NULL),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23),(9,'ron',3),(10,'Sam',22),(11,'nick',19),(12,'fed',18),(13,'kong',13),(14,'hela',45)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t3
+POSTHOOK: Lineage: t3.age SCRIPT []
+POSTHOOK: Lineage: t3.id SCRIPT []
+POSTHOOK: Lineage: t3.name SCRIPT []
+PREHOOK: query: create table t4 (id int,name string, age int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t4
+POSTHOOK: query: create table t4 (id int,name string, age int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t4
+PREHOOK: query: insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t4
+POSTHOOK: query: insert into t4 values(1,'Sagar',23),(3,'Surya',23),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t4
+POSTHOOK: Lineage: t4.age SCRIPT []
+POSTHOOK: Lineage: t4.id SCRIPT []
+POSTHOOK: Lineage: t4.name SCRIPT []
+PREHOOK: query: create table t5 (id int,name string, ages int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t5
+POSTHOOK: query: create table t5 (id int,name string, ages int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t5
+PREHOOK: query: insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t5
+POSTHOOK: query: insert into t5 values(1,'Sagar',23),(3,'Surya',NULL),(4,'Raman',45),(5,'Scott',23),(6,'Ramya',5),(7,'',23),(8,'',23)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t5
+POSTHOOK: Lineage: t5.ages SCRIPT []
+POSTHOOK: Lineage: t5.id SCRIPT []
+POSTHOOK: Lineage: t5.name SCRIPT []
+PREHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+6	Ramya	5
+3	Surya	23
+5	Scott	23
+7		23
+8		23
+1	Sagar	23
+4	Raman	45
+14	hela	45
+Warning: Shuffle Join JOIN[24][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join JOIN[26][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join JOIN[24][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+PREHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+0
+Warning: Shuffle Join JOIN[24][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-2 depends on stages: Stage-1, Stage-3
+  Stage-4 is a root stage
+  Stage-5 depends on stages: Stage-4
+  Stage-1 depends on stages: Stage-5
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t4
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col6
+          Statistics: Num rows: 15 Data size: 276 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: _col6 is null (type: boolean)
+            Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t4
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is null (type: boolean)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                Group By Operator
+                  keys: null (type: int)
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: null (type: int)
+                    sort order: +
+                    Map-reduce partition columns: null (type: int)
+                    Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: null (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Group By Operator
+              aggregations: count()
+              mode: hash
+              outputColumnNames: _col0
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (_col0 = 0L) (type: boolean)
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: 0L (type: bigint)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: id (type: int), name (type: string), age (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Semi Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[24][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-2 depends on stages: Stage-1, Stage-3
+  Stage-4 is a root stage
+  Stage-5 depends on stages: Stage-4
+  Stage-1 depends on stages: Stage-5
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ages is not null (type: boolean)
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col6
+          Statistics: Num rows: 15 Data size: 276 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: _col6 is null (type: boolean)
+            Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ages is null (type: boolean)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                Group By Operator
+                  keys: null (type: int)
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: null (type: int)
+                    sort order: +
+                    Map-reduce partition columns: null (type: int)
+                    Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: null (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Group By Operator
+              aggregations: count()
+              mode: hash
+              outputColumnNames: _col0
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (_col0 = 0L) (type: boolean)
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: 0L (type: bigint)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: id (type: int), name (type: string), age (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Semi Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[26][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-2 depends on stages: Stage-1, Stage-3
+  Stage-4 is a root stage
+  Stage-5 depends on stages: Stage-4
+  Stage-1 depends on stages: Stage-5
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ages is not null (type: boolean)
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col6
+          Statistics: Num rows: 15 Data size: 276 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: _col6 is null (type: boolean)
+            Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 7 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (ages is not null and ages is null) (type: boolean)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                Group By Operator
+                  keys: null (type: int)
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: null (type: int)
+                    sort order: +
+                    Map-reduce partition columns: null (type: int)
+                    Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: null (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Group By Operator
+              aggregations: count()
+              mode: hash
+              outputColumnNames: _col0
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (_col0 = 0L) (type: boolean)
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: 0L (type: bigint)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: id (type: int), name (type: string), age (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Semi Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 14 Data size: 251 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[26][tables = [t3, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+2
+Warning: Shuffle Join JOIN[28][tables = [b, sq_1_notin_nullcheck]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select id, name, age
+from t3 b where b.age not in
+(select min(age)
+ from (select id, age from t3) a
+ where age < 10 and b.age = a.age)
+ order by name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: explain select id, name, age
+from t3 b where b.age not in
+(select min(age)
+ from (select id, age from t3) a
+ where age < 10 and b.age = a.age)
+ order by name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-4 is a root stage
+  Stage-2 depends on stages: Stage-1, Stage-4
+  Stage-3 depends on stages: Stage-2
+  Stage-5 is a root stage
+  Stage-6 depends on stages: Stage-5
+  Stage-1 depends on stages: Stage-6
+  Stage-0 depends on stages: Stage-3
+
+STAGE PLANS:
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (age < 10) (type: boolean)
+              Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: age (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                Group By Operator
+                  aggregations: min(_col1)
+                  keys: _col1 (type: int)
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                    value expressions: _col1 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: min(VALUE._col0)
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: _col1 is not null (type: boolean)
+            Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col1 (type: int), _col0 (type: int)
+              outputColumnNames: _col0, _col1
+              Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int), _col2 (type: int)
+              sort order: ++
+              Map-reduce partition columns: _col2 (type: int), _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 307 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int), _col1 (type: int)
+              sort order: ++
+              Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+              Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int), _col2 (type: int)
+            1 _col0 (type: int), _col1 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col6
+          Statistics: Num rows: 15 Data size: 337 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: _col6 is null (type: boolean)
+            Statistics: Num rows: 7 Data size: 157 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 7 Data size: 157 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col1 (type: string)
+              sort order: +
+              Statistics: Num rows: 7 Data size: 157 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col2 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Select Operator
+          expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 7 Data size: 157 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            Statistics: Num rows: 7 Data size: 157 Basic stats: COMPLETE Column stats: NONE
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (age < 10) (type: boolean)
+              Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: age (type: int)
+                outputColumnNames: _col1
+                Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                Group By Operator
+                  aggregations: min(_col1)
+                  keys: _col1 (type: int)
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int)
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: int)
+                    Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                    value expressions: _col1 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: min(VALUE._col0)
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (_col0 is null or _col1 is null) (type: boolean)
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                aggregations: count()
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-6
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (_col0 = 0L) (type: boolean)
+            Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: 0L (type: bigint)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: b
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: id (type: int), name (type: string), age (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Semi Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 14 Data size: 307 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age in (select distinct(age) age from t4)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+6	Ramya	5
+3	Surya	23
+5	Scott	23
+7		23
+8		23
+1	Sagar	23
+4	Raman	45
+14	hela	45
+Warning: Shuffle Join JOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(age) age from t4  )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join JOIN[23][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+9	ron	3
+13	kong	13
+12	fed	18
+11	nick	19
+10	Sam	22
+Warning: Shuffle Join JOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: select * from t3
+where age not in (select distinct(ages) ages from t5 )
+order by age
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+PREHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from t3
+where age not in (23,22, null )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+0
+Warning: Shuffle Join JOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t4
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(age) age from t4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t4
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-4 depends on stages: Stage-3
+  Stage-1 depends on stages: Stage-4
+  Stage-2 depends on stages: Stage-1, Stage-5
+  Stage-5 is a root stage
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t4
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: age (type: int)
+              outputColumnNames: age
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Group By Operator
+            aggregations: count(), count(_col0)
+            mode: hash
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0), count(VALUE._col1)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: id (type: int), name (type: string), age (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Inner Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+          Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: boolean)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+          Statistics: Num rows: 15 Data size: 399 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+            Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t4
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: age (type: int)
+              outputColumnNames: age
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: _col0 (type: int), true (type: boolean)
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+where age not in (select distinct(ages) ages from t5 )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-4 depends on stages: Stage-3
+  Stage-1 depends on stages: Stage-4
+  Stage-2 depends on stages: Stage-1, Stage-5
+  Stage-5 is a root stage
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: ages (type: int)
+              outputColumnNames: ages
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Group By Operator
+            aggregations: count(), count(_col0)
+            mode: hash
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0), count(VALUE._col1)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: id (type: int), name (type: string), age (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Inner Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+          Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: boolean)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+          Statistics: Num rows: 15 Data size: 399 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+            Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: ages (type: int)
+              outputColumnNames: ages
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: _col0 (type: int), true (type: boolean)
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[23][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+PREHOOK: Input: default@t5
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from t3
+        where age not in (select distinct(ages) ages from t5 where t5.ages is not null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+POSTHOOK: Input: default@t5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-3 is a root stage
+  Stage-4 depends on stages: Stage-3
+  Stage-1 depends on stages: Stage-4
+  Stage-2 depends on stages: Stage-1, Stage-5
+  Stage-5 is a root stage
+  Stage-0 depends on stages: Stage-2
+
+STAGE PLANS:
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ages is not null (type: boolean)
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Group By Operator
+            aggregations: count(), count(_col0)
+            mode: hash
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: count(VALUE._col0), count(VALUE._col1)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: id (type: int), name (type: string), age (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+          TableScan
+            Reduce Output Operator
+              sort order: 
+              Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: bigint), _col1 (type: bigint)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Inner Join 0 to 1
+          keys:
+            0 
+            1 
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+          Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 14 Data size: 363 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string), _col3 (type: bigint), _col4 (type: bigint)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: boolean)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col6
+          Statistics: Num rows: 15 Data size: 399 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: ((_col3 = 0L) or (_col6 is null and _col2 is not null and (_col4 >= _col3))) (type: boolean)
+            Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                Statistics: Num rows: 9 Data size: 239 Basic stats: COMPLETE Column stats: NONE
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t5
+            Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: ages is not null (type: boolean)
+              Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: ages (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 7 Data size: 59 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: _col0 (type: int), true (type: boolean)
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 3 Data size: 25 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+Warning: Shuffle Join JOIN[23][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
+PREHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from t3
+where age not in (select distinct(age)age from t3 t1 where t1.age > 10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+2
+PREHOOK: query: explain select id, name, age
+         from t3 b where b.age not in
+         (select min(age)
+          from (select id, age from t3) a
+          where age < 10 and b.age = a.age)
+          order by name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t3
+#### A masked pattern was here ####
+POSTHOOK: query: explain select id, name, age
+         from t3 b where b.age not in
+         (select min(age)
+          from (select id, age from t3) a
+          where age < 10 and b.age = a.age)
+          order by name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t3
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-4 is a root stage
+  Stage-1 depends on stages: Stage-4
+  Stage-2 depends on stages: Stage-1, Stage-5, Stage-7
+  Stage-3 depends on stages: Stage-2
+  Stage-5 is a root stage
+  Stage-6 is a root stage
+  Stage-7 depends on stages: Stage-6, Stage-8
+  Stage-8 is a root stage
+  Stage-0 depends on stages: Stage-3
+
+STAGE PLANS:
+  Stage: Stage-4
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (age < 10) (type: boolean)
+              Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+          Group By Operator
+            aggregations: count()
+            keys: _col0 (type: int)
+            mode: complete
+            outputColumnNames: _col0, _col1
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-1
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: b
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: id (type: int), name (type: string), age (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Reduce Output Operator
+                key expressions: _col2 (type: int)
+                sort order: +
+                Map-reduce partition columns: _col2 (type: int)
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: bigint)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col4
+          Statistics: Num rows: 15 Data size: 137 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: (sq_count_check(CASE WHEN (_col4 is null) THEN (0) ELSE (_col4) END, true) > 0) (type: boolean)
+            Statistics: Num rows: 5 Data size: 45 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 5 Data size: 45 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-2
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 5 Data size: 45 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col1 (type: string)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: bigint), _col2 (type: bigint)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col2 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col2 (type: int)
+              Statistics: Num rows: 7 Data size: 68 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: boolean)
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Left Outer Join 0 to 1
+               Left Outer Join 0 to 2
+          keys:
+            0 _col2 (type: int)
+            1 _col0 (type: int)
+            2 _col2 (type: int)
+          outputColumnNames: _col0, _col1, _col2, _col4, _col5, _col7
+          Statistics: Num rows: 15 Data size: 149 Basic stats: COMPLETE Column stats: NONE
+          Filter Operator
+            predicate: CASE WHEN ((_col4 = 0L)) THEN (true) WHEN (_col4 is null) THEN (true) WHEN (_col7 is not null) THEN (false) WHEN (_col2 is null) THEN (null) WHEN ((_col5 < _col4)) THEN (false) ELSE (true) END (type: boolean)
+            Statistics: Num rows: 7 Data size: 69 Basic stats: COMPLETE Column stats: NONE
+            Select Operator
+              expressions: _col0 (type: int), _col1 (type: string), _col2 (type: int)
+              outputColumnNames: _col0, _col1, _col2
+              Statistics: Num rows: 7 Data size: 69 Basic stats: COMPLETE Column stats: NONE
+              File Output Operator
+                compressed: false
+                table:
+                    input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                    serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-3
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col1 (type: string)
+              sort order: +
+              Statistics: Num rows: 7 Data size: 69 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col0 (type: int), _col2 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Select Operator
+          expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col1 (type: int)
+          outputColumnNames: _col0, _col1, _col2
+          Statistics: Num rows: 7 Data size: 69 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            Statistics: Num rows: 7 Data size: 69 Basic stats: COMPLETE Column stats: NONE
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-5
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (age < 10) (type: boolean)
+              Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                aggregations: min(age)
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                  value expressions: _col1 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: min(VALUE._col0)
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+          Group By Operator
+            aggregations: count(), count(_col1)
+            keys: _col0 (type: int)
+            mode: complete
+            outputColumnNames: _col0, _col1, _col2
+            Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            File Output Operator
+              compressed: false
+              table:
+                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                  serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-6
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: t3
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: (age < 10) (type: boolean)
+              Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                aggregations: min(age)
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 4 Data size: 35 Basic stats: COMPLETE Column stats: NONE
+                  value expressions: _col1 (type: int)
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          aggregations: min(VALUE._col0)
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0, _col1
+          Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+          Select Operator
+            expressions: _col1 (type: int)
+            outputColumnNames: _col1
+            Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: _col1 is not null (type: boolean)
+              Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+              Select Operator
+                expressions: _col1 (type: int), true (type: boolean)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-7
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 2 Data size: 17 Basic stats: COMPLETE Column stats: NONE
+              value expressions: _col1 (type: boolean)
+          TableScan
+            Reduce Output Operator
+              key expressions: _col0 (type: int)
+              sort order: +
+              Map-reduce partition columns: _col0 (type: int)
+              Statistics: Num rows: 7 Data size: 62 Basic stats: COMPLETE Column stats: NONE
+      Reduce Operator Tree:
+        Join Operator
+          condition map:
+               Inner Join 0 to 1
+          keys:
+            0 _col0 (type: int)
+            1 _col0 (type: int)
+          outputColumnNames: _col1, _col2
+          Statistics: Num rows: 7 Data size: 68 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-8
+    Map Reduce
+      Map Operator Tree:
+          TableScan
+            alias: b
+            Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+            Filter Operator
+              predicate: age is not null (type: boolean)
+              Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+              Group By Operator
+                keys: age (type: int)
+                mode: hash
+                outputColumnNames: _col0
+                Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 14 Data size: 125 Basic stats: COMPLETE Column stats: NONE
+      Execution mode: vectorized
+      Reduce Operator Tree:
+        Group By Operator
+          keys: KEY._col0 (type: int)
+          mode: mergepartial
+          outputColumnNames: _col0
+          Statistics: Num rows: 7 Data size: 62 Basic stats: COMPLETE Column stats: NONE
+          File Output Operator
+            compressed: false
+            table:
+                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                serde: org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/subquery_unqual_corr_expr.q.out
+++ b/ql/src/test/results/clientpositive/subquery_unqual_corr_expr.q.out
@@ -159,10 +159,13 @@ STAGE PLANS:
             alias: src
             Row Limit Per Split: 10
             Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-            Reduce Output Operator
-              sort order: 
+            Filter Operator
+              predicate: concat(key, value) is not null (type: boolean)
               Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-              value expressions: key (type: string), value (type: string)
+              Reduce Output Operator
+                sort order: 
+                Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                value expressions: key (type: string), value (type: string)
           TableScan
             Reduce Output Operator
               sort order: 
@@ -196,15 +199,18 @@ STAGE PLANS:
           TableScan
             alias: src
             Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-            Select Operator
-              expressions: key (type: string)
-              outputColumnNames: _col0
+            Filter Operator
+              predicate: key is not null (type: boolean)
               Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
-              Reduce Output Operator
-                key expressions: _col0 (type: string)
-                sort order: +
-                Map-reduce partition columns: _col0 (type: string)
+              Select Operator
+                expressions: key (type: string)
+                outputColumnNames: _col0
                 Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
       Reduce Operator Tree:
         Join Operator
           condition map:


### PR DESCRIPTION
This is a backport of [HIVE-27324](https://issues.apache.org/jira/browse/HIVE-27324) : Hive query with NOT IN condition is giving incorrect results
This is required for bug fix and improvements for [hive-3.2.0](https://issues.apache.org/jira/browse/HIVE-26751) release.
JIRA link: [HIVE-27852](https://issues.apache.org/jira/browse/HIVE-27852)