### PR TITLE
HIVE-28040 : Upgrade netty to 4.1.100 due to CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <mockito-core.version>3.4.4</mockito-core.version>
     <mockito-inline.version>4.11.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.100.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades Netty version to 4.1.100.Final. 

### Why are the changes needed?
The changes are required because Netty versions below 4.1.100 are impacted due to [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487). [Hadoop](https://github.com/apache/hadoop/blob/trunk/hadoop-project/pom.xml#L146) and [Tez](https://github.com/apache/tez/blob/master/pom.xml#L91) are also currently at netty version 4.1.100.Final.

### Does this PR introduce any user-facing change?
No

### Is the change a dependency upgrade?
Yes

### How was this patch tested?
The automated tests are successful. 

OSS JIRA : [HIVE-28040](https://issues.apache.org/jira/browse/HIVE-28040)