### PR TITLE
HIVE-27951: hcatalog dynamic partitioning fails with partition alread…

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -488,7 +488,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
   }
 
   /**
-   * Move all of the files from the temp directory to the final location
+   * Move task output from the temp directory to the final location
    * @param srcf the file to move
    * @param srcDir the source directory
    * @param destDir the target directory
@@ -538,17 +538,17 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
         final Path finalOutputPath = getFinalPath(destFs, srcF, srcDir, destDir, immutable);
         if (immutable && destFs.exists(finalOutputPath) &&
             !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, finalOutputPath)) {
-          throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
-              "Data already exists in " + finalOutputPath
-                  + ", duplicate publish not possible.");
-        }
-        if (srcStatus.isDirectory()) {
+          if (partitionsDiscoveredByPath.containsKey(srcF.toString())) {
+            throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
+                "Data already exists in " + finalOutputPath
+                    + ", duplicate publish not possible.");
+          }
+          // parent directory may exist for multi-partitions, check lower level partitions
+          Collections.addAll(srcQ, srcFs.listStatus(srcF,HIDDEN_FILES_PATH_FILTER));
+        } else if (srcStatus.isDirectory()) {
           if (canRename && dynamicPartitioningUsed) {
             // If it is partition, move the partition directory instead of each file.
-            // If custom dynamic location provided, need to rename to final output path
-            final Path parentDir = finalOutputPath.getParent();
-            Path dstPath = !customDynamicLocationUsed ? parentDir : finalOutputPath;
-            moves.add(Pair.of(srcF, dstPath));
+            moves.add(Pair.of(srcF, finalOutputPath));
           } else {
             Collections.addAll(srcQ, srcFs.listStatus(srcF, HIDDEN_FILES_PATH_FILTER));
           }
@@ -558,16 +558,27 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
       }
     }
 
-    if (moves.isEmpty()) {
+    bulkMoveFiles(conf, srcFs, destFs, moves);
+  }
+
+  /**
+   * Bulk move files from source to destination.
+   * @param srcFs the source filesystem where the source files are
+   * @param destFs the destionation filesystem where the destionation files are
+   * @param pairs list of pairs of <source_path, destination_path>, move source_path to destination_path
+   * @throws java.io.IOException
+   */
+  private void bulkMoveFiles(final Configuration conf, final FileSystem srcFs, final FileSystem destFs, List<Pair<Path, Path>> pairs) throws IOException{
+    if (pairs.isEmpty()) {
       return;
     }
-
+    final boolean canRename = srcFs.getUri().equals(destFs.getUri());
     final List<Future<Pair<Path, Path>>> futures = new LinkedList<>();
     final ExecutorService pool = conf.getInt(ConfVars.HIVE_MOVE_FILES_THREAD_COUNT.varname, 25) > 0 ?
         Executors.newFixedThreadPool(conf.getInt(ConfVars.HIVE_MOVE_FILES_THREAD_COUNT.varname, 25),
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Move-Thread-%d").build()) : null;
 
-    for (final Pair<Path, Path> pair: moves){
+    for (final Pair<Path, Path> pair: pairs){
       Path srcP = pair.getLeft();
       Path dstP = pair.getRight();
       final String msg = "Unable to move source " + srcP + " to destination " + dstP;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
@@ -53,13 +53,13 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   private static List<HCatFieldSchema> dataColumns;
   private static final Logger LOG = LoggerFactory.getLogger(TestHCatDynamicPartitioned.class);
   protected static final int NUM_RECORDS = 20;
-  protected static final int NUM_PARTITIONS = 5;
+  protected static final int NUM_TOP_PARTITIONS = 5;
 
   public TestHCatDynamicPartitioned(String formatName, String serdeClass, String inputFormatClass,
       String outputFormatClass) throws Exception {
     super(formatName, serdeClass, inputFormatClass, outputFormatClass);
     tableName = "testHCatDynamicPartitionedTable_" + formatName;
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
     generateDataColumns();
   }
 
@@ -68,6 +68,8 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c1", serdeConstants.INT_TYPE_NAME, "")));
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c2", serdeConstants.STRING_TYPE_NAME, "")));
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, "")));
+    dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, "")));
+
   }
 
   protected static void generateWriteRecords(int max, int mod, int offset) {
@@ -79,6 +81,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
       objList.add(i);
       objList.add("strvalue" + i);
       objList.add(String.valueOf((i % mod) + offset));
+      objList.add(String.valueOf((i / (max/2)) + offset));
       writeRecords.add(new DefaultHCatRecord(objList));
     }
   }
@@ -87,6 +90,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   protected List<FieldSchema> getPartitionKeys() {
     List<FieldSchema> fields = new ArrayList<FieldSchema>();
     fields.add(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, ""));
+    fields.add(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, ""));
     return fields;
   }
 
@@ -118,8 +122,9 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
 
   protected void runHCatDynamicPartitionedTable(boolean asSingleMapTask,
       String customDynamicPathPattern) throws Exception {
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
-    runMRCreate(null, dataColumns, writeRecords, NUM_RECORDS, true, asSingleMapTask, customDynamicPathPattern);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
+    runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
+    runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
 
     runMRRead(NUM_RECORDS);
 
@@ -141,7 +146,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     //Test for duplicate publish
     IOException exc = null;
     try {
-      generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+      generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
       Job job = runMRCreate(null, dataColumns, writeRecords, NUM_RECORDS, false,
           true, customDynamicPathPattern);
 
@@ -168,7 +173,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     driver.run(query);
     res = new ArrayList<String>();
     driver.getResults(res);
-    assertEquals(NUM_PARTITIONS, res.size());
+    assertEquals(NUM_TOP_PARTITIONS*2, res.size());
 
     query = "select * from " + tableName;
     driver.run(query);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExternalDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExternalDynamicPartitioned.java
@@ -28,7 +28,7 @@ public class TestHCatExternalDynamicPartitioned extends TestHCatDynamicPartition
       throws Exception {
     super(formatName, serdeClass, inputFormatClass, outputFormatClass);
     tableName = "testHCatExternalDynamicPartitionedTable_" + formatName;
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
     generateDataColumns();
   }
 
@@ -43,7 +43,7 @@ public class TestHCatExternalDynamicPartitioned extends TestHCatDynamicPartition
    */
   @Test
   public void testHCatExternalDynamicCustomLocation() throws Exception {
-    runHCatDynamicPartitionedTable(true, "mapred/externalDynamicOutput/${p1}");
+    runHCatDynamicPartitionedTable(true, "mapred/externalDynamicOutput/${p1}/{p2}");
   }
 
 }


### PR DESCRIPTION
…y exist error when exist parent partitions path

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
clean up the code for readibilty
fix the issue when parent partition path exists for multi partitioned dynamic insert.



### Why are the changes needed?
fix bug:
if a table have multiple partitions (part1=x1, part2=y1), when insert into a new partition(part1=x1, part2=y2) hcatalog FileOutputCommitterContainer throws path part1=x1 already exists error. This is due to the path checking stops at parent level, 

pig -useHcatalog

A = load 'source' using org.apache.hive.hcatalog.pig.HCatLoader();
B = filter A by (part2 == 'y1');

// following succeeds
store B into 'target' USING org.apache.hive.hcatalog.pig.HCatStorer();

//following fails with duplicate publishing error

C = filter A by (part2 == 'y2');
store C into 'target' USING org.apache.hive.hcatalog.pig.HCatStorer();


```
Partition already present with given partition key values : Data already exists in /user/hive/warehouse/target/part1=x1, duplicate publish not possible.
at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigOutputCommitter.commitJob(PigOutputCommitter.java:243)
at org.apache.hadoop.mapreduce.v2.app.commit.CommitterEventHandler$EventProcessor.handleJobCommit(CommitterEventHandler.java:286)
 
Caused by: org.apache.hive.hcatalog.common.HCatException : 2002 : Partition already present with given partition key values : Data already exists in /user/hive/warehouse/target/part1=x1, duplicate publish not possible.
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.moveTaskOutputs(FileOutputCommitterContainer.java:564)
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.registerPartitions(FileOutputCommitterContainer.java:949)
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.commitJob(FileOutputCommitterContainer.java:273)
at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigOutputCommitter.commitJob(PigOutputCommitter.java:241)
```




### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
updated unit test to include the use case that is affected by the bug
mvn clean test -Dtest=TestHCatExternalDynamicPartitioned,TestHCatDynamicPartitioned,TestHCatPartitioned,TestHCatNonPartitioned

also tested locally with pig -useHCatalog
