### PR TITLE
HIVE-27903: Iceberg: Implement Expire Snapshot with default table properties.

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergExpireSnapshots.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergExpireSnapshots.java
@@ -36,6 +36,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 import static org.apache.iceberg.TableProperties.MAX_SNAPSHOT_AGE_MS;
+import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP;
 
 /**
  * Tests covering the rollback feature
@@ -115,6 +116,34 @@ public class TestHiveIcebergExpireSnapshots extends HiveIcebergStorageHandlerWit
     shell.executeStatement("ALTER TABLE " + identifier.name() + " EXECUTE EXPIRE_SNAPSHOTS RETAIN LAST 5");
     table.refresh();
     Assert.assertEquals(5, IterableUtils.size(table.snapshots()));
+  }
+
+  @Test
+  public void testExpireSnapshotsWithDefaultParams() throws IOException, InterruptedException {
+    TableIdentifier identifier = TableIdentifier.of("default", "source");
+    Table table = testTables.createTableWithVersions(shell, identifier.name(),
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 10);
+    // No snapshot should expire, since the max snapshot age to expire is by default 5 days
+    shell.executeStatement("ALTER TABLE " + identifier.name() + " EXECUTE EXPIRE_SNAPSHOTS RETAIN LAST 5");
+    table.refresh();
+    Assert.assertEquals(10, IterableUtils.size(table.snapshots()));
+
+    // Change max snapshot age to expire to 1 ms & min snapshots to keep as 4 & re-execute
+    shell.executeStatement(
+        "ALTER TABLE " + identifier.name() + " SET TBLPROPERTIES('" + MAX_SNAPSHOT_AGE_MS + "'='1'" + ",'" +
+            MIN_SNAPSHOTS_TO_KEEP + "'='3')");
+    shell.executeStatement("ALTER TABLE " + identifier.name() + " EXECUTE EXPIRE_SNAPSHOTS");
+    table.refresh();
+    Assert.assertEquals(3, IterableUtils.size(table.snapshots()));
+
+    // Change the min snapshot to keep as 2
+    shell.executeStatement(
+        "ALTER TABLE " + identifier.name() + " SET TBLPROPERTIES('" + MIN_SNAPSHOTS_TO_KEEP + "'='2')");
+    shell.executeStatement("ALTER TABLE " + identifier.name() + " EXECUTE EXPIRE_SNAPSHOTS");
+    table.refresh();
+    Assert.assertEquals(2, IterableUtils.size(table.snapshots()));
+
   }
 
   @Test

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/AlterClauseParser.g
@@ -475,8 +475,8 @@ alterStatementSuffixExecute
 @after { gParent.popMsg(state); }
     : KW_EXECUTE KW_ROLLBACK LPAREN (rollbackParam=(StringLiteral | Number)) RPAREN
     -> ^(TOK_ALTERTABLE_EXECUTE KW_ROLLBACK $rollbackParam)
-    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS LPAREN (expireParam=StringLiteral) RPAREN
-    -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $expireParam)
+    | KW_EXECUTE KW_EXPIRE_SNAPSHOTS (LPAREN (expireParam=StringLiteral) RPAREN)?
+    -> ^(TOK_ALTERTABLE_EXECUTE KW_EXPIRE_SNAPSHOTS $expireParam?)
     | KW_EXECUTE KW_SET_CURRENT_SNAPSHOT LPAREN (snapshotParam=expression) RPAREN
     -> ^(TOK_ALTERTABLE_EXECUTE KW_SET_CURRENT_SNAPSHOT $snapshotParam)
     | KW_EXECUTE KW_FAST_FORWARD sourceBranch=StringLiteral (targetBranch=StringLiteral)?

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/execute/AlterTableExecuteAnalyzer.java
@@ -141,7 +141,10 @@ public class AlterTableExecuteAnalyzer extends AbstractAlterTableAnalyzer {
   private static AlterTableExecuteDesc getExpireSnapshotDesc(TableName tableName, Map<String, String> partitionSpec,
       List<Node> children) throws SemanticException {
     AlterTableExecuteSpec<ExpireSnapshotsSpec> spec;
-
+    if (children.size() == 1) {
+      spec = new AlterTableExecuteSpec(EXPIRE_SNAPSHOT, null);
+      return new AlterTableExecuteDesc(tableName, partitionSpec, spec);
+    }
     ZoneId timeZone = SessionState.get() == null ?
         new HiveConf().getLocalTimeZone() :
         SessionState.get().getConf().getLocalTimeZone();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Allow expire snapshot with default table properties.

### Why are the changes needed?

Better usability

### Does this PR introduce _any_ user-facing change?

```ALTER TABLE <tableName> execute expire_snasphot``` works

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT