### PR TITLE
HIVE-27801: Exists subquery rewrite results in a wrong plan

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelDecorrelator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelDecorrelator.java
@@ -3014,18 +3014,10 @@ public final class HiveRelDecorrelator implements ReflectiveVisitor {
   }
   /** Builds a {@link org.apache.calcite.sql2rel.RelDecorrelator.CorelMap}. */
   private static class CorelMapBuilder extends HiveRelShuttleImpl {
-    private final SortedMap<CorrelationId, RelNode> mapCorToCorRel =
-        new TreeMap<>();
+    private final SortedMap<CorrelationId, RelNode> mapCorToCorRel = new TreeMap<>();
 
-    private final SortedSetMultimap<RelNode, CorRef> mapRefRelToCorRef =
-        Multimaps.newSortedSetMultimap(
-            new HashMap<RelNode, Collection<CorRef>>(),
-            new Supplier<TreeSet<CorRef>>() {
-              @Override
-              public TreeSet<CorRef> get() {
-                return Sets.newTreeSet();
-              }
-            });
+    private final Multimap<RelNode, CorRef> mapRefRelToCorRef =
+        Multimaps.newListMultimap(new HashMap<>(), Lists::newArrayList);
 
     private final Map<RexFieldAccess, CorRef> mapFieldAccessToCorVar = new HashMap<>();
 

--- a/ql/src/test/queries/clientpositive/subquery_complex_correlation_predicates.q
+++ b/ql/src/test/queries/clientpositive/subquery_complex_correlation_predicates.q
@@ -78,3 +78,18 @@ where not exists
           (select a_authorkey
            from author a
            where coalesce(b.b_authorkey, 400) = coalesce(a.a_authorkey, 400));
+    
+-- HIVE-27801: Exists subquery rewrite results in a wrong plan              
+drop table if exists store_sales;       
+create table store_sales (promo_sk int, sales_price int, list_price int);
+                   
+insert into store_sales values (1, 20, 15), (1, 15, 20), (1, 10, 15);
+
+explain cbo
+select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price);  
+            
+select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price);            

--- a/ql/src/test/results/clientpositive/llap/subquery_complex_correlation_predicates.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_complex_correlation_predicates.q.out
@@ -290,3 +290,69 @@ POSTHOOK: Input: default@author
 POSTHOOK: Input: default@book
 #### A masked pattern was here ####
 Men Without Women
+PREHOOK: query: drop table if exists store_sales
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists store_sales
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: create table store_sales (promo_sk int, sales_price int, list_price int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@store_sales
+POSTHOOK: query: create table store_sales (promo_sk int, sales_price int, list_price int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@store_sales
+PREHOOK: query: insert into store_sales values (1, 20, 15), (1, 15, 20), (1, 10, 15)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@store_sales
+POSTHOOK: query: insert into store_sales values (1, 20, 15), (1, 15, 20), (1, 10, 15)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@store_sales
+POSTHOOK: Lineage: store_sales.list_price SCRIPT []
+POSTHOOK: Lineage: store_sales.promo_sk SCRIPT []
+POSTHOOK: Lineage: store_sales.sales_price SCRIPT []
+PREHOOK: query: explain cbo
+select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[AND(=($3, $0), =($4, $1))], joinType=[semi])
+  HiveProject(promo_sk=[$0], sales_price=[$1], list_price=[$2])
+    HiveFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])
+      HiveTableScan(table=[[default, store_sales]], table:alias=[a])
+  HiveProject(promo_sk0=[$3], sales_price0=[$4])
+    HiveJoin(condition=[AND(=($3, $0), >($4, $2), <($4, $1))], joinType=[inner], algorithm=[none], cost=[not available])
+      HiveProject(promo_sk=[$0], sales_price=[$1], list_price=[$2])
+        HiveFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($2), IS NOT NULL($1))])
+          HiveTableScan(table=[[default, store_sales]], table:alias=[b])
+      HiveProject(promo_sk=[$0], sales_price=[$1])
+        HiveAggregate(group=[{0, 1}])
+          HiveFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])
+            HiveTableScan(table=[[default, store_sales]], table:alias=[a])
+
+PREHOOK: query: select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from store_sales A where exists( 
+select 1 from store_sales B 
+    where A.promo_sk = B.promo_sk and A.sales_price > B.list_price and A.sales_price < B.sales_price)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store_sales
+#### A masked pattern was here ####


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In cases where different Rel nodes refer to the same correlation var, we avoid creating another correlation var and record the 'rel' using the same correlation. 
SortedSetMultimap can't be used since it doesn't allow duplicates. 
`mapFieldAccessToCorVar.containsKey(fieldAccess)` was never positive in previous versions of Calcite (1.16) since RexFieldAccess had no equals() and hashcode() defined.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fixes plan after decorrelation

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=subquery_complex_correlation_predicates.q