### PR TITLE
HIVE-27899: Killed speculative execution task attempt should not comm…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -293,6 +293,12 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       rproc.init(mrReporter, inputs, outputs);
       rproc.run();
 
+      // Try to call canCommit to AM. If there is no other speculative attempt execute canCommit, then continue.
+      // If there are other speculative attempt execute canCommit first, then wait until the attempt is killed
+      // or the committed task fails.
+      while (!this.processorContext.canCommit()) {
+        Thread.sleep(100);
+      }
     } catch (Throwable t) {
       rproc.setAborted(true);
       originalThrowable = t;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -295,7 +295,12 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       // If there are other speculative attempt execute canCommit first, then wait until the attempt is killed
       // or the committed task fails.
       while (!getContext().canCommit()) {
-        Thread.sleep(100);
+        // If canCommit returns false and fall into this loop, it means another task attempt has committed.
+        // And this task attempt is only needs to sleep for a relatively long time to wait for being killed.
+        // However, we need to avoid low-probability events: the rare case where a task attempt fails after
+        // committed, so we can't set an excessively long delay so that this task attempt could react on time.
+        // 500ms is a trade-off value.
+        Thread.sleep(500);
       }
     } catch (Throwable t) {
       rproc.setAborted(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -181,24 +181,25 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
   @Override
   public void initialize() throws IOException {
     perfLogger.perfLogBegin(CLASS_NAME, PerfLogger.TEZ_INITIALIZE_PROCESSOR);
-    Configuration conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    ProcessorContext processorContext = getContext();
+    Configuration conf = TezUtils.createConfFromUserPayload(processorContext.getUserPayload());
     this.jobConf = new JobConf(conf);
     this.jobConf.getCredentials().mergeAll(UserGroupInformation.getCurrentUser().getCredentials());
-    initTezAttributes();
-    ExecutionContext execCtx = getContext().getExecutionContext();
+    initTezAttributes(processorContext);
+    ExecutionContext execCtx = processorContext.getExecutionContext();
     if (execCtx instanceof Hook) {
       ((Hook)execCtx).initializeHook(this);
     }
-    setupMRLegacyConfigs(getContext());
+    setupMRLegacyConfigs(processorContext);
     perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.TEZ_INITIALIZE_PROCESSOR);
   }
 
 
-  private void initTezAttributes() {
-    jobConf.set(HIVE_TEZ_VERTEX_NAME, getContext().getTaskVertexName());
-    jobConf.setInt(HIVE_TEZ_VERTEX_INDEX, getContext().getTaskVertexIndex());
-    jobConf.setInt(HIVE_TEZ_TASK_INDEX, getContext().getTaskIndex());
-    jobConf.setInt(HIVE_TEZ_TASK_ATTEMPT_NUMBER, getContext().getTaskAttemptNumber());
+  private void initTezAttributes(ProcessorContext processorContext) {
+    jobConf.set(HIVE_TEZ_VERTEX_NAME, processorContext.getTaskVertexName());
+    jobConf.setInt(HIVE_TEZ_VERTEX_INDEX, processorContext.getTaskVertexIndex());
+    jobConf.setInt(HIVE_TEZ_TASK_INDEX, processorContext.getTaskIndex());
+    jobConf.setInt(HIVE_TEZ_TASK_ATTEMPT_NUMBER, processorContext.getTaskAttemptNumber());
   }
 
   private void setupMRLegacyConfigs(ProcessorContext processorContext) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -189,7 +189,7 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     if (execCtx instanceof Hook) {
       ((Hook)execCtx).initializeHook(this);
     }
-    setupMRLegacyConfigs();
+    setupMRLegacyConfigs(getContext());
     perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.TEZ_INITIALIZE_PROCESSOR);
   }
 
@@ -201,28 +201,28 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
     jobConf.setInt(HIVE_TEZ_TASK_ATTEMPT_NUMBER, getContext().getTaskAttemptNumber());
   }
 
-  private void setupMRLegacyConfigs() {
+  private void setupMRLegacyConfigs(ProcessorContext processorContext) {
     // Hive "insert overwrite local directory" uses task id as dir name
     // Setting the id in jobconf helps to have the similar dir name as MR
     StringBuilder taskAttemptIdBuilder = new StringBuilder("attempt_");
-    taskAttemptIdBuilder.append(getContext().getApplicationId().getClusterTimestamp())
+    taskAttemptIdBuilder.append(processorContext.getApplicationId().getClusterTimestamp())
         .append("_")
-        .append(jobIdFormat.format(getContext().getApplicationId().getId()))
+        .append(jobIdFormat.format(processorContext.getApplicationId().getId()))
         .append("_");
     if (isMap) {
       taskAttemptIdBuilder.append("m_");
     } else {
       taskAttemptIdBuilder.append("r_");
     }
-    taskAttemptIdBuilder.append(taskIdFormat.format(getContext().getTaskIndex()))
+    taskAttemptIdBuilder.append(taskIdFormat.format(processorContext.getTaskIndex()))
       .append("_")
-      .append(getContext().getTaskAttemptNumber());
+      .append(processorContext.getTaskAttemptNumber());
 
     // In MR, mapreduce.task.attempt.id is same as mapred.task.id. Go figure.
     String taskAttemptIdStr = taskAttemptIdBuilder.toString();
     this.jobConf.set("mapred.task.id", taskAttemptIdStr);
     this.jobConf.set("mapreduce.task.attempt.id", taskAttemptIdStr);
-    this.jobConf.setInt("mapred.task.partition", getContext().getTaskIndex());
+    this.jobConf.setInt("mapred.task.partition", processorContext.getTaskIndex());
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezProcessor.java
@@ -295,11 +295,11 @@ public class TezProcessor extends AbstractLogicalIOProcessor {
       // If there are other speculative attempt execute canCommit first, then wait until the attempt is killed
       // or the committed task fails.
       while (!getContext().canCommit()) {
-        // If canCommit returns false and fall into this loop, it means another task attempt has committed.
-        // And this task attempt is only needs to sleep for a relatively long time to wait for being killed.
-        // However, we need to avoid low-probability events: the rare case where a task attempt fails after
-        // committed, so we can't set an excessively long delay so that this task attempt could react on time.
-        // 500ms is a trade-off value.
+        // If canCommit returns false, and we enter this loop, it means another task attempt has already committed.
+        // This task attempt only needs to sleep for a relatively long time while waiting to be killed.
+        // However, we must avoid a low-probability scenario: a rare case where a task attempt fails after committing.
+        // In that situation, the delay must not be excessively long so this attempt can still react in time.
+        // 500ms is chosen as a trade-off value.
         Thread.sleep(500);
       }
     } catch (Throwable t) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Try canCommit after process.

### Why are the changes needed?

We should avoid speculative tasks being committed at the same time. Detailed information see: https://issues.apache.org/jira/browse/HIVE-27899

### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

test on our cluster
