### PR TITLE
HIVE-27961: Beeline will print duplicate stats info when hive.tez.exec.print.summary is true

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
@@ -309,7 +309,11 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
         TransactionalStatsProcessor transactionalStatsProcessor = new TransactionalStatsProcessor(db, p);
         transactionalStatsProcessor.process(statsAggregator);
 
-        console.printInfo("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
+        if (conf.getBoolVar(ConfVars.TEZ_EXEC_SUMMARY)) {
+          console.printInfo("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
+        } else {
+          LOG.info("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
+        }
 
         // The table object is assigned to the latest table object.
         // So that it can be used by ColStatsProcessor.
@@ -372,7 +376,11 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
             continue;
           }
           updates.add((Partition) res);
-          console.printInfo("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
+          if (conf.getBoolVar(ConfVars.TEZ_EXEC_SUMMARY)) {
+            console.printInfo("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
+          } else {
+            LOG.info("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
+          }
         }
 
         if (!updates.isEmpty()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java
@@ -309,10 +309,7 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
         TransactionalStatsProcessor transactionalStatsProcessor = new TransactionalStatsProcessor(db, p);
         transactionalStatsProcessor.process(statsAggregator);
 
-        if (conf.getBoolVar(ConfVars.TEZ_EXEC_SUMMARY)) {
-          console.printInfo("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
-        }
-        LOG.info("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
+        console.printInfo("Table " + tableFullName + " stats: [" + toString(p.getPartParameters()) + ']');
 
         // The table object is assigned to the latest table object.
         // So that it can be used by ColStatsProcessor.
@@ -375,10 +372,7 @@ public class BasicStatsTask implements Serializable, IStatsProcessor {
             continue;
           }
           updates.add((Partition) res);
-          if (conf.getBoolVar(ConfVars.TEZ_EXEC_SUMMARY)) {
-            console.printInfo("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
-          }
-          LOG.info("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
+          console.printInfo("Partition " + basicStatsProcessor.partish.getPartition().getSpec() + " stats: [" + toString(basicStatsProcessor.partish.getPartParameters()) + ']');
         }
 
         if (!updates.isEmpty()) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Remove the duplicate stats info from beeline console.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
if `hive.tez.exec.print.summary` is true, beeline console will print duplicate stats info.  Please see HIVE-27961 to check the info.
This stats info is displayed by default([BasicStatsTask.java L315](https://github.com/apache/hive/blob/4a057a7cea11029dbda7adaec09117d46e56d925/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java#L315)), and no need to be displayed again when `hive.tez.exec.print.summary` is true.
https://github.com/apache/hive/blob/4a057a7cea11029dbda7adaec09117d46e56d925/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStatsTask.java#L312-L316

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No need test