### PR TITLE
HIVE-27937: Clarifying comments and xml configs around tez container size

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2461,7 +2461,20 @@ public class HiveConf extends Configuration {
         "The default input format for tez. Tez groups splits in the AM."),
 
     HIVE_TEZ_CONTAINER_SIZE("hive.tez.container.size", -1,
-        "By default Tez will spawn containers of the size of a mapper. This can be used to overwrite."),
+        "The memory in MB that's used by a Tez task container (TezChild) in Tez container mode. Hive uses this \n"
+        + "property to create a Resource object which is accepted by Yarn (and used in TezAM to ask for TezChild \n"
+        + "containers). This should be distinguished from the Tez AM's (DAGAppMaster) memory, \n"
+        + "which is driven by tez.am.resource.memory.mb! \n"
+        + "Also, as Hive takes care of TezChild memory by setting this option, there is no need \n "
+        + "to set tez.task.resource.memory.mb differently. \n"
+        + "The final -Xmx arg for TezChild process is not equal to this setting, \n "
+        + "because Tez considers a heap fraction (80%), so by default: \n"
+        + "Xmx = hive.tez.container.size * tez.container.max.java.heap.fraction. \n"
+        + "In case of values <= 0, container size falls back to mapreduce.map.memory.mb. \n"
+        + "LLAP notes: while generating splits, the needed per-task resource is derived from this option \n"
+        + "(refer to HiveSplitGenerator, TezAvailableSlotsCalculator), so even if its value doesn't change the \n"
+        + "LLAP daemons' total physical size, it has to be configured properly. In this context \n"
+        + "4096 implies that you assume a single task will consume 4096MB from a daemon's shared heap."),
     HIVE_TEZ_CPU_VCORES("hive.tez.cpu.vcores", -1,
         "By default Tez will ask for however many cpus map-reduce is configured to use per container.\n" +
         "This can be used to overwrite."),

--- a/data/conf/iceberg/llap/hive-site.xml
+++ b/data/conf/iceberg/llap/hive-site.xml
@@ -38,10 +38,12 @@
         <description>A base for other temporary directories.</description>
     </property>
 
+    <!-- in LLAP mode hive.tez.container.size isn't used to actually determine container size, however while -->
+    <!-- calculating available slots (in split generation) in it's used through -->
+    <!-- the Vertex resource, so this has to be defined in order to get consistent test results -->
     <property>
-        <name>hive.tez.container.size</name>
-        <value>128</value>
-        <description></description>
+      <name>hive.tez.container.size</name>
+      <value>128</value>
     </property>
 
     <property>

--- a/data/conf/iceberg/llap/tez-site.xml
+++ b/data/conf/iceberg/llap/tez-site.xml
@@ -12,10 +12,6 @@
     <value>24</value>
   </property>
   <property>
-    <name>hive.tez.container.size</name>
-    <value>512</value>
-  </property>
-  <property>
     <name>tez.counters.max</name>
     <value>1024</value>
   </property>

--- a/data/conf/iceberg/tez/hive-site.xml
+++ b/data/conf/iceberg/tez/hive-site.xml
@@ -40,8 +40,7 @@
 
 <property>
   <name>hive.tez.container.size</name>
-  <value>128</value>
-  <description></description>
+  <value>512</value>
 </property>
 
 <property>

--- a/data/conf/iceberg/tez/tez-site.xml
+++ b/data/conf/iceberg/tez/tez-site.xml
@@ -12,10 +12,6 @@
     <value>24</value>
   </property>
   <property>
-    <name>hive.tez.container.size</name>
-    <value>512</value>
-  </property>
-  <property>
     <name>tez.counters.max</name>
     <value>1024</value>
   </property>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -44,10 +44,12 @@
   <description>A base for other temporary directories.</description>
 </property>
 
+<!-- in LLAP mode hive.tez.container.size isn't used to actually determine container size, however while -->
+<!-- calculating available slots (in split generation) in it's used through -->
+<!-- the Vertex resource, so this has to be defined in order to get consistent test results -->
 <property>
   <name>hive.tez.container.size</name>
   <value>128</value>
-  <description></description>
 </property>
 
 <property>

--- a/data/conf/llap/tez-site.xml
+++ b/data/conf/llap/tez-site.xml
@@ -10,10 +10,6 @@
     <value>128</value>
   </property>
   <property>
-    <name>tez.task.resource.memory.mb</name>
-    <value>128</value>
-  </property>
-  <property>
     <name>tez.runtime.io.sort.mb</name>
     <value>24</value>
   </property>

--- a/data/conf/tez/tez-site.xml
+++ b/data/conf/tez/tez-site.xml
@@ -4,10 +4,6 @@
     <value>512</value>
   </property>
   <property>
-    <name>tez.task.resource.memory.mb</name>
-    <value>128</value>
-  </property>
-  <property>
     <name>tez.runtime.io.sort.mb</name>
     <value>24</value>
   </property>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezAvailableSlotsCalculator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezAvailableSlotsCalculator.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.hive.ql.exec.tez;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.api.InputInitializerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of AvailableSlotsCalculator which relies on available capacity of the cluster
  */
 public class TezAvailableSlotsCalculator implements AvailableSlotsCalculator {
+  private static final Logger LOG = LoggerFactory.getLogger(TezAvailableSlotsCalculator.class);
+
     private InputInitializerContext inputInitializerContext;
     @Override
     public void initialize(Configuration conf, HiveSplitGenerator splitGenerator) {
@@ -39,6 +43,9 @@ public class TezAvailableSlotsCalculator implements AvailableSlotsCalculator {
         }
         int totalResource = inputInitializerContext.getTotalAvailableResource().getMemory();
         int taskResource = inputInitializerContext.getVertexTaskResource().getMemory();
-        return totalResource / taskResource;
+        int availableSlots = totalResource / taskResource;;
+        LOG.debug("totalResource: {}mb / taskResource: {}mb =  availableSlots: {}", totalResource, taskResource,
+            availableSlots);
+        return availableSlots;
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- added a useful comment in HiveConf for hive.tez.container.size
- cleaned up hive-site and tez-site xml files accordingly:
  - removed hive.tez.container.size from tez-site.xml (even if it works from there, it's a hive option, should be in hive-site for clarity's sake)
  - updated hive.tez.container.size in hive-site where a bigger value was removed from tez-site
- minimal refactor in DagUtils in the same area, added debug level messages



### Why are the changes needed?
Clarity in HiveConf and qtests.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Precommit, and manually checked tez logs.

in DAGAppMaster log:
```
2023-12-05T09:39:06,211 INFO [DelayedContainerManager] rm.YarnTaskSchedulerService: Assigning container to task: containerId=container_1701797922416_0001_01_000002, task=attempt_1701797922416_0001_1_00_000000_0, containerHost=localhost:60444, containerPriority= 2, containerResources=<memory:128, vCores:1>, localityMatchType=NodeLocal, matchedLocation=localhost, honorLocalityFlags=true, reusedContainer=false, delayedContainers=1

```
