### PR TITLE
HIVE-27977: Fix ordering flakiness in TestHplSqlViaBeeLine

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
@@ -184,8 +184,8 @@ public class TestHplSqlViaBeeLine {
             "BEGIN\n" +
             "   RETURN 'This is ' || b;\n" +
             "END;\n" +
-            "SELECT check(col_b) FROM result;\n";
-    testScriptFile(SCRIPT_TEXT, args(), "This is true.*This is false");
+            "SELECT check(col_b) FROM result ORDER BY col_b ASC;\n";
+    testScriptFile(SCRIPT_TEXT, args(), "This is false.*This is true");
   }
 
   @Test
@@ -280,7 +280,7 @@ public class TestHplSqlViaBeeLine {
             "BEGIN\n" +
             "   RETURN 'Hello ' || s || '!';\n" +
             "END;\n" +
-            "SELECT hello(col_s) FROM result;\n";
+            "SELECT hello(col_s) FROM result ORDER BY col_s ASC;\n";
     testScriptFile(SCRIPT_TEXT, args(), "Hello Alice!.*Hello Smith!");
   }
 
@@ -344,8 +344,8 @@ public class TestHplSqlViaBeeLine {
             "BEGIN\n" +
             "   RETURN 'Hello ' || v || '!';\n" +
             "END;\n" +
-            "SELECT hello(col_v) FROM result;\n";
-    testScriptFile(SCRIPT_TEXT, args(), "Hello Smith!.*Hello Sachin!");
+            "SELECT hello(col_v) FROM result ORDER BY col_v ASC;\n";
+    testScriptFile(SCRIPT_TEXT, args(), "Hello Sachin!.*Hello Smith!");
   }
 
   @Test
@@ -360,8 +360,8 @@ public class TestHplSqlViaBeeLine {
             "BEGIN\n" +
             "   RETURN 'Hello ' || c || '!';\n" +
             "END;\n" +
-            "SELECT hello(col_c) FROM result;\n";
-    testScriptFile(SCRIPT_TEXT, args(), "Hello Daya!.*Hello Alice!");
+            "SELECT hello(col_c) FROM result ORDER BY col_c ASC;\n";
+    testScriptFile(SCRIPT_TEXT, args(), "Hello Alice!.*Hello Daya!");
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce ORDER BY clause in some unit tests.

### Why are the changes needed?
Bumped into intermittent test failures in TestHplSqlViaBeeLine while moving it from MR to Tez, and realized that the ordering is not defined in the test cases, so it makes no sense to look for the execution engine differences as long as we don't have a stable golden output.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
With the touched unit tests.