### PR TITLE
HIVE-25803: URL Mapping appends default Fs scheme even for LOCAL DIRECTORY ops.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -8051,8 +8051,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         loadFileDesc.setMoveTaskId(moveTaskId);
         loadFileWork.add(loadFileDesc);
         try {
+          FileSystem fs = isDfsDir ?  destinationPath.getFileSystem(conf) : FileSystem.getLocal(conf);
           Path qualifiedPath = conf.getBoolVar(ConfVars.HIVE_RANGER_USE_FULLY_QUALIFIED_URL) ?
-                  destinationPath.getFileSystem(conf).makeQualified(destinationPath) : destinationPath;
+              fs.makeQualified(destinationPath) : destinationPath;
           if (!outputs.add(new WriteEntity(qualifiedPath, !isDfsDir, isDestTempFile))) {
             throw new SemanticException(ErrorMsg.OUTPUT_SPECIFIED_MULTIPLE_TIMES
                     .getMsg(destinationPath.toUri().toString()));

--- a/ql/src/test/results/clientpositive/llap/ppd_transform.q.out
+++ b/ql/src/test/results/clientpositive/llap/ppd_transform.q.out
@@ -384,8 +384,7 @@ FROM (
 PREHOOK: type: QUERY
 PREHOOK: Input: cat
 PREHOOK: Input: default@src
-PREHOOK: Output: hdfs://### HDFS PATH ###
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: EXPLAIN
 FROM (
     FROM ( SELECT * FROM src ) mapout REDUCE * USING 'cat' AS x,y
@@ -394,8 +393,7 @@ FROM (
 POSTHOOK: type: QUERY
 POSTHOOK: Input: cat
 POSTHOOK: Input: default@src
-POSTHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 STAGE DEPENDENCIES:
   Stage-2 is a root stage
   Stage-3 depends on stages: Stage-2

--- a/ql/src/test/results/clientpositive/llap/schemeAuthority.q.out
+++ b/ql/src/test/results/clientpositive/llap/schemeAuthority.q.out
@@ -9,11 +9,9 @@ POSTHOOK: Output: default@dynPart
 #### A masked pattern was here ####
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
-PREHOOK: Output: hdfs://### HDFS PATH ###
 #### A masked pattern was here ####
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
-POSTHOOK: Output: hdfs://### HDFS PATH ###
 #### A masked pattern was here ####
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/schemeAuthority2.q.out
+++ b/ql/src/test/results/clientpositive/llap/schemeAuthority2.q.out
@@ -9,11 +9,9 @@ POSTHOOK: Output: default@dynPart_n0
 #### A masked pattern was here ####
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
-PREHOOK: Output: hdfs://### HDFS PATH ###
 #### A masked pattern was here ####
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
-POSTHOOK: Output: hdfs://### HDFS PATH ###
 #### A masked pattern was here ####
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use Local FS to qualify a path if LOCAL is used

### Why are the changes needed?

To push correct qualified path to Ranger when using LOCAL

### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?
