### PR TITLE
HIVE-27949: GenericUDFAddMonths doesn't accept DECIMAL with scale zer…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.ql.udf.UDFType;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.io.HiveIntervalDayTimeWritable;
 import org.apache.hadoop.hive.serde2.io.HiveIntervalYearMonthWritable;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
@@ -351,8 +352,12 @@ public abstract class GenericUDF implements Closeable {
     case INT:
     case VOID:
       break;
+    case DECIMAL:
+      if (inOi.scale() == 0) {
+        break;
+      }
     default:
-      throw new UDFArgumentTypeException(i, getFuncName() + " only takes INT/SHORT/BYTE types as "
+      throw new UDFArgumentTypeException(i, getFuncName() + " only takes INT/SHORT/BYTE/DECIMAL(X,0) types as "
           + getArgOrder(i) + " argument, got " + inputType);
     }
 
@@ -607,6 +612,8 @@ public abstract class GenericUDF implements Closeable {
       v = ((ShortWritable) constValue).get();
     } else if (constValue instanceof ByteWritable) {
       v = ((ByteWritable) constValue).get();
+    } else if (constValue instanceof HiveDecimalWritable) {
+      v = ((HiveDecimalWritable) constValue).intValue();
     } else {
       throw new UDFArgumentTypeException(i, getFuncName() + " only takes INT/SHORT/BYTE types as "
           + getArgOrder(i) + " argument, got " + constValue.getClass());

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFAddMonths.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFAddMonths.java
@@ -230,7 +230,7 @@ public class TestGenericUDFAddMonths {
       assertTrue("add_months exception expected", false);
     } catch (UDFArgumentTypeException e) {
       assertEquals("add_months test",
-          "add_months only takes INT/SHORT/BYTE types as 2nd argument, got LONG", e.getMessage());
+          "add_months only takes INT/SHORT/BYTE/DECIMAL(X,0) types as 2nd argument, got LONG", e.getMessage());
     }
   }
 

--- a/ql/src/test/queries/clientpositive/udf_add_months.q
+++ b/ql/src/test/queries/clientpositive/udf_add_months.q
@@ -40,3 +40,15 @@ add_months(cast('2016-01-29 10:30:00' as timestamp), 1),
 add_months(cast('2016-02-29 10:30:00' as timestamp), -1),
 add_months(cast('2016-02-29 10:30:12' as timestamp), 2, 'YYYY-MM-dd HH:mm:ss'),
 add_months(cast(null as timestamp), 1);
+
+select
+add_months('2014-01-14 10:30:00', 1.0),
+add_months('2014-01-31 10:30:00', cast(1.1 as decimal(5,0))),
+add_months('2014-02-28 10:30:00', -1.0),
+add_months('2014-02-28 16:30:00', 2.0),
+add_months('2014-04-30 10:30:00', cast(-2 as decimal(5,0))),
+add_months('2015-02-28 10:30:00', 12.0),
+add_months('2016-02-29 10:30:00', -12.0),
+add_months('2016-01-29 10:30:00', 1.0),
+add_months('2016-02-29 10:30:12', -12.0, 'YYYY-MM-dd HH:mm:ss'),
+add_months('2016-02-29 10:30:00', -1.0);

--- a/ql/src/test/results/clientnegative/udf_add_months_error_2.q.out
+++ b/ql/src/test/results/clientnegative/udf_add_months_error_2.q.out
@@ -1,1 +1,1 @@
-FAILED: SemanticException [Error 10016]: Line 1:32 Argument type mismatch '2.4': add_months only takes INT/SHORT/BYTE types as 2nd argument, got DECIMAL
+FAILED: SemanticException [Error 10016]: Line 1:32 Argument type mismatch '2.4': add_months only takes INT/SHORT/BYTE/DECIMAL(X,0) types as 2nd argument, got DECIMAL

--- a/ql/src/test/results/clientpositive/llap/udf_add_months.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_add_months.q.out
@@ -133,3 +133,32 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 2014-02-14	2014-02-28	2014-01-31	2014-04-30	2014-02-28	2016-02-29	2015-02-28	2016-02-29	2016-01-31	2016-04-30 10:30:12	NULL
+PREHOOK: query: select
+add_months('2014-01-14 10:30:00', 1.0),
+add_months('2014-01-31 10:30:00', cast(1.1 as decimal(5,0))),
+add_months('2014-02-28 10:30:00', -1.0),
+add_months('2014-02-28 16:30:00', 2.0),
+add_months('2014-04-30 10:30:00', cast(-2 as decimal(5,0))),
+add_months('2015-02-28 10:30:00', 12.0),
+add_months('2016-02-29 10:30:00', -12.0),
+add_months('2016-01-29 10:30:00', 1.0),
+add_months('2016-02-29 10:30:12', -12.0, 'YYYY-MM-dd HH:mm:ss'),
+add_months('2016-02-29 10:30:00', -1.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select
+add_months('2014-01-14 10:30:00', 1.0),
+add_months('2014-01-31 10:30:00', cast(1.1 as decimal(5,0))),
+add_months('2014-02-28 10:30:00', -1.0),
+add_months('2014-02-28 16:30:00', 2.0),
+add_months('2014-04-30 10:30:00', cast(-2 as decimal(5,0))),
+add_months('2015-02-28 10:30:00', 12.0),
+add_months('2016-02-29 10:30:00', -12.0),
+add_months('2016-01-29 10:30:00', 1.0),
+add_months('2016-02-29 10:30:12', -12.0, 'YYYY-MM-dd HH:mm:ss'),
+add_months('2016-02-29 10:30:00', -1.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+2014-02-14	2014-02-28	2014-01-31	2014-04-30	2014-02-28	2016-02-29	2015-02-28	2016-02-29	2015-02-28 10:30:12	2016-01-31


### PR DESCRIPTION
…o for num_months

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Second argument of GenericUDFAddMonths `num_months` should accept DECIMAL values with scale zero

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
DECIMALS like `1.0, 2.0`, etc can be easily converted to `INT`s, so they should be valid arguments for the UDF

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this change enables support of DECIMALS with scale=0 for num_months

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
`mvn test  -Dtest=TestMiniLlapLocalCliDriver -Dtest.output.overwrite=true -Dqfile=udf_add_months.q`
`mvn test -Dtest=TestNegativeLlapCliDriver -Dtest.output.overwrite=true -Dqfile=udf_add_months_error_2.q`
`mvn test -Dtest=TestNegativeLlapCliDriver -Dtest.output.overwrite=true -Dqfile=udf_add_months_error_1.q`