### PR TITLE
Hive 23690 : TestNegativeCliDriver#[external_jdbc_negative] is flaky

### DIFF
--- a/ql/src/test/queries/clientnegative/external_jdbc_negative.q
+++ b/ql/src/test/queries/clientnegative/external_jdbc_negative.q
@@ -1,5 +1,4 @@
 --! qt:dataset:src
-set user.name=user1;
 CREATE TEMPORARY FUNCTION dboutput AS 'org.apache.hadoop.hive.contrib.genericudf.example.GenericUDFDBOutput';
 
 FROM src

--- a/ql/src/test/queries/clientnegative/external_jdbc_negative.q
+++ b/ql/src/test/queries/clientnegative/external_jdbc_negative.q
@@ -1,4 +1,3 @@
---! qt:disabled:test is unstable HIVE-23690
 --! qt:dataset:src
 
 CREATE TEMPORARY FUNCTION dboutput AS 'org.apache.hadoop.hive.contrib.genericudf.example.GenericUDFDBOutput';

--- a/ql/src/test/queries/clientnegative/external_jdbc_negative.q
+++ b/ql/src/test/queries/clientnegative/external_jdbc_negative.q
@@ -1,5 +1,5 @@
 --! qt:dataset:src
-
+set user.name=user1;
 CREATE TEMPORARY FUNCTION dboutput AS 'org.apache.hadoop.hive.contrib.genericudf.example.GenericUDFDBOutput';
 
 FROM src

--- a/ql/src/test/results/clientnegative/external_jdbc_negative.q.out
+++ b/ql/src/test/results/clientnegative/external_jdbc_negative.q.out
@@ -43,4 +43,4 @@ TBLPROPERTIES (
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@db1_ext_negative1
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException org.apache.hadoop.hive.serde2.SerDeException: Column numbers do not match. Remote table columns are [ikey] and declared table columns in Hive external table are [ikey, bkey])
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException Caught exception while initializing the SqlSerDe: Column numbers do not match. Remote table columns are [ikey] and declared table columns in Hive external table are [ikey, bkey])


### PR DESCRIPTION

### What changes were proposed in this pull request?
Reenabling external_jdbc_negative.q 


### Why are the changes needed?
http://130.211.9.232/job/hive-flaky-check/34/

### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
NO


### How was this patch tested?
with q file
Flakey run test http://130.211.9.232/job/hive-flaky-check/765/