### PR TITLE
HIVE-27978: Tests in hive-unit module are not running again

### DIFF
--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -27,7 +27,6 @@
     <hive.path.to.root>../..</hive.path.to.root>
     <testcontainers.version>1.15.2</testcontainers.version>
     <htmlunit.version>2.70.0</htmlunit.version>
-    <junit.jupiter.version>5.6.2</junit.jupiter.version>
   </properties>
   <dependencies>
     <!-- intra-project -->
@@ -493,12 +492,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestTimedOutTxnNotificationLogging.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestTimedOutTxnNotificationLogging.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hive.hcatalog.listener.DbNotificationListener;
 import org.apache.thrift.TException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +53,6 @@ import org.junit.runners.Parameterized;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @RunWith(Parameterized.class)
@@ -126,13 +126,13 @@ public class TestTimedOutTxnNotificationLogging {
   public void testTxnNotificationLogging() throws Exception {
     try {
       List<Long> txnIds = openTxns(numberOfTxns, txnType);
-      assertEquals(txnIds.size(), getNumberOfTxnsWithTxnState(txnIds, TxnState.OPEN));
-      assertEquals(expectedNotifications, getNumberOfNotificationsWithEventType(txnIds, MessageBuilder.OPEN_TXN_EVENT));
+      Assert.assertEquals(txnIds.size(), getNumberOfTxnsWithTxnState(txnIds, TxnState.OPEN));
+      Assert.assertEquals(expectedNotifications, getNumberOfNotificationsWithEventType(txnIds, MessageBuilder.OPEN_TXN_EVENT));
       Thread.sleep(1000);
       acidHouseKeeperService.run(); //this will abort timed-out txns
       if (txnType != TxnType.REPL_CREATED) {
-        assertEquals(txnIds.size(), getNumberOfTxnsWithTxnState(txnIds, TxnState.ABORTED));
-        assertEquals(expectedNotifications, getNumberOfNotificationsWithEventType(txnIds, MessageBuilder.ABORT_TXN_EVENT));
+        Assert.assertEquals(txnIds.size(), getNumberOfTxnsWithTxnState(txnIds, TxnState.ABORTED));
+        Assert.assertEquals(expectedNotifications, getNumberOfNotificationsWithEventType(txnIds, MessageBuilder.ABORT_TXN_EVENT));
       }
     } finally {
       runCleanerServices();


### PR DESCRIPTION

### What changes were proposed in this pull request?
To fix hive-unit tests running by removing a jupiter dependency.

### Why are the changes needed?
Because tests in hive-unit module are not running again.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
Not an upgrade, just removing a test-scoped dependency in hive-unit module.

### How was this patch tested?
Precommit tests.
