### PR TITLE
HIVE-27986: Generated file name no longer depend on attemptid.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -915,7 +915,8 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
         fsp.initializeBucketPaths(filesIdx, AcidUtils.BUCKET_PREFIX + String.format(AcidUtils.BUCKET_DIGITS, bucketId),
             isNativeTable(), isSkewedStoredAsSubDirectories);
       } else {
-        fsp.initializeBucketPaths(filesIdx, taskId, isNativeTable(), isSkewedStoredAsSubDirectories);
+        fsp.initializeBucketPaths(filesIdx, Utilities.getTaskIdFromFilename(taskId), isNativeTable(),
+            isSkewedStoredAsSubDirectories);
       }
       if (Utilities.FILE_OP_LOGGER.isTraceEnabled()) {
         Utilities.FILE_OP_LOGGER.trace("createBucketForFileIdx " + filesIdx + ": final path " + fsp.finalPaths[filesIdx]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Generated file name no longer depend on attemptid. Before this PR, 

### Why are the changes needed?

For more information see https://issues.apache.org/jira/browse/HIVE-27985 and https://issues.apache.org/jira/browse/HIVE-27986


### Does this PR introduce _any_ user-facing change?

No

### Is the change a dependency upgrade?

No

### How was this patch tested?

test in cluster manually