### PR TITLE
HIVE-27907:Upragde aws-java-sdk to 1.12.499

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <spotbugs.version>4.0.3</spotbugs.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
     <aws-secretsmanager-caching.version>1.0.1</aws-secretsmanager-caching.version>
-    <aws-java-sdk.version>1.12.132</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.499</aws-java-sdk.version>
     <jansi.version>2.4.0</jansi.version>
     <spring.version>5.2.24.RELEASE</spring.version>
   </properties>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
aws-java-sdk to 1.12.499 from 1.12.132


### Why are the changes needed?
So ,that scanners don't keep flagging CVEs


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Built manually and relying on precommit
