### PR TITLE
HIVE-27859: Backport HIVE-27817: Disable ssl hostname verification for 127.0.0.1

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
@@ -71,7 +71,11 @@ public class HiveAuthUtils {
   private static TSocket getSSLSocketWithHttps(TSocket tSSLSocket) throws TTransportException {
     SSLSocket sslSocket = (SSLSocket) tSSLSocket.getSocket();
     SSLParameters sslParams = sslSocket.getSSLParameters();
-    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    if (sslSocket.getLocalAddress().getHostAddress().equals("127.0.0.1")) {
+      sslParams.setEndpointIdentificationAlgorithm(null);
+    } else {
+      sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    }
     sslSocket.setSSLParameters(sslParams);
     return new TSocket(sslSocket);
   }


### PR DESCRIPTION
(cherry picked from commit 2eef89b5b6f350c2c9a72499c3253760df20a328)
