### PR TITLE
[HIVE-27893] Add a range validator in hive.metastore.batch.retrieve.max to only have values >= 1

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1299,9 +1299,10 @@ public class HiveConf extends Configuration {
      */
     @Deprecated
     METASTORE_BATCH_RETRIEVE_MAX("hive.metastore.batch.retrieve.max", 300,
+         new RangeValidator(1, null),
         "Maximum number of objects (tables/partitions) can be retrieved from metastore in one batch. \n" +
         "The higher the number, the less the number of round trips is needed to the Hive metastore server, \n" +
-        "but it may also cause higher memory requirement at the client side."),
+        "but it may also cause higher memory requirement at the client side. Batch value should be > 0 "),
     /**
      * @deprecated Use MetastoreConf.BATCH_RETRIEVE_OBJECTS_MAX
      */

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4153,43 +4153,14 @@ private void constructOneLBLocationMap(FileStatus fSta,
   }
 
   /**
-   * Get all the partitions; unlike {@link #getPartitions(Table)}, does not include auth.
-   * @param tbl table for which partitions are needed
-   * @return list of partition objects
-   */
-  public Set<Partition> getAllPartitions(Table tbl) throws HiveException {
-    if (!tbl.isPartitioned()) {
-      return Sets.newHashSet(new Partition(tbl));
-    }
-
-    List<org.apache.hadoop.hive.metastore.api.Partition> tParts;
-    try {
-      tParts = getMSC().listPartitions(tbl.getDbName(), tbl.getTableName(), (short)-1);
-    } catch (Exception e) {
-      LOG.error("Failed getAllPartitionsOf", e);
-      throw new HiveException(e);
-    }
-    Set<Partition> parts = new LinkedHashSet<Partition>(tParts.size());
-    for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
-      parts.add(new Partition(tbl, tpart));
-    }
-    return parts;
-  }
-
-  /**
-   * Get all the partitions. Do it in batches if batchSize is more than 0 else get it in one call.
+   * Get all the partitions in batches. Does not include auth information.
    * @param tbl table for which partitions are needed
    * @return list of partition objects
    */
   public Set<Partition> getAllPartitionsOf(Table tbl) throws HiveException {
-    int batchSize= MetastoreConf.getIntVar(
-            Hive.get().getConf(), MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
-    if (batchSize > 0) {
-      return getAllPartitionsInBatches(tbl, batchSize, DEFAULT_BATCH_DECAYING_FACTOR, MetastoreConf.getIntVar(
+    int batchSize= MetastoreConf.getIntVar(Hive.get().getConf(), MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
+    return getAllPartitionsInBatches(tbl, batchSize, DEFAULT_BATCH_DECAYING_FACTOR, MetastoreConf.getIntVar(
               Hive.get().getConf(), MetastoreConf.ConfVars.GETPARTITIONS_BATCH_MAX_RETRIES));
-    } else {
-      return getAllPartitions(tbl);
-    }
   }
 
   public Set<Partition> getAllPartitionsInBatches(Table tbl, int batchSize, int decayingFactor,

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/PartitionIterable.java
@@ -156,6 +156,9 @@ public class PartitionIterable implements Iterable<Partition> {
    */
   public PartitionIterable(Hive db, Table table, Map<String, String> partialPartitionSpec,
                            int batchSize, boolean getColStats) throws HiveException {
+    if (batchSize < 1) {
+      throw new HiveException("Batch Size for Partition Iterable should be > 0");
+    }
     this.currType = Type.LAZY_FETCH_PARTITIONS;
     this.db = db;
     this.table = table;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionInBatches.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestGetPartitionInBatches.java
@@ -23,11 +23,13 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 
 import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.MetastoreException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.PartitionIterable;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.Assert;
 import org.junit.After;
@@ -255,5 +257,22 @@ public class TestGetPartitionInBatches {
         assert(partitionNames.size() == 30);
         // In case any duplicate/incomplete list is given by hive.getAllPartitionsInBatches, the below assertion will fail
         assert(partNames.size() == 0);
+    }
+
+    @Test
+    public void testBatchingWhenBatchSizeIsZero() throws MetaException {
+        HiveMetaStoreClient spyMSC = spy(msc);
+        hive.setMSC(spyMSC);
+        int batchSize = 0;
+        try {
+            new PartitionIterable(hive, hive.getTable(dbName, tableName), null, batchSize);
+        } catch (HiveException e) {
+            Assert.assertTrue(e.getMessage().contains("Batch Size for Partition Iterable should be > 0"));
+        }
+        try {
+            new org.apache.hadoop.hive.metastore.PartitionIterable(msc, table, batchSize);
+        } catch (MetastoreException e) {
+            Assert.assertTrue(e.getMessage().contains("Batch Size for Partition Iterable should be > 0"));
+        }
     }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -353,9 +353,10 @@ public class MetastoreConf {
             + "To enable auto create also set hive.metastore.schema.verification=false. Auto creation is not "
             + "recommended for production use cases, run schematool command instead." ),
     BATCH_RETRIEVE_MAX("metastore.batch.retrieve.max", "hive.metastore.batch.retrieve.max", 300,
+            new RangeValidator(1, null),
         "Maximum number of objects (tables/partitions) can be retrieved from metastore in one batch. \n" +
             "The higher the number, the less the number of round trips is needed to the Hive metastore server, \n" +
-            "but it may also cause higher memory requirement at the client side."),
+            "but it may also cause higher memory requirement at the client side. Batch value should be > 0"),
     BATCH_RETRIEVE_OBJECTS_MAX("metastore.batch.retrieve.table.partition.max",
         "hive.metastore.batch.retrieve.table.partition.max", 1000,
         "Maximum number of objects that metastore internally retrieves in one batch."),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -276,12 +276,8 @@ public class HiveMetaStoreChecker {
             .addProjectField("createTime").addProjectField("tableName")
             .addProjectField("values").build());
         request.setCatName(table.getCatName());
-        int batchSize = MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX);
-        if (batchSize > 0) {
-          parts = new PartitionIterable(getMsc(), table, batchSize).withProjectSpec(request);
-        } else {
-          parts = new PartitionIterable(getPartitionsByProjectSpec(msc, request));
-        }
+        parts = new PartitionIterable(getMsc(), table, MetastoreConf.getIntVar(conf,
+                MetastoreConf.ConfVars.BATCH_RETRIEVE_MAX)).withProjectSpec(request);
       }
     } else {
       parts = new PartitionIterable(Collections.emptyList());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionIterable.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionIterable.java
@@ -164,6 +164,9 @@ public class PartitionIterable implements Iterable<Partition> {
    * a Hive object and a table object, and a partial partition spec.
    */
   public PartitionIterable(IMetaStoreClient msc, Table table, int batch_size) throws MetastoreException {
+    if (batch_size < 1) {
+      throw new MetastoreException("Batch Size for Partition Iterable should be > 0");
+    }
     this.currType = Type.LAZY_FETCH_PARTITIONS;
     this.msc = msc;
     this.table = table;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
 Blocking the setting of the property hive.metastore.batch.retrieve.max to < 1. Added a Range validator when setting the conf as well in PartitionIterable Constructor to fallback to default value in case if the batchsize is < 1
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
PartitionIterable gives a NoSuchElementException when batchsize has been configured as 0 or less than 0. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
Added a test case for the same
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
