### PR TITLE
HIVE-27938: Iceberg: Fix java.lang.ClassCastException during vectoriz…

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/HiveIdentityPartitionConverters.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/HiveIdentityPartitionConverters.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.mapreduce;
+
+import java.math.BigDecimal;
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.hive.common.type.Date;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+
+public class HiveIdentityPartitionConverters {
+
+  private HiveIdentityPartitionConverters() {
+  }
+
+  public static Object convertConstant(Type type, Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case STRING:
+        return value.toString();
+      case TIME:
+        return DateTimeUtil.timeFromMicros((Long) value);
+      case DATE:
+        return Date.ofEpochDay((Integer) value);
+      case TIMESTAMP:
+        if (((Types.TimestampType) type).shouldAdjustToUTC()) {
+          return DateTimeUtil.timestamptzFromMicros((Long) value).toOffsetTime();
+        } else {
+          return new Timestamp(DateTimeUtil.timestampFromMicros((Long) value));
+        }
+      case DECIMAL:
+        if (value.getClass().isAssignableFrom(BigDecimal.class)) {
+          return HiveDecimal.create((BigDecimal) value);
+        }
+        return value;
+      case FIXED:
+        if (value instanceof GenericData.Fixed) {
+          return ((GenericData.Fixed) value).bytes();
+        }
+        return value;
+      default:
+    }
+    return value;
+  }
+
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -391,7 +391,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           "Vectorized read is unsupported for Hive 2 integration.");
 
       Path path = new Path(task.file().path().toString());
-      Map<Integer, ?> idToConstant = constantsMap(task, IdentityPartitionConverters::convertConstant);
+      Map<Integer, ?> idToConstant = constantsMap(task, HiveIdentityPartitionConverters::convertConstant);
       Expression residual = HiveIcebergInputFormat.residualForTask(task, context.getConfiguration());
 
       // TODO: We have to take care of the EncryptionManager when LLAP and vectorization is used
@@ -544,7 +544,8 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
         Types.StructType partitionType = Partitioning.partitionType(table);
         return PartitionUtil.constantsMap(task, partitionType, converter);
       } else if (projectsIdentityPartitionColumns) {
-        return PartitionUtil.constantsMap(task, converter);
+        Types.StructType partitionType = Partitioning.partitionType(table);
+        return PartitionUtil.constantsMap(task, partitionType, converter);
       } else {
         return Collections.emptyMap();
       }

--- a/iceberg/iceberg-handler/src/test/queries/positive/iceberg_partition_vectorized_read.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/iceberg_partition_vectorized_read.q
@@ -1,0 +1,24 @@
+set hive.vectorized.execution.enabled=true;
+
+CREATE EXTERNAL TABLE ice_date   (`col1` int, `day` date, `calday` date) PARTITIONED BY SPEC (calday)   stored by
+iceberg tblproperties('format-version'='2');
+insert into ice_date values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20');
+select * from ice_date;
+select count(calday) from ice_date;
+select distinct(calday) from ice_date;
+
+
+CREATE EXTERNAL TABLE ice_timestamp   (`col1` int, `day` date, `times` timestamp) PARTITIONED BY SPEC (times)   stored
+by iceberg tblproperties('format-version'='2');
+insert into ice_timestamp values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20');
+select * from ice_timestamp;
+select count(times) from ice_timestamp;
+select distinct(times) from ice_timestamp;
+
+
+CREATE EXTERNAL TABLE ice_decimal  (`col1` int, `decimalA` decimal(5,2), `decimalC` decimal(5,2)) PARTITIONED BY SPEC
+(decimalC) stored by iceberg tblproperties('format-version'='2');
+insert into ice_decimal values(1, 122.91, 102.21), (1, 12.32, 200.12);
+select * from ice_decimal;
+select distinct(decimalc) from ice_decimal;
+select count(decimala) from ice_decimal where decimala=122.91;

--- a/iceberg/iceberg-handler/src/test/results/positive/iceberg_partition_vectorized_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/iceberg_partition_vectorized_read.q.out
@@ -1,0 +1,139 @@
+PREHOOK: query: CREATE EXTERNAL TABLE ice_date   (`col1` int, `day` date, `calday` date) PARTITIONED BY SPEC (calday)   stored by
+iceberg tblproperties('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_date
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_date   (`col1` int, `day` date, `calday` date) PARTITIONED BY SPEC (calday)   stored by
+iceberg tblproperties('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_date
+PREHOOK: query: insert into ice_date values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_date
+POSTHOOK: query: insert into ice_date values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_date
+PREHOOK: query: select * from ice_date
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_date
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_date
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_date
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	2020-11-20	2020-11-20
+1	2020-11-20	2020-11-20
+PREHOOK: query: select count(calday) from ice_date
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_date
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(calday) from ice_date
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_date
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2
+PREHOOK: query: select distinct(calday) from ice_date
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_date
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select distinct(calday) from ice_date
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_date
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2020-11-20
+PREHOOK: query: CREATE EXTERNAL TABLE ice_timestamp   (`col1` int, `day` date, `times` timestamp) PARTITIONED BY SPEC (times)   stored
+by iceberg tblproperties('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_timestamp
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_timestamp   (`col1` int, `day` date, `times` timestamp) PARTITIONED BY SPEC (times)   stored
+by iceberg tblproperties('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_timestamp
+PREHOOK: query: insert into ice_timestamp values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_timestamp
+POSTHOOK: query: insert into ice_timestamp values(1, '2020-11-20', '2020-11-20'), (1, '2020-11-20', '2020-11-20')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_timestamp
+PREHOOK: query: select * from ice_timestamp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_timestamp
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_timestamp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_timestamp
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	2020-11-20	2020-11-20 00:00:00
+1	2020-11-20	2020-11-20 00:00:00
+PREHOOK: query: select count(times) from ice_timestamp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_timestamp
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(times) from ice_timestamp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_timestamp
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2
+PREHOOK: query: select distinct(times) from ice_timestamp
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_timestamp
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select distinct(times) from ice_timestamp
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_timestamp
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+2020-11-20 00:00:00
+PREHOOK: query: CREATE EXTERNAL TABLE ice_decimal  (`col1` int, `decimalA` decimal(5,2), `decimalC` decimal(5,2)) PARTITIONED BY SPEC
+(decimalC) stored by iceberg tblproperties('format-version'='2')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_decimal
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_decimal  (`col1` int, `decimalA` decimal(5,2), `decimalC` decimal(5,2)) PARTITIONED BY SPEC
+(decimalC) stored by iceberg tblproperties('format-version'='2')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_decimal
+PREHOOK: query: insert into ice_decimal values(1, 122.91, 102.21), (1, 12.32, 200.12)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ice_decimal
+POSTHOOK: query: insert into ice_decimal values(1, 122.91, 102.21), (1, 12.32, 200.12)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ice_decimal
+PREHOOK: query: select * from ice_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_decimal
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from ice_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_decimal
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	122.91	102.21
+1	12.32	200.12
+PREHOOK: query: select distinct(decimalc) from ice_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_decimal
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select distinct(decimalc) from ice_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_decimal
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+102.21
+200.12
+PREHOOK: query: select count(decimala) from ice_decimal where decimala=122.91
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ice_decimal
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(decimala) from ice_decimal where decimala=122.91
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ice_decimal
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1


### PR DESCRIPTION
…ed reads on partition columns

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add [HiveIdentityPartitionConverters.java](https://github.com/apache/hive/compare/master...simhadri-g:hive:HIVE-27938?expand=1#diff-ef270a84e5f54cdb0225c7cca328a2fc1dfb126fb593287c5b47d809d85633c7) for converting partitions datatypes . 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In this pull request https://github.com/apache/iceberg/pull/1130  -   Identity Partitioning: Introduced a iceberg specific constants map  to convert data from java internal representations (e.g., long for timestamps) to Iceberg generics (LocalDateTime or OffsetDateTime for timestamps) . 

A similar constants map is required for Hive as quoted in the following discussion. 

> When we add support for Pig or Hive objects, we would need to convert differently for those.
> https://github.com/apache/iceberg/pull/1130#discussion_r443701477 

Without this change, vectorised read queries on partition columns fail with java.lang.ClassCastException for DATE, TIMESTAMP and DECIMAL datatypes as described in the jira https://issues.apache.org/jira/browse/HIVE-27938 .

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Qfile : 
[iceberg_partition_vectorized_read.q](https://github.com/apache/hive/compare/master...simhadri-g:hive:HIVE-27938?expand=1#diff-62f4a4032db78a040d7120035d69ef5d2420236c15b65dac89b6d6315185f1fd) 


