### PR TITLE
HIVE-28024: Support sources profile for hive metastore modules

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -658,5 +658,24 @@
         </plugins>
       </reporting>
     </profile>
+    <profile>
+      <id>sources</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Maven profile **sources** in Hive supports to generate source jar for all submodules. Since Hive Metastore modules are separated from hive parent module, it would be convenient to add this profile in standalone-metastore module.

### Why are the changes needed?
To support generate sources in hive metastore submodules by profile `-Psources`


### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Test locally to check if the HMS source jar was generated by
```bash
mvn clean install -DskipTests -Psources
```
