### PR TITLE
HIVE-27966: Disable flaky testFetchResultsOfLogWithOrientation

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithMr.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithMr.java
@@ -30,6 +30,7 @@ import org.apache.hive.service.cli.OperationStatus;
 import org.apache.hive.service.cli.RowSet;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -127,6 +128,7 @@ public class TestOperationLoggingAPIWithMr extends OperationLoggingAPITestBase {
   }
 
   @Test
+  @Ignore("HIVE-27966")
   public void testFetchResultsOfLogWithOrientation() throws Exception {
     // (FETCH_FIRST) execute a sql, and fetch its sql operation log as expected value
     OperationHandle operationHandle = client.executeStatement(sessionHandle, sql, null);


### PR DESCRIPTION
### What changes were proposed in this pull request?
org.apache.hive.service.cli.operation.TestOperationLoggingAPIWithMr#testFetchResultsOfLogWithOrientation test is flaky and can easily result into CI failed.

Here are some affected pipelines:
http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-4959/3/tests

http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-4755/15/tests

http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-4966/1/tests

http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-4517/25/tests

### Why are the changes needed?
Disable unstable test.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Pass existing tests.
