### PR TITLE
HIVE-27913: Wrap NoSuchObjectException into HiveException in Hive.dro…

### DIFF
--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/HcatTestUtils.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/HcatTestUtils.java
@@ -60,7 +60,7 @@ public class HcatTestUtils {
    * Removes all databases and tables from the metastore
    */
   public static void cleanupHMS(Hive hive, Warehouse wh, FsPermission defaultPerm)
-    throws HiveException, MetaException, NoSuchObjectException {
+    throws HiveException, MetaException {
     for (String dbName : hive.getAllDatabases()) {
       if (dbName.equals("default")) {
         continue;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/dataconnector/drop/DropDataConnectorOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/dataconnector/drop/DropDataConnectorOperation.java
@@ -34,12 +34,7 @@ public class DropDataConnectorOperation extends DDLOperation<DropDataConnectorDe
 
   @Override
   public int execute() throws HiveException {
-    try {
-      context.getDb().dropDataConnector(desc.getConnectorName(), desc.getIfExists());
-    } catch (NoSuchObjectException ex) {
-      throw new HiveException(ex, ErrorMsg.DATACONNECTOR_NOT_EXISTS, desc.getConnectorName());
-    }
-
+    context.getDb().dropDataConnector(desc.getConnectorName(), desc.getIfExists());
     return 0;
   }
 }


### PR DESCRIPTION
…pDatabase and Hive.dropConnector


### What changes were proposed in this pull request?
Wrap `NoSuchObjectException` into `HiveException` for dropDatabase and dropDataConnector api in `Hive`.

### Why are the changes needed?
To align the `drop_database` and `drop_dataconnector` behavior with `drop_table`.


### Does this PR introduce _any_ user-facing change?
Yes, the Hive client user need handle the `NoSuchObjectException` inside `HiveException` after this change.

### Is the change a dependency upgrade?
No


### How was this patch tested?
Pass existing tests.
