### PR TITLE
HIVE-27951: hcatalog dynamic partitioning fails with partition already exist error when exist parent partitions path

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -581,7 +581,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
         Path dstP = pair.getRight();
         if (!moveFile(srcFs, srcP, destFs, dstP, conf, canRename)) {
           throw new HCatException(ErrorType.ERROR_MOVE_FAILED,
-              "Unable to move source " + " , src = " + srcP + ", dest = " + dstP);
+              "Unable to move from " + srcP + " to " + dstP);
         }
       }
       return;
@@ -600,7 +600,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
             return pair;
           } else {
             throw new HCatException(ErrorType.ERROR_MOVE_FAILED,
-                "Unable to move source " + " , src = " + srcP + ", dest = " + dstP);
+                "Unable to move from " + srcP + " to " + dstP);
           }
         }
       }));
@@ -617,7 +617,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
   }
 
   private boolean moveFile(FileSystem srcFs, Path srcf, FileSystem destFs, Path destf, Configuration conf, boolean canRename) throws IOException {
-    LOG.debug("Moving src: {}, to dest: {}", srcf.toString(), destf.toString());
+    LOG.debug("Moving src: {}, to dest: {}", srcf, destf);
     boolean moved;
     if (canRename) {
       destFs.mkdirs(destf.getParent());

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -488,7 +488,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
   }
 
   /**
-   * Move all of the files from the temp directory to the final location
+   * Move task output from the temp directory to the final location
    * @param srcf the file to move
    * @param srcDir the source directory
    * @param destDir the target directory
@@ -538,17 +538,17 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
         final Path finalOutputPath = getFinalPath(destFs, srcF, srcDir, destDir, immutable);
         if (immutable && destFs.exists(finalOutputPath) &&
             !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, finalOutputPath)) {
-          throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
-              "Data already exists in " + finalOutputPath
-                  + ", duplicate publish not possible.");
-        }
-        if (srcStatus.isDirectory()) {
+          if (partitionsDiscoveredByPath.containsKey(srcF.toString())) {
+            throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
+                "Data already exists in " + finalOutputPath
+                    + ", duplicate publish not possible.");
+          }
+          // parent directory may exist for multi-partitions, check lower level partitions
+          Collections.addAll(srcQ, srcFs.listStatus(srcF,HIDDEN_FILES_PATH_FILTER));
+        } else if (srcStatus.isDirectory()) {
           if (canRename && dynamicPartitioningUsed) {
             // If it is partition, move the partition directory instead of each file.
-            // If custom dynamic location provided, need to rename to final output path
-            final Path parentDir = finalOutputPath.getParent();
-            Path dstPath = !customDynamicLocationUsed ? parentDir : finalOutputPath;
-            moves.add(Pair.of(srcF, dstPath));
+            moves.add(Pair.of(srcF, finalOutputPath));
           } else {
             Collections.addAll(srcQ, srcFs.listStatus(srcF, HIDDEN_FILES_PATH_FILTER));
           }
@@ -558,16 +558,27 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
       }
     }
 
-    if (moves.isEmpty()) {
+    bulkMoveFiles(conf, srcFs, destFs, moves);
+  }
+
+  /**
+   * Bulk move files from source to destination.
+   * @param srcFs the source filesystem where the source files are
+   * @param destFs the destionation filesystem where the destionation files are
+   * @param pairs list of pairs of <source_path, destination_path>, move source_path to destination_path
+   * @throws java.io.IOException
+   */
+  private void bulkMoveFiles(final Configuration conf, final FileSystem srcFs, final FileSystem destFs, List<Pair<Path, Path>> pairs) throws IOException{
+    if (pairs.isEmpty()) {
       return;
     }
-
+    final boolean canRename = srcFs.getUri().equals(destFs.getUri());
     final List<Future<Pair<Path, Path>>> futures = new LinkedList<>();
     final ExecutorService pool = conf.getInt(ConfVars.HIVE_MOVE_FILES_THREAD_COUNT.varname, 25) > 0 ?
         Executors.newFixedThreadPool(conf.getInt(ConfVars.HIVE_MOVE_FILES_THREAD_COUNT.varname, 25),
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Move-Thread-%d").build()) : null;
 
-    for (final Pair<Path, Path> pair: moves){
+    for (final Pair<Path, Path> pair: pairs){
       Path srcP = pair.getLeft();
       Path dstP = pair.getRight();
       final String msg = "Unable to move source " + srcP + " to destination " + dstP;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -497,7 +497,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
    */
   private void moveTaskOutputs(final Configuration conf, Path srcf, Path srcDir,
       Path destDir, boolean immutable) throws IOException {
-    if(LOG.isDebugEnabled()) {
+    if (LOG.isDebugEnabled()) {
       LOG.debug("moveTaskOutputs "
           + srcf + " from: " + srcDir + " to: " + destDir + " immutable: " + immutable);
     }
@@ -516,8 +516,8 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
 
     LinkedList<Pair<Path, Path>> moves = new LinkedList<>();
     if (customDynamicLocationUsed) {
-      if (immutable && destFs.exists(destDir) &&
-          !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, destDir)) {
+      if (immutable && destFs.exists(destDir)
+          && !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, destDir)) {
         throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
             "Data already exists in " + destDir
                 + ", duplicate publish not possible.");
@@ -536,14 +536,14 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
         FileStatus srcStatus = srcQ.remove();
         Path srcF = srcStatus.getPath();
         final Path finalOutputPath = getFinalPath(destFs, srcF, srcDir, destDir, immutable);
-        if (immutable && destFs.exists(finalOutputPath) &&
-            !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, finalOutputPath)) {
+        if (immutable && destFs.exists(finalOutputPath)
+            && !org.apache.hadoop.hive.metastore.utils.FileUtils.isDirEmpty(destFs, finalOutputPath)) {
           if (partitionsDiscoveredByPath.containsKey(srcF.toString())) {
             throw new HCatException(ErrorType.ERROR_DUPLICATE_PARTITION,
                 "Data already exists in " + finalOutputPath + ", duplicate publish not possible.");
           }
           // parent directory may exist for multi-partitions, check lower level partitions
-          Collections.addAll(srcQ, srcFs.listStatus(srcF,HIDDEN_FILES_PATH_FILTER));
+          Collections.addAll(srcQ, srcFs.listStatus(srcF, HIDDEN_FILES_PATH_FILTER));
         } else if (srcStatus.isDirectory()) {
           if (canRename && dynamicPartitioningUsed) {
             // If it is partition, move the partition directory instead of each file.
@@ -567,7 +567,8 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
    * @param pairs list of pairs of <source_path, destination_path>, move source_path to destination_path
    * @throws java.io.IOException
    */
-  private void bulkMoveFiles(final Configuration conf, final FileSystem srcFs, final FileSystem destFs, List<Pair<Path, Path>> pairs) throws IOException{
+  private void bulkMoveFiles(final Configuration conf, final FileSystem srcFs, final FileSystem destFs,
+      final List<Pair<Path, Path>> pairs) throws IOException {
     if (pairs.isEmpty()) {
       return;
     }
@@ -575,7 +576,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
     final List<Future<Pair<Path, Path>>> futures = new LinkedList<>();
     final int moveThreadsCount = conf.getInt(ConfVars.HIVE_MOVE_FILES_THREAD_COUNT.varname, 25);
 
-    if (moveThreadsCount<=0) {
+    if (moveThreadsCount <= 0) {
       for (final Pair<Path, Path> pair: pairs) {
         Path srcP = pair.getLeft();
         Path dstP = pair.getRight();
@@ -590,7 +591,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
     final ExecutorService pool = Executors.newFixedThreadPool(moveThreadsCount,
         new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Move-Thread-%d").build());
 
-    for (final Pair<Path, Path> pair: pairs){
+    for (final Pair<Path, Path> pair: pairs) {
       Path srcP = pair.getLeft();
       Path dstP = pair.getRight();
       futures.add(pool.submit(new Callable<Pair<Path, Path>>() {
@@ -616,7 +617,8 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
     }
   }
 
-  private boolean moveFile(FileSystem srcFs, Path srcf, FileSystem destFs, Path destf, Configuration conf, boolean canRename) throws IOException {
+  private boolean moveFile(final FileSystem srcFs, final Path srcf, final FileSystem destFs, final Path destf,
+      final Configuration conf, final boolean canRename) throws IOException {
     LOG.debug("Moving src: {}, to dest: {}", srcf, destf);
     boolean moved;
     if (canRename) {

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
@@ -122,8 +122,10 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   protected void runHCatDynamicPartitionedTable(boolean asSingleMapTask,
       String customDynamicPathPattern) throws Exception {
     generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
-    runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
-    runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
+    runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2,
+        true, asSingleMapTask, customDynamicPathPattern);
+    runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2,
+        true, asSingleMapTask, customDynamicPathPattern);
 
     runMRRead(NUM_RECORDS);
 

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatDynamicPartitioned.java
@@ -52,13 +52,13 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   private static List<HCatFieldSchema> dataColumns;
   private static final Logger LOG = LoggerFactory.getLogger(TestHCatDynamicPartitioned.class);
   protected static final int NUM_RECORDS = 20;
-  protected static final int NUM_PARTITIONS = 5;
+  protected static final int NUM_TOP_PARTITIONS = 5;
 
   public TestHCatDynamicPartitioned(String formatName, String serdeClass, String inputFormatClass,
       String outputFormatClass) throws Exception {
     super(formatName, serdeClass, inputFormatClass, outputFormatClass);
     tableName = "testHCatDynamicPartitionedTable_" + formatName;
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
     generateDataColumns();
   }
 
@@ -67,6 +67,8 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c1", serdeConstants.INT_TYPE_NAME, "")));
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("c2", serdeConstants.STRING_TYPE_NAME, "")));
     dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, "")));
+    dataColumns.add(HCatSchemaUtils.getHCatFieldSchema(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, "")));
+
   }
 
   protected static void generateWriteRecords(int max, int mod, int offset) {
@@ -78,6 +80,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
       objList.add(i);
       objList.add("strvalue" + i);
       objList.add(String.valueOf((i % mod) + offset));
+      objList.add(String.valueOf((i / (max/2)) + offset));
       writeRecords.add(new DefaultHCatRecord(objList));
     }
   }
@@ -86,6 +89,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
   protected List<FieldSchema> getPartitionKeys() {
     List<FieldSchema> fields = new ArrayList<FieldSchema>();
     fields.add(new FieldSchema("p1", serdeConstants.STRING_TYPE_NAME, ""));
+    fields.add(new FieldSchema("p2", serdeConstants.STRING_TYPE_NAME, ""));
     return fields;
   }
 
@@ -117,8 +121,9 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
 
   protected void runHCatDynamicPartitionedTable(boolean asSingleMapTask,
       String customDynamicPathPattern) throws Exception {
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
-    runMRCreate(null, dataColumns, writeRecords, NUM_RECORDS, true, asSingleMapTask, customDynamicPathPattern);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
+    runMRCreate(null, dataColumns, writeRecords.subList(0,NUM_RECORDS/2), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
+    runMRCreate(null, dataColumns, writeRecords.subList(NUM_RECORDS/2,NUM_RECORDS), NUM_RECORDS/2, true, asSingleMapTask, customDynamicPathPattern);
 
     runMRRead(NUM_RECORDS);
 
@@ -140,7 +145,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     //Test for duplicate publish
     IOException exc = null;
     try {
-      generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+      generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
       Job job = runMRCreate(null, dataColumns, writeRecords, NUM_RECORDS, false,
           true, customDynamicPathPattern);
 
@@ -167,7 +172,7 @@ public class TestHCatDynamicPartitioned extends HCatMapReduceTest {
     driver.run(query);
     res = new ArrayList<String>();
     driver.getResults(res);
-    assertEquals(NUM_PARTITIONS, res.size());
+    assertEquals(NUM_TOP_PARTITIONS*2, res.size());
 
     query = "select * from " + tableName;
     driver.run(query);

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExternalDynamicPartitioned.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatExternalDynamicPartitioned.java
@@ -28,7 +28,7 @@ public class TestHCatExternalDynamicPartitioned extends TestHCatDynamicPartition
       throws Exception {
     super(formatName, serdeClass, inputFormatClass, outputFormatClass);
     tableName = "testHCatExternalDynamicPartitionedTable_" + formatName;
-    generateWriteRecords(NUM_RECORDS, NUM_PARTITIONS, 0);
+    generateWriteRecords(NUM_RECORDS, NUM_TOP_PARTITIONS, 0);
     generateDataColumns();
   }
 
@@ -43,7 +43,7 @@ public class TestHCatExternalDynamicPartitioned extends TestHCatDynamicPartition
    */
   @Test
   public void testHCatExternalDynamicCustomLocation() throws Exception {
-    runHCatDynamicPartitionedTable(true, "mapred/externalDynamicOutput/${p1}");
+    runHCatDynamicPartitionedTable(true, "mapred/externalDynamicOutput/${p1}/${p2}");
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
clean up the code for readibilty
fix the issue when parent partition path exists for multi partitioned dynamic insert.



### Why are the changes needed?
fix bug:
if a table have multiple partitions (part1=x1, part2=y1), when insert into a new partition(part1=x1, part2=y2) hcatalog FileOutputCommitterContainer throws path part1=x1 already exists error. This is due to the path checking stops at parent level, 

pig -useHcatalog

A = load 'source' using org.apache.hive.hcatalog.pig.HCatLoader();
B = filter A by (part2 == 'y1');

// following succeeds
store B into 'target' USING org.apache.hive.hcatalog.pig.HCatStorer();

//following fails with duplicate publishing error

C = filter A by (part2 == 'y2');
store C into 'target' USING org.apache.hive.hcatalog.pig.HCatStorer();


```
Partition already present with given partition key values : Data already exists in /user/hive/warehouse/target/part1=x1, duplicate publish not possible.
at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigOutputCommitter.commitJob(PigOutputCommitter.java:243)
at org.apache.hadoop.mapreduce.v2.app.commit.CommitterEventHandler$EventProcessor.handleJobCommit(CommitterEventHandler.java:286)
 
Caused by: org.apache.hive.hcatalog.common.HCatException : 2002 : Partition already present with given partition key values : Data already exists in /user/hive/warehouse/target/part1=x1, duplicate publish not possible.
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.moveTaskOutputs(FileOutputCommitterContainer.java:564)
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.registerPartitions(FileOutputCommitterContainer.java:949)
at org.apache.hive.hcatalog.mapreduce.FileOutputCommitterContainer.commitJob(FileOutputCommitterContainer.java:273)
at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigOutputCommitter.commitJob(PigOutputCommitter.java:241)
```




### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
updated unit test to include the use case that is affected by the bug
mvn clean test -Dtest=TestHCatExternalDynamicPartitioned,TestHCatDynamicPartitioned,TestHCatPartitioned,TestHCatNonPartitioned

also tested locally with pig -useHCatalog
