### PR TITLE
HIVE-27916: Increase tez.am.resource.memory.mb for TestIcebergCliDrver to 512MB

### DIFF
--- a/data/conf/iceberg/tez/tez-site.xml
+++ b/data/conf/iceberg/tez/tez-site.xml
@@ -5,7 +5,7 @@
   </property>
   <property>
     <name>tez.am.resource.memory.mb</name>
-    <value>256</value>
+    <value>512</value>
   </property>
   <property>
     <name>tez.runtime.io.sort.mb</name>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Increasing tez.am.resource.memory.mb for tez based iceberg cli driver.

### Why are the changes needed?
To improve test stability.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Precommit.
