### PR TITLE
HIVE-28046: Using serdeConstants fields instead of string literals for 'columns' and 'columns.types'

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/IOConstants.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/IOConstants.java
@@ -39,7 +39,7 @@ public final class IOConstants {
 
   /**
    * The desired TABLE column names and types for input format schema evolution.
-   * This is different than COLUMNS and COLUMNS_TYPES, which are based on individual partition
+   * This is different from COLUMNS and COLUMNS_TYPES, which are based on individual partition
    * metadata.
    *
    * Virtual columns and partition columns are not included

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/RCFileOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/RCFileOutputFormat.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
@@ -124,7 +125,7 @@ public class RCFileOutputFormat extends
       boolean isCompressed, Properties tableProperties, Progressable progress) throws IOException {
 
     String[] cols = null;
-    String columns = tableProperties.getProperty("columns");
+    String columns = tableProperties.getProperty(serdeConstants.LIST_COLUMNS);
     if (columns == null || columns.trim().equals("")) {
       cols = new String[0];
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -1955,8 +1955,8 @@ public abstract class BaseSemanticAnalyzer {
     prop.setProperty(serdeConstants.SERIALIZATION_FORMAT, Integer.toString(Utilities.tabCode));
     prop.setProperty(serdeConstants.SERIALIZATION_NULL_FORMAT, " ");
     String[] colTypes = schema.split("#");
-    prop.setProperty("columns", colTypes[0]);
-    prop.setProperty("columns.types", colTypes[1]);
+    prop.setProperty(serdeConstants.LIST_COLUMNS, colTypes[0]);
+    prop.setProperty(serdeConstants.LIST_COLUMN_TYPES, colTypes[1]);
     prop.setProperty(serdeConstants.SERIALIZATION_LIB, LazySimpleSerDe.class.getName());
     prop.setProperty(hive_metastoreConstants.TABLE_BUCKETING_VERSION, "-1");
     FetchWork fetch =

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -543,9 +543,9 @@ public final class PlanUtils {
               serdeConstants.SERIALIZATION_LIB, BinarySortableSerDe.class.getName()));
     } else {
       return new TableDesc(SequenceFileInputFormat.class,
-          SequenceFileOutputFormat.class, Utilities.makeProperties("columns",
+          SequenceFileOutputFormat.class, Utilities.makeProperties(serdeConstants.LIST_COLUMNS,
               MetaStoreUtils.getColumnNamesFromFieldSchema(fieldSchemas),
-              "columns.types", MetaStoreUtils
+              serdeConstants.LIST_COLUMN_TYPES, MetaStoreUtils
               .getColumnTypesFromFieldSchema(fieldSchemas),
               serdeConstants.ESCAPE_CHAR, "\\",
               serdeConstants.SERIALIZATION_LIB,LazyBinarySerDe.class.getName()));

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorSerDeRow.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorSerDeRow.java
@@ -364,8 +364,8 @@ public class TestVectorSerDeRow {
     // Set the configuration parameters
     tbl.setProperty(serdeConstants.SERIALIZATION_FORMAT, "9");
 
-    tbl.setProperty("columns", fieldNames);
-    tbl.setProperty("columns.types", fieldTypes);
+    tbl.setProperty(serdeConstants.LIST_COLUMNS, fieldNames);
+    tbl.setProperty(serdeConstants.LIST_COLUMN_TYPES, fieldTypes);
 
     tbl.setProperty(serdeConstants.SERIALIZATION_NULL_FORMAT, "\\N");
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestRCFile.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestRCFile.java
@@ -511,9 +511,9 @@ public class TestRCFile {
 
     // Set the configuration parameters
     tbl.setProperty(serdeConstants.SERIALIZATION_FORMAT, "9");
-    tbl.setProperty("columns",
+    tbl.setProperty(serdeConstants.LIST_COLUMNS,
         "abyte,ashort,aint,along,adouble,astring,anullint,anullstring");
-    tbl.setProperty("columns.types",
+    tbl.setProperty(serdeConstants.LIST_COLUMN_TYPES,
         "tinyint:smallint:int:bigint:double:string:int:string");
     tbl.setProperty(serdeConstants.SERIALIZATION_NULL_FORMAT, "NULL");
     return tbl;

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -1840,8 +1840,8 @@ public class TestInputOutputFormat {
   @Test
   public void testInOutFormat() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("columns", "x,y");
-    properties.setProperty("columns.types", "int:int");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "x,y");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:int");
     StructObjectInspector inspector;
     synchronized (TestOrcFile.class) {
       inspector = (StructObjectInspector)
@@ -1995,8 +1995,8 @@ public class TestInputOutputFormat {
         serde.serialize(new NestedRow(7,8,9), inspector));
     writer.close(Reporter.NULL);
     serde = new OrcSerde();
-    properties.setProperty("columns", "z,r");
-    properties.setProperty("columns.types", "int:struct<x:int,y:int>");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "z,r");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:struct<x:int,y:int>");
     serde.initialize(conf, properties, null);
     inspector = (StructObjectInspector) serde.getObjectInspector();
     InputFormat<?,?> in = new OrcInputFormat();
@@ -2004,8 +2004,8 @@ public class TestInputOutputFormat {
     InputSplit[] splits = in.getSplits(conf, 1);
     assertEquals(1, splits.length);
     ColumnProjectionUtils.appendReadColumns(conf, Collections.singletonList(1));
-    conf.set("columns", "z,r");
-    conf.set("columns.types", "int:struct<x:int,y:int>");
+    conf.set(serdeConstants.LIST_COLUMNS, "z,r");
+    conf.set(serdeConstants.LIST_COLUMN_TYPES, "int:struct<x:int,y:int>");
     org.apache.hadoop.mapred.RecordReader reader =
         in.getRecordReader(splits[0], conf, Reporter.NULL);
     Object key = reader.createKey();
@@ -2034,8 +2034,8 @@ public class TestInputOutputFormat {
   @Test
   public void testEmptyFile() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("columns", "x,y");
-    properties.setProperty("columns.types", "int:int");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "x,y");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:int");
     HiveOutputFormat<?, ?> outFormat = new OrcOutputFormat();
     org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter writer =
         outFormat.getHiveRecordWriter(conf, testFilePath, MyRow.class, true,
@@ -2099,8 +2099,8 @@ public class TestInputOutputFormat {
   @Test
   public void testDefaultTypes() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("columns", "str,str2");
-    properties.setProperty("columns.types", "string:string");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "str,str2");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "string:string");
     StructObjectInspector inspector;
     synchronized (TestOrcFile.class) {
       inspector = (StructObjectInspector)
@@ -2129,8 +2129,8 @@ public class TestInputOutputFormat {
     assertEquals(1, splits.length);
 
     // read the whole file
-    conf.set("columns", StringRow.getColumnNamesProperty());
-    conf.set("columns.types", StringRow.getColumnTypesProperty());
+    conf.set(serdeConstants.LIST_COLUMNS, StringRow.getColumnNamesProperty());
+    conf.set(serdeConstants.LIST_COLUMN_TYPES, StringRow.getColumnTypesProperty());
     org.apache.hadoop.mapred.RecordReader reader =
         in.getRecordReader(splits[0], conf, Reporter.NULL);
     Object key = reader.createKey();
@@ -2230,8 +2230,8 @@ public class TestInputOutputFormat {
     Properties tblProps = new Properties();
     tblProps.put("name", tableName);
     tblProps.put("serialization.lib", OrcSerde.class.getName());
-    tblProps.put("columns", columnNames.toString());
-    tblProps.put("columns.types", columnTypes.toString());
+    tblProps.put(serdeConstants.LIST_COLUMNS, columnNames.toString());
+    tblProps.put(serdeConstants.LIST_COLUMN_TYPES, columnTypes.toString());
     TableDesc tbl = new TableDesc(OrcInputFormat.class, OrcOutputFormat.class,
         tblProps);
 
@@ -2672,8 +2672,8 @@ public class TestInputOutputFormat {
   @Test
   public void testSplitElimination() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("columns", "z,r");
-    properties.setProperty("columns.types", "int:struct<x:int,y:int>");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "z,r");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:struct<x:int,y:int>");
     StructObjectInspector inspector;
     synchronized (TestOrcFile.class) {
       inspector = (StructObjectInspector)
@@ -2736,8 +2736,8 @@ public class TestInputOutputFormat {
             .build();
     conf.set("sarg.pushdown", sargToKryo(sarg));
     conf.set("hive.io.file.readcolumn.names", "z");
-    properties.setProperty("columns", "z");
-    properties.setProperty("columns.types", "string");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "z");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "string");
     serde.initialize(conf, properties, null);
     inspector = (StructObjectInspector) serde.getObjectInspector();
     InputFormat<?,?> in = new OrcInputFormat();
@@ -3774,8 +3774,8 @@ public class TestInputOutputFormat {
   @Test
   public void testRowNumberUniquenessInDifferentSplits() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("columns", "x,y");
-    properties.setProperty("columns.types", "int:int");
+    properties.setProperty(serdeConstants.LIST_COLUMNS, "x,y");
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:int");
     StructObjectInspector inspector;
     synchronized (TestOrcFile.class) {
       inspector = (StructObjectInspector)

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSplitElimination.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcSplitElimination.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrLessThan;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -105,8 +106,8 @@ public class TestOrcSplitElimination {
   public void openFileSystem() throws Exception {
     conf = new JobConf();
     // all columns
-    conf.set("columns", "userid,string1,subtype,decimal1,ts");
-    conf.set("columns.types", "bigint,string,double,decimal,timestamp");
+    conf.set(serdeConstants.LIST_COLUMNS, "userid,string1,subtype,decimal1,ts");
+    conf.set(serdeConstants.LIST_COLUMN_TYPES, "bigint,string,double,decimal,timestamp");
     // needed columns
     conf.set(ColumnProjectionUtils.READ_ALL_COLUMNS, "false");
     conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "0,2");

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -691,8 +692,8 @@ public class TestVectorizedOrcAcidRowBatchReader {
 
     // Create 3 original files with 3 rows each
     Properties properties = new Properties();
-    properties.setProperty("columns", DummyOriginalRow.getColumnNamesProperty());
-    properties.setProperty("columns.types", DummyOriginalRow.getColumnTypesProperty());
+    properties.setProperty(serdeConstants.LIST_COLUMNS, DummyOriginalRow.getColumnNamesProperty());
+    properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, DummyOriginalRow.getColumnTypesProperty());
 
     OrcFile.WriterOptions writerOptions = OrcFile.writerOptions(properties, conf);
     writerOptions.inspector(originalInspector);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestDataWritableWriter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestDataWritableWriter.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ArrayWritableObjectInspector;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
@@ -189,8 +190,8 @@ public class TestDataWritableWriter {
 
   private ParquetHiveRecord getParquetWritable(String columnNames, String columnTypes, ArrayWritable record) throws SerDeException {
     Properties recordProperties = new Properties();
-    recordProperties.setProperty("columns", columnNames);
-    recordProperties.setProperty("columns.types", columnTypes);
+    recordProperties.setProperty(serdeConstants.LIST_COLUMNS, columnNames);
+    recordProperties.setProperty(serdeConstants.LIST_COLUMN_TYPES, columnTypes);
 
     ParquetHiveSerDe serDe = new ParquetHiveSerDe();
     serDe.initialize(conf, recordProperties, null);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestMapredParquetOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestMapredParquetOutputFormat.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.hive.ql.io.parquet.write.ParquetRecordWriterWrapper;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.Progressable;
@@ -48,8 +49,8 @@ public class TestMapredParquetOutputFormat {
   @Test
   public void testGetHiveRecordWriter() throws IOException {
     Properties tableProps = new Properties();
-    tableProps.setProperty("columns", "foo,bar");
-    tableProps.setProperty("columns.types", "int:int");
+    tableProps.setProperty(serdeConstants.LIST_COLUMNS, "foo,bar");
+    tableProps.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:int");
 
     final Progressable mockProgress = mock(Progressable.class);
     final ParquetOutputFormat<ParquetHiveRecord> outputFormat = (ParquetOutputFormat<ParquetHiveRecord>) mock(ParquetOutputFormat.class);
@@ -83,8 +84,8 @@ public class TestMapredParquetOutputFormat {
   public void testInvalidCompressionTableProperties() throws IOException {
     Properties tableProps = new Properties();
     tableProps.setProperty("parquet.compression", "unsupported");
-    tableProps.setProperty("columns", "foo,bar");
-    tableProps.setProperty("columns.types", "int:int");
+    tableProps.setProperty(serdeConstants.LIST_COLUMNS, "foo,bar");
+    tableProps.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int:int");
 
     JobConf jobConf = new JobConf();
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetRowGroupFilter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetRowGroupFilter.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPGreaterThan;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
@@ -75,8 +76,8 @@ public class TestParquetRowGroupFilter extends AbstractTestParquetDirect {
     );
 
     conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "intCol");
-    conf.set("columns", "intCol");
-    conf.set("columns.types", "int");
+    conf.set(serdeConstants.LIST_COLUMNS, "intCol");
+    conf.set(serdeConstants.LIST_COLUMN_TYPES, "int");
 
     // create Parquet file with specific data
     Path testPath = writeDirect("RowGroupFilterTakeEffect", fileSchema,

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetSerDe.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetSerDe.java
@@ -144,8 +144,8 @@ public class TestParquetSerDe {
     final Properties tbl = new Properties();
 
     // Set the configuration parameters
-    tbl.setProperty("columns", "abyte,ashort,aint,along,adouble,astring,abinary,amap,alist");
-    tbl.setProperty("columns.types",
+    tbl.setProperty(serdeConstants.LIST_COLUMNS, "abyte,ashort,aint,along,adouble,astring,abinary,amap,alist");
+    tbl.setProperty(serdeConstants.LIST_COLUMN_TYPES,
       "tinyint:smallint:int:bigint:double:string:binary:map<string,int>:array<string>");
     tbl.setProperty(org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_NULL_FORMAT, "NULL");
     return tbl;


### PR DESCRIPTION
Using serdeConstants fields instead of string literals for 'columns' and 'columns.types'

### Why are the changes needed?
to improve the use of existing constants

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
using existing tests