### PR TITLE
HIVE-27942: Missing aux jar errors during LLAP launch

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyAuxJars.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyAuxJars.java
@@ -45,8 +45,8 @@ class AsyncTaskCopyAuxJars implements Callable<Void> {
 
   private static final String[] DEFAULT_AUX_CLASSES =
       new String[] {"org.apache.hive.hcatalog.data.JsonSerDe", "org.apache.hadoop.hive.druid.DruidStorageHandler",
-          "org.apache.hive.storage.jdbc.JdbcStorageHandler", "org.apache.commons.dbcp.BasicDataSourceFactory",
-          "org.apache.commons.pool.impl.GenericObjectPool", "org.apache.hadoop.hive.kafka.KafkaStorageHandler",
+          "org.apache.hive.storage.jdbc.JdbcStorageHandler", "org.apache.commons.dbcp2.BasicDataSourceFactory",
+          "org.apache.commons.pool2.impl.GenericObjectPool", "org.apache.hadoop.hive.kafka.KafkaStorageHandler",
           "org.apache.hadoop.hive.kudu.KuduStorageHandler"};
   private static final String HBASE_SERDE_CLASS = "org.apache.hadoop.hive.hbase.HBaseSerDe";
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
LLAP was failing to launch daemons due to incorrect class references not being packed anymore
https://issues.apache.org/jira/browse/HIVE-27942

Why are the changes needed?
Updated class references in default aux classes for pool and dbcp to correct class names

Does this PR introduce any user-facing change?
No

Is the change a dependency upgrade?
No

How was this patch tested?
NA