### PR TITLE
HIVE-27788: Exception when join has 2 Group By operators in the same branch in the same reducer

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -193,10 +193,10 @@ public class OperatorUtils {
   private static boolean hasMoreOperatorsThan(
       Operator<?> start, Class<?> opClazz, int limit, Set<Operator<?>> visited) {
     if (!visited.add(start)) {
-      return limit <= 0;
+      return limit < 0;
     }
 
-    if (limit <= 0) {
+    if (limit < 0) {
       return false;
     }
 
@@ -215,7 +215,7 @@ public class OperatorUtils {
         }
       }
     }
-    return limit <= 0;
+    return limit < 0;
   }
 
   public static void setChildrenCollector(List<Operator<? extends OperatorDesc>> childOperators, OutputCollector out) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -179,16 +179,16 @@ public class OperatorUtils {
   /**
    * Check whether there are more operators in the specified operator tree branch than the given limit
    * until a ReduceSinkOperator is reached.
+   * The method traverses the parent operators of the specified root operator in dept first manner.
    * @param start root of the operator tree to check
    * @param opClazz type of operator to track
    * @param limit maximum allowed number of operator in a branch of the tree
-   * @return true of limit is exceeded false otherwise
+   * @return true if limit is exceeded false otherwise
    * @param <T> type of operator to track
    */
   public static <T> boolean hasMoreOperatorsThan(Operator<?> start, Class<T> opClazz, int limit) {
-    int count = limit;
-    if (count <= 0) {
-      return true;
+    if (limit <= 0) {
+      return false;
     }
 
     if (start instanceof ReduceSinkOperator) {
@@ -196,17 +196,17 @@ public class OperatorUtils {
     }
 
     if (opClazz.isInstance(start)) {
-      count--;
+      limit--;
     }
 
     if (start.getParentOperators() != null) {
       for (Operator<?> parent : start.getParentOperators()) {
-        if (hasMoreOperatorsThan(parent, opClazz, count)) {
+        if (hasMoreOperatorsThan(parent, opClazz, limit)) {
           return true;
         }
       }
     }
-    return count <= 0;
+    return limit <= 0;
   }
 
   public static void setChildrenCollector(List<Operator<? extends OperatorDesc>> childOperators, OutputCollector out) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -178,6 +178,7 @@ public class OperatorUtils {
 
   /**
    * Check whether there are more operators in the specified operator tree branch than the given limit
+   * until a ReduceSinkOperator is reached.
    * @param start root of the operator tree to check
    * @param opClazz type of operator to track
    * @param limit maximum allowed number of operator in a branch of the tree

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -193,7 +193,7 @@ public class OperatorUtils {
 
   private static <T> boolean hasMoreOperatorsThan(
       Operator<?> start, Class<T> opClazz, int limit, Set<Operator<?>> visited) {
-    if (visited.contains(start)) {
+    if (!visited.add(start)) {
       return limit <= 0;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -184,15 +184,14 @@ public class OperatorUtils {
    * @param opClazz type of operator to track
    * @param limit maximum allowed number of operator in a branch of the tree
    * @return true if limit is exceeded false otherwise
-   * @param <T> type of operator to track
    */
-  public static <T> boolean hasMoreOperatorsThan(
-      Operator<?> start, Class<T> opClazz, int limit) {
+  public static boolean hasMoreOperatorsThan(
+      Operator<?> start, Class<?> opClazz, int limit) {
     return hasMoreOperatorsThan(start, opClazz, limit, new HashSet<>());
   }
 
-  private static <T> boolean hasMoreOperatorsThan(
-      Operator<?> start, Class<T> opClazz, int limit, Set<Operator<?>> visited) {
+  private static boolean hasMoreOperatorsThan(
+      Operator<?> start, Class<?> opClazz, int limit, Set<Operator<?>> visited) {
     if (!visited.add(start)) {
       return limit <= 0;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -177,7 +177,7 @@ public class OperatorUtils {
   }
 
   /**
-   * Check whether there are more operators in the specified operator tree branch than the give limit
+   * Check whether there are more operators in the specified operator tree branch than the given limit
    * @param start root of the operator tree to check
    * @param opClazz type of operator to track
    * @param limit maximum allowed number of operator in a branch of the tree

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -186,7 +186,17 @@ public class OperatorUtils {
    * @return true if limit is exceeded false otherwise
    * @param <T> type of operator to track
    */
-  public static <T> boolean hasMoreOperatorsThan(Operator<?> start, Class<T> opClazz, int limit) {
+  public static <T> boolean hasMoreOperatorsThan(
+      Operator<?> start, Class<T> opClazz, int limit) {
+    return hasMoreOperatorsThan(start, opClazz, limit, new HashSet<>());
+  }
+
+  private static <T> boolean hasMoreOperatorsThan(
+      Operator<?> start, Class<T> opClazz, int limit, Set<Operator<?>> visited) {
+    if (visited.contains(start)) {
+      return limit <= 0;
+    }
+
     if (limit <= 0) {
       return false;
     }
@@ -201,7 +211,7 @@ public class OperatorUtils {
 
     if (start.getParentOperators() != null) {
       for (Operator<?> parent : start.getParentOperators()) {
-        if (hasMoreOperatorsThan(parent, opClazz, limit)) {
+        if (hasMoreOperatorsThan(parent, opClazz, limit, visited)) {
           return true;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -188,7 +188,7 @@ public class OperatorUtils {
     int count = limit;
     if (count <= 0) {
       return true;
-    };
+    }
 
     if (start instanceof ReduceSinkOperator) {
       return false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OperatorUtils.java
@@ -176,6 +176,37 @@ public class OperatorUtils {
     return found;
   }
 
+  /**
+   * Check whether there are more operators in the specified operator tree branch than the give limit
+   * @param start root of the operator tree to check
+   * @param opClazz type of operator to track
+   * @param limit maximum allowed number of operator in a branch of the tree
+   * @return true of limit is exceeded false otherwise
+   * @param <T> type of operator to track
+   */
+  public static <T> boolean hasMoreOperatorsThan(Operator<?> start, Class<T> opClazz, int limit) {
+    int count = limit;
+    if (count <= 0) {
+      return true;
+    };
+
+    if (start instanceof ReduceSinkOperator) {
+      return false;
+    }
+
+    if (opClazz.isInstance(start)) {
+      count--;
+    }
+
+    if (start.getParentOperators() != null) {
+      for (Operator<?> parent : start.getParentOperators()) {
+        if (hasMoreOperatorsThan(parent, opClazz, count)) {
+          return true;
+        }
+      }
+    }
+    return count <= 0;
+  }
 
   public static void setChildrenCollector(List<Operator<? extends OperatorDesc>> childOperators, OutputCollector out) {
     if (childOperators == null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -762,6 +762,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
       // not process all buffered records.
       // HIVE-27788
       if (parentOp.getParentOperators() != null) {
+        // Parent operator is RS and hasMoreOperatorsThan traverses until the next RS, so we start from grandparent
         for (Operator<?> grandParent : parentOp.getParentOperators()) {
           if (hasMoreOperatorsThan(grandParent, GroupByOperator.class, 2)) {
             LOG.info("We cannot convert to SMB join " +

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -764,7 +764,7 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
       if (parentOp.getParentOperators() != null) {
         // Parent operator is RS and hasMoreOperatorsThan traverses until the next RS, so we start from grandparent
         for (Operator<?> grandParent : parentOp.getParentOperators()) {
-          if (hasMoreOperatorsThan(grandParent, GroupByOperator.class, 2)) {
+          if (hasMoreOperatorsThan(grandParent, GroupByOperator.class, 1)) {
             LOG.info("We cannot convert to SMB join " +
                 "because one of the join branches has more than one Group by operators in the same reducer.");
             return false;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TestOperatorUtils {
   @Test
   void testHasMoreGBYsReturnsTrueWhenLimitIs0() {
+    // RS-SEL-LIM-FIL
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
     Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
@@ -49,6 +50,7 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsFalseWhenNoGBYInBranchAndLimitIsMoreThan0() {
+    // RS-SEL-LIM-FIL
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
     Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
@@ -63,6 +65,7 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsFalseWhenNumberOfGBYIsLessThanLimit() {
+    // RS-GBY-SEL-LIM-FIL
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
     Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
@@ -79,6 +82,7 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsTrueWhenNumberOfGBYIsEqualsWithLimit() {
+    // RS-GBY-FIL-SEL-GBY
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
     Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
@@ -95,6 +99,7 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsFalseWhenNumberOfGBYIsEqualsWithLimitButHasAnRSInTheMiddle() {
+    // TS-GBY-RS-SEL-GBY
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
     Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
@@ -111,19 +116,21 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsTrueWhenBranchHasJoinAndNumberOfGBYIsEqualsWithLimit() {
+    // RS-GBY-FIL--JOIN-GBY
+    //     RS-SEL-/
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
     Operator<?> join = OperatorFactory.get(context, CommonMergeJoinDesc.class);
     gby1.setParentOperators(singletonList(join));
 
-    // Branch #1 has the second GBY
+    // Join branch #1 has the second GBY
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
     Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
     filter.setParentOperators(singletonList(gby2));
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     gby2.setParentOperators(singletonList(rs));
 
-    // Branch #2
+    // Join branch #2
     Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
     Operator<?> rs2 = OperatorFactory.get(context, ReduceSinkDesc.class);
     select.setParentOperators(singletonList(rs2));
@@ -135,17 +142,19 @@ class TestOperatorUtils {
 
   @Test
   void testHasMoreGBYsReturnsFalseWhenBranchHasJoinAndBothJoinBranchesHasLessGBYThanLimit() {
+    // RS-GBY-SEL--JOIN
+    // RS-GBY-FIL-/
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> join = OperatorFactory.get(context, CommonMergeJoinDesc.class);
 
-    // Branch #1 has the second GBY
+    // Join branch #1
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
     Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
     filter.setParentOperators(singletonList(gby1));
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     gby1.setParentOperators(singletonList(rs));
 
-    // Branch #2
+    // Join branch #2
     Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
     Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
     select.setParentOperators(singletonList(gby2));

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
@@ -1,0 +1,141 @@
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.plan.CommonMergeJoinDesc;
+import org.apache.hadoop.hive.ql.plan.FilterDesc;
+import org.apache.hadoop.hive.ql.plan.GroupByDesc;
+import org.apache.hadoop.hive.ql.plan.LimitDesc;
+import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
+import org.apache.hadoop.hive.ql.plan.SelectDesc;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestOperatorUtils {
+  @Test
+  void testHasMoreGBYsReturnsTrueWhenLimitIs0() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
+    filter.setParentOperators(singletonList(limit));
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    limit.setParentOperators(singletonList(select));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    select.setParentOperators(singletonList(rs));
+
+    assertTrue(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 0));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsFalseWhenNoGBYInBranchAndLimitIsMoreThan0() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
+    filter.setParentOperators(singletonList(limit));
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    limit.setParentOperators(singletonList(select));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    select.setParentOperators(singletonList(rs));
+
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 2));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsFalseWhenNumberOfGBYIsLessThanLimit() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    Operator<?> limit = OperatorFactory.get(context, LimitDesc.class);
+    filter.setParentOperators(singletonList(limit));
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    limit.setParentOperators(singletonList(select));
+    Operator<?> gby = OperatorFactory.get(context, GroupByDesc.class);
+    select.setParentOperators(singletonList(gby));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    gby.setParentOperators(singletonList(rs));
+
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 2));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsTrueWhenNumberOfGBYIsEqualsWithLimit() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    gby1.setParentOperators(singletonList(select));
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    select.setParentOperators(singletonList(filter));
+    Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
+    filter.setParentOperators(singletonList(gby2));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    gby2.setParentOperators(singletonList(rs));
+
+    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsFalseWhenNumberOfGBYIsEqualsWithLimitButHasAnRSInTheMiddle() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    gby1.setParentOperators(singletonList(select));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    select.setParentOperators(singletonList(rs));
+    Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
+    rs.setParentOperators(singletonList(gby2));
+    Operator<?> ts = OperatorFactory.get(context, TableScanDesc.class);
+    gby2.setParentOperators(singletonList(ts));
+
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsTrueWhenBranchHasJoinAndNumberOfGBYIsEqualsWithLimit() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
+    Operator<?> join = OperatorFactory.get(context, CommonMergeJoinDesc.class);
+    gby1.setParentOperators(singletonList(join));
+
+    // Branch #1 has the second GBY
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
+    filter.setParentOperators(singletonList(gby2));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    gby2.setParentOperators(singletonList(rs));
+
+    // Branch #2
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    Operator<?> rs2 = OperatorFactory.get(context, ReduceSinkDesc.class);
+    select.setParentOperators(singletonList(rs2));
+
+    join.setParentOperators(asList(filter, select));
+
+    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+  }
+
+  @Test
+  void testHasMoreGBYsReturnsFalseWhenBranchHasJoinAndBothJoinBranchesHasLessGBYThanLimit() {
+    CompilationOpContext context = new CompilationOpContext();
+    Operator<?> join = OperatorFactory.get(context, CommonMergeJoinDesc.class);
+
+    // Branch #1 has the second GBY
+    Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
+    Operator<?> gby1 = OperatorFactory.get(context, GroupByDesc.class);
+    filter.setParentOperators(singletonList(gby1));
+    Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
+    gby1.setParentOperators(singletonList(rs));
+
+    // Branch #2
+    Operator<?> select = OperatorFactory.get(context, SelectDesc.class);
+    Operator<?> gby2 = OperatorFactory.get(context, GroupByDesc.class);
+    select.setParentOperators(singletonList(gby2));
+    Operator<?> rs2 = OperatorFactory.get(context, ReduceSinkDesc.class);
+    gby2.setParentOperators(singletonList(rs2));
+
+    join.setParentOperators(asList(filter, select));
+
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(join, GroupByOperator.class, 2));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.exec;
 
 import org.apache.hadoop.hive.ql.CompilationOpContext;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class TestOperatorUtils {
   @Test
-  void testHasMoreGBYsReturnsTrueWhenLimitIs0() {
+  void testHasMoreGBYsReturnsFalseWhenLimitIs0() {
     // RS-SEL-LIM-FIL
     CompilationOpContext context = new CompilationOpContext();
     Operator<?> filter = OperatorFactory.get(context, FilterDesc.class);
@@ -45,7 +45,7 @@ class TestOperatorUtils {
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     select.setParentOperators(singletonList(rs));
 
-    assertTrue(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 0));
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 0));
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestOperatorUtils.java
@@ -60,7 +60,7 @@ class TestOperatorUtils {
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     select.setParentOperators(singletonList(rs));
 
-    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 2));
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 1));
   }
 
   @Test
@@ -77,7 +77,7 @@ class TestOperatorUtils {
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     gby.setParentOperators(singletonList(rs));
 
-    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 2));
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(filter, GroupByOperator.class, 1));
   }
 
   @Test
@@ -94,7 +94,7 @@ class TestOperatorUtils {
     Operator<?> rs = OperatorFactory.get(context, ReduceSinkDesc.class);
     gby2.setParentOperators(singletonList(rs));
 
-    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 1));
   }
 
   @Test
@@ -111,7 +111,7 @@ class TestOperatorUtils {
     Operator<?> ts = OperatorFactory.get(context, TableScanDesc.class);
     gby2.setParentOperators(singletonList(ts));
 
-    assertFalse(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 1));
   }
 
   @Test
@@ -137,7 +137,7 @@ class TestOperatorUtils {
 
     join.setParentOperators(asList(filter, select));
 
-    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 2));
+    assertTrue(OperatorUtils.hasMoreOperatorsThan(gby1, GroupByOperator.class, 1));
   }
 
   @Test
@@ -163,6 +163,6 @@ class TestOperatorUtils {
 
     join.setParentOperators(asList(filter, select));
 
-    assertFalse(OperatorUtils.hasMoreOperatorsThan(join, GroupByOperator.class, 2));
+    assertFalse(OperatorUtils.hasMoreOperatorsThan(join, GroupByOperator.class, 1));
   }
 }

--- a/ql/src/test/queries/clientpositive/auto_sortmerge_join_17.q
+++ b/ql/src/test/queries/clientpositive/auto_sortmerge_join_17.q
@@ -1,0 +1,22 @@
+CREATE TABLE tbl1_n5(key int, value string) CLUSTERED BY (key) SORTED BY (key) INTO 2 BUCKETS;
+
+insert into tbl1_n5(key, value)
+values
+(0, 'val_0'),
+(2, 'val_2'),
+(9, 'val_9');
+
+set hive.optimize.semijoin.conversion = false;
+
+explain
+SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1;
+
+SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1;

--- a/ql/src/test/queries/clientpositive/auto_sortmerge_join_17.q
+++ b/ql/src/test/queries/clientpositive/auto_sortmerge_join_17.q
@@ -6,8 +6,6 @@ values
 (2, 'val_2'),
 (9, 'val_9');
 
-set hive.optimize.semijoin.conversion = false;
-
 explain
 SELECT t1.key from
 (SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1

--- a/ql/src/test/results/clientpositive/llap/auto_sortmerge_join_17.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_sortmerge_join_17.q.out
@@ -81,7 +81,7 @@ STAGE PLANS:
                         key expressions: _col0 (type: int), _col1 (type: string)
                         null sort order: zz
                         sort order: ++
-                        Map-reduce partition columns: _col0 (type: int)
+                        Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
                         Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -130,7 +130,7 @@ STAGE PLANS:
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
-                     Inner Join 0 to 1
+                     Left Semi Join 0 to 1
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
@@ -154,10 +154,11 @@ STAGE PLANS:
                 Select Operator
                   expressions: _col0 (type: int)
                   outputColumnNames: _col0
-                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
                     keys: _col0 (type: int)
-                    mode: complete
+                    minReductionHashAggr: 0.4
+                    mode: hash
                     outputColumnNames: _col0
                     Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator

--- a/ql/src/test/results/clientpositive/llap/auto_sortmerge_join_17.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_sortmerge_join_17.q.out
@@ -1,0 +1,194 @@
+PREHOOK: query: CREATE TABLE tbl1_n5(key int, value string) CLUSTERED BY (key) SORTED BY (key) INTO 2 BUCKETS
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl1_n5
+POSTHOOK: query: CREATE TABLE tbl1_n5(key int, value string) CLUSTERED BY (key) SORTED BY (key) INTO 2 BUCKETS
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl1_n5
+PREHOOK: query: insert into tbl1_n5(key, value)
+values
+(0, 'val_0'),
+(2, 'val_2'),
+(9, 'val_9')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tbl1_n5
+POSTHOOK: query: insert into tbl1_n5(key, value)
+values
+(0, 'val_0'),
+(2, 'val_2'),
+(9, 'val_9')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tbl1_n5
+POSTHOOK: Lineage: tbl1_n5.key SCRIPT []
+POSTHOOK: Lineage: tbl1_n5.value SCRIPT []
+PREHOOK: query: explain
+SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl1_n5
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl1_n5
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl1_n5
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: key (type: int), value (type: string)
+                      null sort order: aa
+                      sort order: +-
+                      Map-reduce partition columns: key (type: int)
+                      Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: key (type: int), value (type: string)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: string)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: int, _col1: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 DESC NULLS FIRST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: row_number_window_0
+                              name: row_number
+                              window function: GenericUDAFRowNumberEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (row_number_window_0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 93 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col0 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: int)
+                    mode: complete
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl1_n5
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT t1.key from
+(SELECT  key , row_number() over(partition by key order by value desc) as rk from tbl1_n5) t1
+join
+( SELECT key,count(distinct value) as cp_count from tbl1_n5 group by key) t2
+on t1.key = t2.key where rk = 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl1_n5
+#### A masked pattern was here ####
+0
+2
+9

--- a/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
@@ -282,7 +282,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -308,17 +310,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint), _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part_subq
-                  filterExpr: p_mfgr is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_mfgr is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       aggregations: max(p_size), min(p_size)
                       keys: p_mfgr (type: string)
@@ -336,6 +327,45 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col0 (type: string), (UDFToDouble(_col1) / _col2) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: string)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    value expressions: _col1 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
                 aggregations: max(VALUE._col0), min(VALUE._col1)
@@ -352,37 +382,16 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       keys: _col0 (type: string)
-                      mode: final
+                      minReductionHashAggr: 0.99
+                      mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Dummy Store
-            Execution mode: llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: sum(VALUE._col0), count(VALUE._col1)
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: _col0 (type: string), (UDFToDouble(_col1) / _col2) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Merge Join Operator
-                    condition map:
-                         Left Semi Join 0 to 1
-                    keys:
-                      0 _col0 (type: string)
-                      1 _col0 (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
-                      table:
-                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
 
   Stage: Stage-0
     Fetch Operator
@@ -425,7 +434,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -451,17 +462,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: bigint), _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part_subq
-                  filterExpr: p_mfgr is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_mfgr is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       aggregations: max(p_size), min(p_size)
                       keys: p_mfgr (type: string)
@@ -479,6 +479,45 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col0 (type: string), (UDFToDouble(_col1) / _col2) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: string)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    value expressions: _col1 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col0 (type: string)
+                  1 _col0 (type: string)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
                 aggregations: max(VALUE._col0), min(VALUE._col1)
@@ -495,37 +534,16 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       keys: _col0 (type: string)
-                      mode: final
+                      minReductionHashAggr: 0.99
+                      mode: hash
                       outputColumnNames: _col0
                       Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Dummy Store
-            Execution mode: llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: sum(VALUE._col0), count(VALUE._col1)
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: _col0 (type: string), (UDFToDouble(_col1) / _col2) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Merge Join Operator
-                    condition map:
-                         Left Semi Join 0 to 1
-                    keys:
-                      0 _col0 (type: string)
-                      1 _col0 (type: string)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
-                    File Output Operator
-                      compressed: false
-                      Statistics: Num rows: 1 Data size: 206 Basic stats: COMPLETE Column stats: NONE
-                      table:
-                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
 
   Stage: Stage-0
     Fetch Operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Do not convert a Common merge join operator to SMB join when any of the join branches has more than one Group by operators in the same reducer.

### Why are the changes needed?
Each GBY operator buffers one record. These are processed when ReduceRecordSources flushes the operator tree
when end of record stream reached. If the tree has more than two GBY operators CommonMergeJoinOperator can
not process all buffered records and throws exception if the buffered records has different key values. See jira for details https://issues.apache.org/jira/browse/HIVE-27788

### Does this PR introduce _any_ user-facing change?
Yes. No exception is thrown in such cases.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=auto_sortmerge_join_17.q -pl itests/qtest -Pitests
```