### PR TITLE
HIVE-27867: Incremental materialized view throws NPE whew Iceberg source table is empty

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
@@ -131,6 +131,11 @@ public class HiveAugmentSnapshotMaterializationRule extends RelRule<HiveAugmentS
     Table table = hiveTable.getHiveTableMD();
 
     SnapshotContext mvMetaTableSnapshot = mvMetaStoredSnapshot.get(table.getFullyQualifiedName());
+    if (table.getStorageHandler() == null) {
+      throw new UnsupportedOperationException(String.format("Table %s does not have Storage handler defined. " +
+          "Mixing native and non-native tables in a materialized view definition is currently not supported!",
+          table.getFullyQualifiedName()));
+    }
     if (Objects.equals(mvMetaTableSnapshot, table.getStorageHandler().getCurrentSnapshotContext(table))) {
       return;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
@@ -138,11 +138,8 @@ public class HiveAugmentSnapshotMaterializationRule extends RelRule<HiveAugmentS
       return;
     }
 
-    Long snapshotId = null;
-    if (mvMetaTableSnapshot != null) {
-      snapshotId = mvMetaTableSnapshot.getSnapshotId();
-      table.setVersionIntervalFrom(Long.toString(snapshotId));
-    }
+    Long snapshotId = mvMetaTableSnapshot != null ? mvMetaTableSnapshot.getSnapshotId() : null;
+    table.setVersionIntervalFrom(Objects.toString(snapshotId, null));
 
     RexBuilder rexBuilder = call.builder().getRexBuilder();
     int snapshotIdIndex = tableScan.getTable().getRowType().getField(

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
@@ -148,10 +148,10 @@ public class HiveAugmentSnapshotMaterializationRule extends RelRule<HiveAugmentS
 
     final RelBuilder relBuilder = call.builder();
     relBuilder.push(tableScan);
-    final RexNode literalSnapshotId = rexBuilder.makeLiteral(
+    final RexNode snapshotIdLiteral = rexBuilder.makeLiteral(
         snapshotId, snapshotIdType(relBuilder.getTypeFactory()), false);
     final RexNode predicateWithSnapShotId = rexBuilder.makeCall(
-        SqlStdOperatorTable.LESS_THAN_OR_EQUAL, snapshotIdInputRef, literalSnapshotId);
+        SqlStdOperatorTable.LESS_THAN_OR_EQUAL, snapshotIdInputRef, snapshotIdLiteral);
     relBuilder.filter(singletonList(predicateWithSnapShotId));
     call.transformTo(relBuilder.build());
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAugmentSnapshotMaterializationRule.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
@@ -39,12 +38,12 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.TypeConverter;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import static java.util.Collections.singletonList;
 
 /**
  * This rule will rewrite the materialized view with information about
@@ -149,11 +148,11 @@ public class HiveAugmentSnapshotMaterializationRule extends RelRule<HiveAugmentS
 
     final RelBuilder relBuilder = call.builder();
     relBuilder.push(tableScan);
-    List<RexNode> conds = new ArrayList<>();
-    final RexNode literalHighWatermark = rexBuilder.makeLiteral(
+    final RexNode literalSnapshotId = rexBuilder.makeLiteral(
         snapshotId, snapshotIdType(relBuilder.getTypeFactory()), false);
-    conds.add(rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, snapshotIdInputRef, literalHighWatermark));
-    relBuilder.filter(conds);
+    final RexNode predicateWithSnapShotId = rexBuilder.makeCall(
+        SqlStdOperatorTable.LESS_THAN_OR_EQUAL, snapshotIdInputRef, literalSnapshotId);
+    relBuilder.filter(singletonList(predicateWithSnapShotId));
     call.transformTo(relBuilder.build());
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
@@ -79,7 +80,6 @@ import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hive.common.util.TxnIdUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -284,8 +284,8 @@ public class HiveMaterializedViewUtils {
   /**
    * Method to apply a rule to a query plan.
    */
-  @NotNull
-  private static RelNode applyRule(
+  @VisibleForTesting
+  static RelNode applyRule(
           RelNode basePlan, RelOptRule relOptRule) {
     final HepProgramBuilder programBuilder = new HepProgramBuilder();
     programBuilder.addRuleInstance(relOptRule);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 
 import java.util.Set;
 
+import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveAugmentSnapshotMaterializationRule.NULL_SNAPSHOT_ID;
+
 /**
  * Calcite rule to push down predicates contains {@link VirtualColumn#SNAPSHOT_ID} reference to TableScan.
  * <p>
@@ -124,7 +126,8 @@ public class HivePushdownSnapshotFilterRule extends RelRule<HivePushdownSnapshot
       }
 
       RelOptHiveTable hiveTable = (RelOptHiveTable) relOptTable;
-      hiveTable.getHiveTableMD().setVersionIntervalFrom(Long.toString(snapshotId));
+      String snapshotIdText = snapshotId != NULL_SNAPSHOT_ID ? Long.toString(snapshotId) : null;
+      hiveTable.getHiveTableMD().setVersionIntervalFrom(snapshotIdText);
       return true;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -124,8 +125,7 @@ public class HivePushdownSnapshotFilterRule extends RelRule<HivePushdownSnapshot
       }
 
       RelOptHiveTable hiveTable = (RelOptHiveTable) relOptTable;
-      String snapshotIdText = snapshotId != null ? Long.toString(snapshotId) : null;
-      hiveTable.getHiveTableMD().setVersionIntervalFrom(snapshotIdText);
+      hiveTable.getHiveTableMD().setVersionIntervalFrom(Objects.toString(snapshotId, null));
       return true;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HivePushdownSnapshotFilterRule.java
@@ -40,8 +40,6 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 
 import java.util.Set;
 
-import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveAugmentSnapshotMaterializationRule.NULL_SNAPSHOT_ID;
-
 /**
  * Calcite rule to push down predicates contains {@link VirtualColumn#SNAPSHOT_ID} reference to TableScan.
  * <p>
@@ -118,7 +116,7 @@ public class HivePushdownSnapshotFilterRule extends RelRule<HivePushdownSnapshot
         return false;
       }
 
-      long snapshotId = literal.getValueAs(Long.class);
+      Long snapshotId = literal.getValueAs(Long.class);
 
       RelOptTable relOptTable = getRelOptTableOf(op2);
       if (relOptTable == null) {
@@ -126,7 +124,7 @@ public class HivePushdownSnapshotFilterRule extends RelRule<HivePushdownSnapshot
       }
 
       RelOptHiveTable hiveTable = (RelOptHiveTable) relOptTable;
-      String snapshotIdText = snapshotId != NULL_SNAPSHOT_ID ? Long.toString(snapshotId) : null;
+      String snapshotIdText = snapshotId != null ? Long.toString(snapshotId) : null;
       hiveTable.getHiveTableMD().setVersionIntervalFrom(snapshotIdText);
       return true;
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHiveAugmentSnapshotMaterializationRule.java
@@ -57,7 +57,7 @@ public class TestHiveAugmentSnapshotMaterializationRule extends TestRuleBase {
 
     assertThat(newRoot, instanceOf(HiveFilter.class));
     HiveFilter filter = (HiveFilter) newRoot;
-    assertThat(filter.getCondition().toString(), is("<=($3, -1)"));
+    assertThat(filter.getCondition().toString(), is("<=($3, null)"));
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHiveAugmentSnapshotMaterializationRule.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHiveAugmentSnapshotMaterializationRule.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.hadoop.hive.common.type.SnapshotContext;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestHiveAugmentSnapshotMaterializationRule extends TestRuleBase {
+
+  @Test
+  public void testWhenSnapshotAndTableAreEmptyNoFilterAdded() {
+    RelNode tableScan = createTS();
+    RelOptRule rule = HiveAugmentSnapshotMaterializationRule.with(Collections.emptyMap());
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(tableScan, rule);
+
+    assertThat(newRoot, is(tableScan));
+  }
+
+  @Test
+  public void testWhenNoSnapshotButTableHasNewDataAFilterWithDefaultSnapshotIDAdded() {
+    doReturn(new SnapshotContext(42)).when(table2storageHandler).getCurrentSnapshotContext(table2);
+    RelNode tableScan = createTS();
+    RelOptRule rule = HiveAugmentSnapshotMaterializationRule.with(Collections.emptyMap());
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(tableScan, rule);
+
+    assertThat(newRoot, instanceOf(HiveFilter.class));
+    HiveFilter filter = (HiveFilter) newRoot;
+    assertThat(filter.getCondition().toString(), is("<=($3, -1)"));
+  }
+
+  @Test
+  public void testWhenMVAndTableCurrentSnapshotAreTheSameNoFilterAdded() {
+    doReturn(new SnapshotContext(42)).when(table2storageHandler).getCurrentSnapshotContext(table2);
+    RelNode tableScan = createTS();
+    Map<String, SnapshotContext> mvSnapshot = new HashMap<>();
+    mvSnapshot.put(table2.getFullyQualifiedName(), new SnapshotContext(42));
+    RelOptRule rule = HiveAugmentSnapshotMaterializationRule.with(mvSnapshot);
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(tableScan, rule);
+
+    assertThat(newRoot, is(tableScan));
+  }
+
+  @Test
+  public void testWhenMVSnapshotIsDifferentThanTableCurrentSnapshotHasNewDataAFilterWithMVSnapshotIdAdded() {
+    doReturn(new SnapshotContext(10)).when(table2storageHandler).getCurrentSnapshotContext(table2);
+    RelNode tableScan = createTS();
+    Map<String, SnapshotContext> mvSnapshot = new HashMap<>();
+    mvSnapshot.put(table2.getFullyQualifiedName(), new SnapshotContext(42));
+    RelOptRule rule = HiveAugmentSnapshotMaterializationRule.with(mvSnapshot);
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(tableScan, rule);
+
+    assertThat(newRoot, instanceOf(HiveFilter.class));
+    HiveFilter filter = (HiveFilter) newRoot;
+    assertThat(filter.getCondition().toString(), is("<=($3, 42)"));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHivePushdownSnapshotFilterRule.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestHivePushdownSnapshotFilterRule.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
+
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
+import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestHivePushdownSnapshotFilterRule extends TestRuleBase {
+
+  @Mock
+  private RelOptSchema schemaMock;
+
+  @Test
+  public void testFilterIsRemovedAndVersionIntervalFromIsSetWhenFilterHasSnapshotIdPredicate() {
+    RelNode tableScan = createTS();
+
+    RelBuilder relBuilder = HiveRelFactories.HIVE_BUILDER.create(relOptCluster, schemaMock);
+    RelNode root = relBuilder.push(tableScan)
+        .filter(REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            REX_BUILDER.makeInputRef(HiveAugmentSnapshotMaterializationRule.snapshotIdType(TYPE_FACTORY), 3),
+            REX_BUILDER.makeLiteral(42, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER), false)))
+        .build();
+
+    System.out.println(RelOptUtil.toString(root));
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(root, HivePushdownSnapshotFilterRule.INSTANCE);
+
+    assertThat(newRoot, instanceOf(HiveTableScan.class));
+    HiveTableScan newScan = (HiveTableScan) newRoot;
+    RelOptHiveTable optHiveTable = (RelOptHiveTable) newScan.getTable();
+    assertThat(optHiveTable.getHiveTableMD().getVersionIntervalFrom(), is("42"));
+  }
+
+  @Test
+  public void testFilterLeftIntactWhenItDoesNotHaveSnapshotIdPredicate() {
+    RelNode tableScan = createTS();
+
+    RelBuilder relBuilder = HiveRelFactories.HIVE_BUILDER.create(relOptCluster, schemaMock);
+    RelNode root = relBuilder.push(tableScan)
+        .filter(REX_BUILDER.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            REX_BUILDER.makeInputRef(TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER), 1),
+            REX_BUILDER.makeLiteral(42, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER), false)))
+        .build();
+
+    System.out.println(RelOptUtil.toString(root));
+
+    RelNode newRoot = HiveMaterializedViewUtils.applyRule(root, HivePushdownSnapshotFilterRule.INSTANCE);
+
+    assertThat(newRoot.getDigest(), is(root.getDigest()));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestRuleBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/TestRuleBase.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
+import org.apache.hadoop.hive.ql.optimizer.calcite.HiveTypeSystemImpl;
+import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveRelNode;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveTableScan;
+import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.doReturn;
+
+public class TestRuleBase {
+  protected static final RexBuilder REX_BUILDER = new RexBuilder(new JavaTypeFactoryImpl(new HiveTypeSystemImpl()));
+  protected static final RelDataTypeFactory TYPE_FACTORY = REX_BUILDER.getTypeFactory();
+
+  protected static RelOptCluster relOptCluster;
+  @Mock
+  protected RelOptHiveTable table2Mock;
+  protected static RelDataType table2Type;
+  protected static Table table2;
+  @Mock
+  protected static HiveStorageHandler table2storageHandler;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    RelOptPlanner planner = CalcitePlanner.createPlanner(new HiveConf());
+    relOptCluster = RelOptCluster.create(planner, REX_BUILDER);
+    List<RelDataType> t2Schema = asList(
+        TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER),
+        TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR),
+        TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER),
+        HiveAugmentSnapshotMaterializationRule.snapshotIdType(TYPE_FACTORY));
+    table2Type = TYPE_FACTORY.createStructType(t2Schema, asList("d", "e", "f", VirtualColumn.SNAPSHOT_ID.getName()));
+    table2 = new Table();
+    table2.setTTable(new org.apache.hadoop.hive.metastore.api.Table());
+    table2.setDbName("default");
+    table2.setTableName("t2");
+  }
+
+  @Before
+  public void setup() {
+    doReturn(table2Type).when(table2Mock).getRowType();
+    doReturn(table2).when(table2Mock).getHiveTableMD();
+    table2.setStorageHandler(table2storageHandler);
+  }
+
+  protected HiveTableScan createTS() {
+    return new HiveTableScan(relOptCluster, relOptCluster.traitSetOf(HiveRelNode.CONVENTION),
+        table2Mock, "t2", null, false, false);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
* Use Objects.equals for comparing saved snapshot in MV metadata and table current snapshot.
* HiveStorageHandler.getCurrentSnapshotContext() returns null when table is empty and no snapshot exists. Add null check of snapshotId when creating filter predicate

### Why are the changes needed?
If both saved snapshot in MV metadata and table current snapshot are null NPE was thrown.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
```
mvn test -Dtest=TestHiveAugmentSnapshotMaterializationRule,TestHivePushdownSnapshotFilterRule -pl ql
mvn test -Dtest.output.overwrite -Dtest=TestIcebergLlapLocalCliDriver -Dqfile=mv_iceberg_orc.q -pl itests/qtest-iceberg -Piceberg -Pitests
```
and search for NPE in `hive.log`