### PR TITLE
HIVE-27958: Refactor DirectSqlUpdatePart class

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -789,13 +789,13 @@ public class DatabaseProduct implements Configurable {
    * with Derby database.  See more notes at class level.
    */
   public void lockInternal() {
-    if(isDERBY()) {
+    if (isDERBY()) {
       derbyLock.lock();
     }
   }
 
   public void unlockInternal() {
-    if(isDERBY()) {
+    if (isDERBY()) {
       derbyLock.unlock();
     }
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdatePart.java
@@ -67,7 +67,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hive.common.StatsSetupConst.COLUMN_STATS_ACCURATE;
@@ -92,8 +91,6 @@ class DirectSqlUpdatePart {
   private final int maxBatchSize;
   private final SQLGenerator sqlGenerator;
 
-  private static final ReentrantLock derbyLock = new ReentrantLock(true);
-
   public DirectSqlUpdatePart(PersistenceManager pm, Configuration conf,
                              DatabaseProduct dbType, int batchSize) {
     this.pm = pm;
@@ -101,23 +98,6 @@ class DirectSqlUpdatePart {
     this.dbType = dbType;
     this.maxBatchSize = batchSize;
     sqlGenerator = new SQLGenerator(dbType, conf);
-  }
-
-  /**
-   * {@link #lockInternal()} and {@link #unlockInternal()} are used to serialize those operations that require
-   * Select ... For Update to sequence operations properly.  In practice that means when running
-   * with Derby database.  See more notes at class level.
-   */
-  private void lockInternal() {
-    if(dbType.isDERBY()) {
-      derbyLock.lock();
-    }
-  }
-
-  private void unlockInternal() {
-    if(dbType.isDERBY()) {
-      derbyLock.unlock();
-    }
   }
 
   void rollbackDBConn(Connection dbConn) {
@@ -138,33 +118,8 @@ class DirectSqlUpdatePart {
     }
   }
 
-  void closeStmt(Statement stmt) {
-    try {
-      if (stmt != null && !stmt.isClosed()) stmt.close();
-    } catch (SQLException e) {
-      LOG.warn("Failed to close statement ", e);
-    }
-  }
-
-  void close(ResultSet rs) {
-    try {
-      if (rs != null && !rs.isClosed()) {
-        rs.close();
-      }
-    }
-    catch(SQLException ex) {
-      LOG.warn("Failed to close statement ", ex);
-    }
-  }
-
   static String quoteString(String input) {
     return "'" + input + "'";
-  }
-
-  void close(ResultSet rs, Statement stmt, JDOConnection dbConn) {
-    close(rs);
-    closeStmt(stmt);
-    closeDbConn(dbConn);
   }
 
   private void populateInsertUpdateMap(Map<PartitionInfo, ColumnStatistics> statsPartInfoMap,
@@ -173,8 +128,6 @@ class DirectSqlUpdatePart {
                                        Connection dbConn, Table tbl) throws SQLException, MetaException, NoSuchObjectException {
     StringBuilder prefix = new StringBuilder();
     StringBuilder suffix = new StringBuilder();
-    Statement statement = null;
-    ResultSet rs = null;
     List<String> queries = new ArrayList<>();
     Set<PartColNameInfo> selectedParts = new HashSet<>();
 
@@ -187,15 +140,12 @@ class DirectSqlUpdatePart {
             partIdList, "\"PART_ID\"", true, false);
 
     for (String query : queries) {
-      try {
-        statement = dbConn.createStatement();
-        LOG.debug("Going to execute query " + query);
-        rs = statement.executeQuery(query);
+      LOG.debug("Going to execute query " + query);
+      try (Statement statement = dbConn.createStatement();
+           ResultSet rs = statement.executeQuery(query)) {
         while (rs.next()) {
           selectedParts.add(new PartColNameInfo(rs.getLong(1), rs.getString(2), rs.getString(3)));
         }
-      } finally {
-        close(rs, statement, null);
       }
     }
 
@@ -270,7 +220,6 @@ class DirectSqlUpdatePart {
   private void insertIntoPartColStatTable(Map<PartColNameInfo, MPartitionColumnStatistics> insertMap,
                                           long maxCsId,
                                           Connection dbConn) throws SQLException, MetaException, NoSuchObjectException {
-    PreparedStatement preparedStatement = null;
     int numRows = 0;
     String insert = "INSERT INTO \"PART_COL_STATS\" (\"CS_ID\", \"CAT_NAME\", \"DB_NAME\","
             + "\"TABLE_NAME\", \"PARTITION_NAME\", \"COLUMN_NAME\", \"COLUMN_TYPE\", \"PART_ID\","
@@ -279,8 +228,7 @@ class DirectSqlUpdatePart {
             + " \"HISTOGRAM\", \"AVG_COL_LEN\", \"MAX_COL_LEN\", \"NUM_TRUES\", \"NUM_FALSES\", \"LAST_ANALYZED\", \"ENGINE\") values "
             + "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-    try {
-      preparedStatement = dbConn.prepareStatement(insert);
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insert)) {
       for (Map.Entry entry : insertMap.entrySet()) {
         PartColNameInfo partColNameInfo = (PartColNameInfo) entry.getKey();
         Long partId = partColNameInfo.partitionId;
@@ -323,8 +271,6 @@ class DirectSqlUpdatePart {
       if (numRows != 0) {
         preparedStatement.executeBatch();
       }
-    } finally {
-      closeStmt(preparedStatement);
     }
   }
 
@@ -332,8 +278,6 @@ class DirectSqlUpdatePart {
     List<String> queries = new ArrayList<>();
     StringBuilder prefix = new StringBuilder();
     StringBuilder suffix = new StringBuilder();
-    Statement statement = null;
-    ResultSet rs = null;
 
     prefix.append("select \"PART_ID\", \"PARAM_VALUE\" "
             + " from \"PARTITION_PARAMS\" where "
@@ -344,15 +288,12 @@ class DirectSqlUpdatePart {
 
     Map<Long, String> partIdToParaMap = new HashMap<>();
     for (String query : queries) {
-      try {
-        statement = dbConn.createStatement();
-        LOG.debug("Going to execute query " + query);
-        rs = statement.executeQuery(query);
+      LOG.debug("Going to execute query " + query);
+      try (Statement statement = dbConn.createStatement();
+           ResultSet rs = statement.executeQuery(query)) {
         while (rs.next()) {
           partIdToParaMap.put(rs.getLong(1), rs.getString(2));
         }
-      } finally {
-        close(rs, statement, null);
       }
     }
     return partIdToParaMap;
@@ -367,14 +308,10 @@ class DirectSqlUpdatePart {
     TxnUtils.buildQueryWithINClause(conf, queries, prefix, suffix,
             partIdList, "\"PART_ID\"", false, false);
 
-    Statement statement = null;
     for (String query : queries) {
-      try {
-        statement = dbConn.createStatement();
-        LOG.debug("Going to execute update " + query);
+      LOG.debug("Going to execute update " + query);
+      try (Statement statement = dbConn.createStatement()) {
         statement.executeUpdate(query);
-      } finally {
-        closeStmt(statement);
       }
     }
   }
@@ -503,8 +440,6 @@ class DirectSqlUpdatePart {
     List<String> queries = new ArrayList<>();
     StringBuilder prefix = new StringBuilder();
     StringBuilder suffix = new StringBuilder();
-    Statement statement = null;
-    ResultSet rs = null;
     Map<PartitionInfo, ColumnStatistics> partitionInfoMap = new HashMap<>();
 
     List<String> partKeys = partColStatsMap.keySet().stream().map(
@@ -519,17 +454,14 @@ class DirectSqlUpdatePart {
     for (String query : queries) {
       // Select for update makes sure that the partitions are not modified while the stats are getting updated.
       query = sqlGenerator.addForUpdateClause(query);
-      try {
-        statement = dbConn.createStatement();
-        LOG.debug("Going to execute query <" + query + ">");
-        rs = statement.executeQuery(query);
+      LOG.debug("Going to execute query <" + query + ">");
+      try (Statement statement = dbConn.createStatement();
+           ResultSet rs = statement.executeQuery(query)) {
         while (rs.next()) {
           PartitionInfo partitionInfo = new PartitionInfo(rs.getLong(1),
                   rs.getLong(2), rs.getString(3));
           partitionInfoMap.put(partitionInfo, partColStatsMap.get(rs.getString(3)));
         }
-      } finally {
-        close(rs, statement, null);
       }
     }
     return partitionInfoMap;
@@ -556,7 +488,7 @@ class DirectSqlUpdatePart {
     Connection dbConn = null;
     boolean committed = false;
     try {
-      lockInternal();
+      dbType.lockInternal();
       jdoConn = pm.getDataStoreConnection();
       dbConn = (Connection) (jdoConn.getNativeConnection());
 
@@ -606,7 +538,7 @@ class DirectSqlUpdatePart {
         rollbackDBConn(dbConn);
       }
       closeDbConn(jdoConn);
-      unlockInternal();
+      dbType.unlockInternal();
     }
   }
 
@@ -615,15 +547,13 @@ class DirectSqlUpdatePart {
    * @return The CD id before update.
    */
   public long getNextCSIdForMPartitionColumnStatistics(long numStats) throws MetaException {
-    Statement statement = null;
-    ResultSet rs = null;
     long maxCsId = 0;
     boolean committed = false;
     Connection dbConn = null;
     JDOConnection jdoConn = null;
 
     try {
-      lockInternal();
+      dbType.lockInternal();
       jdoConn = pm.getDataStoreConnection();
       dbConn = (Connection) (jdoConn.getNativeConnection());
 
@@ -638,42 +568,39 @@ class DirectSqlUpdatePart {
                 + "WHERE \"SEQUENCE_NAME\"= "
                 + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics"));
         LOG.debug("Going to execute query " + query);
-        statement = dbConn.createStatement();
-        rs = statement.executeQuery(query);
-        if (rs.next()) {
-          maxCsId = rs.getLong(1);
-        } else if (insertDone) {
-          throw new MetaException("Invalid state of SEQUENCE_TABLE for MPartitionColumnStatistics");
-        } else {
-          insertDone = true;
-          closeStmt(statement);
-          statement = dbConn.createStatement();
-          query = "INSERT INTO \"SEQUENCE_TABLE\" (\"SEQUENCE_NAME\", \"NEXT_VAL\")  VALUES ( "
-                  + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics") + "," + 1
-                  + ")";
-          try {
-            statement.executeUpdate(query);
-          } catch (SQLException e) {
-            // If the record is already inserted by some other thread continue to select.
-            if (dbType.isDuplicateKeyError(e)) {
-              continue;
+        try (Statement statement = dbConn.createStatement();
+             ResultSet rs = statement.executeQuery(query)) {
+          if (rs.next()) {
+            maxCsId = rs.getLong(1);
+          } else if (insertDone) {
+            throw new MetaException("Invalid state of SEQUENCE_TABLE for MPartitionColumnStatistics");
+          } else {
+            insertDone = true;
+            query = "INSERT INTO \"SEQUENCE_TABLE\" (\"SEQUENCE_NAME\", \"NEXT_VAL\")  VALUES ( "
+                    + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics") + "," + 1
+                    + ")";
+            try (Statement stmt = dbConn.createStatement()) {
+              stmt.executeUpdate(query);
+            } catch (SQLException e) {
+              // If the record is already inserted by some other thread continue to select.
+              if (dbType.isDuplicateKeyError(e)) {
+                continue;
+              }
+              LOG.error("Unable to insert into SEQUENCE_TABLE for MPartitionColumnStatistics.", e);
+              throw e;
             }
-            LOG.error("Unable to insert into SEQUENCE_TABLE for MPartitionColumnStatistics.", e);
-            throw e;
-          } finally {
-            closeStmt(statement);
           }
         }
       }
 
       long nextMaxCsId = maxCsId + numStats + 1;
-      closeStmt(statement);
-      statement = dbConn.createStatement();
-      String query = "UPDATE \"SEQUENCE_TABLE\" SET \"NEXT_VAL\" = "
-              + nextMaxCsId
-              + " WHERE \"SEQUENCE_NAME\" = "
-              + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics");
-      statement.executeUpdate(query);
+      try (Statement statement = dbConn.createStatement()) {
+        String query = "UPDATE \"SEQUENCE_TABLE\" SET \"NEXT_VAL\" = "
+                + nextMaxCsId
+                + " WHERE \"SEQUENCE_NAME\" = "
+                + quoteString("org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics");
+        statement.executeUpdate(query);
+      }
       dbConn.commit();
       committed = true;
       return maxCsId;
@@ -685,8 +612,7 @@ class DirectSqlUpdatePart {
       if (!committed) {
         rollbackDBConn(dbConn);
       }
-      close(rs, statement, jdoConn);
-      unlockInternal();
+      dbType.unlockInternal();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Code refactor for `DirectSqlUpdatePart` class:
1. Move lock and unlock operations into `DatabaseProduct` class
2. Use try-for-resources instead of finally close

### Why are the changes needed?
Code refactor.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Pass existing tests.
