### PR TITLE
HIVE-28019 Fix query type information in proto files for load queries

### DIFF
--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_load_data.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_load_data.q.out
@@ -15,11 +15,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice_parquet
 PREHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 PREHOOK: Output: default@ice_parquet
 POSTHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 POSTHOOK: Output: default@ice_parquet
 Vertex dependency in root stage
@@ -61,19 +61,19 @@ Stage-3
                            Please refer to the previous Select Operator [SEL_12]
 
 PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 PREHOOK: Output: default@ice_parquet
 POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 POSTHOOK: Output: default@ice_parquet
 PREHOOK: query: explain analyze LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 PREHOOK: Output: default@ice_parquet
 POSTHOOK: query: explain analyze LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 POSTHOOK: Output: default@ice_parquet
 Vertex dependency in root stage
@@ -115,11 +115,11 @@ Stage-3
                            Please refer to the previous Select Operator [SEL_12]
 
 PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 PREHOOK: Output: default@ice_parquet
 POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/parquet_partition' OVERWRITE INTO TABLE ice_parquet
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@ice_parquet__temp_table_for_load_data__
 POSTHOOK: Output: default@ice_parquet
 PREHOOK: query: select * from ice_parquet order by intcol
@@ -173,11 +173,11 @@ Stage-0
     table:{"name:":"default.ice_avro"}
 
 PREHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/doctors.avro' OVERWRITE INTO TABLE ice_avro
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@ice_avro__temp_table_for_load_data__
 PREHOOK: Output: default@ice_avro
 POSTHOOK: query: explain LOAD DATA LOCAL INPATH '../../data/files/doctors.avro' OVERWRITE INTO TABLE ice_avro
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@ice_avro__temp_table_for_load_data__
 POSTHOOK: Output: default@ice_avro
 Vertex dependency in root stage

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.plan.BasicStatsWork;
+import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
 import org.apache.hadoop.hive.ql.plan.LoadTableDesc.LoadFileType;
 import org.apache.hadoop.hive.ql.plan.MoveWork;
@@ -244,6 +245,7 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     } else {
       analyzeLoad(ast);
     }
+    queryState.setCommandType(HiveOperation.LOAD);
   }
 
   private void analyzeLoad(ASTNode ast) throws SemanticException {

--- a/ql/src/test/results/clientpositive/llap/acid_insert_overwrite_update.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_insert_overwrite_update.q.out
@@ -166,11 +166,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 PREHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 POSTHOOK: Output: default@orc_test_txn
 POSTHOOK: Output: default@orc_test_txn@year=2016

--- a/ql/src/test/results/clientpositive/llap/load_data_using_job.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_data_using_job.q.out
@@ -191,11 +191,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -266,11 +266,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08
@@ -423,11 +423,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -499,11 +499,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08/hr=0
@@ -661,11 +661,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -737,11 +737,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08/hr=0
@@ -1017,11 +1017,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/bucketing.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/bucketing.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -1090,11 +1090,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/bucketing.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/bucketing.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Lineage: srcbucket_mapjoin_n8.key SIMPLE [(srcbucket_mapjoin_n8__temp_table_for_load_data__)srcbucket_mapjoin_n8__temp_table_for_load_data__.FieldSchema(name:key, type:int, comment:null), ]
@@ -1244,11 +1244,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -1319,11 +1319,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08
@@ -1476,11 +1476,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -1552,11 +1552,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08/hr=0
@@ -1714,11 +1714,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -1790,11 +1790,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/subdir' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08/hr=0
@@ -2070,11 +2070,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -2146,11 +2146,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08/hr=0
@@ -2662,11 +2662,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -2737,11 +2737,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/partitions/load_data_2_partitions.txt' INTO TABLE srcbucket_mapjoin_n8
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@hr=0
@@ -2903,13 +2903,13 @@ POSTHOOK: Output: default@srcbucket_mapjoin_n8
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
 INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
 INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 STAGE DEPENDENCIES:
@@ -2982,13 +2982,13 @@ STAGE PLANS:
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
 INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 PREHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE srcbucket_mapjoin_n8
 INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@srcbucket_mapjoin_n8__temp_table_for_load_data__
 POSTHOOK: Output: default@srcbucket_mapjoin_n8
 POSTHOOK: Output: default@srcbucket_mapjoin_n8@ds=2008-04-08
@@ -3141,11 +3141,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 PREHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 POSTHOOK: Output: default@orc_test_txn
 STAGE DEPENDENCIES:
@@ -3218,11 +3218,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 #### A masked pattern was here ####
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 PREHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 POSTHOOK: Output: default@orc_test_txn
 POSTHOOK: Output: default@orc_test_txn@year=2016
@@ -3255,11 +3255,11 @@ POSTHOOK: Input: default@orc_test_txn@year=2018
 8	Henry	CSE	2016
 9	Harris	CSE	2017
 #### A masked pattern was here ####
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 PREHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 POSTHOOK: Output: default@orc_test_txn
 POSTHOOK: Output: default@orc_test_txn@year=2016
@@ -3301,11 +3301,11 @@ POSTHOOK: Input: default@orc_test_txn@year=2018
 8	Henry	CSE	2016
 9	Harris	CSE	2017
 #### A masked pattern was here ####
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 PREHOOK: Output: default@orc_test_txn
 #### A masked pattern was here ####
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@orc_test_txn__temp_table_for_load_data__
 POSTHOOK: Output: default@orc_test_txn
 POSTHOOK: Output: default@orc_test_txn@year=2016

--- a/ql/src/test/results/clientpositive/llap/load_static_ptn_into_bucketed_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_static_ptn_into_bucketed_table.q.out
@@ -7,11 +7,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@src_bucket_tbl
 PREHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds='2008-04-08')
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@ds=2008-04-08
 POSTHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds='2008-04-08')
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@ds=2008-04-08
 STAGE DEPENDENCIES:
@@ -82,11 +82,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds='2008-04-08')
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@ds=2008-04-08
 POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds='2008-04-08')
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@ds=2008-04-08
 POSTHOOK: Lineage: src_bucket_tbl PARTITION(ds=2008-04-08).key SIMPLE [(src_bucket_tbl__temp_table_for_load_data__)src_bucket_tbl__temp_table_for_load_data__.FieldSchema(name:key, type:int, comment:null), ]
@@ -238,11 +238,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@src_bucket_tbl
 PREHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds, hr=10)
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=10
 POSTHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds, hr=10)
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -313,11 +313,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds, hr=10)
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=10
 POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(ds, hr=10)
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@hr=10/ds=__HIVE_DEFAULT_PARTITION__
 POSTHOOK: Lineage: src_bucket_tbl PARTITION(hr=10,ds=__HIVE_DEFAULT_PARTITION__).key SIMPLE [(src_bucket_tbl__temp_table_for_load_data__)src_bucket_tbl__temp_table_for_load_data__.FieldSchema(name:key, type:int, comment:null), ]
@@ -469,11 +469,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@src_bucket_tbl
 PREHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE src_bucket_tbl partition(hr=20, ds)
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=20
 POSTHOOK: query: explain load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE src_bucket_tbl partition(hr=20, ds)
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 STAGE DEPENDENCIES:
   Stage-1 is a root stage
@@ -544,11 +544,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE src_bucket_tbl partition(hr=20, ds)
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=20
 POSTHOOK: query: load data local inpath '../../data/files/load_data_job/load_data_1_partition.txt' INTO TABLE src_bucket_tbl partition(hr=20, ds)
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@hr=20/ds=2008-04-08
 POSTHOOK: Lineage: src_bucket_tbl PARTITION(hr=20,ds=2008-04-08).key SIMPLE [(src_bucket_tbl__temp_table_for_load_data__)src_bucket_tbl__temp_table_for_load_data__.FieldSchema(name:key, type:int, comment:null), ]
@@ -700,11 +700,11 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@src_bucket_tbl
 PREHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(hr=30, ds='2010-05-07')
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=30/ds=2010-05-07
 POSTHOOK: query: explain load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(hr=30, ds='2010-05-07')
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@hr=30/ds=2010-05-07
 STAGE DEPENDENCIES:
@@ -776,11 +776,11 @@ STAGE PLANS:
       Basic Stats Work:
 
 PREHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(hr=30, ds='2010-05-07')
-PREHOOK: type: QUERY
+PREHOOK: type: LOAD
 PREHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 PREHOOK: Output: default@src_bucket_tbl@hr=30/ds=2010-05-07
 POSTHOOK: query: load data local inpath '../../data/files/bmj/000000_0' INTO TABLE src_bucket_tbl partition(hr=30, ds='2010-05-07')
-POSTHOOK: type: QUERY
+POSTHOOK: type: LOAD
 POSTHOOK: Input: default@src_bucket_tbl__temp_table_for_load_data__
 POSTHOOK: Output: default@src_bucket_tbl@hr=30/ds=2010-05-07
 POSTHOOK: Lineage: src_bucket_tbl PARTITION(hr=30,ds=2010-05-07).key SIMPLE [(src_bucket_tbl__temp_table_for_load_data__)src_bucket_tbl__temp_table_for_load_data__.FieldSchema(name:key, type:int, comment:null), ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Query Type information for certain load queries are currently tagged as 'QUERY' operation type. As part of this change, load queries will be tagged as 'LOAD' query type.

### Why are the changes needed?
Query Type information for load queries are not corrected tagged. This information needs to rightly set since it also gets logged to hive proto files, which in turn might get used to generate reports on the kind of queries that are being run.


### Does this PR introduce _any_ user-facing change?
Yes, log files will contain the query type field for load queries

### Is the change a dependency upgrade?
No

### How was this patch tested?
Most of the existing tests results that contain any load queries were modified righty and verified.

