### PR TITLE
HIVE-27995: Fix inconsistent behavior of LOAD DATA command for partitoned and non-partitioned tables

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
@@ -3428,4 +3428,26 @@ public class TestJdbcDriver2 {
       stmt.close();
     }
   }
+  /**
+   * These test methods validate the error handling when attempting to load data from a non-existent file into different types of Hive tables.
+   * Each test creates a specific type of table ( dynamically partitioned, or bucketed), and then attempts to load data from a non-existent file.
+   * The tests pass if an exception is thrown with a message containing the string "Invalid path".
+   */
+  @Test
+  public void testLoadDataNegativeForDynamicPartition() throws Exception {
+    HiveStatement stmt = (HiveStatement) con.createStatement();
+    try {
+      stmt.execute("drop table if exists T");
+      stmt.execute("create table T (a int, b int) partitioned by (p int) stored as orc");
+      try {
+        stmt.execute("load data local inpath '/path/to/nonexistent/file.txt' into table T");
+        fail("Expected an exception to be thrown");
+      } catch (Exception e) {
+        assertTrue("load data inpath",
+                e.getMessage() != null && e.getMessage().contains("Invalid path"));
+      }
+    } finally {
+      stmt.close();
+    }
+  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnLoadData.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnLoadData.java
@@ -391,16 +391,16 @@ public class TestTxnLoadData extends TxnCommandsBaseForTests {
    */
   @Test
   public void testValidations() throws Exception {
-    runStatementOnDriver("drop table if exists T");
-    runStatementOnDriver("drop table if exists Tstage");
-    runStatementOnDriver("create table T (a int, b int) clustered by (a) into 2 buckets stored as orc tblproperties('transactional'='true')");
+    runStatementOnDriver("drop table if exists t");
+    runStatementOnDriver("drop table if exists tstage");
+    runStatementOnDriver("create table t (a int, b int) clustered by (a) into 2 buckets stored as orc tblproperties('transactional'='true')");
     File createdFile= folder.newFile("myfile.txt");
     FileUtils.writeStringToFile(createdFile, "hello world");
-    runStatementOnDriver("create table Tstage (a int, b int) stored as orc tblproperties('transactional'='false')");
+    runStatementOnDriver("create table tstage (a int, b int) stored as orc tblproperties('transactional'='false')");
     //this creates an ORC data file with correct schema under table root
-    runStatementOnDriver("insert into Tstage values(1,2),(3,4)");
+    runStatementOnDriver("insert into tstage values(1,2),(3,4)");
     // This will work with the new support of rewriting load into IAS.
-    runStatementOnDriver("load data local inpath '" + getWarehouseDir() + "/Tstage' into table T");
+    runStatementOnDriver("load data local inpath '" + getWarehouseDir() + "/tstage' into table t");
   }
 
   private void checkExpected(List<String> rs, String[][] expected, String msg) {

--- a/ql/src/test/queries/clientnegative/load_data_partition.q
+++ b/ql/src/test/queries/clientnegative/load_data_partition.q
@@ -1,0 +1,6 @@
+drop table if exists validate_load_data;
+CREATE TABLE validate_load_data(key int, value string) partitioned by (hr int) STORED AS TEXTFILE;
+LOAD DATA INPATH '/tmp/kv1.txt' INTO TABLE validate_load_data;
+SELECT * FROM validate_load_data;
+DROP TABLE validate_load_data;
+``````

--- a/ql/src/test/queries/clientnegative/load_wrong_noof_part.q
+++ b/ql/src/test/queries/clientnegative/load_wrong_noof_part.q
@@ -1,3 +1,3 @@
 
 CREATE TABLE loadpart1(a STRING, b STRING) PARTITIONED BY (ds STRING,ds1 STRING);
-LOAD DATA LOCAL INPATH '../../data1/files/kv1.txt' INTO TABLE loadpart1 PARTITION(ds='2009-05-05');
+LOAD DATA LOCAL INPATH '../../data/files/kv1.txt' INTO TABLE loadpart1 PARTITION(ds='2009-05-05');

--- a/ql/src/test/results/clientnegative/load_data_partition.q.out
+++ b/ql/src/test/results/clientnegative/load_data_partition.q.out
@@ -1,0 +1,15 @@
+PREHOOK: query: drop table if exists validate_load_data
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: drop table if exists validate_load_data
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: CREATE TABLE validate_load_data(key int, value string) partitioned by (hr int) STORED AS TEXTFILE
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@validate_load_data
+POSTHOOK: query: CREATE TABLE validate_load_data(key int, value string) partitioned by (hr int) STORED AS TEXTFILE
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@validate_load_data
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/load_wrong_noof_part.q.out
+++ b/ql/src/test/results/clientnegative/load_wrong_noof_part.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: CREATE TABLE loadpart1(a STRING, b STRING) PARTITIONED BY (ds S
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@loadpart1
-FAILED: SemanticException [Error 10006]: Line 2:82 Partition not found ''2009-05-05''
+FAILED: SemanticException [Error 10006]: Line 2:81 Partition not found ''2009-05-05''


### PR DESCRIPTION
### What changes were proposed in this pull request?
Earlier, the code flows for partitioned and non-partitioned tables were different. The partitioned tables skipped constraints checks before submitting the job for execution. This Pull request ensures that both, the partitioned and non-partitioned tables go through the constraints validations in `applyConstraintsAndGetFiles` function.


### Why are the changes needed?
For partitioned tables, while executing LOAD DATA/ LOAD DATA LOCAL commands, the check for file existence is not executed on HiveServer2, and this in turn throws `java.io.FileNotFoundException` during Runtime once the job is launched. 
This PR prevents such cases at compile time.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
The test cases already exist. The error messages prompted back to the user are now consistent if the file is not found at HiveServer2

Load Data Error (Non Partitioned Tables)
<img width="1049" alt="Load Data Error" src="https://github.com/apache/hive/assets/149884343/5133da3d-21d4-43f5-bec0-2b76f63ef979">

File Not Found Exception (Partitioned Tables)
<img width="452" alt="Load" src="https://github.com/apache/hive/assets/149884343/3490422a-de97-4750-8cab-fb81d5319a2b">

Fixed: For partitioned tables
<img width="1349" alt="Load (1)" src="https://github.com/apache/hive/assets/149884343/95ad648f-3233-4032-a438-db032a82401b">


