### PR TITLE
 HIVE-27824 : Upgrade ivy to 2.5.2 and htmunit to 2.70.0

### DIFF
--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <hive.path.to.root>../..</hive.path.to.root>
     <testcontainers.version>1.15.2</testcontainers.version>
-    <htmlunit.version>2.67.0</htmlunit.version>
+    <htmlunit.version>2.70.0</htmlunit.version>
   </properties>
   <dependencies>
     <!-- intra-project -->

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <!-- httpcomponents are not always in version sync -->
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
-    <ivy.version>2.5.1</ivy.version>
+    <ivy.version>2.5.2</ivy.version>
     <jackson.version>2.13.5</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Upgrade ivy to 2.5.2 and htmunit to 2.70.0


### Why are the changes needed?
CVE Fixing


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Locally built , relying on precommit.
