### PR TITLE
HIVE-27868: Backport a subset of HIVE-18755 to branch-2.3 to support reading from catalog in HMS 3+

### DIFF
--- a/metastore/if/hive_metastore.thrift
+++ b/metastore/if/hive_metastore.thrift
@@ -98,7 +98,7 @@ enum PartitionEventType {
   LOAD_DONE = 1,
 }
 
-// Enums for transaction and lock management 
+// Enums for transaction and lock management
 enum TxnState {
     COMMITTED = 1,
     ABORTED = 2,
@@ -157,6 +157,7 @@ struct HiveObjectRef{
   3: string objectName,
   4: list<string> partValues,
   5: string columnName,
+  6: optional string catName,
 }
 
 struct PrivilegeGrantInfo {
@@ -250,7 +251,8 @@ struct Database {
   4: map<string, string> parameters, // properties associated with the database
   5: optional PrincipalPrivilegeSet privileges,
   6: optional string ownerName,
-  7: optional PrincipalType ownerType
+  7: optional PrincipalType ownerType,
+  8: optional string catalogName
 }
 
 // This object holds the information needed by SerDes
@@ -305,7 +307,8 @@ struct Table {
   12: string tableType,                // table type enum, e.g. EXTERNAL_TABLE
   13: optional PrincipalPrivilegeSet privileges,
   14: optional bool temporary=false,
-  15: optional bool rewriteEnabled     // rewrite enabled or not
+  15: optional bool rewriteEnabled,     // rewrite enabled or not
+  16: optional string catName
 }
 
 struct Partition {
@@ -316,7 +319,8 @@ struct Partition {
   5: i32          lastAccessTime,
   6: StorageDescriptor   sd,
   7: map<string, string> parameters,
-  8: optional PrincipalPrivilegeSet privileges
+  8: optional PrincipalPrivilegeSet privileges,
+  9: optional string catName
 }
 
 struct PartitionWithoutSD {
@@ -342,7 +346,8 @@ struct PartitionSpec {
   2: string tableName,
   3: string rootPath,
   4: optional PartitionSpecWithSharedSD sharedSDPartitionSpec,
-  5: optional PartitionListComposingSpec partitionList
+  5: optional PartitionListComposingSpec partitionList,
+  6: optional string catName
 }
 
 struct Index {
@@ -444,7 +449,8 @@ struct ColumnStatisticsDesc {
 2: required string dbName,
 3: required string tableName,
 4: optional string partName,
-5: optional i64 lastAnalyzed
+5: optional i64 lastAnalyzed,
+6: optional string catName
 }
 
 struct ColumnStatistics {
@@ -498,7 +504,7 @@ struct ForeignKeysResponse {
 }
 
 struct DropConstraintRequest {
-  1: required string dbname, 
+  1: required string dbname,
   2: required string tablename,
   3: required string constraintname
 }
@@ -523,7 +529,8 @@ struct PartitionsByExprRequest {
   2: required string tblName,
   3: required binary expr,
   4: optional string defaultPartitionName,
-  5: optional i16 maxParts=-1
+  5: optional i16 maxParts=-1,
+  6: optional string catName
 }
 
 struct TableStatsResult {
@@ -544,7 +551,8 @@ struct PartitionsStatsRequest {
  1: required string dbName,
  2: required string tblName,
  3: required list<string> colNames,
- 4: required list<string> partNames
+ 4: required list<string> partNames,
+ 5: optional string catName
 }
 
 // Return type for add_partitions_req
@@ -558,7 +566,8 @@ struct AddPartitionsRequest {
   2: required string tblName,
   3: required list<Partition> parts,
   4: required bool ifNotExists,
-  5: optional bool needResult=true
+  5: optional bool needResult=true,
+  6: optional string catName
 }
 
 // Return type for drop_partitions_req
@@ -586,7 +595,8 @@ struct DropPartitionsRequest {
   5: optional bool ifExists=true, // currently verified on client
   6: optional bool ignoreProtection,
   7: optional EnvironmentContext environmentContext,
-  8: optional bool needResult=true
+  8: optional bool needResult=true,
+  9: optional string catName
 }
 
 struct PartitionValuesRequest {
@@ -598,6 +608,7 @@ struct PartitionValuesRequest {
   6: optional list<FieldSchema> partitionOrder;
   7: optional bool ascending = true;
   8: optional i64 maxParts = -1;
+  9: optional string catName
 }
 
 struct PartitionValuesRow {
@@ -633,6 +644,7 @@ struct Function {
   6: i32              createTime,
   7: FunctionType     functionType,
   8: list<ResourceUri> resourceUris,
+  9: optional string  catName
 }
 
 // Structs for transaction and locks
@@ -853,7 +865,7 @@ struct FireEventRequest {
 struct FireEventResponse {
     // NOP for now, this is just a place holder for future responses
 }
-    
+
 struct MetadataPpdResult {
   1: optional binary metadata,
   2: optional binary includeBitset
@@ -1081,7 +1093,7 @@ service ThriftHiveMetastore extends fb303.FacebookService
   void add_primary_key(1:AddPrimaryKeyRequest req)
       throws(1:NoSuchObjectException o1, 2:MetaException o2)
   void add_foreign_key(1:AddForeignKeyRequest req)
-      throws(1:NoSuchObjectException o1, 2:MetaException o2)  
+      throws(1:NoSuchObjectException o1, 2:MetaException o2)
 
   // drops the table and all the partitions associated with it if the table has partitions
   // delete data (including partitions) if deleteData is set to true
@@ -1491,13 +1503,13 @@ service ThriftHiveMetastore extends fb303.FacebookService
   ShowLocksResponse show_locks(1:ShowLocksRequest rqst)
   void heartbeat(1:HeartbeatRequest ids) throws (1:NoSuchLockException o1, 2:NoSuchTxnException o2, 3:TxnAbortedException o3)
   HeartbeatTxnRangeResponse heartbeat_txn_range(1:HeartbeatTxnRangeRequest txns)
-  void compact(1:CompactionRequest rqst) 
-  CompactionResponse compact2(1:CompactionRequest rqst) 
+  void compact(1:CompactionRequest rqst)
+  CompactionResponse compact2(1:CompactionRequest rqst)
   ShowCompactResponse show_compact(1:ShowCompactRequest rqst)
   void add_dynamic_partitions(1:AddDynamicPartitions rqst) throws (1:NoSuchTxnException o1, 2:TxnAbortedException o2)
 
   // Notification logging calls
-  NotificationEventResponse get_next_notification(1:NotificationEventRequest rqst) 
+  NotificationEventResponse get_next_notification(1:NotificationEventRequest rqst)
   CurrentNotificationEventId get_current_notificationEventId()
   FireEventResponse fire_listener_event(1:FireEventRequest rqst)
   void flushCache()

--- a/metastore/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/metastore/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -1500,6 +1500,11 @@ void HiveObjectRef::__set_partValues(const std::vector<std::string> & val) {
 void HiveObjectRef::__set_columnName(const std::string& val) {
   this->columnName = val;
 }
+
+void HiveObjectRef::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const HiveObjectRef& obj)
 {
   obj.printTo(out);
@@ -1582,6 +1587,14 @@ uint32_t HiveObjectRef::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -1627,6 +1640,11 @@ uint32_t HiveObjectRef::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeString(this->columnName);
   xfer += oprot->writeFieldEnd();
 
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 6);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -1639,6 +1657,7 @@ void swap(HiveObjectRef &a, HiveObjectRef &b) {
   swap(a.objectName, b.objectName);
   swap(a.partValues, b.partValues);
   swap(a.columnName, b.columnName);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -1648,6 +1667,7 @@ HiveObjectRef::HiveObjectRef(const HiveObjectRef& other23) {
   objectName = other23.objectName;
   partValues = other23.partValues;
   columnName = other23.columnName;
+  catName = other23.catName;
   __isset = other23.__isset;
 }
 HiveObjectRef& HiveObjectRef::operator=(const HiveObjectRef& other24) {
@@ -1656,6 +1676,7 @@ HiveObjectRef& HiveObjectRef::operator=(const HiveObjectRef& other24) {
   objectName = other24.objectName;
   partValues = other24.partValues;
   columnName = other24.columnName;
+  catName = other24.catName;
   __isset = other24.__isset;
   return *this;
 }
@@ -1667,6 +1688,7 @@ void HiveObjectRef::printTo(std::ostream& out) const {
   out << ", " << "objectName=" << to_string(objectName);
   out << ", " << "partValues=" << to_string(partValues);
   out << ", " << "columnName=" << to_string(columnName);
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -3738,6 +3760,11 @@ void Database::__set_ownerType(const PrincipalType::type val) {
   this->ownerType = val;
 __isset.ownerType = true;
 }
+
+void Database::__set_catalogName(const std::string& val) {
+  this->catalogName = val;
+__isset.catalogName = true;
+}
 std::ostream& operator<<(std::ostream& out, const Database& obj)
 {
   obj.printTo(out);
@@ -3839,6 +3866,14 @@ uint32_t Database::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catalogName);
+          this->__isset.catalogName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -3896,6 +3931,11 @@ uint32_t Database::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeI32((int32_t)this->ownerType);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catalogName) {
+    xfer += oprot->writeFieldBegin("catalogName", ::apache::thrift::protocol::T_STRING, 8);
+    xfer += oprot->writeString(this->catalogName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -3910,6 +3950,7 @@ void swap(Database &a, Database &b) {
   swap(a.privileges, b.privileges);
   swap(a.ownerName, b.ownerName);
   swap(a.ownerType, b.ownerType);
+  swap(a.catalogName, b.catalogName);
   swap(a.__isset, b.__isset);
 }
 
@@ -3921,6 +3962,7 @@ Database::Database(const Database& other131) {
   privileges = other131.privileges;
   ownerName = other131.ownerName;
   ownerType = other131.ownerType;
+  catalogName = other131.catalogName;
   __isset = other131.__isset;
 }
 Database& Database::operator=(const Database& other132) {
@@ -3931,6 +3973,7 @@ Database& Database::operator=(const Database& other132) {
   privileges = other132.privileges;
   ownerName = other132.ownerName;
   ownerType = other132.ownerType;
+  catalogName = other132.catalogName;
   __isset = other132.__isset;
   return *this;
 }
@@ -3944,6 +3987,7 @@ void Database::printTo(std::ostream& out) const {
   out << ", " << "privileges="; (__isset.privileges ? (out << to_string(privileges)) : (out << "<null>"));
   out << ", " << "ownerName="; (__isset.ownerName ? (out << to_string(ownerName)) : (out << "<null>"));
   out << ", " << "ownerType="; (__isset.ownerType ? (out << to_string(ownerType)) : (out << "<null>"));
+  out << ", " << "catalogName="; (__isset.catalogName ? (out << to_string(catalogName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -4918,6 +4962,11 @@ void Table::__set_rewriteEnabled(const bool val) {
   this->rewriteEnabled = val;
 __isset.rewriteEnabled = true;
 }
+
+void Table::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const Table& obj)
 {
   obj.printTo(out);
@@ -5093,6 +5142,14 @@ uint32_t Table::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 16:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5190,6 +5247,11 @@ uint32_t Table::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeBool(this->rewriteEnabled);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 16);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -5212,6 +5274,7 @@ void swap(Table &a, Table &b) {
   swap(a.privileges, b.privileges);
   swap(a.temporary, b.temporary);
   swap(a.rewriteEnabled, b.rewriteEnabled);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -5231,6 +5294,7 @@ Table::Table(const Table& other221) {
   privileges = other221.privileges;
   temporary = other221.temporary;
   rewriteEnabled = other221.rewriteEnabled;
+  catName = other221.catName;
   __isset = other221.__isset;
 }
 Table& Table::operator=(const Table& other222) {
@@ -5249,6 +5313,7 @@ Table& Table::operator=(const Table& other222) {
   privileges = other222.privileges;
   temporary = other222.temporary;
   rewriteEnabled = other222.rewriteEnabled;
+  catName = other222.catName;
   __isset = other222.__isset;
   return *this;
 }
@@ -5270,6 +5335,7 @@ void Table::printTo(std::ostream& out) const {
   out << ", " << "privileges="; (__isset.privileges ? (out << to_string(privileges)) : (out << "<null>"));
   out << ", " << "temporary="; (__isset.temporary ? (out << to_string(temporary)) : (out << "<null>"));
   out << ", " << "rewriteEnabled="; (__isset.rewriteEnabled ? (out << to_string(rewriteEnabled)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -5309,6 +5375,11 @@ void Partition::__set_parameters(const std::map<std::string, std::string> & val)
 void Partition::__set_privileges(const PrincipalPrivilegeSet& val) {
   this->privileges = val;
 __isset.privileges = true;
+}
+
+void Partition::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
 }
 std::ostream& operator<<(std::ostream& out, const Partition& obj)
 {
@@ -5429,6 +5500,14 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5496,6 +5575,11 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += this->privileges.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 9);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -5511,6 +5595,7 @@ void swap(Partition &a, Partition &b) {
   swap(a.sd, b.sd);
   swap(a.parameters, b.parameters);
   swap(a.privileges, b.privileges);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -5523,6 +5608,7 @@ Partition::Partition(const Partition& other237) {
   sd = other237.sd;
   parameters = other237.parameters;
   privileges = other237.privileges;
+  catName = other237.catName;
   __isset = other237.__isset;
 }
 Partition& Partition::operator=(const Partition& other238) {
@@ -5534,6 +5620,7 @@ Partition& Partition::operator=(const Partition& other238) {
   sd = other238.sd;
   parameters = other238.parameters;
   privileges = other238.privileges;
+  catName = other238.catName;
   __isset = other238.__isset;
   return *this;
 }
@@ -5548,6 +5635,7 @@ void Partition::printTo(std::ostream& out) const {
   out << ", " << "sd=" << to_string(sd);
   out << ", " << "parameters=" << to_string(parameters);
   out << ", " << "privileges="; (__isset.privileges ? (out << to_string(privileges)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -6059,6 +6147,11 @@ void PartitionSpec::__set_partitionList(const PartitionListComposingSpec& val) {
   this->partitionList = val;
 __isset.partitionList = true;
 }
+
+void PartitionSpec::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const PartitionSpec& obj)
 {
   obj.printTo(out);
@@ -6127,6 +6220,14 @@ uint32_t PartitionSpec::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -6166,6 +6267,11 @@ uint32_t PartitionSpec::write(::apache::thrift::protocol::TProtocol* oprot) cons
     xfer += this->partitionList.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 6);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -6178,6 +6284,7 @@ void swap(PartitionSpec &a, PartitionSpec &b) {
   swap(a.rootPath, b.rootPath);
   swap(a.sharedSDPartitionSpec, b.sharedSDPartitionSpec);
   swap(a.partitionList, b.partitionList);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -6187,6 +6294,7 @@ PartitionSpec::PartitionSpec(const PartitionSpec& other271) {
   rootPath = other271.rootPath;
   sharedSDPartitionSpec = other271.sharedSDPartitionSpec;
   partitionList = other271.partitionList;
+  catName = other271.catName;
   __isset = other271.__isset;
 }
 PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other272) {
@@ -6195,6 +6303,7 @@ PartitionSpec& PartitionSpec::operator=(const PartitionSpec& other272) {
   rootPath = other272.rootPath;
   sharedSDPartitionSpec = other272.sharedSDPartitionSpec;
   partitionList = other272.partitionList;
+  catName = other272.catName;
   __isset = other272.__isset;
   return *this;
 }
@@ -6206,6 +6315,7 @@ void PartitionSpec::printTo(std::ostream& out) const {
   out << ", " << "rootPath=" << to_string(rootPath);
   out << ", " << "sharedSDPartitionSpec="; (__isset.sharedSDPartitionSpec ? (out << to_string(sharedSDPartitionSpec)) : (out << "<null>"));
   out << ", " << "partitionList="; (__isset.partitionList ? (out << to_string(partitionList)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -8350,6 +8460,11 @@ void ColumnStatisticsDesc::__set_lastAnalyzed(const int64_t val) {
   this->lastAnalyzed = val;
 __isset.lastAnalyzed = true;
 }
+
+void ColumnStatisticsDesc::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const ColumnStatisticsDesc& obj)
 {
   obj.printTo(out);
@@ -8421,6 +8536,14 @@ uint32_t ColumnStatisticsDesc::read(::apache::thrift::protocol::TProtocol* iprot
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -8466,6 +8589,11 @@ uint32_t ColumnStatisticsDesc::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeI64(this->lastAnalyzed);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 6);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -8478,6 +8606,7 @@ void swap(ColumnStatisticsDesc &a, ColumnStatisticsDesc &b) {
   swap(a.tableName, b.tableName);
   swap(a.partName, b.partName);
   swap(a.lastAnalyzed, b.lastAnalyzed);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -8487,6 +8616,7 @@ ColumnStatisticsDesc::ColumnStatisticsDesc(const ColumnStatisticsDesc& other305)
   tableName = other305.tableName;
   partName = other305.partName;
   lastAnalyzed = other305.lastAnalyzed;
+  catName = other305.catName;
   __isset = other305.__isset;
 }
 ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc& other306) {
@@ -8495,6 +8625,7 @@ ColumnStatisticsDesc& ColumnStatisticsDesc::operator=(const ColumnStatisticsDesc
   tableName = other306.tableName;
   partName = other306.partName;
   lastAnalyzed = other306.lastAnalyzed;
+  catName = other306.catName;
   __isset = other306.__isset;
   return *this;
 }
@@ -8506,6 +8637,7 @@ void ColumnStatisticsDesc::printTo(std::ostream& out) const {
   out << ", " << "tableName=" << to_string(tableName);
   out << ", " << "partName="; (__isset.partName ? (out << to_string(partName)) : (out << "<null>"));
   out << ", " << "lastAnalyzed="; (__isset.lastAnalyzed ? (out << to_string(lastAnalyzed)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -10202,6 +10334,11 @@ void PartitionsByExprRequest::__set_maxParts(const int16_t val) {
   this->maxParts = val;
 __isset.maxParts = true;
 }
+
+void PartitionsByExprRequest::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const PartitionsByExprRequest& obj)
 {
   obj.printTo(out);
@@ -10273,6 +10410,14 @@ uint32_t PartitionsByExprRequest::read(::apache::thrift::protocol::TProtocol* ip
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -10318,6 +10463,11 @@ uint32_t PartitionsByExprRequest::write(::apache::thrift::protocol::TProtocol* o
     xfer += oprot->writeI16(this->maxParts);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 6);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -10330,6 +10480,7 @@ void swap(PartitionsByExprRequest &a, PartitionsByExprRequest &b) {
   swap(a.expr, b.expr);
   swap(a.defaultPartitionName, b.defaultPartitionName);
   swap(a.maxParts, b.maxParts);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -10339,6 +10490,7 @@ PartitionsByExprRequest::PartitionsByExprRequest(const PartitionsByExprRequest& 
   expr = other403.expr;
   defaultPartitionName = other403.defaultPartitionName;
   maxParts = other403.maxParts;
+  catName = other403.catName;
   __isset = other403.__isset;
 }
 PartitionsByExprRequest& PartitionsByExprRequest::operator=(const PartitionsByExprRequest& other404) {
@@ -10347,6 +10499,7 @@ PartitionsByExprRequest& PartitionsByExprRequest::operator=(const PartitionsByEx
   expr = other404.expr;
   defaultPartitionName = other404.defaultPartitionName;
   maxParts = other404.maxParts;
+  catName = other404.catName;
   __isset = other404.__isset;
   return *this;
 }
@@ -10358,6 +10511,7 @@ void PartitionsByExprRequest::printTo(std::ostream& out) const {
   out << ", " << "expr=" << to_string(expr);
   out << ", " << "defaultPartitionName="; (__isset.defaultPartitionName ? (out << to_string(defaultPartitionName)) : (out << "<null>"));
   out << ", " << "maxParts="; (__isset.maxParts ? (out << to_string(maxParts)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -10787,6 +10941,11 @@ void PartitionsStatsRequest::__set_colNames(const std::vector<std::string> & val
 void PartitionsStatsRequest::__set_partNames(const std::vector<std::string> & val) {
   this->partNames = val;
 }
+
+void PartitionsStatsRequest::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const PartitionsStatsRequest& obj)
 {
   obj.printTo(out);
@@ -10875,6 +11034,14 @@ uint32_t PartitionsStatsRequest::read(::apache::thrift::protocol::TProtocol* ipr
           xfer += iprot->skip(ftype);
         }
         break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -10932,6 +11099,11 @@ uint32_t PartitionsStatsRequest::write(::apache::thrift::protocol::TProtocol* op
   }
   xfer += oprot->writeFieldEnd();
 
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 5);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -10943,6 +11115,8 @@ void swap(PartitionsStatsRequest &a, PartitionsStatsRequest &b) {
   swap(a.tblName, b.tblName);
   swap(a.colNames, b.colNames);
   swap(a.partNames, b.partNames);
+  swap(a.catName, b.catName);
+  swap(a.__isset, b.__isset);
 }
 
 PartitionsStatsRequest::PartitionsStatsRequest(const PartitionsStatsRequest& other449) {
@@ -10950,12 +11124,16 @@ PartitionsStatsRequest::PartitionsStatsRequest(const PartitionsStatsRequest& oth
   tblName = other449.tblName;
   colNames = other449.colNames;
   partNames = other449.partNames;
+  catName = other449.catName;
+  __isset = other449.__isset;
 }
 PartitionsStatsRequest& PartitionsStatsRequest::operator=(const PartitionsStatsRequest& other450) {
   dbName = other450.dbName;
   tblName = other450.tblName;
   colNames = other450.colNames;
   partNames = other450.partNames;
+  catName = other450.catName;
+  __isset = other450.__isset;
   return *this;
 }
 void PartitionsStatsRequest::printTo(std::ostream& out) const {
@@ -10965,6 +11143,7 @@ void PartitionsStatsRequest::printTo(std::ostream& out) const {
   out << ", " << "tblName=" << to_string(tblName);
   out << ", " << "colNames=" << to_string(colNames);
   out << ", " << "partNames=" << to_string(partNames);
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -11107,6 +11286,11 @@ void AddPartitionsRequest::__set_needResult(const bool val) {
   this->needResult = val;
 __isset.needResult = true;
 }
+
+void AddPartitionsRequest::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const AddPartitionsRequest& obj)
 {
   obj.printTo(out);
@@ -11191,6 +11375,14 @@ uint32_t AddPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -11245,6 +11437,11 @@ uint32_t AddPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeBool(this->needResult);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 6);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -11257,6 +11454,7 @@ void swap(AddPartitionsRequest &a, AddPartitionsRequest &b) {
   swap(a.parts, b.parts);
   swap(a.ifNotExists, b.ifNotExists);
   swap(a.needResult, b.needResult);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -11266,6 +11464,7 @@ AddPartitionsRequest::AddPartitionsRequest(const AddPartitionsRequest& other465)
   parts = other465.parts;
   ifNotExists = other465.ifNotExists;
   needResult = other465.needResult;
+  catName = other465.catName;
   __isset = other465.__isset;
 }
 AddPartitionsRequest& AddPartitionsRequest::operator=(const AddPartitionsRequest& other466) {
@@ -11274,6 +11473,7 @@ AddPartitionsRequest& AddPartitionsRequest::operator=(const AddPartitionsRequest
   parts = other466.parts;
   ifNotExists = other466.ifNotExists;
   needResult = other466.needResult;
+  catName = other466.catName;
   __isset = other466.__isset;
   return *this;
 }
@@ -11285,6 +11485,7 @@ void AddPartitionsRequest::printTo(std::ostream& out) const {
   out << ", " << "parts=" << to_string(parts);
   out << ", " << "ifNotExists=" << to_string(ifNotExists);
   out << ", " << "needResult="; (__isset.needResult ? (out << to_string(needResult)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -11716,6 +11917,11 @@ void DropPartitionsRequest::__set_needResult(const bool val) {
   this->needResult = val;
 __isset.needResult = true;
 }
+
+void DropPartitionsRequest::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const DropPartitionsRequest& obj)
 {
   obj.printTo(out);
@@ -11811,6 +12017,14 @@ uint32_t DropPartitionsRequest::read(::apache::thrift::protocol::TProtocol* ipro
           xfer += iprot->skip(ftype);
         }
         break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -11871,6 +12085,11 @@ uint32_t DropPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opr
     xfer += oprot->writeBool(this->needResult);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 9);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -11886,6 +12105,7 @@ void swap(DropPartitionsRequest &a, DropPartitionsRequest &b) {
   swap(a.ignoreProtection, b.ignoreProtection);
   swap(a.environmentContext, b.environmentContext);
   swap(a.needResult, b.needResult);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -11898,6 +12118,7 @@ DropPartitionsRequest::DropPartitionsRequest(const DropPartitionsRequest& other4
   ignoreProtection = other491.ignoreProtection;
   environmentContext = other491.environmentContext;
   needResult = other491.needResult;
+  catName = other491.catName;
   __isset = other491.__isset;
 }
 DropPartitionsRequest& DropPartitionsRequest::operator=(const DropPartitionsRequest& other492) {
@@ -11909,6 +12130,7 @@ DropPartitionsRequest& DropPartitionsRequest::operator=(const DropPartitionsRequ
   ignoreProtection = other492.ignoreProtection;
   environmentContext = other492.environmentContext;
   needResult = other492.needResult;
+  catName = other492.catName;
   __isset = other492.__isset;
   return *this;
 }
@@ -11923,6 +12145,7 @@ void DropPartitionsRequest::printTo(std::ostream& out) const {
   out << ", " << "ignoreProtection="; (__isset.ignoreProtection ? (out << to_string(ignoreProtection)) : (out << "<null>"));
   out << ", " << "environmentContext="; (__isset.environmentContext ? (out << to_string(environmentContext)) : (out << "<null>"));
   out << ", " << "needResult="; (__isset.needResult ? (out << to_string(needResult)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -11966,6 +12189,11 @@ __isset.ascending = true;
 void PartitionValuesRequest::__set_maxParts(const int64_t val) {
   this->maxParts = val;
 __isset.maxParts = true;
+}
+
+void PartitionValuesRequest::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
 }
 std::ostream& operator<<(std::ostream& out, const PartitionValuesRequest& obj)
 {
@@ -12086,6 +12314,14 @@ uint32_t PartitionValuesRequest::read(::apache::thrift::protocol::TProtocol* ipr
           xfer += iprot->skip(ftype);
         }
         break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -12162,6 +12398,11 @@ uint32_t PartitionValuesRequest::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeI64(this->maxParts);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 9);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -12177,6 +12418,7 @@ void swap(PartitionValuesRequest &a, PartitionValuesRequest &b) {
   swap(a.partitionOrder, b.partitionOrder);
   swap(a.ascending, b.ascending);
   swap(a.maxParts, b.maxParts);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -12189,6 +12431,7 @@ PartitionValuesRequest::PartitionValuesRequest(const PartitionValuesRequest& oth
   partitionOrder = other505.partitionOrder;
   ascending = other505.ascending;
   maxParts = other505.maxParts;
+  catName = other505.catName;
   __isset = other505.__isset;
 }
 PartitionValuesRequest& PartitionValuesRequest::operator=(const PartitionValuesRequest& other506) {
@@ -12200,6 +12443,7 @@ PartitionValuesRequest& PartitionValuesRequest::operator=(const PartitionValuesR
   partitionOrder = other506.partitionOrder;
   ascending = other506.ascending;
   maxParts = other506.maxParts;
+  catName = other506.catName;
   __isset = other506.__isset;
   return *this;
 }
@@ -12214,6 +12458,7 @@ void PartitionValuesRequest::printTo(std::ostream& out) const {
   out << ", " << "partitionOrder="; (__isset.partitionOrder ? (out << to_string(partitionOrder)) : (out << "<null>"));
   out << ", " << "ascending="; (__isset.ascending ? (out << to_string(ascending)) : (out << "<null>"));
   out << ", " << "maxParts="; (__isset.maxParts ? (out << to_string(maxParts)) : (out << "<null>"));
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 
@@ -12591,6 +12836,11 @@ void Function::__set_functionType(const FunctionType::type val) {
 void Function::__set_resourceUris(const std::vector<ResourceUri> & val) {
   this->resourceUris = val;
 }
+
+void Function::__set_catName(const std::string& val) {
+  this->catName = val;
+__isset.catName = true;
+}
 std::ostream& operator<<(std::ostream& out, const Function& obj)
 {
   obj.printTo(out);
@@ -12699,6 +12949,14 @@ uint32_t Function::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->catName);
+          this->__isset.catName = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -12756,6 +13014,11 @@ uint32_t Function::write(::apache::thrift::protocol::TProtocol* oprot) const {
   }
   xfer += oprot->writeFieldEnd();
 
+  if (this->__isset.catName) {
+    xfer += oprot->writeFieldBegin("catName", ::apache::thrift::protocol::T_STRING, 9);
+    xfer += oprot->writeString(this->catName);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -12771,6 +13034,7 @@ void swap(Function &a, Function &b) {
   swap(a.createTime, b.createTime);
   swap(a.functionType, b.functionType);
   swap(a.resourceUris, b.resourceUris);
+  swap(a.catName, b.catName);
   swap(a.__isset, b.__isset);
 }
 
@@ -12783,6 +13047,7 @@ Function::Function(const Function& other534) {
   createTime = other534.createTime;
   functionType = other534.functionType;
   resourceUris = other534.resourceUris;
+  catName = other534.catName;
   __isset = other534.__isset;
 }
 Function& Function::operator=(const Function& other535) {
@@ -12794,6 +13059,7 @@ Function& Function::operator=(const Function& other535) {
   createTime = other535.createTime;
   functionType = other535.functionType;
   resourceUris = other535.resourceUris;
+  catName = other535.catName;
   __isset = other535.__isset;
   return *this;
 }
@@ -12808,6 +13074,7 @@ void Function::printTo(std::ostream& out) const {
   out << ", " << "createTime=" << to_string(createTime);
   out << ", " << "functionType=" << to_string(functionType);
   out << ", " << "resourceUris=" << to_string(resourceUris);
+  out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ")";
 }
 

--- a/metastore/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/metastore/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -881,12 +881,13 @@ void swap(Type &a, Type &b);
 std::ostream& operator<<(std::ostream& out, const Type& obj);
 
 typedef struct _HiveObjectRef__isset {
-  _HiveObjectRef__isset() : objectType(false), dbName(false), objectName(false), partValues(false), columnName(false) {}
+  _HiveObjectRef__isset() : objectType(false), dbName(false), objectName(false), partValues(false), columnName(false), catName(false) {}
   bool objectType :1;
   bool dbName :1;
   bool objectName :1;
   bool partValues :1;
   bool columnName :1;
+  bool catName :1;
 } _HiveObjectRef__isset;
 
 class HiveObjectRef : public virtual ::apache::thrift::TBase {
@@ -894,7 +895,7 @@ class HiveObjectRef : public virtual ::apache::thrift::TBase {
 
   HiveObjectRef(const HiveObjectRef&);
   HiveObjectRef& operator=(const HiveObjectRef&);
-  HiveObjectRef() : objectType((HiveObjectType::type)0), dbName(), objectName(), columnName() {
+  HiveObjectRef() : objectType((HiveObjectType::type)0), dbName(), objectName(), columnName(), catName() {
   }
 
   virtual ~HiveObjectRef() noexcept;
@@ -907,6 +908,7 @@ class HiveObjectRef : public virtual ::apache::thrift::TBase {
   std::string objectName;
   std::vector<std::string>  partValues;
   std::string columnName;
+  std::string catName;
 
   _HiveObjectRef__isset __isset;
 
@@ -920,6 +922,8 @@ class HiveObjectRef : public virtual ::apache::thrift::TBase {
 
   void __set_columnName(const std::string& val);
 
+  void __set_catName(const std::string& val);
+
   bool operator == (const HiveObjectRef & rhs) const
   {
     if (!(objectType == rhs.objectType))
@@ -931,6 +935,10 @@ class HiveObjectRef : public virtual ::apache::thrift::TBase {
     if (!(partValues == rhs.partValues))
       return false;
     if (!(columnName == rhs.columnName))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -1718,7 +1726,7 @@ void swap(GrantRevokeRoleResponse &a, GrantRevokeRoleResponse &b);
 std::ostream& operator<<(std::ostream& out, const GrantRevokeRoleResponse& obj);
 
 typedef struct _Database__isset {
-  _Database__isset() : name(false), description(false), locationUri(false), parameters(false), privileges(false), ownerName(false), ownerType(false) {}
+  _Database__isset() : name(false), description(false), locationUri(false), parameters(false), privileges(false), ownerName(false), ownerType(false), catalogName(false) {}
   bool name :1;
   bool description :1;
   bool locationUri :1;
@@ -1726,6 +1734,7 @@ typedef struct _Database__isset {
   bool privileges :1;
   bool ownerName :1;
   bool ownerType :1;
+  bool catalogName :1;
 } _Database__isset;
 
 class Database : public virtual ::apache::thrift::TBase {
@@ -1733,7 +1742,7 @@ class Database : public virtual ::apache::thrift::TBase {
 
   Database(const Database&);
   Database& operator=(const Database&);
-  Database() : name(), description(), locationUri(), ownerName(), ownerType((PrincipalType::type)0) {
+  Database() : name(), description(), locationUri(), ownerName(), ownerType((PrincipalType::type)0), catalogName() {
   }
 
   virtual ~Database() noexcept;
@@ -1748,6 +1757,7 @@ class Database : public virtual ::apache::thrift::TBase {
    * @see PrincipalType
    */
   PrincipalType::type ownerType;
+  std::string catalogName;
 
   _Database__isset __isset;
 
@@ -1764,6 +1774,8 @@ class Database : public virtual ::apache::thrift::TBase {
   void __set_ownerName(const std::string& val);
 
   void __set_ownerType(const PrincipalType::type val);
+
+  void __set_catalogName(const std::string& val);
 
   bool operator == (const Database & rhs) const
   {
@@ -1786,6 +1798,10 @@ class Database : public virtual ::apache::thrift::TBase {
     if (__isset.ownerType != rhs.__isset.ownerType)
       return false;
     else if (__isset.ownerType && !(ownerType == rhs.ownerType))
+      return false;
+    if (__isset.catalogName != rhs.__isset.catalogName)
+      return false;
+    else if (__isset.catalogName && !(catalogName == rhs.catalogName))
       return false;
     return true;
   }
@@ -2074,7 +2090,7 @@ void swap(StorageDescriptor &a, StorageDescriptor &b);
 std::ostream& operator<<(std::ostream& out, const StorageDescriptor& obj);
 
 typedef struct _Table__isset {
-  _Table__isset() : tableName(false), dbName(false), owner(false), createTime(false), lastAccessTime(false), retention(false), sd(false), partitionKeys(false), parameters(false), viewOriginalText(false), viewExpandedText(false), tableType(false), privileges(false), temporary(true), rewriteEnabled(false) {}
+  _Table__isset() : tableName(false), dbName(false), owner(false), createTime(false), lastAccessTime(false), retention(false), sd(false), partitionKeys(false), parameters(false), viewOriginalText(false), viewExpandedText(false), tableType(false), privileges(false), temporary(true), rewriteEnabled(false), catName(false) {}
   bool tableName :1;
   bool dbName :1;
   bool owner :1;
@@ -2090,6 +2106,7 @@ typedef struct _Table__isset {
   bool privileges :1;
   bool temporary :1;
   bool rewriteEnabled :1;
+  bool catName :1;
 } _Table__isset;
 
 class Table : public virtual ::apache::thrift::TBase {
@@ -2097,7 +2114,7 @@ class Table : public virtual ::apache::thrift::TBase {
 
   Table(const Table&);
   Table& operator=(const Table&);
-  Table() : tableName(), dbName(), owner(), createTime(0), lastAccessTime(0), retention(0), viewOriginalText(), viewExpandedText(), tableType(), temporary(false), rewriteEnabled(0) {
+  Table() : tableName(), dbName(), owner(), createTime(0), lastAccessTime(0), retention(0), viewOriginalText(), viewExpandedText(), tableType(), temporary(false), rewriteEnabled(0), catName() {
   }
 
   virtual ~Table() noexcept;
@@ -2116,6 +2133,7 @@ class Table : public virtual ::apache::thrift::TBase {
   PrincipalPrivilegeSet privileges;
   bool temporary;
   bool rewriteEnabled;
+  std::string catName;
 
   _Table__isset __isset;
 
@@ -2148,6 +2166,8 @@ class Table : public virtual ::apache::thrift::TBase {
   void __set_temporary(const bool val);
 
   void __set_rewriteEnabled(const bool val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const Table & rhs) const
   {
@@ -2187,6 +2207,10 @@ class Table : public virtual ::apache::thrift::TBase {
       return false;
     else if (__isset.rewriteEnabled && !(rewriteEnabled == rhs.rewriteEnabled))
       return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
+      return false;
     return true;
   }
   bool operator != (const Table &rhs) const {
@@ -2206,7 +2230,7 @@ void swap(Table &a, Table &b);
 std::ostream& operator<<(std::ostream& out, const Table& obj);
 
 typedef struct _Partition__isset {
-  _Partition__isset() : values(false), dbName(false), tableName(false), createTime(false), lastAccessTime(false), sd(false), parameters(false), privileges(false) {}
+  _Partition__isset() : values(false), dbName(false), tableName(false), createTime(false), lastAccessTime(false), sd(false), parameters(false), privileges(false), catName(false) {}
   bool values :1;
   bool dbName :1;
   bool tableName :1;
@@ -2215,6 +2239,7 @@ typedef struct _Partition__isset {
   bool sd :1;
   bool parameters :1;
   bool privileges :1;
+  bool catName :1;
 } _Partition__isset;
 
 class Partition : public virtual ::apache::thrift::TBase {
@@ -2222,7 +2247,7 @@ class Partition : public virtual ::apache::thrift::TBase {
 
   Partition(const Partition&);
   Partition& operator=(const Partition&);
-  Partition() : dbName(), tableName(), createTime(0), lastAccessTime(0) {
+  Partition() : dbName(), tableName(), createTime(0), lastAccessTime(0), catName() {
   }
 
   virtual ~Partition() noexcept;
@@ -2234,6 +2259,7 @@ class Partition : public virtual ::apache::thrift::TBase {
   StorageDescriptor sd;
   std::map<std::string, std::string>  parameters;
   PrincipalPrivilegeSet privileges;
+  std::string catName;
 
   _Partition__isset __isset;
 
@@ -2252,6 +2278,8 @@ class Partition : public virtual ::apache::thrift::TBase {
   void __set_parameters(const std::map<std::string, std::string> & val);
 
   void __set_privileges(const PrincipalPrivilegeSet& val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const Partition & rhs) const
   {
@@ -2272,6 +2300,10 @@ class Partition : public virtual ::apache::thrift::TBase {
     if (__isset.privileges != rhs.__isset.privileges)
       return false;
     else if (__isset.privileges && !(privileges == rhs.privileges))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -2456,12 +2488,13 @@ void swap(PartitionListComposingSpec &a, PartitionListComposingSpec &b);
 std::ostream& operator<<(std::ostream& out, const PartitionListComposingSpec& obj);
 
 typedef struct _PartitionSpec__isset {
-  _PartitionSpec__isset() : dbName(false), tableName(false), rootPath(false), sharedSDPartitionSpec(false), partitionList(false) {}
+  _PartitionSpec__isset() : dbName(false), tableName(false), rootPath(false), sharedSDPartitionSpec(false), partitionList(false), catName(false) {}
   bool dbName :1;
   bool tableName :1;
   bool rootPath :1;
   bool sharedSDPartitionSpec :1;
   bool partitionList :1;
+  bool catName :1;
 } _PartitionSpec__isset;
 
 class PartitionSpec : public virtual ::apache::thrift::TBase {
@@ -2469,7 +2502,7 @@ class PartitionSpec : public virtual ::apache::thrift::TBase {
 
   PartitionSpec(const PartitionSpec&);
   PartitionSpec& operator=(const PartitionSpec&);
-  PartitionSpec() : dbName(), tableName(), rootPath() {
+  PartitionSpec() : dbName(), tableName(), rootPath(), catName() {
   }
 
   virtual ~PartitionSpec() noexcept;
@@ -2478,6 +2511,7 @@ class PartitionSpec : public virtual ::apache::thrift::TBase {
   std::string rootPath;
   PartitionSpecWithSharedSD sharedSDPartitionSpec;
   PartitionListComposingSpec partitionList;
+  std::string catName;
 
   _PartitionSpec__isset __isset;
 
@@ -2490,6 +2524,8 @@ class PartitionSpec : public virtual ::apache::thrift::TBase {
   void __set_sharedSDPartitionSpec(const PartitionSpecWithSharedSD& val);
 
   void __set_partitionList(const PartitionListComposingSpec& val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const PartitionSpec & rhs) const
   {
@@ -2506,6 +2542,10 @@ class PartitionSpec : public virtual ::apache::thrift::TBase {
     if (__isset.partitionList != rhs.__isset.partitionList)
       return false;
     else if (__isset.partitionList && !(partitionList == rhs.partitionList))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -3299,9 +3339,10 @@ void swap(ColumnStatisticsObj &a, ColumnStatisticsObj &b);
 std::ostream& operator<<(std::ostream& out, const ColumnStatisticsObj& obj);
 
 typedef struct _ColumnStatisticsDesc__isset {
-  _ColumnStatisticsDesc__isset() : partName(false), lastAnalyzed(false) {}
+  _ColumnStatisticsDesc__isset() : partName(false), lastAnalyzed(false), catName(false) {}
   bool partName :1;
   bool lastAnalyzed :1;
+  bool catName :1;
 } _ColumnStatisticsDesc__isset;
 
 class ColumnStatisticsDesc : public virtual ::apache::thrift::TBase {
@@ -3309,7 +3350,7 @@ class ColumnStatisticsDesc : public virtual ::apache::thrift::TBase {
 
   ColumnStatisticsDesc(const ColumnStatisticsDesc&);
   ColumnStatisticsDesc& operator=(const ColumnStatisticsDesc&);
-  ColumnStatisticsDesc() : isTblLevel(0), dbName(), tableName(), partName(), lastAnalyzed(0) {
+  ColumnStatisticsDesc() : isTblLevel(0), dbName(), tableName(), partName(), lastAnalyzed(0), catName() {
   }
 
   virtual ~ColumnStatisticsDesc() noexcept;
@@ -3318,6 +3359,7 @@ class ColumnStatisticsDesc : public virtual ::apache::thrift::TBase {
   std::string tableName;
   std::string partName;
   int64_t lastAnalyzed;
+  std::string catName;
 
   _ColumnStatisticsDesc__isset __isset;
 
@@ -3330,6 +3372,8 @@ class ColumnStatisticsDesc : public virtual ::apache::thrift::TBase {
   void __set_partName(const std::string& val);
 
   void __set_lastAnalyzed(const int64_t val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const ColumnStatisticsDesc & rhs) const
   {
@@ -3346,6 +3390,10 @@ class ColumnStatisticsDesc : public virtual ::apache::thrift::TBase {
     if (__isset.lastAnalyzed != rhs.__isset.lastAnalyzed)
       return false;
     else if (__isset.lastAnalyzed && !(lastAnalyzed == rhs.lastAnalyzed))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -3919,9 +3967,10 @@ void swap(PartitionsByExprResult &a, PartitionsByExprResult &b);
 std::ostream& operator<<(std::ostream& out, const PartitionsByExprResult& obj);
 
 typedef struct _PartitionsByExprRequest__isset {
-  _PartitionsByExprRequest__isset() : defaultPartitionName(false), maxParts(true) {}
+  _PartitionsByExprRequest__isset() : defaultPartitionName(false), maxParts(true), catName(false) {}
   bool defaultPartitionName :1;
   bool maxParts :1;
+  bool catName :1;
 } _PartitionsByExprRequest__isset;
 
 class PartitionsByExprRequest : public virtual ::apache::thrift::TBase {
@@ -3929,7 +3978,7 @@ class PartitionsByExprRequest : public virtual ::apache::thrift::TBase {
 
   PartitionsByExprRequest(const PartitionsByExprRequest&);
   PartitionsByExprRequest& operator=(const PartitionsByExprRequest&);
-  PartitionsByExprRequest() : dbName(), tblName(), expr(), defaultPartitionName(), maxParts(-1) {
+  PartitionsByExprRequest() : dbName(), tblName(), expr(), defaultPartitionName(), maxParts(-1), catName() {
   }
 
   virtual ~PartitionsByExprRequest() noexcept;
@@ -3938,6 +3987,7 @@ class PartitionsByExprRequest : public virtual ::apache::thrift::TBase {
   std::string expr;
   std::string defaultPartitionName;
   int16_t maxParts;
+  std::string catName;
 
   _PartitionsByExprRequest__isset __isset;
 
@@ -3950,6 +4000,8 @@ class PartitionsByExprRequest : public virtual ::apache::thrift::TBase {
   void __set_defaultPartitionName(const std::string& val);
 
   void __set_maxParts(const int16_t val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const PartitionsByExprRequest & rhs) const
   {
@@ -3966,6 +4018,10 @@ class PartitionsByExprRequest : public virtual ::apache::thrift::TBase {
     if (__isset.maxParts != rhs.__isset.maxParts)
       return false;
     else if (__isset.maxParts && !(maxParts == rhs.maxParts))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -4103,13 +4159,17 @@ void swap(TableStatsRequest &a, TableStatsRequest &b);
 
 std::ostream& operator<<(std::ostream& out, const TableStatsRequest& obj);
 
+typedef struct _PartitionsStatsRequest__isset {
+  _PartitionsStatsRequest__isset() : catName(false) {}
+  bool catName :1;
+} _PartitionsStatsRequest__isset;
 
 class PartitionsStatsRequest : public virtual ::apache::thrift::TBase {
  public:
 
   PartitionsStatsRequest(const PartitionsStatsRequest&);
   PartitionsStatsRequest& operator=(const PartitionsStatsRequest&);
-  PartitionsStatsRequest() : dbName(), tblName() {
+  PartitionsStatsRequest() : dbName(), tblName(), catName() {
   }
 
   virtual ~PartitionsStatsRequest() noexcept;
@@ -4117,6 +4177,9 @@ class PartitionsStatsRequest : public virtual ::apache::thrift::TBase {
   std::string tblName;
   std::vector<std::string>  colNames;
   std::vector<std::string>  partNames;
+  std::string catName;
+
+  _PartitionsStatsRequest__isset __isset;
 
   void __set_dbName(const std::string& val);
 
@@ -4125,6 +4188,8 @@ class PartitionsStatsRequest : public virtual ::apache::thrift::TBase {
   void __set_colNames(const std::vector<std::string> & val);
 
   void __set_partNames(const std::vector<std::string> & val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const PartitionsStatsRequest & rhs) const
   {
@@ -4135,6 +4200,10 @@ class PartitionsStatsRequest : public virtual ::apache::thrift::TBase {
     if (!(colNames == rhs.colNames))
       return false;
     if (!(partNames == rhs.partNames))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -4199,8 +4268,9 @@ void swap(AddPartitionsResult &a, AddPartitionsResult &b);
 std::ostream& operator<<(std::ostream& out, const AddPartitionsResult& obj);
 
 typedef struct _AddPartitionsRequest__isset {
-  _AddPartitionsRequest__isset() : needResult(true) {}
+  _AddPartitionsRequest__isset() : needResult(true), catName(false) {}
   bool needResult :1;
+  bool catName :1;
 } _AddPartitionsRequest__isset;
 
 class AddPartitionsRequest : public virtual ::apache::thrift::TBase {
@@ -4208,7 +4278,7 @@ class AddPartitionsRequest : public virtual ::apache::thrift::TBase {
 
   AddPartitionsRequest(const AddPartitionsRequest&);
   AddPartitionsRequest& operator=(const AddPartitionsRequest&);
-  AddPartitionsRequest() : dbName(), tblName(), ifNotExists(0), needResult(true) {
+  AddPartitionsRequest() : dbName(), tblName(), ifNotExists(0), needResult(true), catName() {
   }
 
   virtual ~AddPartitionsRequest() noexcept;
@@ -4217,6 +4287,7 @@ class AddPartitionsRequest : public virtual ::apache::thrift::TBase {
   std::vector<Partition>  parts;
   bool ifNotExists;
   bool needResult;
+  std::string catName;
 
   _AddPartitionsRequest__isset __isset;
 
@@ -4229,6 +4300,8 @@ class AddPartitionsRequest : public virtual ::apache::thrift::TBase {
   void __set_ifNotExists(const bool val);
 
   void __set_needResult(const bool val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const AddPartitionsRequest & rhs) const
   {
@@ -4243,6 +4316,10 @@ class AddPartitionsRequest : public virtual ::apache::thrift::TBase {
     if (__isset.needResult != rhs.__isset.needResult)
       return false;
     else if (__isset.needResult && !(needResult == rhs.needResult))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -4408,12 +4485,13 @@ void swap(RequestPartsSpec &a, RequestPartsSpec &b);
 std::ostream& operator<<(std::ostream& out, const RequestPartsSpec& obj);
 
 typedef struct _DropPartitionsRequest__isset {
-  _DropPartitionsRequest__isset() : deleteData(false), ifExists(true), ignoreProtection(false), environmentContext(false), needResult(true) {}
+  _DropPartitionsRequest__isset() : deleteData(false), ifExists(true), ignoreProtection(false), environmentContext(false), needResult(true), catName(false) {}
   bool deleteData :1;
   bool ifExists :1;
   bool ignoreProtection :1;
   bool environmentContext :1;
   bool needResult :1;
+  bool catName :1;
 } _DropPartitionsRequest__isset;
 
 class DropPartitionsRequest : public virtual ::apache::thrift::TBase {
@@ -4421,7 +4499,7 @@ class DropPartitionsRequest : public virtual ::apache::thrift::TBase {
 
   DropPartitionsRequest(const DropPartitionsRequest&);
   DropPartitionsRequest& operator=(const DropPartitionsRequest&);
-  DropPartitionsRequest() : dbName(), tblName(), deleteData(0), ifExists(true), ignoreProtection(0), needResult(true) {
+  DropPartitionsRequest() : dbName(), tblName(), deleteData(0), ifExists(true), ignoreProtection(0), needResult(true), catName() {
   }
 
   virtual ~DropPartitionsRequest() noexcept;
@@ -4433,6 +4511,7 @@ class DropPartitionsRequest : public virtual ::apache::thrift::TBase {
   bool ignoreProtection;
   EnvironmentContext environmentContext;
   bool needResult;
+  std::string catName;
 
   _DropPartitionsRequest__isset __isset;
 
@@ -4451,6 +4530,8 @@ class DropPartitionsRequest : public virtual ::apache::thrift::TBase {
   void __set_environmentContext(const EnvironmentContext& val);
 
   void __set_needResult(const bool val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const DropPartitionsRequest & rhs) const
   {
@@ -4480,6 +4561,10 @@ class DropPartitionsRequest : public virtual ::apache::thrift::TBase {
       return false;
     else if (__isset.needResult && !(needResult == rhs.needResult))
       return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
+      return false;
     return true;
   }
   bool operator != (const DropPartitionsRequest &rhs) const {
@@ -4499,12 +4584,13 @@ void swap(DropPartitionsRequest &a, DropPartitionsRequest &b);
 std::ostream& operator<<(std::ostream& out, const DropPartitionsRequest& obj);
 
 typedef struct _PartitionValuesRequest__isset {
-  _PartitionValuesRequest__isset() : applyDistinct(true), filter(false), partitionOrder(false), ascending(true), maxParts(true) {}
+  _PartitionValuesRequest__isset() : applyDistinct(true), filter(false), partitionOrder(false), ascending(true), maxParts(true), catName(false) {}
   bool applyDistinct :1;
   bool filter :1;
   bool partitionOrder :1;
   bool ascending :1;
   bool maxParts :1;
+  bool catName :1;
 } _PartitionValuesRequest__isset;
 
 class PartitionValuesRequest : public virtual ::apache::thrift::TBase {
@@ -4512,7 +4598,7 @@ class PartitionValuesRequest : public virtual ::apache::thrift::TBase {
 
   PartitionValuesRequest(const PartitionValuesRequest&);
   PartitionValuesRequest& operator=(const PartitionValuesRequest&);
-  PartitionValuesRequest() : dbName(), tblName(), applyDistinct(true), filter(), ascending(true), maxParts(-1LL) {
+  PartitionValuesRequest() : dbName(), tblName(), applyDistinct(true), filter(), ascending(true), maxParts(-1LL), catName() {
   }
 
   virtual ~PartitionValuesRequest() noexcept;
@@ -4524,6 +4610,7 @@ class PartitionValuesRequest : public virtual ::apache::thrift::TBase {
   std::vector<FieldSchema>  partitionOrder;
   bool ascending;
   int64_t maxParts;
+  std::string catName;
 
   _PartitionValuesRequest__isset __isset;
 
@@ -4542,6 +4629,8 @@ class PartitionValuesRequest : public virtual ::apache::thrift::TBase {
   void __set_ascending(const bool val);
 
   void __set_maxParts(const int64_t val);
+
+  void __set_catName(const std::string& val);
 
   bool operator == (const PartitionValuesRequest & rhs) const
   {
@@ -4570,6 +4659,10 @@ class PartitionValuesRequest : public virtual ::apache::thrift::TBase {
     if (__isset.maxParts != rhs.__isset.maxParts)
       return false;
     else if (__isset.maxParts && !(maxParts == rhs.maxParts))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }
@@ -4714,7 +4807,7 @@ void swap(ResourceUri &a, ResourceUri &b);
 std::ostream& operator<<(std::ostream& out, const ResourceUri& obj);
 
 typedef struct _Function__isset {
-  _Function__isset() : functionName(false), dbName(false), className(false), ownerName(false), ownerType(false), createTime(false), functionType(false), resourceUris(false) {}
+  _Function__isset() : functionName(false), dbName(false), className(false), ownerName(false), ownerType(false), createTime(false), functionType(false), resourceUris(false), catName(false) {}
   bool functionName :1;
   bool dbName :1;
   bool className :1;
@@ -4723,6 +4816,7 @@ typedef struct _Function__isset {
   bool createTime :1;
   bool functionType :1;
   bool resourceUris :1;
+  bool catName :1;
 } _Function__isset;
 
 class Function : public virtual ::apache::thrift::TBase {
@@ -4730,7 +4824,7 @@ class Function : public virtual ::apache::thrift::TBase {
 
   Function(const Function&);
   Function& operator=(const Function&);
-  Function() : functionName(), dbName(), className(), ownerName(), ownerType((PrincipalType::type)0), createTime(0), functionType((FunctionType::type)0) {
+  Function() : functionName(), dbName(), className(), ownerName(), ownerType((PrincipalType::type)0), createTime(0), functionType((FunctionType::type)0), catName() {
   }
 
   virtual ~Function() noexcept;
@@ -4750,6 +4844,7 @@ class Function : public virtual ::apache::thrift::TBase {
    */
   FunctionType::type functionType;
   std::vector<ResourceUri>  resourceUris;
+  std::string catName;
 
   _Function__isset __isset;
 
@@ -4769,6 +4864,8 @@ class Function : public virtual ::apache::thrift::TBase {
 
   void __set_resourceUris(const std::vector<ResourceUri> & val);
 
+  void __set_catName(const std::string& val);
+
   bool operator == (const Function & rhs) const
   {
     if (!(functionName == rhs.functionName))
@@ -4786,6 +4883,10 @@ class Function : public virtual ::apache::thrift::TBase {
     if (!(functionType == rhs.functionType))
       return false;
     if (!(resourceUris == rhs.resourceUris))
+      return false;
+    if (__isset.catName != rhs.__isset.catName)
+      return false;
+    else if (__isset.catName && !(catName == rhs.catName))
       return false;
     return true;
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsRequest.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AddPartitionsRequest.java
@@ -16,6 +16,7 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
   private static final org.apache.thrift.protocol.TField PARTS_FIELD_DESC = new org.apache.thrift.protocol.TField("parts", org.apache.thrift.protocol.TType.LIST, (short)3);
   private static final org.apache.thrift.protocol.TField IF_NOT_EXISTS_FIELD_DESC = new org.apache.thrift.protocol.TField("ifNotExists", org.apache.thrift.protocol.TType.BOOL, (short)4);
   private static final org.apache.thrift.protocol.TField NEED_RESULT_FIELD_DESC = new org.apache.thrift.protocol.TField("needResult", org.apache.thrift.protocol.TType.BOOL, (short)5);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new AddPartitionsRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new AddPartitionsRequestTupleSchemeFactory();
@@ -25,6 +26,7 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
   private @org.apache.thrift.annotation.Nullable java.util.List<Partition> parts; // required
   private boolean ifNotExists; // required
   private boolean needResult; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32,7 +34,8 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
     TBL_NAME((short)2, "tblName"),
     PARTS((short)3, "parts"),
     IF_NOT_EXISTS((short)4, "ifNotExists"),
-    NEED_RESULT((short)5, "needResult");
+    NEED_RESULT((short)5, "needResult"),
+    CAT_NAME((short)6, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -58,6 +61,8 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
           return IF_NOT_EXISTS;
         case 5: // NEED_RESULT
           return NEED_RESULT;
+        case 6: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -102,7 +107,7 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
   private static final int __IFNOTEXISTS_ISSET_ID = 0;
   private static final int __NEEDRESULT_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.NEED_RESULT};
+  private static final _Fields optionals[] = {_Fields.NEED_RESULT,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -117,6 +122,8 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.NEED_RESULT, new org.apache.thrift.meta_data.FieldMetaData("needResult", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(AddPartitionsRequest.class, metaDataMap);
   }
@@ -160,6 +167,9 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
     }
     this.ifNotExists = other.ifNotExists;
     this.needResult = other.needResult;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public AddPartitionsRequest deepCopy() {
@@ -175,6 +185,7 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
     this.ifNotExists = false;
     this.needResult = true;
 
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -309,6 +320,30 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __NEEDRESULT_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -351,6 +386,14 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -371,6 +414,9 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
 
     case NEED_RESULT:
       return isNeedResult();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -393,6 +439,8 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
       return isSetIfNotExists();
     case NEED_RESULT:
       return isSetNeedResult();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -455,6 +503,15 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -479,6 +536,10 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
     hashCode = hashCode * 8191 + ((isSetNeedResult()) ? 131071 : 524287);
     if (isSetNeedResult())
       hashCode = hashCode * 8191 + ((needResult) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -541,6 +602,16 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -593,6 +664,16 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
       if (!first) sb.append(", ");
       sb.append("needResult:");
       sb.append(this.needResult);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -707,6 +788,14 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -750,6 +839,13 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
         oprot.writeBool(struct.needResult);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -781,9 +877,15 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
       if (struct.isSetNeedResult()) {
         optionals.set(0);
       }
-      oprot.writeBitSet(optionals, 1);
+      if (struct.isSetCatName()) {
+        optionals.set(1);
+      }
+      oprot.writeBitSet(optionals, 2);
       if (struct.isSetNeedResult()) {
         oprot.writeBool(struct.needResult);
+      }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
       }
     }
 
@@ -808,10 +910,14 @@ public class AddPartitionsRequest implements org.apache.thrift.TBase<AddPartitio
       struct.setPartsIsSet(true);
       struct.ifNotExists = iprot.readBool();
       struct.setIfNotExistsIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(1);
+      java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         struct.needResult = iprot.readBool();
         struct.setNeedResultIsSet(true);
+      }
+      if (incoming.get(1)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatisticsDesc.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/ColumnStatisticsDesc.java
@@ -16,6 +16,7 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
   private static final org.apache.thrift.protocol.TField TABLE_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("tableName", org.apache.thrift.protocol.TType.STRING, (short)3);
   private static final org.apache.thrift.protocol.TField PART_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("partName", org.apache.thrift.protocol.TType.STRING, (short)4);
   private static final org.apache.thrift.protocol.TField LAST_ANALYZED_FIELD_DESC = new org.apache.thrift.protocol.TField("lastAnalyzed", org.apache.thrift.protocol.TType.I64, (short)5);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ColumnStatisticsDescStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new ColumnStatisticsDescTupleSchemeFactory();
@@ -25,6 +26,7 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
   private @org.apache.thrift.annotation.Nullable java.lang.String tableName; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String partName; // optional
   private long lastAnalyzed; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32,7 +34,8 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
     DB_NAME((short)2, "dbName"),
     TABLE_NAME((short)3, "tableName"),
     PART_NAME((short)4, "partName"),
-    LAST_ANALYZED((short)5, "lastAnalyzed");
+    LAST_ANALYZED((short)5, "lastAnalyzed"),
+    CAT_NAME((short)6, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -58,6 +61,8 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
           return PART_NAME;
         case 5: // LAST_ANALYZED
           return LAST_ANALYZED;
+        case 6: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -102,7 +107,7 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
   private static final int __ISTBLLEVEL_ISSET_ID = 0;
   private static final int __LASTANALYZED_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PART_NAME,_Fields.LAST_ANALYZED};
+  private static final _Fields optionals[] = {_Fields.PART_NAME,_Fields.LAST_ANALYZED,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -116,6 +121,8 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.LAST_ANALYZED, new org.apache.thrift.meta_data.FieldMetaData("lastAnalyzed", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(ColumnStatisticsDesc.class, metaDataMap);
   }
@@ -151,6 +158,9 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       this.partName = other.partName;
     }
     this.lastAnalyzed = other.lastAnalyzed;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public ColumnStatisticsDesc deepCopy() {
@@ -166,6 +176,7 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
     this.partName = null;
     setLastAnalyzedIsSet(false);
     this.lastAnalyzed = 0;
+    this.catName = null;
   }
 
   public boolean isIsTblLevel() {
@@ -284,6 +295,30 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __LASTANALYZED_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case IS_TBL_LEVEL:
@@ -326,6 +361,14 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -346,6 +389,9 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
 
     case LAST_ANALYZED:
       return getLastAnalyzed();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -368,6 +414,8 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       return isSetPartName();
     case LAST_ANALYZED:
       return isSetLastAnalyzed();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -430,6 +478,15 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -454,6 +511,10 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
     hashCode = hashCode * 8191 + ((isSetLastAnalyzed()) ? 131071 : 524287);
     if (isSetLastAnalyzed())
       hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(lastAnalyzed);
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -516,6 +577,16 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -570,6 +641,16 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       if (!first) sb.append(", ");
       sb.append("lastAnalyzed:");
       sb.append(this.lastAnalyzed);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -669,6 +750,14 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -707,6 +796,13 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
         oprot.writeI64(struct.lastAnalyzed);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -734,12 +830,18 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       if (struct.isSetLastAnalyzed()) {
         optionals.set(1);
       }
-      oprot.writeBitSet(optionals, 2);
+      if (struct.isSetCatName()) {
+        optionals.set(2);
+      }
+      oprot.writeBitSet(optionals, 3);
       if (struct.isSetPartName()) {
         oprot.writeString(struct.partName);
       }
       if (struct.isSetLastAnalyzed()) {
         oprot.writeI64(struct.lastAnalyzed);
+      }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
       }
     }
 
@@ -752,7 +854,7 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       struct.setDbNameIsSet(true);
       struct.tableName = iprot.readString();
       struct.setTableNameIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(2);
+      java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         struct.partName = iprot.readString();
         struct.setPartNameIsSet(true);
@@ -760,6 +862,10 @@ public class ColumnStatisticsDesc implements org.apache.thrift.TBase<ColumnStati
       if (incoming.get(1)) {
         struct.lastAnalyzed = iprot.readI64();
         struct.setLastAnalyzedIsSet(true);
+      }
+      if (incoming.get(2)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
@@ -18,6 +18,7 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
   private static final org.apache.thrift.protocol.TField PRIVILEGES_FIELD_DESC = new org.apache.thrift.protocol.TField("privileges", org.apache.thrift.protocol.TType.STRUCT, (short)5);
   private static final org.apache.thrift.protocol.TField OWNER_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("ownerName", org.apache.thrift.protocol.TType.STRING, (short)6);
   private static final org.apache.thrift.protocol.TField OWNER_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("ownerType", org.apache.thrift.protocol.TType.I32, (short)7);
+  private static final org.apache.thrift.protocol.TField CATALOG_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catalogName", org.apache.thrift.protocol.TType.STRING, (short)8);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new DatabaseStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new DatabaseTupleSchemeFactory();
@@ -29,6 +30,7 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
   private @org.apache.thrift.annotation.Nullable PrincipalPrivilegeSet privileges; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String ownerName; // optional
   private @org.apache.thrift.annotation.Nullable PrincipalType ownerType; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catalogName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -42,7 +44,8 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
      * 
      * @see PrincipalType
      */
-    OWNER_TYPE((short)7, "ownerType");
+    OWNER_TYPE((short)7, "ownerType"),
+    CATALOG_NAME((short)8, "catalogName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -72,6 +75,8 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
           return OWNER_NAME;
         case 7: // OWNER_TYPE
           return OWNER_TYPE;
+        case 8: // CATALOG_NAME
+          return CATALOG_NAME;
         default:
           return null;
       }
@@ -113,7 +118,7 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
   }
 
   // isset id assignments
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.OWNER_NAME,_Fields.OWNER_TYPE};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.OWNER_NAME,_Fields.OWNER_TYPE,_Fields.CATALOG_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -133,6 +138,8 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.OWNER_TYPE, new org.apache.thrift.meta_data.FieldMetaData("ownerType", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.EnumMetaData(org.apache.thrift.protocol.TType.ENUM, PrincipalType.class)));
+    tmpMap.put(_Fields.CATALOG_NAME, new org.apache.thrift.meta_data.FieldMetaData("catalogName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Database.class, metaDataMap);
   }
@@ -179,6 +186,9 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     if (other.isSetOwnerType()) {
       this.ownerType = other.ownerType;
     }
+    if (other.isSetCatalogName()) {
+      this.catalogName = other.catalogName;
+    }
   }
 
   public Database deepCopy() {
@@ -194,6 +204,7 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     this.privileges = null;
     this.ownerName = null;
     this.ownerType = null;
+    this.catalogName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -383,6 +394,30 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatalogName() {
+    return this.catalogName;
+  }
+
+  public void setCatalogName(@org.apache.thrift.annotation.Nullable java.lang.String catalogName) {
+    this.catalogName = catalogName;
+  }
+
+  public void unsetCatalogName() {
+    this.catalogName = null;
+  }
+
+  /** Returns true if field catalogName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatalogName() {
+    return this.catalogName != null;
+  }
+
+  public void setCatalogNameIsSet(boolean value) {
+    if (!value) {
+      this.catalogName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case NAME:
@@ -441,6 +476,14 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
       }
       break;
 
+    case CATALOG_NAME:
+      if (value == null) {
+        unsetCatalogName();
+      } else {
+        setCatalogName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -468,6 +511,9 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     case OWNER_TYPE:
       return getOwnerType();
 
+    case CATALOG_NAME:
+      return getCatalogName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -493,6 +539,8 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
       return isSetOwnerName();
     case OWNER_TYPE:
       return isSetOwnerType();
+    case CATALOG_NAME:
+      return isSetCatalogName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -573,6 +621,15 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
         return false;
     }
 
+    boolean this_present_catalogName = true && this.isSetCatalogName();
+    boolean that_present_catalogName = true && that.isSetCatalogName();
+    if (this_present_catalogName || that_present_catalogName) {
+      if (!(this_present_catalogName && that_present_catalogName))
+        return false;
+      if (!this.catalogName.equals(that.catalogName))
+        return false;
+    }
+
     return true;
   }
 
@@ -607,6 +664,10 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     hashCode = hashCode * 8191 + ((isSetOwnerType()) ? 131071 : 524287);
     if (isSetOwnerType())
       hashCode = hashCode * 8191 + ownerType.getValue();
+
+    hashCode = hashCode * 8191 + ((isSetCatalogName()) ? 131071 : 524287);
+    if (isSetCatalogName())
+      hashCode = hashCode * 8191 + catalogName.hashCode();
 
     return hashCode;
   }
@@ -685,6 +746,16 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
     }
     if (isSetOwnerType()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.ownerType, other.ownerType);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.compare(isSetCatalogName(), other.isSetCatalogName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatalogName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catalogName, other.catalogName);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -768,6 +839,16 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
         sb.append("null");
       } else {
         sb.append(this.ownerType);
+      }
+      first = false;
+    }
+    if (isSetCatalogName()) {
+      if (!first) sb.append(", ");
+      sb.append("catalogName:");
+      if (this.catalogName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catalogName);
       }
       first = false;
     }
@@ -886,6 +967,14 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 8: // CATALOG_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catalogName = iprot.readString();
+              struct.setCatalogNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -948,6 +1037,13 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
           oprot.writeFieldEnd();
         }
       }
+      if (struct.catalogName != null) {
+        if (struct.isSetCatalogName()) {
+          oprot.writeFieldBegin(CATALOG_NAME_FIELD_DESC);
+          oprot.writeString(struct.catalogName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -987,7 +1083,10 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
       if (struct.isSetOwnerType()) {
         optionals.set(6);
       }
-      oprot.writeBitSet(optionals, 7);
+      if (struct.isSetCatalogName()) {
+        optionals.set(7);
+      }
+      oprot.writeBitSet(optionals, 8);
       if (struct.isSetName()) {
         oprot.writeString(struct.name);
       }
@@ -1016,12 +1115,15 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
       if (struct.isSetOwnerType()) {
         oprot.writeI32(struct.ownerType.getValue());
       }
+      if (struct.isSetCatalogName()) {
+        oprot.writeString(struct.catalogName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Database struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(7);
+      java.util.BitSet incoming = iprot.readBitSet(8);
       if (incoming.get(0)) {
         struct.name = iprot.readString();
         struct.setNameIsSet(true);
@@ -1061,6 +1163,10 @@ public class Database implements org.apache.thrift.TBase<Database, Database._Fie
       if (incoming.get(6)) {
         struct.ownerType = org.apache.hadoop.hive.metastore.api.PrincipalType.findByValue(iprot.readI32());
         struct.setOwnerTypeIsSet(true);
+      }
+      if (incoming.get(7)) {
+        struct.catalogName = iprot.readString();
+        struct.setCatalogNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DropPartitionsRequest.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/DropPartitionsRequest.java
@@ -19,6 +19,7 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
   private static final org.apache.thrift.protocol.TField IGNORE_PROTECTION_FIELD_DESC = new org.apache.thrift.protocol.TField("ignoreProtection", org.apache.thrift.protocol.TType.BOOL, (short)6);
   private static final org.apache.thrift.protocol.TField ENVIRONMENT_CONTEXT_FIELD_DESC = new org.apache.thrift.protocol.TField("environmentContext", org.apache.thrift.protocol.TType.STRUCT, (short)7);
   private static final org.apache.thrift.protocol.TField NEED_RESULT_FIELD_DESC = new org.apache.thrift.protocol.TField("needResult", org.apache.thrift.protocol.TType.BOOL, (short)8);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)9);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new DropPartitionsRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new DropPartitionsRequestTupleSchemeFactory();
@@ -31,6 +32,7 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
   private boolean ignoreProtection; // optional
   private @org.apache.thrift.annotation.Nullable EnvironmentContext environmentContext; // optional
   private boolean needResult; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41,7 +43,8 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
     IF_EXISTS((short)5, "ifExists"),
     IGNORE_PROTECTION((short)6, "ignoreProtection"),
     ENVIRONMENT_CONTEXT((short)7, "environmentContext"),
-    NEED_RESULT((short)8, "needResult");
+    NEED_RESULT((short)8, "needResult"),
+    CAT_NAME((short)9, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -73,6 +76,8 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
           return ENVIRONMENT_CONTEXT;
         case 8: // NEED_RESULT
           return NEED_RESULT;
+        case 9: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -119,7 +124,7 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
   private static final int __IGNOREPROTECTION_ISSET_ID = 2;
   private static final int __NEEDRESULT_ISSET_ID = 3;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.DELETE_DATA,_Fields.IF_EXISTS,_Fields.IGNORE_PROTECTION,_Fields.ENVIRONMENT_CONTEXT,_Fields.NEED_RESULT};
+  private static final _Fields optionals[] = {_Fields.DELETE_DATA,_Fields.IF_EXISTS,_Fields.IGNORE_PROTECTION,_Fields.ENVIRONMENT_CONTEXT,_Fields.NEED_RESULT,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -139,6 +144,8 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, EnvironmentContext.class)));
     tmpMap.put(_Fields.NEED_RESULT, new org.apache.thrift.meta_data.FieldMetaData("needResult", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(DropPartitionsRequest.class, metaDataMap);
   }
@@ -182,6 +189,9 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       this.environmentContext = new EnvironmentContext(other.environmentContext);
     }
     this.needResult = other.needResult;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public DropPartitionsRequest deepCopy() {
@@ -202,6 +212,7 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
     this.environmentContext = null;
     this.needResult = true;
 
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -388,6 +399,30 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __NEEDRESULT_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -454,6 +489,14 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -484,6 +527,9 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
     case NEED_RESULT:
       return isNeedResult();
 
+    case CAT_NAME:
+      return getCatName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -511,6 +557,8 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       return isSetEnvironmentContext();
     case NEED_RESULT:
       return isSetNeedResult();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -600,6 +648,15 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -638,6 +695,10 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
     hashCode = hashCode * 8191 + ((isSetNeedResult()) ? 131071 : 524287);
     if (isSetNeedResult())
       hashCode = hashCode * 8191 + ((needResult) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -730,6 +791,16 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -806,6 +877,16 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       if (!first) sb.append(", ");
       sb.append("needResult:");
       sb.append(this.needResult);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -934,6 +1015,14 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 9: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -989,6 +1078,13 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
         oprot.writeBool(struct.needResult);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1025,7 +1121,10 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       if (struct.isSetNeedResult()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetCatName()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetDeleteData()) {
         oprot.writeBool(struct.deleteData);
       }
@@ -1041,6 +1140,9 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       if (struct.isSetNeedResult()) {
         oprot.writeBool(struct.needResult);
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
@@ -1053,7 +1155,7 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       struct.parts = new RequestPartsSpec();
       struct.parts.read(iprot);
       struct.setPartsIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         struct.deleteData = iprot.readBool();
         struct.setDeleteDataIsSet(true);
@@ -1074,6 +1176,10 @@ public class DropPartitionsRequest implements org.apache.thrift.TBase<DropPartit
       if (incoming.get(4)) {
         struct.needResult = iprot.readBool();
         struct.setNeedResultIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Function.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Function.java
@@ -19,6 +19,7 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
   private static final org.apache.thrift.protocol.TField CREATE_TIME_FIELD_DESC = new org.apache.thrift.protocol.TField("createTime", org.apache.thrift.protocol.TType.I32, (short)6);
   private static final org.apache.thrift.protocol.TField FUNCTION_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("functionType", org.apache.thrift.protocol.TType.I32, (short)7);
   private static final org.apache.thrift.protocol.TField RESOURCE_URIS_FIELD_DESC = new org.apache.thrift.protocol.TField("resourceUris", org.apache.thrift.protocol.TType.LIST, (short)8);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)9);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new FunctionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new FunctionTupleSchemeFactory();
@@ -31,6 +32,7 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
   private int createTime; // required
   private @org.apache.thrift.annotation.Nullable FunctionType functionType; // required
   private @org.apache.thrift.annotation.Nullable java.util.List<ResourceUri> resourceUris; // required
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -49,7 +51,8 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
      * @see FunctionType
      */
     FUNCTION_TYPE((short)7, "functionType"),
-    RESOURCE_URIS((short)8, "resourceUris");
+    RESOURCE_URIS((short)8, "resourceUris"),
+    CAT_NAME((short)9, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -81,6 +84,8 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
           return FUNCTION_TYPE;
         case 8: // RESOURCE_URIS
           return RESOURCE_URIS;
+        case 9: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -124,6 +129,7 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
   // isset id assignments
   private static final int __CREATETIME_ISSET_ID = 0;
   private byte __isset_bitfield = 0;
+  private static final _Fields optionals[] = {_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -144,6 +150,8 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
     tmpMap.put(_Fields.RESOURCE_URIS, new org.apache.thrift.meta_data.FieldMetaData("resourceUris", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
             new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ResourceUri.class))));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Function.class, metaDataMap);
   }
@@ -204,6 +212,9 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
       }
       this.resourceUris = __this__resourceUris;
     }
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public Function deepCopy() {
@@ -221,6 +232,7 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
     this.createTime = 0;
     this.functionType = null;
     this.resourceUris = null;
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -445,6 +457,30 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case FUNCTION_NAME:
@@ -511,6 +547,14 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -541,6 +585,9 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
     case RESOURCE_URIS:
       return getResourceUris();
 
+    case CAT_NAME:
+      return getCatName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -568,6 +615,8 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
       return isSetFunctionType();
     case RESOURCE_URIS:
       return isSetResourceUris();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -657,6 +706,15 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -693,6 +751,10 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
     hashCode = hashCode * 8191 + ((isSetResourceUris()) ? 131071 : 524287);
     if (isSetResourceUris())
       hashCode = hashCode * 8191 + resourceUris.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -785,6 +847,16 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -865,6 +937,16 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
       sb.append(this.resourceUris);
     }
     first = false;
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
+      first = false;
+    }
     sb.append(")");
     return sb.toString();
   }
@@ -985,6 +1067,14 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 9: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1043,6 +1133,13 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
         }
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1085,7 +1182,10 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
       if (struct.isSetResourceUris()) {
         optionals.set(7);
       }
-      oprot.writeBitSet(optionals, 8);
+      if (struct.isSetCatName()) {
+        optionals.set(8);
+      }
+      oprot.writeBitSet(optionals, 9);
       if (struct.isSetFunctionName()) {
         oprot.writeString(struct.functionName);
       }
@@ -1116,12 +1216,15 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
           }
         }
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Function struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(8);
+      java.util.BitSet incoming = iprot.readBitSet(9);
       if (incoming.get(0)) {
         struct.functionName = iprot.readString();
         struct.setFunctionNameIsSet(true);
@@ -1163,6 +1266,10 @@ public class Function implements org.apache.thrift.TBase<Function, Function._Fie
           }
         }
         struct.setResourceUrisIsSet(true);
+      }
+      if (incoming.get(8)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HiveObjectRef.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/HiveObjectRef.java
@@ -16,6 +16,7 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
   private static final org.apache.thrift.protocol.TField OBJECT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("objectName", org.apache.thrift.protocol.TType.STRING, (short)3);
   private static final org.apache.thrift.protocol.TField PART_VALUES_FIELD_DESC = new org.apache.thrift.protocol.TField("partValues", org.apache.thrift.protocol.TType.LIST, (short)4);
   private static final org.apache.thrift.protocol.TField COLUMN_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("columnName", org.apache.thrift.protocol.TType.STRING, (short)5);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new HiveObjectRefStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new HiveObjectRefTupleSchemeFactory();
@@ -25,6 +26,7 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
   private @org.apache.thrift.annotation.Nullable java.lang.String objectName; // required
   private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> partValues; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String columnName; // required
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -36,7 +38,8 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     DB_NAME((short)2, "dbName"),
     OBJECT_NAME((short)3, "objectName"),
     PART_VALUES((short)4, "partValues"),
-    COLUMN_NAME((short)5, "columnName");
+    COLUMN_NAME((short)5, "columnName"),
+    CAT_NAME((short)6, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -62,6 +65,8 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
           return PART_VALUES;
         case 5: // COLUMN_NAME
           return COLUMN_NAME;
+        case 6: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -103,6 +108,7 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
   }
 
   // isset id assignments
+  private static final _Fields optionals[] = {_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -116,6 +122,8 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
         new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
     tmpMap.put(_Fields.COLUMN_NAME, new org.apache.thrift.meta_data.FieldMetaData("columnName", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(HiveObjectRef.class, metaDataMap);
@@ -159,6 +167,9 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     if (other.isSetColumnName()) {
       this.columnName = other.columnName;
     }
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public HiveObjectRef deepCopy() {
@@ -172,6 +183,7 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     this.objectName = null;
     this.partValues = null;
     this.columnName = null;
+    this.catName = null;
   }
 
   /**
@@ -318,6 +330,30 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case OBJECT_TYPE:
@@ -360,6 +396,14 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -380,6 +424,9 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
 
     case COLUMN_NAME:
       return getColumnName();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -402,6 +449,8 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       return isSetPartValues();
     case COLUMN_NAME:
       return isSetColumnName();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -464,6 +513,15 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -490,6 +548,10 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     hashCode = hashCode * 8191 + ((isSetColumnName()) ? 131071 : 524287);
     if (isSetColumnName())
       hashCode = hashCode * 8191 + columnName.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -548,6 +610,16 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
     }
     if (isSetColumnName()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.columnName, other.columnName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -612,6 +684,16 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       sb.append(this.columnName);
     }
     first = false;
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
+      first = false;
+    }
     sb.append(")");
     return sb.toString();
   }
@@ -705,6 +787,14 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -750,6 +840,13 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
         oprot.writeString(struct.columnName);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -783,7 +880,10 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       if (struct.isSetColumnName()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetCatName()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetObjectType()) {
         oprot.writeI32(struct.objectType.getValue());
       }
@@ -805,12 +905,15 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       if (struct.isSetColumnName()) {
         oprot.writeString(struct.columnName);
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, HiveObjectRef struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         struct.objectType = org.apache.hadoop.hive.metastore.api.HiveObjectType.findByValue(iprot.readI32());
         struct.setObjectTypeIsSet(true);
@@ -839,6 +942,10 @@ public class HiveObjectRef implements org.apache.thrift.TBase<HiveObjectRef, Hiv
       if (incoming.get(4)) {
         struct.columnName = iprot.readString();
         struct.setColumnNameIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
@@ -19,6 +19,7 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
   private static final org.apache.thrift.protocol.TField SD_FIELD_DESC = new org.apache.thrift.protocol.TField("sd", org.apache.thrift.protocol.TType.STRUCT, (short)6);
   private static final org.apache.thrift.protocol.TField PARAMETERS_FIELD_DESC = new org.apache.thrift.protocol.TField("parameters", org.apache.thrift.protocol.TType.MAP, (short)7);
   private static final org.apache.thrift.protocol.TField PRIVILEGES_FIELD_DESC = new org.apache.thrift.protocol.TField("privileges", org.apache.thrift.protocol.TType.STRUCT, (short)8);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)9);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionTupleSchemeFactory();
@@ -31,6 +32,7 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
   private @org.apache.thrift.annotation.Nullable StorageDescriptor sd; // required
   private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> parameters; // required
   private @org.apache.thrift.annotation.Nullable PrincipalPrivilegeSet privileges; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41,7 +43,8 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     LAST_ACCESS_TIME((short)5, "lastAccessTime"),
     SD((short)6, "sd"),
     PARAMETERS((short)7, "parameters"),
-    PRIVILEGES((short)8, "privileges");
+    PRIVILEGES((short)8, "privileges"),
+    CAT_NAME((short)9, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -73,6 +76,8 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
           return PARAMETERS;
         case 8: // PRIVILEGES
           return PRIVILEGES;
+        case 9: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -117,7 +122,7 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
   private static final int __CREATETIME_ISSET_ID = 0;
   private static final int __LASTACCESSTIME_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -140,6 +145,8 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
     tmpMap.put(_Fields.PRIVILEGES, new org.apache.thrift.meta_data.FieldMetaData("privileges", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, PrincipalPrivilegeSet.class)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Partition.class, metaDataMap);
   }
@@ -195,6 +202,9 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     if (other.isSetPrivileges()) {
       this.privileges = new PrincipalPrivilegeSet(other.privileges);
     }
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public Partition deepCopy() {
@@ -213,6 +223,7 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     this.sd = null;
     this.parameters = null;
     this.privileges = null;
+    this.catName = null;
   }
 
   public int getValuesSize() {
@@ -430,6 +441,30 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case VALUES:
@@ -496,6 +531,14 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -526,6 +569,9 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     case PRIVILEGES:
       return getPrivileges();
 
+    case CAT_NAME:
+      return getCatName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -553,6 +599,8 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
       return isSetParameters();
     case PRIVILEGES:
       return isSetPrivileges();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -642,6 +690,15 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -676,6 +733,10 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
     hashCode = hashCode * 8191 + ((isSetPrivileges()) ? 131071 : 524287);
     if (isSetPrivileges())
       hashCode = hashCode * 8191 + privileges.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -768,6 +829,16 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -843,6 +914,16 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
         sb.append("null");
       } else {
         sb.append(this.privileges);
+      }
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
       }
       first = false;
     }
@@ -985,6 +1066,14 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 9: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1051,6 +1140,13 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
           oprot.writeFieldEnd();
         }
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1093,7 +1189,10 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
       if (struct.isSetPrivileges()) {
         optionals.set(7);
       }
-      oprot.writeBitSet(optionals, 8);
+      if (struct.isSetCatName()) {
+        optionals.set(8);
+      }
+      oprot.writeBitSet(optionals, 9);
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
@@ -1131,12 +1230,15 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
       if (struct.isSetPrivileges()) {
         struct.privileges.write(oprot);
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Partition struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(8);
+      java.util.BitSet incoming = iprot.readBitSet(9);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list219 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
@@ -1190,6 +1292,10 @@ public class Partition implements org.apache.thrift.TBase<Partition, Partition._
         struct.privileges = new PrincipalPrivilegeSet();
         struct.privileges.read(iprot);
         struct.setPrivilegesIsSet(true);
+      }
+      if (incoming.get(8)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpec.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionSpec.java
@@ -16,6 +16,7 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
   private static final org.apache.thrift.protocol.TField ROOT_PATH_FIELD_DESC = new org.apache.thrift.protocol.TField("rootPath", org.apache.thrift.protocol.TType.STRING, (short)3);
   private static final org.apache.thrift.protocol.TField SHARED_SDPARTITION_SPEC_FIELD_DESC = new org.apache.thrift.protocol.TField("sharedSDPartitionSpec", org.apache.thrift.protocol.TType.STRUCT, (short)4);
   private static final org.apache.thrift.protocol.TField PARTITION_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("partitionList", org.apache.thrift.protocol.TType.STRUCT, (short)5);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionSpecStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionSpecTupleSchemeFactory();
@@ -25,6 +26,7 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
   private @org.apache.thrift.annotation.Nullable java.lang.String rootPath; // required
   private @org.apache.thrift.annotation.Nullable PartitionSpecWithSharedSD sharedSDPartitionSpec; // optional
   private @org.apache.thrift.annotation.Nullable PartitionListComposingSpec partitionList; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32,7 +34,8 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     TABLE_NAME((short)2, "tableName"),
     ROOT_PATH((short)3, "rootPath"),
     SHARED_SDPARTITION_SPEC((short)4, "sharedSDPartitionSpec"),
-    PARTITION_LIST((short)5, "partitionList");
+    PARTITION_LIST((short)5, "partitionList"),
+    CAT_NAME((short)6, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -58,6 +61,8 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
           return SHARED_SDPARTITION_SPEC;
         case 5: // PARTITION_LIST
           return PARTITION_LIST;
+        case 6: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -99,7 +104,7 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
   }
 
   // isset id assignments
-  private static final _Fields optionals[] = {_Fields.SHARED_SDPARTITION_SPEC,_Fields.PARTITION_LIST};
+  private static final _Fields optionals[] = {_Fields.SHARED_SDPARTITION_SPEC,_Fields.PARTITION_LIST,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -113,6 +118,8 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, PartitionSpecWithSharedSD.class)));
     tmpMap.put(_Fields.PARTITION_LIST, new org.apache.thrift.meta_data.FieldMetaData("partitionList", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, PartitionListComposingSpec.class)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(PartitionSpec.class, metaDataMap);
   }
@@ -150,6 +157,9 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     if (other.isSetPartitionList()) {
       this.partitionList = new PartitionListComposingSpec(other.partitionList);
     }
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public PartitionSpec deepCopy() {
@@ -163,6 +173,7 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     this.rootPath = null;
     this.sharedSDPartitionSpec = null;
     this.partitionList = null;
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -285,6 +296,30 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -327,6 +362,14 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -347,6 +390,9 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
 
     case PARTITION_LIST:
       return getPartitionList();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -369,6 +415,8 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
       return isSetSharedSDPartitionSpec();
     case PARTITION_LIST:
       return isSetPartitionList();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -431,6 +479,15 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -457,6 +514,10 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     hashCode = hashCode * 8191 + ((isSetPartitionList()) ? 131071 : 524287);
     if (isSetPartitionList())
       hashCode = hashCode * 8191 + partitionList.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -515,6 +576,16 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
     }
     if (isSetPartitionList()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.partitionList, other.partitionList);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -580,6 +651,16 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
         sb.append("null");
       } else {
         sb.append(this.partitionList);
+      }
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
       }
       first = false;
     }
@@ -674,6 +755,14 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -716,6 +805,13 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
           oprot.writeFieldEnd();
         }
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -749,7 +845,10 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
       if (struct.isSetPartitionList()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetCatName()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetDbName()) {
         oprot.writeString(struct.dbName);
       }
@@ -765,12 +864,15 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
       if (struct.isSetPartitionList()) {
         struct.partitionList.write(oprot);
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionSpec struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         struct.dbName = iprot.readString();
         struct.setDbNameIsSet(true);
@@ -792,6 +894,10 @@ public class PartitionSpec implements org.apache.thrift.TBase<PartitionSpec, Par
         struct.partitionList = new PartitionListComposingSpec();
         struct.partitionList.read(iprot);
         struct.setPartitionListIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRequest.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionValuesRequest.java
@@ -19,6 +19,7 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
   private static final org.apache.thrift.protocol.TField PARTITION_ORDER_FIELD_DESC = new org.apache.thrift.protocol.TField("partitionOrder", org.apache.thrift.protocol.TType.LIST, (short)6);
   private static final org.apache.thrift.protocol.TField ASCENDING_FIELD_DESC = new org.apache.thrift.protocol.TField("ascending", org.apache.thrift.protocol.TType.BOOL, (short)7);
   private static final org.apache.thrift.protocol.TField MAX_PARTS_FIELD_DESC = new org.apache.thrift.protocol.TField("maxParts", org.apache.thrift.protocol.TType.I64, (short)8);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)9);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionValuesRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionValuesRequestTupleSchemeFactory();
@@ -31,6 +32,7 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
   private @org.apache.thrift.annotation.Nullable java.util.List<FieldSchema> partitionOrder; // optional
   private boolean ascending; // optional
   private long maxParts; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41,7 +43,8 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
     FILTER((short)5, "filter"),
     PARTITION_ORDER((short)6, "partitionOrder"),
     ASCENDING((short)7, "ascending"),
-    MAX_PARTS((short)8, "maxParts");
+    MAX_PARTS((short)8, "maxParts"),
+    CAT_NAME((short)9, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -73,6 +76,8 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
           return ASCENDING;
         case 8: // MAX_PARTS
           return MAX_PARTS;
+        case 9: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -118,7 +123,7 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
   private static final int __ASCENDING_ISSET_ID = 1;
   private static final int __MAXPARTS_ISSET_ID = 2;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.APPLY_DISTINCT,_Fields.FILTER,_Fields.PARTITION_ORDER,_Fields.ASCENDING,_Fields.MAX_PARTS};
+  private static final _Fields optionals[] = {_Fields.APPLY_DISTINCT,_Fields.FILTER,_Fields.PARTITION_ORDER,_Fields.ASCENDING,_Fields.MAX_PARTS,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -140,6 +145,8 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.MAX_PARTS, new org.apache.thrift.meta_data.FieldMetaData("maxParts", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(PartitionValuesRequest.class, metaDataMap);
   }
@@ -195,6 +202,9 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
     }
     this.ascending = other.ascending;
     this.maxParts = other.maxParts;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public PartitionValuesRequest deepCopy() {
@@ -214,6 +224,7 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
 
     this.maxParts = -1L;
 
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -434,6 +445,30 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __MAXPARTS_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -500,6 +535,14 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -530,6 +573,9 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
     case MAX_PARTS:
       return getMaxParts();
 
+    case CAT_NAME:
+      return getCatName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -557,6 +603,8 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       return isSetAscending();
     case MAX_PARTS:
       return isSetMaxParts();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -646,6 +694,15 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -684,6 +741,10 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
     hashCode = hashCode * 8191 + ((isSetMaxParts()) ? 131071 : 524287);
     if (isSetMaxParts())
       hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(maxParts);
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -776,6 +837,16 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -856,6 +927,16 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       if (!first) sb.append(", ");
       sb.append("maxParts:");
       sb.append(this.maxParts);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -1001,6 +1082,14 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 9: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1072,6 +1161,13 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
         oprot.writeI64(struct.maxParts);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1114,7 +1210,10 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       if (struct.isSetMaxParts()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetCatName()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetApplyDistinct()) {
         oprot.writeBool(struct.applyDistinct);
       }
@@ -1135,6 +1234,9 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       }
       if (struct.isSetMaxParts()) {
         oprot.writeI64(struct.maxParts);
+      }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
       }
     }
 
@@ -1157,7 +1259,7 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
         }
       }
       struct.setPartitionKeysIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         struct.applyDistinct = iprot.readBool();
         struct.setApplyDistinctIsSet(true);
@@ -1187,6 +1289,10 @@ public class PartitionValuesRequest implements org.apache.thrift.TBase<Partition
       if (incoming.get(4)) {
         struct.maxParts = iprot.readI64();
         struct.setMaxPartsIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsByExprRequest.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsByExprRequest.java
@@ -16,6 +16,7 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
   private static final org.apache.thrift.protocol.TField EXPR_FIELD_DESC = new org.apache.thrift.protocol.TField("expr", org.apache.thrift.protocol.TType.STRING, (short)3);
   private static final org.apache.thrift.protocol.TField DEFAULT_PARTITION_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("defaultPartitionName", org.apache.thrift.protocol.TType.STRING, (short)4);
   private static final org.apache.thrift.protocol.TField MAX_PARTS_FIELD_DESC = new org.apache.thrift.protocol.TField("maxParts", org.apache.thrift.protocol.TType.I16, (short)5);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionsByExprRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionsByExprRequestTupleSchemeFactory();
@@ -25,6 +26,7 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
   private @org.apache.thrift.annotation.Nullable java.nio.ByteBuffer expr; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String defaultPartitionName; // optional
   private short maxParts; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32,7 +34,8 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
     TBL_NAME((short)2, "tblName"),
     EXPR((short)3, "expr"),
     DEFAULT_PARTITION_NAME((short)4, "defaultPartitionName"),
-    MAX_PARTS((short)5, "maxParts");
+    MAX_PARTS((short)5, "maxParts"),
+    CAT_NAME((short)6, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -58,6 +61,8 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
           return DEFAULT_PARTITION_NAME;
         case 5: // MAX_PARTS
           return MAX_PARTS;
+        case 6: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -101,7 +106,7 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
   // isset id assignments
   private static final int __MAXPARTS_ISSET_ID = 0;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.DEFAULT_PARTITION_NAME,_Fields.MAX_PARTS};
+  private static final _Fields optionals[] = {_Fields.DEFAULT_PARTITION_NAME,_Fields.MAX_PARTS,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -115,6 +120,8 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.MAX_PARTS, new org.apache.thrift.meta_data.FieldMetaData("maxParts", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(PartitionsByExprRequest.class, metaDataMap);
   }
@@ -153,6 +160,9 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       this.defaultPartitionName = other.defaultPartitionName;
     }
     this.maxParts = other.maxParts;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public PartitionsByExprRequest deepCopy() {
@@ -167,6 +177,7 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
     this.defaultPartitionName = null;
     this.maxParts = (short)-1;
 
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -295,6 +306,30 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __MAXPARTS_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -341,6 +376,14 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -361,6 +404,9 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
 
     case MAX_PARTS:
       return getMaxParts();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -383,6 +429,8 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       return isSetDefaultPartitionName();
     case MAX_PARTS:
       return isSetMaxParts();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -445,6 +493,15 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -471,6 +528,10 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
     hashCode = hashCode * 8191 + ((isSetMaxParts()) ? 131071 : 524287);
     if (isSetMaxParts())
       hashCode = hashCode * 8191 + maxParts;
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -533,6 +594,16 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -591,6 +662,16 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       if (!first) sb.append(", ");
       sb.append("maxParts:");
       sb.append(this.maxParts);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -690,6 +771,14 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -730,6 +819,13 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
         oprot.writeI16(struct.maxParts);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -757,12 +853,18 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       if (struct.isSetMaxParts()) {
         optionals.set(1);
       }
-      oprot.writeBitSet(optionals, 2);
+      if (struct.isSetCatName()) {
+        optionals.set(2);
+      }
+      oprot.writeBitSet(optionals, 3);
       if (struct.isSetDefaultPartitionName()) {
         oprot.writeString(struct.defaultPartitionName);
       }
       if (struct.isSetMaxParts()) {
         oprot.writeI16(struct.maxParts);
+      }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
       }
     }
 
@@ -775,7 +877,7 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       struct.setTblNameIsSet(true);
       struct.expr = iprot.readBinary();
       struct.setExprIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(2);
+      java.util.BitSet incoming = iprot.readBitSet(3);
       if (incoming.get(0)) {
         struct.defaultPartitionName = iprot.readString();
         struct.setDefaultPartitionNameIsSet(true);
@@ -783,6 +885,10 @@ public class PartitionsByExprRequest implements org.apache.thrift.TBase<Partitio
       if (incoming.get(1)) {
         struct.maxParts = iprot.readI16();
         struct.setMaxPartsIsSet(true);
+      }
+      if (incoming.get(2)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsRequest.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionsStatsRequest.java
@@ -15,6 +15,7 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
   private static final org.apache.thrift.protocol.TField TBL_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("tblName", org.apache.thrift.protocol.TType.STRING, (short)2);
   private static final org.apache.thrift.protocol.TField COL_NAMES_FIELD_DESC = new org.apache.thrift.protocol.TField("colNames", org.apache.thrift.protocol.TType.LIST, (short)3);
   private static final org.apache.thrift.protocol.TField PART_NAMES_FIELD_DESC = new org.apache.thrift.protocol.TField("partNames", org.apache.thrift.protocol.TType.LIST, (short)4);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)5);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionsStatsRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionsStatsRequestTupleSchemeFactory();
@@ -23,13 +24,15 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
   private @org.apache.thrift.annotation.Nullable java.lang.String tblName; // required
   private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> colNames; // required
   private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> partNames; // required
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
     DB_NAME((short)1, "dbName"),
     TBL_NAME((short)2, "tblName"),
     COL_NAMES((short)3, "colNames"),
-    PART_NAMES((short)4, "partNames");
+    PART_NAMES((short)4, "partNames"),
+    CAT_NAME((short)5, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -53,6 +56,8 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
           return COL_NAMES;
         case 4: // PART_NAMES
           return PART_NAMES;
+        case 5: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -94,6 +99,7 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
   }
 
   // isset id assignments
+  private static final _Fields optionals[] = {_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -107,6 +113,8 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
     tmpMap.put(_Fields.PART_NAMES, new org.apache.thrift.meta_data.FieldMetaData("partNames", org.apache.thrift.TFieldRequirementType.REQUIRED, 
         new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(PartitionsStatsRequest.class, metaDataMap);
   }
@@ -145,6 +153,9 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
       java.util.List<java.lang.String> __this__partNames = new java.util.ArrayList<java.lang.String>(other.partNames);
       this.partNames = __this__partNames;
     }
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public PartitionsStatsRequest deepCopy() {
@@ -157,6 +168,7 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
     this.tblName = null;
     this.colNames = null;
     this.partNames = null;
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -287,6 +299,30 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -321,6 +357,14 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -338,6 +382,9 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
 
     case PART_NAMES:
       return getPartNames();
+
+    case CAT_NAME:
+      return getCatName();
 
     }
     throw new java.lang.IllegalStateException();
@@ -358,6 +405,8 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
       return isSetColNames();
     case PART_NAMES:
       return isSetPartNames();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -411,6 +460,15 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -433,6 +491,10 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
     hashCode = hashCode * 8191 + ((isSetPartNames()) ? 131071 : 524287);
     if (isSetPartNames())
       hashCode = hashCode * 8191 + partNames.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -481,6 +543,16 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
     }
     if (isSetPartNames()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.partNames, other.partNames);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -537,6 +609,16 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
       sb.append(this.partNames);
     }
     first = false;
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
+      first = false;
+    }
     sb.append(")");
     return sb.toString();
   }
@@ -648,6 +730,14 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 5: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -695,6 +785,13 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
         }
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -728,6 +825,14 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
           oprot.writeString(_iter405);
         }
       }
+      java.util.BitSet optionals = new java.util.BitSet();
+      if (struct.isSetCatName()) {
+        optionals.set(0);
+      }
+      oprot.writeBitSet(optionals, 1);
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
@@ -759,6 +864,11 @@ public class PartitionsStatsRequest implements org.apache.thrift.TBase<Partition
         }
       }
       struct.setPartNamesIsSet(true);
+      java.util.BitSet incoming = iprot.readBitSet(1);
+      if (incoming.get(0)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
+      }
     }
   }
 

--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Table.java
@@ -26,6 +26,7 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
   private static final org.apache.thrift.protocol.TField PRIVILEGES_FIELD_DESC = new org.apache.thrift.protocol.TField("privileges", org.apache.thrift.protocol.TType.STRUCT, (short)13);
   private static final org.apache.thrift.protocol.TField TEMPORARY_FIELD_DESC = new org.apache.thrift.protocol.TField("temporary", org.apache.thrift.protocol.TType.BOOL, (short)14);
   private static final org.apache.thrift.protocol.TField REWRITE_ENABLED_FIELD_DESC = new org.apache.thrift.protocol.TField("rewriteEnabled", org.apache.thrift.protocol.TType.BOOL, (short)15);
+  private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)16);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TableStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TableTupleSchemeFactory();
@@ -45,6 +46,7 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
   private @org.apache.thrift.annotation.Nullable PrincipalPrivilegeSet privileges; // optional
   private boolean temporary; // optional
   private boolean rewriteEnabled; // optional
+  private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -62,7 +64,8 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
     TABLE_TYPE((short)12, "tableType"),
     PRIVILEGES((short)13, "privileges"),
     TEMPORARY((short)14, "temporary"),
-    REWRITE_ENABLED((short)15, "rewriteEnabled");
+    REWRITE_ENABLED((short)15, "rewriteEnabled"),
+    CAT_NAME((short)16, "catName");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -108,6 +111,8 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
           return TEMPORARY;
         case 15: // REWRITE_ENABLED
           return REWRITE_ENABLED;
+        case 16: // CAT_NAME
+          return CAT_NAME;
         default:
           return null;
       }
@@ -155,7 +160,7 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
   private static final int __TEMPORARY_ISSET_ID = 3;
   private static final int __REWRITEENABLED_ISSET_ID = 4;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.TEMPORARY,_Fields.REWRITE_ENABLED};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.TEMPORARY,_Fields.REWRITE_ENABLED,_Fields.CAT_NAME};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -192,6 +197,8 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.REWRITE_ENABLED, new org.apache.thrift.meta_data.FieldMetaData("rewriteEnabled", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.CAT_NAME, new org.apache.thrift.meta_data.FieldMetaData("catName", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Table.class, metaDataMap);
   }
@@ -278,6 +285,9 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
     }
     this.temporary = other.temporary;
     this.rewriteEnabled = other.rewriteEnabled;
+    if (other.isSetCatName()) {
+      this.catName = other.catName;
+    }
   }
 
   public Table deepCopy() {
@@ -306,6 +316,7 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
 
     setRewriteEnabledIsSet(false);
     this.rewriteEnabled = false;
+    this.catName = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -685,6 +696,30 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __REWRITEENABLED_ISSET_ID, value);
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public java.lang.String getCatName() {
+    return this.catName;
+  }
+
+  public void setCatName(@org.apache.thrift.annotation.Nullable java.lang.String catName) {
+    this.catName = catName;
+  }
+
+  public void unsetCatName() {
+    this.catName = null;
+  }
+
+  /** Returns true if field catName is set (has been assigned a value) and false otherwise */
+  public boolean isSetCatName() {
+    return this.catName != null;
+  }
+
+  public void setCatNameIsSet(boolean value) {
+    if (!value) {
+      this.catName = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case TABLE_NAME:
@@ -807,6 +842,14 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       }
       break;
 
+    case CAT_NAME:
+      if (value == null) {
+        unsetCatName();
+      } else {
+        setCatName((java.lang.String)value);
+      }
+      break;
+
     }
   }
 
@@ -858,6 +901,9 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
     case REWRITE_ENABLED:
       return isRewriteEnabled();
 
+    case CAT_NAME:
+      return getCatName();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -899,6 +945,8 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       return isSetTemporary();
     case REWRITE_ENABLED:
       return isSetRewriteEnabled();
+    case CAT_NAME:
+      return isSetCatName();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -1051,6 +1099,15 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
         return false;
     }
 
+    boolean this_present_catName = true && this.isSetCatName();
+    boolean that_present_catName = true && that.isSetCatName();
+    if (this_present_catName || that_present_catName) {
+      if (!(this_present_catName && that_present_catName))
+        return false;
+      if (!this.catName.equals(that.catName))
+        return false;
+    }
+
     return true;
   }
 
@@ -1111,6 +1168,10 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
     hashCode = hashCode * 8191 + ((isSetRewriteEnabled()) ? 131071 : 524287);
     if (isSetRewriteEnabled())
       hashCode = hashCode * 8191 + ((rewriteEnabled) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetCatName()) ? 131071 : 524287);
+    if (isSetCatName())
+      hashCode = hashCode * 8191 + catName.hashCode();
 
     return hashCode;
   }
@@ -1273,6 +1334,16 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.compare(isSetCatName(), other.isSetCatName());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetCatName()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.catName, other.catName);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1397,6 +1468,16 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       if (!first) sb.append(", ");
       sb.append("rewriteEnabled:");
       sb.append(this.rewriteEnabled);
+      first = false;
+    }
+    if (isSetCatName()) {
+      if (!first) sb.append(", ");
+      sb.append("catName:");
+      if (this.catName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.catName);
+      }
       first = false;
     }
     sb.append(")");
@@ -1595,6 +1676,14 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 16: // CAT_NAME
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.catName = iprot.readString();
+              struct.setCatNameIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1694,6 +1783,13 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
         oprot.writeBool(struct.rewriteEnabled);
         oprot.writeFieldEnd();
       }
+      if (struct.catName != null) {
+        if (struct.isSetCatName()) {
+          oprot.writeFieldBegin(CAT_NAME_FIELD_DESC);
+          oprot.writeString(struct.catName);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1757,7 +1853,10 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       if (struct.isSetRewriteEnabled()) {
         optionals.set(14);
       }
-      oprot.writeBitSet(optionals, 15);
+      if (struct.isSetCatName()) {
+        optionals.set(15);
+      }
+      oprot.writeBitSet(optionals, 16);
       if (struct.isSetTableName()) {
         oprot.writeString(struct.tableName);
       }
@@ -1816,12 +1915,15 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       if (struct.isSetRewriteEnabled()) {
         oprot.writeBool(struct.rewriteEnabled);
       }
+      if (struct.isSetCatName()) {
+        oprot.writeString(struct.catName);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Table struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(15);
+      java.util.BitSet incoming = iprot.readBitSet(16);
       if (incoming.get(0)) {
         struct.tableName = iprot.readString();
         struct.setTableNameIsSet(true);
@@ -1904,6 +2006,10 @@ public class Table implements org.apache.thrift.TBase<Table, Table._Fields>, jav
       if (incoming.get(14)) {
         struct.rewriteEnabled = iprot.readBool();
         struct.setRewriteEnabledIsSet(true);
+      }
+      if (incoming.get(15)) {
+        struct.catName = iprot.readString();
+        struct.setCatNameIsSet(true);
       }
     }
   }

--- a/metastore/src/gen/thrift/gen-php/metastore/AddPartitionsRequest.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/AddPartitionsRequest.php
@@ -51,6 +51,11 @@ class AddPartitionsRequest
             'isRequired' => false,
             'type' => TType::BOOL,
         ),
+        6 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -73,6 +78,10 @@ class AddPartitionsRequest
      * @var bool
      */
     public $needResult = true;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -91,6 +100,9 @@ class AddPartitionsRequest
             }
             if (isset($vals['needResult'])) {
                 $this->needResult = $vals['needResult'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -159,6 +171,13 @@ class AddPartitionsRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -203,6 +222,11 @@ class AddPartitionsRequest
         if ($this->needResult !== null) {
             $xfer += $output->writeFieldBegin('needResult', TType::BOOL, 5);
             $xfer += $output->writeBool($this->needResult);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 6);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/ColumnStatisticsDesc.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/ColumnStatisticsDesc.php
@@ -46,6 +46,11 @@ class ColumnStatisticsDesc
             'isRequired' => false,
             'type' => TType::I64,
         ),
+        6 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -68,6 +73,10 @@ class ColumnStatisticsDesc
      * @var int
      */
     public $lastAnalyzed = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -86,6 +95,9 @@ class ColumnStatisticsDesc
             }
             if (isset($vals['lastAnalyzed'])) {
                 $this->lastAnalyzed = $vals['lastAnalyzed'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -144,6 +156,13 @@ class ColumnStatisticsDesc
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -181,6 +200,11 @@ class ColumnStatisticsDesc
         if ($this->lastAnalyzed !== null) {
             $xfer += $output->writeFieldBegin('lastAnalyzed', TType::I64, 5);
             $xfer += $output->writeI64($this->lastAnalyzed);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 6);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/Database.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/Database.php
@@ -66,6 +66,11 @@ class Database
             'type' => TType::I32,
             'class' => '\metastore\PrincipalType',
         ),
+        8 => array(
+            'var' => 'catalogName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -96,6 +101,10 @@ class Database
      * @var int
      */
     public $ownerType = null;
+    /**
+     * @var string
+     */
+    public $catalogName = null;
 
     public function __construct($vals = null)
     {
@@ -120,6 +129,9 @@ class Database
             }
             if (isset($vals['ownerType'])) {
                 $this->ownerType = $vals['ownerType'];
+            }
+            if (isset($vals['catalogName'])) {
+                $this->catalogName = $vals['catalogName'];
             }
         }
     }
@@ -205,6 +217,13 @@ class Database
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 8:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catalogName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -263,6 +282,11 @@ class Database
         if ($this->ownerType !== null) {
             $xfer += $output->writeFieldBegin('ownerType', TType::I32, 7);
             $xfer += $output->writeI32($this->ownerType);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catalogName !== null) {
+            $xfer += $output->writeFieldBegin('catalogName', TType::STRING, 8);
+            $xfer += $output->writeString($this->catalogName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/DropPartitionsRequest.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/DropPartitionsRequest.php
@@ -63,6 +63,11 @@ class DropPartitionsRequest
             'isRequired' => false,
             'type' => TType::BOOL,
         ),
+        9 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -97,6 +102,10 @@ class DropPartitionsRequest
      * @var bool
      */
     public $needResult = true;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -124,6 +133,9 @@ class DropPartitionsRequest
             }
             if (isset($vals['needResult'])) {
                 $this->needResult = $vals['needResult'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -205,6 +217,13 @@ class DropPartitionsRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 9:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -263,6 +282,11 @@ class DropPartitionsRequest
         if ($this->needResult !== null) {
             $xfer += $output->writeFieldBegin('needResult', TType::BOOL, 8);
             $xfer += $output->writeBool($this->needResult);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 9);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/Function.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/Function.php
@@ -68,6 +68,11 @@ class Function
                 'class' => '\metastore\ResourceUri',
                 ),
         ),
+        9 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -102,6 +107,10 @@ class Function
      * @var \metastore\ResourceUri[]
      */
     public $resourceUris = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -129,6 +138,9 @@ class Function
             }
             if (isset($vals['resourceUris'])) {
                 $this->resourceUris = $vals['resourceUris'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -218,6 +230,13 @@ class Function
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 9:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -277,6 +296,11 @@ class Function
                 $xfer += $iter433->write($output);
             }
             $output->writeListEnd();
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 9);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/HiveObjectRef.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/HiveObjectRef.php
@@ -51,6 +51,11 @@ class HiveObjectRef
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        6 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -73,6 +78,10 @@ class HiveObjectRef
      * @var string
      */
     public $columnName = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -91,6 +100,9 @@ class HiveObjectRef
             }
             if (isset($vals['columnName'])) {
                 $this->columnName = $vals['columnName'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -158,6 +170,13 @@ class HiveObjectRef
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -202,6 +221,11 @@ class HiveObjectRef
         if ($this->columnName !== null) {
             $xfer += $output->writeFieldBegin('columnName', TType::STRING, 5);
             $xfer += $output->writeString($this->columnName);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 6);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/Partition.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/Partition.php
@@ -75,6 +75,11 @@ class Partition
             'type' => TType::STRUCT,
             'class' => '\metastore\PrincipalPrivilegeSet',
         ),
+        9 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -109,6 +114,10 @@ class Partition
      * @var \metastore\PrincipalPrivilegeSet
      */
     public $privileges = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -136,6 +145,9 @@ class Partition
             }
             if (isset($vals['privileges'])) {
                 $this->privileges = $vals['privileges'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -238,6 +250,13 @@ class Partition
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 9:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -311,6 +330,11 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('privileges', TType::STRUCT, 8);
             $xfer += $this->privileges->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 9);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/PartitionSpec.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/PartitionSpec.php
@@ -48,6 +48,11 @@ class PartitionSpec
             'type' => TType::STRUCT,
             'class' => '\metastore\PartitionListComposingSpec',
         ),
+        6 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -70,6 +75,10 @@ class PartitionSpec
      * @var \metastore\PartitionListComposingSpec
      */
     public $partitionList = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -88,6 +97,9 @@ class PartitionSpec
             }
             if (isset($vals['partitionList'])) {
                 $this->partitionList = $vals['partitionList'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -148,6 +160,13 @@ class PartitionSpec
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -191,6 +210,11 @@ class PartitionSpec
             }
             $xfer += $output->writeFieldBegin('partitionList', TType::STRUCT, 5);
             $xfer += $this->partitionList->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 6);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/PartitionValuesRequest.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/PartitionValuesRequest.php
@@ -71,6 +71,11 @@ class PartitionValuesRequest
             'isRequired' => false,
             'type' => TType::I64,
         ),
+        9 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -105,6 +110,10 @@ class PartitionValuesRequest
      * @var int
      */
     public $maxParts = -1;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -132,6 +141,9 @@ class PartitionValuesRequest
             }
             if (isset($vals['maxParts'])) {
                 $this->maxParts = $vals['maxParts'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -231,6 +243,13 @@ class PartitionValuesRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 9:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -297,6 +316,11 @@ class PartitionValuesRequest
         if ($this->maxParts !== null) {
             $xfer += $output->writeFieldBegin('maxParts', TType::I64, 8);
             $xfer += $output->writeI64($this->maxParts);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 9);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/PartitionsByExprRequest.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/PartitionsByExprRequest.php
@@ -46,6 +46,11 @@ class PartitionsByExprRequest
             'isRequired' => false,
             'type' => TType::I16,
         ),
+        6 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -68,6 +73,10 @@ class PartitionsByExprRequest
      * @var int
      */
     public $maxParts = -1;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -86,6 +95,9 @@ class PartitionsByExprRequest
             }
             if (isset($vals['maxParts'])) {
                 $this->maxParts = $vals['maxParts'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -144,6 +156,13 @@ class PartitionsByExprRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -181,6 +200,11 @@ class PartitionsByExprRequest
         if ($this->maxParts !== null) {
             $xfer += $output->writeFieldBegin('maxParts', TType::I16, 5);
             $xfer += $output->writeI16($this->maxParts);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 6);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/PartitionsStatsRequest.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/PartitionsStatsRequest.php
@@ -49,6 +49,11 @@ class PartitionsStatsRequest
                 'type' => TType::STRING,
                 ),
         ),
+        5 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -67,6 +72,10 @@ class PartitionsStatsRequest
      * @var string[]
      */
     public $partNames = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -82,6 +91,9 @@ class PartitionsStatsRequest
             }
             if (isset($vals['partNames'])) {
                 $this->partNames = $vals['partNames'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -151,6 +163,13 @@ class PartitionsStatsRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 5:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -197,6 +216,11 @@ class PartitionsStatsRequest
                 $xfer += $output->writeString($iter363);
             }
             $output->writeListEnd();
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 5);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-php/metastore/Table.php
+++ b/metastore/src/gen/thrift/gen-php/metastore/Table.php
@@ -111,6 +111,11 @@ class Table
             'isRequired' => false,
             'type' => TType::BOOL,
         ),
+        16 => array(
+            'var' => 'catName',
+            'isRequired' => false,
+            'type' => TType::STRING,
+        ),
     );
 
     /**
@@ -173,6 +178,10 @@ class Table
      * @var bool
      */
     public $rewriteEnabled = null;
+    /**
+     * @var string
+     */
+    public $catName = null;
 
     public function __construct($vals = null)
     {
@@ -221,6 +230,9 @@ class Table
             }
             if (isset($vals['rewriteEnabled'])) {
                 $this->rewriteEnabled = $vals['rewriteEnabled'];
+            }
+            if (isset($vals['catName'])) {
+                $this->catName = $vals['catName'];
             }
         }
     }
@@ -373,6 +385,13 @@ class Table
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 16:
+                    if ($ftype == TType::STRING) {
+                        $xfer += $input->readString($this->catName);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -481,6 +500,11 @@ class Table
         if ($this->rewriteEnabled !== null) {
             $xfer += $output->writeFieldBegin('rewriteEnabled', TType::BOOL, 15);
             $xfer += $output->writeBool($this->rewriteEnabled);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->catName !== null) {
+            $xfer += $output->writeFieldBegin('catName', TType::STRING, 16);
+            $xfer += $output->writeString($this->catName);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/metastore/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/metastore/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -863,16 +863,18 @@ class HiveObjectRef(object):
      - objectName
      - partValues
      - columnName
+     - catName
 
     """
 
 
-    def __init__(self, objectType=None, dbName=None, objectName=None, partValues=None, columnName=None,):
+    def __init__(self, objectType=None, dbName=None, objectName=None, partValues=None, columnName=None, catName=None,):
         self.objectType = objectType
         self.dbName = dbName
         self.objectName = objectName
         self.partValues = partValues
         self.columnName = columnName
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -913,6 +915,11 @@ class HiveObjectRef(object):
                     self.columnName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -945,6 +952,10 @@ class HiveObjectRef(object):
         if self.columnName is not None:
             oprot.writeFieldBegin('columnName', TType.STRING, 5)
             oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 6)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -2155,11 +2166,12 @@ class Database(object):
      - privileges
      - ownerName
      - ownerType
+     - catalogName
 
     """
 
 
-    def __init__(self, name=None, description=None, locationUri=None, parameters=None, privileges=None, ownerName=None, ownerType=None,):
+    def __init__(self, name=None, description=None, locationUri=None, parameters=None, privileges=None, ownerName=None, ownerType=None, catalogName=None,):
         self.name = name
         self.description = description
         self.locationUri = locationUri
@@ -2167,6 +2179,7 @@ class Database(object):
         self.privileges = privileges
         self.ownerName = ownerName
         self.ownerType = ownerType
+        self.catalogName = catalogName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -2219,6 +2232,11 @@ class Database(object):
                     self.ownerType = iprot.readI32()
                 else:
                     iprot.skip(ftype)
+            elif fid == 8:
+                if ftype == TType.STRING:
+                    self.catalogName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -2260,6 +2278,10 @@ class Database(object):
         if self.ownerType is not None:
             oprot.writeFieldBegin('ownerType', TType.I32, 7)
             oprot.writeI32(self.ownerType)
+            oprot.writeFieldEnd()
+        if self.catalogName is not None:
+            oprot.writeFieldBegin('catalogName', TType.STRING, 8)
+            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -2791,11 +2813,12 @@ class Table(object):
      - privileges
      - temporary
      - rewriteEnabled
+     - catName
 
     """
 
 
-    def __init__(self, tableName=None, dbName=None, owner=None, createTime=None, lastAccessTime=None, retention=None, sd=None, partitionKeys=None, parameters=None, viewOriginalText=None, viewExpandedText=None, tableType=None, privileges=None, temporary=False, rewriteEnabled=None,):
+    def __init__(self, tableName=None, dbName=None, owner=None, createTime=None, lastAccessTime=None, retention=None, sd=None, partitionKeys=None, parameters=None, viewOriginalText=None, viewExpandedText=None, tableType=None, privileges=None, temporary=False, rewriteEnabled=None, catName=None,):
         self.tableName = tableName
         self.dbName = dbName
         self.owner = owner
@@ -2811,6 +2834,7 @@ class Table(object):
         self.privileges = privileges
         self.temporary = temporary
         self.rewriteEnabled = rewriteEnabled
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -2910,6 +2934,11 @@ class Table(object):
                     self.rewriteEnabled = iprot.readBool()
                 else:
                     iprot.skip(ftype)
+            elif fid == 16:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -2987,6 +3016,10 @@ class Table(object):
             oprot.writeFieldBegin('rewriteEnabled', TType.BOOL, 15)
             oprot.writeBool(self.rewriteEnabled)
             oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 16)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -3016,11 +3049,12 @@ class Partition(object):
      - sd
      - parameters
      - privileges
+     - catName
 
     """
 
 
-    def __init__(self, values=None, dbName=None, tableName=None, createTime=None, lastAccessTime=None, sd=None, parameters=None, privileges=None,):
+    def __init__(self, values=None, dbName=None, tableName=None, createTime=None, lastAccessTime=None, sd=None, parameters=None, privileges=None, catName=None,):
         self.values = values
         self.dbName = dbName
         self.tableName = tableName
@@ -3029,6 +3063,7 @@ class Partition(object):
         self.sd = sd
         self.parameters = parameters
         self.privileges = privileges
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3092,6 +3127,11 @@ class Partition(object):
                     self.privileges.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 9:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3140,6 +3180,10 @@ class Partition(object):
         if self.privileges is not None:
             oprot.writeFieldBegin('privileges', TType.STRUCT, 8)
             self.privileges.write(oprot)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 9)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3442,16 +3486,18 @@ class PartitionSpec(object):
      - rootPath
      - sharedSDPartitionSpec
      - partitionList
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tableName=None, rootPath=None, sharedSDPartitionSpec=None, partitionList=None,):
+    def __init__(self, dbName=None, tableName=None, rootPath=None, sharedSDPartitionSpec=None, partitionList=None, catName=None,):
         self.dbName = dbName
         self.tableName = tableName
         self.rootPath = rootPath
         self.sharedSDPartitionSpec = sharedSDPartitionSpec
         self.partitionList = partitionList
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3489,6 +3535,11 @@ class PartitionSpec(object):
                     self.partitionList.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3518,6 +3569,10 @@ class PartitionSpec(object):
         if self.partitionList is not None:
             oprot.writeFieldBegin('partitionList', TType.STRUCT, 5)
             self.partitionList.write(oprot)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 6)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4784,16 +4839,18 @@ class ColumnStatisticsDesc(object):
      - tableName
      - partName
      - lastAnalyzed
+     - catName
 
     """
 
 
-    def __init__(self, isTblLevel=None, dbName=None, tableName=None, partName=None, lastAnalyzed=None,):
+    def __init__(self, isTblLevel=None, dbName=None, tableName=None, partName=None, lastAnalyzed=None, catName=None,):
         self.isTblLevel = isTblLevel
         self.dbName = dbName
         self.tableName = tableName
         self.partName = partName
         self.lastAnalyzed = lastAnalyzed
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -4829,6 +4886,11 @@ class ColumnStatisticsDesc(object):
                     self.lastAnalyzed = iprot.readI64()
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -4858,6 +4920,10 @@ class ColumnStatisticsDesc(object):
         if self.lastAnalyzed is not None:
             oprot.writeFieldBegin('lastAnalyzed', TType.I64, 5)
             oprot.writeI64(self.lastAnalyzed)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 6)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5887,16 +5953,18 @@ class PartitionsByExprRequest(object):
      - expr
      - defaultPartitionName
      - maxParts
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tblName=None, expr=None, defaultPartitionName=None, maxParts=-1,):
+    def __init__(self, dbName=None, tblName=None, expr=None, defaultPartitionName=None, maxParts=-1, catName=None,):
         self.dbName = dbName
         self.tblName = tblName
         self.expr = expr
         self.defaultPartitionName = defaultPartitionName
         self.maxParts = maxParts
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -5932,6 +6000,11 @@ class PartitionsByExprRequest(object):
                     self.maxParts = iprot.readI16()
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -5961,6 +6034,10 @@ class PartitionsByExprRequest(object):
         if self.maxParts is not None:
             oprot.writeFieldBegin('maxParts', TType.I16, 5)
             oprot.writeI16(self.maxParts)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 6)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6232,15 +6309,17 @@ class PartitionsStatsRequest(object):
      - tblName
      - colNames
      - partNames
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tblName=None, colNames=None, partNames=None,):
+    def __init__(self, dbName=None, tblName=None, colNames=None, partNames=None, catName=None,):
         self.dbName = dbName
         self.tblName = tblName
         self.colNames = colNames
         self.partNames = partNames
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6281,6 +6360,11 @@ class PartitionsStatsRequest(object):
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
+            elif fid == 5:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6312,6 +6396,10 @@ class PartitionsStatsRequest(object):
             for iter363 in self.partNames:
                 oprot.writeString(iter363.encode('utf-8') if sys.version_info[0] == 2 else iter363)
             oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 5)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6413,16 +6501,18 @@ class AddPartitionsRequest(object):
      - parts
      - ifNotExists
      - needResult
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tblName=None, parts=None, ifNotExists=None, needResult=True,):
+    def __init__(self, dbName=None, tblName=None, parts=None, ifNotExists=None, needResult=True, catName=None,):
         self.dbName = dbName
         self.tblName = tblName
         self.parts = parts
         self.ifNotExists = ifNotExists
         self.needResult = needResult
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6464,6 +6554,11 @@ class AddPartitionsRequest(object):
                     self.needResult = iprot.readBool()
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6496,6 +6591,10 @@ class AddPartitionsRequest(object):
         if self.needResult is not None:
             oprot.writeFieldBegin('needResult', TType.BOOL, 5)
             oprot.writeBool(self.needResult)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 6)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6755,11 +6854,12 @@ class DropPartitionsRequest(object):
      - ignoreProtection
      - environmentContext
      - needResult
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tblName=None, parts=None, deleteData=None, ifExists=True, ignoreProtection=None, environmentContext=None, needResult=True,):
+    def __init__(self, dbName=None, tblName=None, parts=None, deleteData=None, ifExists=True, ignoreProtection=None, environmentContext=None, needResult=True, catName=None,):
         self.dbName = dbName
         self.tblName = tblName
         self.parts = parts
@@ -6768,6 +6868,7 @@ class DropPartitionsRequest(object):
         self.ignoreProtection = ignoreProtection
         self.environmentContext = environmentContext
         self.needResult = needResult
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6820,6 +6921,11 @@ class DropPartitionsRequest(object):
                     self.needResult = iprot.readBool()
                 else:
                     iprot.skip(ftype)
+            elif fid == 9:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6862,6 +6968,10 @@ class DropPartitionsRequest(object):
             oprot.writeFieldBegin('needResult', TType.BOOL, 8)
             oprot.writeBool(self.needResult)
             oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 9)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -6897,11 +7007,12 @@ class PartitionValuesRequest(object):
      - partitionOrder
      - ascending
      - maxParts
+     - catName
 
     """
 
 
-    def __init__(self, dbName=None, tblName=None, partitionKeys=None, applyDistinct=True, filter=None, partitionOrder=None, ascending=True, maxParts=-1,):
+    def __init__(self, dbName=None, tblName=None, partitionKeys=None, applyDistinct=True, filter=None, partitionOrder=None, ascending=True, maxParts=-1, catName=None,):
         self.dbName = dbName
         self.tblName = tblName
         self.partitionKeys = partitionKeys
@@ -6910,6 +7021,7 @@ class PartitionValuesRequest(object):
         self.partitionOrder = partitionOrder
         self.ascending = ascending
         self.maxParts = maxParts
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6972,6 +7084,11 @@ class PartitionValuesRequest(object):
                     self.maxParts = iprot.readI64()
                 else:
                     iprot.skip(ftype)
+            elif fid == 9:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -7019,6 +7136,10 @@ class PartitionValuesRequest(object):
         if self.maxParts is not None:
             oprot.writeFieldBegin('maxParts', TType.I64, 8)
             oprot.writeI64(self.maxParts)
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 9)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -7258,11 +7379,12 @@ class Function(object):
      - createTime
      - functionType
      - resourceUris
+     - catName
 
     """
 
 
-    def __init__(self, functionName=None, dbName=None, className=None, ownerName=None, ownerType=None, createTime=None, functionType=None, resourceUris=None,):
+    def __init__(self, functionName=None, dbName=None, className=None, ownerName=None, ownerType=None, createTime=None, functionType=None, resourceUris=None, catName=None,):
         self.functionName = functionName
         self.dbName = dbName
         self.className = className
@@ -7271,6 +7393,7 @@ class Function(object):
         self.createTime = createTime
         self.functionType = functionType
         self.resourceUris = resourceUris
+        self.catName = catName
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -7327,6 +7450,11 @@ class Function(object):
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
+            elif fid == 9:
+                if ftype == TType.STRING:
+                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -7371,6 +7499,10 @@ class Function(object):
             for iter433 in self.resourceUris:
                 iter433.write(oprot)
             oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.catName is not None:
+            oprot.writeFieldBegin('catName', TType.STRING, 9)
+            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12969,6 +13101,7 @@ HiveObjectRef.thrift_spec = (
     (3, TType.STRING, 'objectName', 'UTF8', None, ),  # 3
     (4, TType.LIST, 'partValues', (TType.STRING, 'UTF8', False), None, ),  # 4
     (5, TType.STRING, 'columnName', 'UTF8', None, ),  # 5
+    (6, TType.STRING, 'catName', 'UTF8', None, ),  # 6
 )
 all_structs.append(PrivilegeGrantInfo)
 PrivilegeGrantInfo.thrift_spec = (
@@ -13076,6 +13209,7 @@ Database.thrift_spec = (
     (5, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 5
     (6, TType.STRING, 'ownerName', 'UTF8', None, ),  # 6
     (7, TType.I32, 'ownerType', None, None, ),  # 7
+    (8, TType.STRING, 'catalogName', 'UTF8', None, ),  # 8
 )
 all_structs.append(SerDeInfo)
 SerDeInfo.thrift_spec = (
@@ -13131,6 +13265,7 @@ Table.thrift_spec = (
     (13, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 13
     (14, TType.BOOL, 'temporary', None, False, ),  # 14
     (15, TType.BOOL, 'rewriteEnabled', None, None, ),  # 15
+    (16, TType.STRING, 'catName', 'UTF8', None, ),  # 16
 )
 all_structs.append(Partition)
 Partition.thrift_spec = (
@@ -13143,6 +13278,7 @@ Partition.thrift_spec = (
     (6, TType.STRUCT, 'sd', [StorageDescriptor, None], None, ),  # 6
     (7, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 7
     (8, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 8
+    (9, TType.STRING, 'catName', 'UTF8', None, ),  # 9
 )
 all_structs.append(PartitionWithoutSD)
 PartitionWithoutSD.thrift_spec = (
@@ -13173,6 +13309,7 @@ PartitionSpec.thrift_spec = (
     (3, TType.STRING, 'rootPath', 'UTF8', None, ),  # 3
     (4, TType.STRUCT, 'sharedSDPartitionSpec', [PartitionSpecWithSharedSD, None], None, ),  # 4
     (5, TType.STRUCT, 'partitionList', [PartitionListComposingSpec, None], None, ),  # 5
+    (6, TType.STRING, 'catName', 'UTF8', None, ),  # 6
 )
 all_structs.append(Index)
 Index.thrift_spec = (
@@ -13287,6 +13424,7 @@ ColumnStatisticsDesc.thrift_spec = (
     (3, TType.STRING, 'tableName', 'UTF8', None, ),  # 3
     (4, TType.STRING, 'partName', 'UTF8', None, ),  # 4
     (5, TType.I64, 'lastAnalyzed', None, None, ),  # 5
+    (6, TType.STRING, 'catName', 'UTF8', None, ),  # 6
 )
 all_structs.append(ColumnStatistics)
 ColumnStatistics.thrift_spec = (
@@ -13372,6 +13510,7 @@ PartitionsByExprRequest.thrift_spec = (
     (3, TType.STRING, 'expr', 'BINARY', None, ),  # 3
     (4, TType.STRING, 'defaultPartitionName', 'UTF8', None, ),  # 4
     (5, TType.I16, 'maxParts', None, -1, ),  # 5
+    (6, TType.STRING, 'catName', 'UTF8', None, ),  # 6
 )
 all_structs.append(TableStatsResult)
 TableStatsResult.thrift_spec = (
@@ -13397,6 +13536,7 @@ PartitionsStatsRequest.thrift_spec = (
     (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
     (3, TType.LIST, 'colNames', (TType.STRING, 'UTF8', False), None, ),  # 3
     (4, TType.LIST, 'partNames', (TType.STRING, 'UTF8', False), None, ),  # 4
+    (5, TType.STRING, 'catName', 'UTF8', None, ),  # 5
 )
 all_structs.append(AddPartitionsResult)
 AddPartitionsResult.thrift_spec = (
@@ -13411,6 +13551,7 @@ AddPartitionsRequest.thrift_spec = (
     (3, TType.LIST, 'parts', (TType.STRUCT, [Partition, None], False), None, ),  # 3
     (4, TType.BOOL, 'ifNotExists', None, None, ),  # 4
     (5, TType.BOOL, 'needResult', None, True, ),  # 5
+    (6, TType.STRING, 'catName', 'UTF8', None, ),  # 6
 )
 all_structs.append(DropPartitionsResult)
 DropPartitionsResult.thrift_spec = (
@@ -13440,6 +13581,7 @@ DropPartitionsRequest.thrift_spec = (
     (6, TType.BOOL, 'ignoreProtection', None, None, ),  # 6
     (7, TType.STRUCT, 'environmentContext', [EnvironmentContext, None], None, ),  # 7
     (8, TType.BOOL, 'needResult', None, True, ),  # 8
+    (9, TType.STRING, 'catName', 'UTF8', None, ),  # 9
 )
 all_structs.append(PartitionValuesRequest)
 PartitionValuesRequest.thrift_spec = (
@@ -13452,6 +13594,7 @@ PartitionValuesRequest.thrift_spec = (
     (6, TType.LIST, 'partitionOrder', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 6
     (7, TType.BOOL, 'ascending', None, True, ),  # 7
     (8, TType.I64, 'maxParts', None, -1, ),  # 8
+    (9, TType.STRING, 'catName', 'UTF8', None, ),  # 9
 )
 all_structs.append(PartitionValuesRow)
 PartitionValuesRow.thrift_spec = (
@@ -13480,6 +13623,7 @@ Function.thrift_spec = (
     (6, TType.I32, 'createTime', None, None, ),  # 6
     (7, TType.I32, 'functionType', None, None, ),  # 7
     (8, TType.LIST, 'resourceUris', (TType.STRUCT, [ResourceUri, None], False), None, ),  # 8
+    (9, TType.STRING, 'catName', 'UTF8', None, ),  # 9
 )
 all_structs.append(TxnInfo)
 TxnInfo.thrift_spec = (

--- a/metastore/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/metastore/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -543,13 +543,15 @@ class HiveObjectRef
   OBJECTNAME = 3
   PARTVALUES = 4
   COLUMNNAME = 5
+  CATNAME = 6
 
   FIELDS = {
     OBJECTTYPE => {:type => ::Thrift::Types::I32, :name => 'objectType', :enum_class => ::HiveObjectType},
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     OBJECTNAME => {:type => ::Thrift::Types::STRING, :name => 'objectName'},
     PARTVALUES => {:type => ::Thrift::Types::LIST, :name => 'partValues', :element => {:type => ::Thrift::Types::STRING}},
-    COLUMNNAME => {:type => ::Thrift::Types::STRING, :name => 'columnName'}
+    COLUMNNAME => {:type => ::Thrift::Types::STRING, :name => 'columnName'},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -880,6 +882,7 @@ class Database
   PRIVILEGES = 5
   OWNERNAME = 6
   OWNERTYPE = 7
+  CATALOGNAME = 8
 
   FIELDS = {
     NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
@@ -888,7 +891,8 @@ class Database
     PARAMETERS => {:type => ::Thrift::Types::MAP, :name => 'parameters', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}},
     PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true},
     OWNERNAME => {:type => ::Thrift::Types::STRING, :name => 'ownerName', :optional => true},
-    OWNERTYPE => {:type => ::Thrift::Types::I32, :name => 'ownerType', :optional => true, :enum_class => ::PrincipalType}
+    OWNERTYPE => {:type => ::Thrift::Types::I32, :name => 'ownerType', :optional => true, :enum_class => ::PrincipalType},
+    CATALOGNAME => {:type => ::Thrift::Types::STRING, :name => 'catalogName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1015,6 +1019,7 @@ class Table
   PRIVILEGES = 13
   TEMPORARY = 14
   REWRITEENABLED = 15
+  CATNAME = 16
 
   FIELDS = {
     TABLENAME => {:type => ::Thrift::Types::STRING, :name => 'tableName'},
@@ -1031,7 +1036,8 @@ class Table
     TABLETYPE => {:type => ::Thrift::Types::STRING, :name => 'tableType'},
     PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true},
     TEMPORARY => {:type => ::Thrift::Types::BOOL, :name => 'temporary', :default => false, :optional => true},
-    REWRITEENABLED => {:type => ::Thrift::Types::BOOL, :name => 'rewriteEnabled', :optional => true}
+    REWRITEENABLED => {:type => ::Thrift::Types::BOOL, :name => 'rewriteEnabled', :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1052,6 +1058,7 @@ class Partition
   SD = 6
   PARAMETERS = 7
   PRIVILEGES = 8
+  CATNAME = 9
 
   FIELDS = {
     VALUES => {:type => ::Thrift::Types::LIST, :name => 'values', :element => {:type => ::Thrift::Types::STRING}},
@@ -1061,7 +1068,8 @@ class Partition
     LASTACCESSTIME => {:type => ::Thrift::Types::I32, :name => 'lastAccessTime'},
     SD => {:type => ::Thrift::Types::STRUCT, :name => 'sd', :class => ::StorageDescriptor},
     PARAMETERS => {:type => ::Thrift::Types::MAP, :name => 'parameters', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}},
-    PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true}
+    PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1139,13 +1147,15 @@ class PartitionSpec
   ROOTPATH = 3
   SHAREDSDPARTITIONSPEC = 4
   PARTITIONLIST = 5
+  CATNAME = 6
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TABLENAME => {:type => ::Thrift::Types::STRING, :name => 'tableName'},
     ROOTPATH => {:type => ::Thrift::Types::STRING, :name => 'rootPath'},
     SHAREDSDPARTITIONSPEC => {:type => ::Thrift::Types::STRUCT, :name => 'sharedSDPartitionSpec', :class => ::PartitionSpecWithSharedSD, :optional => true},
-    PARTITIONLIST => {:type => ::Thrift::Types::STRUCT, :name => 'partitionList', :class => ::PartitionListComposingSpec, :optional => true}
+    PARTITIONLIST => {:type => ::Thrift::Types::STRUCT, :name => 'partitionList', :class => ::PartitionListComposingSpec, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1498,13 +1508,15 @@ class ColumnStatisticsDesc
   TABLENAME = 3
   PARTNAME = 4
   LASTANALYZED = 5
+  CATNAME = 6
 
   FIELDS = {
     ISTBLLEVEL => {:type => ::Thrift::Types::BOOL, :name => 'isTblLevel'},
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TABLENAME => {:type => ::Thrift::Types::STRING, :name => 'tableName'},
     PARTNAME => {:type => ::Thrift::Types::STRING, :name => 'partName', :optional => true},
-    LASTANALYZED => {:type => ::Thrift::Types::I64, :name => 'lastAnalyzed', :optional => true}
+    LASTANALYZED => {:type => ::Thrift::Types::I64, :name => 'lastAnalyzed', :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1771,13 +1783,15 @@ class PartitionsByExprRequest
   EXPR = 3
   DEFAULTPARTITIONNAME = 4
   MAXPARTS = 5
+  CATNAME = 6
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TBLNAME => {:type => ::Thrift::Types::STRING, :name => 'tblName'},
     EXPR => {:type => ::Thrift::Types::STRING, :name => 'expr', :binary => true},
     DEFAULTPARTITIONNAME => {:type => ::Thrift::Types::STRING, :name => 'defaultPartitionName', :optional => true},
-    MAXPARTS => {:type => ::Thrift::Types::I16, :name => 'maxParts', :default => -1, :optional => true}
+    MAXPARTS => {:type => ::Thrift::Types::I16, :name => 'maxParts', :default => -1, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1854,12 +1868,14 @@ class PartitionsStatsRequest
   TBLNAME = 2
   COLNAMES = 3
   PARTNAMES = 4
+  CATNAME = 5
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TBLNAME => {:type => ::Thrift::Types::STRING, :name => 'tblName'},
     COLNAMES => {:type => ::Thrift::Types::LIST, :name => 'colNames', :element => {:type => ::Thrift::Types::STRING}},
-    PARTNAMES => {:type => ::Thrift::Types::LIST, :name => 'partNames', :element => {:type => ::Thrift::Types::STRING}}
+    PARTNAMES => {:type => ::Thrift::Types::LIST, :name => 'partNames', :element => {:type => ::Thrift::Types::STRING}},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1897,13 +1913,15 @@ class AddPartitionsRequest
   PARTS = 3
   IFNOTEXISTS = 4
   NEEDRESULT = 5
+  CATNAME = 6
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TBLNAME => {:type => ::Thrift::Types::STRING, :name => 'tblName'},
     PARTS => {:type => ::Thrift::Types::LIST, :name => 'parts', :element => {:type => ::Thrift::Types::STRUCT, :class => ::Partition}},
     IFNOTEXISTS => {:type => ::Thrift::Types::BOOL, :name => 'ifNotExists'},
-    NEEDRESULT => {:type => ::Thrift::Types::BOOL, :name => 'needResult', :default => true, :optional => true}
+    NEEDRESULT => {:type => ::Thrift::Types::BOOL, :name => 'needResult', :default => true, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1992,6 +2010,7 @@ class DropPartitionsRequest
   IGNOREPROTECTION = 6
   ENVIRONMENTCONTEXT = 7
   NEEDRESULT = 8
+  CATNAME = 9
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
@@ -2001,7 +2020,8 @@ class DropPartitionsRequest
     IFEXISTS => {:type => ::Thrift::Types::BOOL, :name => 'ifExists', :default => true, :optional => true},
     IGNOREPROTECTION => {:type => ::Thrift::Types::BOOL, :name => 'ignoreProtection', :optional => true},
     ENVIRONMENTCONTEXT => {:type => ::Thrift::Types::STRUCT, :name => 'environmentContext', :class => ::EnvironmentContext, :optional => true},
-    NEEDRESULT => {:type => ::Thrift::Types::BOOL, :name => 'needResult', :default => true, :optional => true}
+    NEEDRESULT => {:type => ::Thrift::Types::BOOL, :name => 'needResult', :default => true, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -2025,6 +2045,7 @@ class PartitionValuesRequest
   PARTITIONORDER = 6
   ASCENDING = 7
   MAXPARTS = 8
+  CATNAME = 9
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
@@ -2034,7 +2055,8 @@ class PartitionValuesRequest
     FILTER => {:type => ::Thrift::Types::STRING, :name => 'filter', :optional => true},
     PARTITIONORDER => {:type => ::Thrift::Types::LIST, :name => 'partitionOrder', :element => {:type => ::Thrift::Types::STRUCT, :class => ::FieldSchema}, :optional => true},
     ASCENDING => {:type => ::Thrift::Types::BOOL, :name => 'ascending', :default => true, :optional => true},
-    MAXPARTS => {:type => ::Thrift::Types::I64, :name => 'maxParts', :default => -1, :optional => true}
+    MAXPARTS => {:type => ::Thrift::Types::I64, :name => 'maxParts', :default => -1, :optional => true},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -2113,6 +2135,7 @@ class Function
   CREATETIME = 6
   FUNCTIONTYPE = 7
   RESOURCEURIS = 8
+  CATNAME = 9
 
   FIELDS = {
     FUNCTIONNAME => {:type => ::Thrift::Types::STRING, :name => 'functionName'},
@@ -2122,7 +2145,8 @@ class Function
     OWNERTYPE => {:type => ::Thrift::Types::I32, :name => 'ownerType', :enum_class => ::PrincipalType},
     CREATETIME => {:type => ::Thrift::Types::I32, :name => 'createTime'},
     FUNCTIONTYPE => {:type => ::Thrift::Types::I32, :name => 'functionType', :enum_class => ::FunctionType},
-    RESOURCEURIS => {:type => ::Thrift::Types::LIST, :name => 'resourceUris', :element => {:type => ::Thrift::Types::STRUCT, :class => ::ResourceUri}}
+    RESOURCEURIS => {:type => ::Thrift::Types::LIST, :name => 'resourceUris', :element => {:type => ::Thrift::Types::STRUCT, :class => ::ResourceUri}},
+    CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true}
   }
 
   def struct_fields; FIELDS; end


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Backport a small subset of thrift related changes from HIVE-18755 to `branch-2.3`, which allows Hive 2.3.x client to specify catalog to read when communicating with HMS of version 3.x+.

Note this only adds a optional `catalog` field in several of the HMS thrift APIs, and is backward compatible. I plan to open a few follow-up PRs to introduce the actual changes to `HiveMetaStoreClient`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[HIVE-18755](https://issues.apache.org/jira/browse/HIVE-18755) introduced the concept of catalog which adds another level of namespace on top of tables and databases. Given HMS using Hive 3.x already has this feature and Hive 2.3 client is commonly used to talk to these metastores through frameworks such as Spark, this JIRA proposes to backport a subset of the features to allow Hive 2.3 client to specify catalog to read from the 3.x metastores.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This is only thrift related changes and is backward compatible.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests