### PR TITLE
HIVE-28038: Disable fallback to jdo for DeadlineException

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configurable;
@@ -52,9 +51,10 @@ import com.google.common.base.Preconditions;
  * */
 public class DatabaseProduct implements Configurable {
   static final private Logger LOG = LoggerFactory.getLogger(DatabaseProduct.class.getName());
-  private static final Class<SQLException>[] unrecoverableSqlExceptions = new Class[]{
-          // TODO: collect more unrecoverable SQLExceptions
-          SQLIntegrityConstraintViolationException.class
+  private static final Class<Exception>[] unrecoverableExceptions = new Class[]{
+          // TODO: collect more unrecoverable Exceptions
+          SQLIntegrityConstraintViolationException.class,
+          DeadlineException.class
   };
 
   public enum DbType {DERBY, MYSQL, POSTGRES, ORACLE, SQLSERVER, CUSTOM, UNDEFINED};
@@ -164,7 +164,7 @@ public class DatabaseProduct implements Configurable {
   }
 
   public static boolean isRecoverableException(Throwable t) {
-    return Stream.of(unrecoverableSqlExceptions)
+    return Stream.of(unrecoverableExceptions)
                  .allMatch(ex -> ExceptionUtils.indexOfType(t, ex) < 0);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mark `DeadlineException` as unrecoverable exception to avoid falling back to jdo query.

### Why are the changes needed?
`DeadlineException` should be terminated immediately, instead of falling back to jdo query.
https://github.com/apache/hive/blob/b75a59779dcf9c5ef74890c8916dbe9a2c13aef4/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java#L137-L142

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
Passing test:
```bash
mvn test -Dtest=org.apache.hadoop.hive.metastore.TestObjectStore -pl :hive-standalone-metastore-server
```
