### PR TITLE
HIVE-27974: Fix flaky test - TestReplicationMetricCollector.testSuccessStageFailure

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
@@ -49,7 +49,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
@@ -70,16 +69,17 @@ public class TestReplicationMetricCollector {
 
   HiveConf conf;
 
-  @Mock
   private FailoverMetaData fmd;
 
-  @Mock
   private MetricSink metricSinkInstance;
 
   MockedStatic<MetricSink> metricSinkMockedStatic;
 
   @Before
   public void setup() throws Exception {
+    fmd = Mockito.mock(FailoverMetaData.class);
+    metricSinkInstance = Mockito.mock(MetricSink.class);
+
     conf = new HiveConf();
     conf.set(Constants.SCHEDULED_QUERY_SCHEDULENAME, "repl");
     conf.set(Constants.SCHEDULED_QUERY_EXECUTIONID, "1");

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/repl/metric/TestReplicationMetricCollector.java
@@ -76,7 +76,7 @@ public class TestReplicationMetricCollector {
   @Mock
   private MetricSink metricSinkInstance;
 
-  static MockedStatic<MetricSink> metricSinkMockedStatic;
+  MockedStatic<MetricSink> metricSinkMockedStatic;
 
   @Before
   public void setup() throws Exception {


### PR DESCRIPTION
Fix flaky test. Details in the ticket.

Flaky test on the branch: http://ci.hive.apache.org/job/hive-flaky-check/786/
And also on master: http://ci.hive.apache.org/job/hive-flaky-check/784/

Note: it seems, it became flaky only on downstream. 

### What changes were proposed in this pull request?
Per test case object shouldn't be static


### Why are the changes needed?
To fix the test


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
By running tests and flaky test checker
