### PR TITLE
HIVE-27979: HMS alter_partitions log adds table name

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5919,7 +5919,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     if (LOG.isInfoEnabled()) {
       for (Partition tmpPart : new_parts) {
-        LOG.info("New partition values: {}.{}.{}:{} ", catName, db_name, tbl_name, tmpPart.getValues());
+        LOG.info("New partition values: catalog: {} database: {} table: {} partition: {}",
+                catName, db_name, tbl_name, tmpPart.getValues());
       }
     }
     // all partitions are altered atomically

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -5919,7 +5919,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     if (LOG.isInfoEnabled()) {
       for (Partition tmpPart : new_parts) {
-        LOG.info("New partition values:" + tmpPart.getValues());
+        LOG.info("New partition values: {}.{}.{}:{} ", catName, db_name, tbl_name, tmpPart.getValues());
       }
     }
     // all partitions are altered atomically

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -663,7 +663,7 @@ public class MetaStoreServerUtils {
     if (!madeDir) {
       // The partition location already existed and may contain data. Lets try to
       // populate those statistics that don't require a full scan of the data.
-      LOG.info("Updating partition stats fast for: {}.{}.{}:{}",
+      LOG.info("Updating partition stats fast for: catalog: {} database: {} table: {} partition: {}",
               part.getCatName(), part.getDbName(), part.getTableName(), part.getCurrent().getValues());
       List<FileStatus> fileStatus = wh.getFileStatusesForLocation(part.getLocation());
       // TODO: this is invalid for ACID tables, and we cannot access AcidUtils here.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -663,7 +663,8 @@ public class MetaStoreServerUtils {
     if (!madeDir) {
       // The partition location already existed and may contain data. Lets try to
       // populate those statistics that don't require a full scan of the data.
-      LOG.info("Updating partition stats fast for: {}", part.getTableName());
+      LOG.info("Updating partition stats fast for: {}.{}.{}:{}",
+              part.getCatName(), part.getDbName(), part.getTableName(), part.getCurrent().getValues());
       List<FileStatus> fileStatus = wh.getFileStatusesForLocation(part.getLocation());
       // TODO: this is invalid for ACID tables, and we cannot access AcidUtils here.
       populateQuickStats(fileStatus, params);


### PR DESCRIPTION
### What changes were proposed in this pull request?
add log


### Why are the changes needed?
1. `alter_partitions` outputs multiple partition values, but there is no table name. 
2. When updating the statistics of the partition, there is only the table name, but the partition name is not known.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?

