### PR TITLE
HIVE-27941: Update LLAP Daemon log4j2 routing properties

### DIFF
--- a/llap-server/bin/llapDaemon.sh
+++ b/llap-server/bin/llapDaemon.sh
@@ -84,6 +84,7 @@ if [ "$LLAP_DAEMON_PID_DIR" = "" ]; then
 fi
 
 # some variables
+export LLAP_LOG4J2_PROPERTIES_FILE_NAME='llap-daemon-log4j2.properties'
 LLAP_DAEMON_LOG_BASE=llap-daemon-$USER-$HOSTNAME
 export LLAP_DAEMON_LOG_FILE=$LLAP_DAEMON_LOG_BASE.log
 logLog=$LLAP_DAEMON_LOG_DIR/$LLAP_DAEMON_LOG_BASE.log

--- a/llap-server/bin/runLlapDaemon.sh
+++ b/llap-server/bin/runLlapDaemon.sh
@@ -96,7 +96,7 @@ if [ "$LLAP_DAEMON_LOGFILE" = "" ]; then
   LLAP_DAEMON_LOG_FILE='llapdaemon.log'
 fi
 
-if [ "LLAP_LOG4J2_PROPERTIES_FILE_NAME" = "" ]; then
+if [ ! -n "${LLAP_LOG4J2_PROPERTIES_FILE_NAME}" ]; then
   LLAP_LOG4J2_PROPERTIES_FILE_NAME='llap-daemon-log4j2.properties'
 fi
 


### PR DESCRIPTION
What changes were proposed in this pull request?
Define LLAP_LOG4J2_PROPERTIES_FILE_NAME variable to properties file for the update llap-daemon log4j template

Why are the changes needed?
Adding a conditional statement in a shell script that checks if the variable LLAP_LOG4J2_PROPERTIES_FILE_NAME is not set or is empty (! -n checks if the length of the string is not greater than zero).

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
NA