### PR TITLE
HIVE-27999: Upgrade to Java 17 to run sonar analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ def sonarAnalysis(args) {
       """+args+" -DskipTests -Dit.skipTests -Dmaven.javadoc.skip"
 
       sh """#!/bin/bash -e
-      sw java 11 && . /etc/profile.d/java.sh
+      sw java 17 && . /etc/profile.d/java.sh
       export MAVEN_OPTS=-Xmx5G
       """+mvnCmd
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ def sonarAnalysis(args) {
 def hdbPodTemplate(closure) {
   podTemplate(
   containers: [
-    containerTemplate(name: 'hdb', image: 'kgyrtkirk/hive-dev-box:executor', ttyEnabled: true, command: 'tini -- cat',
+    containerTemplate(name: 'hdb', image: 'wecharyu/hive-dev-box:executor', ttyEnabled: true, command: 'tini -- cat',
         alwaysPullImage: true,
         resourceRequestCpu: '1800m',
         resourceLimitCpu: '8000m',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,7 +287,6 @@ set -x
 echo 127.0.0.1 dev_$dbType | sudo tee -a /etc/hosts
 . /etc/profile.d/confs.sh
 sw hive-dev $PWD
-ping -c2 dev_$dbType
 export DOCKER_NETWORK=host
 export DBNAME=metastore
 reinit_metastore $dbType


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade to java 17 in CI to run sonar analysis.


### Why are the changes needed?
To make CI pass.


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Pass CI.
