### PR TITLE
HIVE-28023: CVE fixes for Apache hive JDBC driver

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -59,6 +59,12 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-shims</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In order to resolve the CVE fixes for Apache hive JDBC driver, we are trying to remove the snakeyaml dependency in jdbc module in Hive.


### Why are the changes needed?
We need to remove snakeyaml from Hive JDBC to remove dependency on this library for CVEs, as it is not used by the JDBC driver.
We need to remove these items from our jar to overcome this CVE issue due to its usage and distribution in the customer environment. 


### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No


### How was this patch tested?
Manual tests.
After removing the snakeyaml dependency, we build a jdbc driver jar. 
After manually tested some DDL and SQL commands, the jdbc driver is working as expected.

