### PR TITLE
HIVE-28021: Iceberg: Attempting to create a table with a percent symbol fails

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
@@ -126,7 +126,7 @@ public class MetastoreLock implements HiveLock {
             Executors.newSingleThreadScheduledExecutor(
                     new ThreadFactoryBuilder()
                             .setDaemon(true)
-                            .setNameFormat("iceberg-hive-lock-heartbeat-" + fullName + "-%d")
+                            .setNameFormat("iceberg-hive-lock-heartbeat-" + fullName.replace("%", "%%") + "-%d")
                             .build());
 
     initTableLevelLockCache(tableLevelLockCacheEvictionTimeout);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2075,7 +2075,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue("This test is only for hive catalog", testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    Assume.assumeTrue("This test is only for hive catalog",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2060,7 +2060,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
-    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
+    Assume.assumeTrue("This test is only for hive catalog", testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
@@ -2077,9 +2077,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue(
-        "This test is only for hive catalog",
-        testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2060,6 +2060,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithPercentInName() throws IOException {
+    Assume.assumeTrue("This test requires Hive Version 4.", HiveVersion.min(HiveVersion.HIVE_4));
+
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
     shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2062,25 +2062,16 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableWithPercentInName() throws IOException {
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
-    shell.executeStatement(
-        "CREATE EXTERNAL TABLE `[|]#&%_@` "
-            + "STORED BY ICEBERG "
-            + testTables.locationForCreateTableSQL(identifier)
-            + "TBLPROPERTIES ('"
-            + InputFormatConfig.TABLE_SCHEMA
-            + "'='"
-            + SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-            + "', '"
-            + InputFormatConfig.PARTITION_SPEC
-            + "'='"
-            + PartitionSpecParser.toJson(PartitionSpec.unpartitioned())
-            + "', 'dummy'='test', '"
-            + InputFormatConfig.EXTERNAL_TABLE_PURGE
-            + "'='TRUE', '"
-            + InputFormatConfig.CATALOG_NAME
-            + "'='"
-            + testTables.catalogName()
-            + "')");
+    shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +
+        "STORED BY ICEBERG " +
+        testTables.locationForCreateTableSQL(identifier) +
+        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
+        SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
+        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
+        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
+        "'dummy'='test', " +
+        "'" + InputFormatConfig.EXTERNAL_TABLE_PURGE + "'='TRUE', " +
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2059,7 +2059,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testCreateTableWithPercentInName() throws TException, IOException, InterruptedException {
+  public void testCreateTableWithPercentInName() throws IOException {
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
     shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +
@@ -2075,6 +2075,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+    Assume.assumeTrue("This test is only for hive catalog", testTableType == TestTables.TestTableType.HIVE_CATALOG);
     Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -2062,22 +2062,33 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableWithPercentInName() throws IOException {
     TableIdentifier identifier = TableIdentifier.of("default", "[|]#&%_@");
 
-    shell.executeStatement("CREATE EXTERNAL TABLE `[|]#&%_@` " +
-        "STORED BY ICEBERG " +
-        testTables.locationForCreateTableSQL(identifier) +
-        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
-        SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
-        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
-        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
-        "'dummy'='test', " +
-        "'" + InputFormatConfig.EXTERNAL_TABLE_PURGE + "'='TRUE', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
+    shell.executeStatement(
+        "CREATE EXTERNAL TABLE `[|]#&%_@` "
+            + "STORED BY ICEBERG "
+            + testTables.locationForCreateTableSQL(identifier)
+            + "TBLPROPERTIES ('"
+            + InputFormatConfig.TABLE_SCHEMA
+            + "'='"
+            + SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+            + "', '"
+            + InputFormatConfig.PARTITION_SPEC
+            + "'='"
+            + PartitionSpecParser.toJson(PartitionSpec.unpartitioned())
+            + "', 'dummy'='test', '"
+            + InputFormatConfig.EXTERNAL_TABLE_PURGE
+            + "'='TRUE', '"
+            + InputFormatConfig.CATALOG_NAME
+            + "'='"
+            + testTables.catalogName()
+            + "')");
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
-    Assume.assumeTrue("This test is only for hive catalog",
+    Assume.assumeTrue(
+        "This test is only for hive catalog",
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
-    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
+    Assert.assertEquals(
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.asStruct(),
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
   }


### PR DESCRIPTION
In order to allow the percent symbol to be used as a schema or table name, the percent symbol needs to be escaped.

### What changes were proposed in this pull request?
In alpha 2 and earlier, including a percent symbol wouldn't cause exceptions.  This change is to make beta 1 and beyond compatible.

### Why are the changes needed?
Currently, in the beta 1 code, if the percent symbol is used as a schema or table name, you will get an UnknownFormatConversionException: Conversion = '_'

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Tested it manually by creating a table with a percent, specifically "[|]#&%@"."[|]#&%@"
