### PR TITLE
HIVE-27885 : Cast decimal from string with space without digits before dot returns NULL

### DIFF
--- a/ql/src/test/queries/clientpositive/cast2.q
+++ b/ql/src/test/queries/clientpositive/cast2.q
@@ -3,3 +3,6 @@ select cast('1' as tinyint), cast('1' as smallint), cast('1' as int), cast('1' a
 
 -- Check that leading/trailing space is handled consistently for numeric types
 select cast(' 1 ' as tinyint), cast(' 1 ' as smallint), cast(' 1 ' as int), cast(' 1 ' as bigint), cast(' 1 ' as float), cast(' 1 ' as double), cast(' 1 ' as decimal(10,2));
+
+-- Decimal cast with spaces/without digits before dot & only dot.
+select cast(".0000 " as decimal(8,4)), cast(" .0000" as decimal(8,4)), cast(" .0000  " as decimal(8,4)), cast("." as decimal(8,4)), cast(".  " as decimal(8,4)), cast("  .  " as decimal(8,4)), cast(".00 00 " as decimal(8,4));

--- a/ql/src/test/results/clientpositive/llap/cast2.q.out
+++ b/ql/src/test/results/clientpositive/llap/cast2.q.out
@@ -16,3 +16,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 1	1	1	1	1.0	1.0	1.00
+PREHOOK: query: select cast(".0000 " as decimal(8,4)), cast(" .0000" as decimal(8,4)), cast(" .0000  " as decimal(8,4)), cast("." as decimal(8,4)), cast(".  " as decimal(8,4)), cast("  .  " as decimal(8,4)), cast(".00 00 " as decimal(8,4))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select cast(".0000 " as decimal(8,4)), cast(" .0000" as decimal(8,4)), cast(" .0000  " as decimal(8,4)), cast("." as decimal(8,4)), cast(".  " as decimal(8,4)), cast("  .  " as decimal(8,4)), cast(".00 00 " as decimal(8,4))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+0.0000	0.0000	0.0000	NULL	NULL	NULL	NULL

--- a/storage-api/src/java/org/apache/hadoop/hive/common/type/FastHiveDecimalImpl.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/type/FastHiveDecimalImpl.java
@@ -443,6 +443,7 @@ public class FastHiveDecimalImpl extends FastHiveDecimal {
           }
           break;
         }
+        haveInteger = true;
         digitValue = work - BYTE_DIGIT_ZERO;
         if (digitNum == 0) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support valid decimal which has only scale.

### Why are the changes needed?
Incorrect results

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Yes, added testcase in cast2.q file