### PR TITLE
HIVE-27944:When HIVE-LLAP reads the ICEBERG table, a deadlock may occur.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
@@ -29,7 +29,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat;
@@ -72,7 +71,7 @@ public class SplitGrouper {
   // TODO This needs to be looked at. Map of Map to Map... Made concurrent for now since split generation
   // can happen in parallel.
   private final Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cache =
-      new ConcurrentHashMap<>();
+      new HashMap<>();
 
   private final TezMapredSplitsGrouper tezGrouper = new TezMapredSplitsGrouper();
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/SplitGrouper.java
@@ -71,7 +71,7 @@ public class SplitGrouper {
 
   // TODO This needs to be looked at. Map of Map to Map... Made concurrent for now since split generation
   // can happen in parallel.
-  private static final Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cache =
+  private final Map<Map<Path, PartitionDesc>, Map<Path, PartitionDesc>> cache =
       new ConcurrentHashMap<>();
 
   private final TezMapredSplitsGrouper tezGrouper = new TezMapredSplitsGrouper();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modified the modifier of the cache property in the SplitGroup class to make it non-static.

JIRA: https://issues.apache.org/jira/browse/HIVE-27944

### Why are the changes needed?
Since the Properties object implement HashTable interface, all the methods of the HashTable interface are synchronised.
In a multi-threaded environment, a deadlock will occur when propA.equals(propB)  and propB.equals(propA) occur at the same time.
The problem can be solved with minimal modification by changing SplitGroup.cache to a non-static property.


### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?
no


### How was this patch tested?
no need. Because this patch doesn't change the execution logic of any code
