### PR TITLE
HIVE-27911 : Drop database query failing with Invalid ACL Exception

### DIFF
--- a/llap-client/src/java/org/apache/hadoop/hive/llap/registry/impl/LlapZookeeperRegistryImpl.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/registry/impl/LlapZookeeperRegistryImpl.java
@@ -168,6 +168,16 @@ public class LlapZookeeperRegistryImpl
     String uniqueId = UNIQUE_ID.toString();
     long znodeCreationTimeout = 120;
 
+    /* When no LLAP executors are running, the getInstances()/ llapRegistryService.getInstances() method results in
+     InvalidACL exception when Hive tries to evict the cache in DROP DATABASE/TABLE
+
+     As ContainerManager of zookeeper makes sure to cleanup znodes periodically, once query-coordinator zookeeper
+     client session is terminated,entire path will get deleted sooner or later. This results in InvalidACL exception
+
+     PersistentNode created on server will be preserved through restarts of query executor and makes sure
+     proactive eviction call of DROP DATABASE/ DROP TABLE go through
+     successfully. */
+    ensurePersistentNodePath(daemonZkRecord);
     initializeWithoutRegisteringInternal();
     // Create a znode under the rootNamespace parent for this instance of the server
     try {

--- a/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
@@ -55,6 +56,7 @@ import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.InvalidACLException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.apache.zookeeper.ZooDefs;
@@ -114,6 +116,8 @@ public abstract class ZkRegistryBase<InstanceType extends ServiceInstance> {
   private PersistentNode znode;
   private String znodePath; // unique identity for this instance
 
+  final String namespace;
+
   private PathChildrenCache instancesCache; // Created on demand.
 
   /** Local hostname. */
@@ -160,7 +164,7 @@ public abstract class ZkRegistryBase<InstanceType extends ServiceInstance> {
     this.stateChangeListeners = new HashSet<>();
     this.pathToInstanceCache = new ConcurrentHashMap<>();
     this.nodeToInstanceCache = new ConcurrentHashMap<>();
-    final String namespace = getRootNamespace(conf, rootNs, nsPrefix);
+    this.namespace = getRootNamespace(conf, rootNs, nsPrefix);
     ACLProvider aclProvider;
     // get acl provider for most outer path that is non-null
     if (userPathPrefix == null) {
@@ -353,6 +357,30 @@ public abstract class ZkRegistryBase<InstanceType extends ServiceInstance> {
     }
   }
 
+  @VisibleForTesting
+  public String getPersistentNodePath() {
+    return "/" + PATH_JOINER.join(namespace, StringUtils.substringBetween(workersPath, "/", "/"), "pnode0");
+  }
+
+  protected void ensurePersistentNodePath(ServiceRecord srv) throws IOException {
+    String pNodePath = getPersistentNodePath();
+    try {
+      LOG.info("Check if persistent node  path {}  exists, create if not", pNodePath);
+      if (zooKeeperClient.checkExists().forPath(pNodePath) == null) {
+        zooKeeperClient.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT)
+            .forPath(pNodePath, encoder.toBytes(srv));
+        LOG.info("Created persistent path at: {}", pNodePath);
+      }
+    } catch (Exception e) {
+      // throw exception if it is other than NODEEXISTS.
+      if (!(e instanceof KeeperException) || ((KeeperException) e).code() != KeeperException.Code.NODEEXISTS) {
+        LOG.error("Unable to create a persistent znode for this server instance", e);
+        throw new IOException(e);
+      } else {
+        LOG.debug("Ignoring KeeperException while ensuring path as the parent node {} already exists.", pNodePath);
+      }
+    }
+  }
 
   final protected void initializeWithoutRegisteringInternal() throws IOException {
     // Create a znode under the rootNamespace parent for this instance of the server

--- a/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/registry/impl/ZkRegistryBase.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ACLProvider;

--- a/llap-client/src/test/org/apache/hadoop/hive/llap/registry/impl/TestLlapZookeeperRegistryImpl.java
+++ b/llap-client/src/test/org/apache/hadoop/hive/llap/registry/impl/TestLlapZookeeperRegistryImpl.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.llap.registry.LlapServiceInstance;
 import org.apache.hadoop.hive.registry.ServiceInstanceSet;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +48,7 @@ public class TestLlapZookeeperRegistryImpl {
 
   private CuratorFramework curatorFramework;
   private TestingServer server;
+  private final static String NAMESPACE_PREFIX = "llap-";
 
   @Before
   public void setUp() throws Exception {
@@ -122,6 +124,16 @@ public class TestLlapZookeeperRegistryImpl {
             attributes.get(LlapRegistryService.LLAP_DAEMON_TASK_SCHEDULER_ENABLED_WAIT_QUEUE_SIZE));
     assertEquals(expectedExecutorCount,
             attributes.get(LlapRegistryService.LLAP_DAEMON_NUM_ENABLED_EXECUTORS));
+  }
+
+  @Test
+  public void testPersistentNodePath() {
+    String llapRootNameSpace = "/" + LlapZookeeperRegistryImpl.getRootNamespace(hiveConf,
+        HiveConf.getVar(hiveConf, HiveConf.ConfVars.LLAP_ZK_REGISTRY_NAMESPACE), NAMESPACE_PREFIX);
+    String persistentNodeName = "/pnode0";
+
+    Assert.assertEquals(llapRootNameSpace + "/user-" + System.getProperty("user.name") + persistentNodeName,
+        registry.getPersistentNodePath());
   }
 
   static <T> void trySetMock(Object o, String field, T value) {


### PR DESCRIPTION


### What changes were proposed in this pull request?
In the query-executor, we create ephemeral nodes which have the special behaviour that they are automatically deleted when the query-coordinator zookeeper client session is terminated. If there are no other Hive VWs on the cluster, sooner or later the entire path will be deleted.
To avoid this, we need to have a persistent node on path /llap-sasl/user-hivefoo0/pnode0.

### Why are the changes needed?
Hue or beeline session thows InvalidACL exception when executing drop database, drop table or alter table drop partition operations on a Hive Virtual Warehouse that is in Stopped state: "org.apache.zookeeper.KeeperException$InvalidACLException: KeeperErrorCode = InvalidACL for /llap-sasl/user-hive".
The exception appears because the Hive VW wants to evict the cache in the LLAP executors, but those computes in a Stopped warehouse are not running.

In the query-executor, we create ephemeral nodes which have the special behaviour that they are automatically deleted when the query-coordinator zookeeper client session is terminated. If there are no other Hive VWs on the cluster, sooner or later the entire path will be deleted.
To avoid this, we need to have a persistent node on path.


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
Manually. This was tested on private cluster with crating data catalog and VWs and stopping VWS manually
