### PR TITLE
HIVE-27960:Invalid function error when using custom udaf

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -339,7 +339,14 @@ public class Registry {
   }
 
   public WindowFunctionInfo getWindowFunctionInfo(String functionName) throws SemanticException {
+    // First try without qualifiers - would resolve builtin/temp functions
     FunctionInfo info = getFunctionInfo(WINDOW_FUNC_PREFIX + functionName);
+    // Try qualifying with current db name for permanent functions
+    if (info == null && FunctionRegistry.getFunctionInfo(functionName) != null) {
+      String qualifiedName = FunctionUtils.qualifyFunctionName(
+        functionName, SessionState.get().getCurrentDatabase().toLowerCase());
+      info = getFunctionInfo(WINDOW_FUNC_PREFIX + qualifiedName);
+    }
     if (info instanceof WindowFunctionInfo) {
       return (WindowFunctionInfo) info;
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?
[HIVE-27960](https://issues.apache.org/jira/browse/HIVE-27960) : Invalid function error when using custom udaf

### Why are the changes needed?
When a permanent udaf used before over() function, hive will throw invalid function error.

### Does this PR introduce _any_ user-facing change?
no

### Is the change a dependency upgrade?
no

### How was this patch tested?
on aliyun emr hive 2.3.9
