### PR TITLE
HIVE-28051: LLAP: cleanup local folders on startup and periodically

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5508,6 +5508,17 @@ public class HiveConf extends Configuration {
     LLAP_TASK_TIME_SUMMARY(
         "hive.llap.task.time.print.summary", false,
         "Display queue and runtime of tasks by host for every query executed by the shell."),
+
+    LLAP_LOCAL_DIR_CLEANER_CLEANUP_INTERVAL(
+        "hive.llap.local.dir.cleaner.cleanup.interval", "2h", new TimeValidator(TimeUnit.HOURS),
+      "Interval by which the LocalDirCleaner service in LLAP daemon checks for stale/old files." +
+      "Under normal circumstances, local files are cleaned up properly, so it's not recommended to" +
+      "set this more frequent than a couple of hours. Default is 2 hours."),
+    LLAP_LOCAL_DIR_CLEANER_FILE_MODIFY_TIME_THRESHOLD("hive.llap.local.dir.cleaner.file.modify.time.threshold", "24h",
+        new TimeValidator(TimeUnit.HOURS),
+      "Threshold time for LocalDirCleaner: if a regular file's modify time is older than this value, the file gets deleted." +
+      "Defaults to 86400s (1 day), which is a reasonable period for a local file to be considered as a stale one."),
+
     HIVE_TRIGGER_VALIDATION_INTERVAL("hive.trigger.validation.interval", "500ms",
       new TimeValidator(TimeUnit.MILLISECONDS),
       "Interval for validating triggers during execution of a query. Triggers defined in resource plan will get\n" +

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
@@ -383,6 +383,7 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
     // AMReporter after the server so that it gets the correct address. It knows how to deal with
     // requests before it is started.
     addIfService(amReporter);
+    addIfService(new LocalDirCleaner(localDirs, daemonConf));
   }
 
   private static long determineXmxHeadroom(

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LocalDirCleaner.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LocalDirCleaner.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.llap.daemon.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.service.AbstractService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * LocalDirCleaner is an LLAP daemon service to clean up old local files. Under normal circumstances,
+ * intermediate/local files are cleaned up (typically at end of the DAG), but daemons crash sometimes,
+ * and the attached local disk might end up being the same when a new daemon starts (this applies to
+ * on-prem as well as cloud scenarios).
+ */
+public class LocalDirCleaner extends AbstractService {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalDirCleaner.class);
+
+  private List<String> localDirs;
+
+  private long cleanupIntervalSec;
+  private long fileModifyTimeThresholdSec;
+
+  ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+  public LocalDirCleaner(String[] localDirs, Configuration conf) {
+    super("LocalDirCleaner");
+    this.localDirs = Arrays.asList(localDirs);
+    this.cleanupIntervalSec = getInterval(conf);
+    this.fileModifyTimeThresholdSec = getFileModifyTimeThreshold(conf);
+    LOG.info("Initialized local dir cleaner: interval: {}s, threshold: {}s", cleanupIntervalSec,
+        fileModifyTimeThresholdSec);
+  }
+
+  @Override
+  public void serviceStart() throws IOException {
+    scheduler.scheduleAtFixedRate(this::cleanup, 0, cleanupIntervalSec, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void serviceStop() throws IOException {
+    // we can shutdown this service now and ignore leftovers, because under normal circumstances,
+    // files from the local dirs are cleaned up (so LocalDirCleaner is a best effort utility)
+    scheduler.shutdownNow();
+  }
+
+  private long getFileModifyTimeThreshold(Configuration conf) {
+    return HiveConf.getTimeVar(conf, HiveConf.ConfVars.LLAP_LOCAL_DIR_CLEANER_FILE_MODIFY_TIME_THRESHOLD,
+        TimeUnit.SECONDS);
+  }
+
+  private long getInterval(Configuration conf) {
+    return HiveConf.getTimeVar(conf, HiveConf.ConfVars.LLAP_LOCAL_DIR_CLEANER_CLEANUP_INTERVAL, TimeUnit.SECONDS);
+  }
+
+  private void cleanup() {
+    Instant deleteBefore = Instant.now().minus(fileModifyTimeThresholdSec, ChronoUnit.SECONDS);
+
+    localDirs.forEach(localDir -> cleanupPath(deleteBefore, Paths.get(localDir)));
+  }
+
+  private void cleanupPath(Instant deleteBefore, Path pathLocalDir) {
+    LOG.info("Cleaning up files older than {} from {}", deleteBefore, pathLocalDir);
+
+    try (Stream<Path> files = Files.walk(pathLocalDir)) {
+      files.filter(f -> {
+        try {
+          FileTime modified = Files.getLastModifiedTime(f);
+          LOG.debug("Checking: {}, modified: {}", f, modified);
+          return Files.isRegularFile(f) && modified.toInstant().isBefore(deleteBefore);
+        } catch (IOException ex) {
+          LOG.warn("IOException caught while checking file for deletion", ex);
+          return false;
+        }
+      }).forEach(f -> {
+        try {
+          LOG.info("Delete old local file: {}", f);
+          Files.delete(f);
+        } catch (IOException ex) {
+          LOG.warn("Failed to delete file", ex);
+        }
+      });
+    } catch (IOException e) {
+      LOG.warn("IOException caught while walking over local files", e);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement a LocalDirCleaner which can remove old files from LLAP local dirs.


### Why are the changes needed?
Because LLAP cannot take care of cleaning up old files in every failure scenario, this was shown in a customer problem. When I investigated [HIVE-24272](https://issues.apache.org/jira/browse/HIVE-24272) I found that local files for failed queries/DAGs are cleaned up, so this is clearly about leftovers after daemon crashes.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
Unit test added, tested on llap daemon, added a file as:
```
mkdir -p  /apps/llap/work/usercache/hive/appcache/application_1707917402901_0001/3/output
touch  /apps/llap/work/usercache/hive/appcache/application_1707917402901_0001/3/output/file.out
```

set quick intervals like:
```
hive.llap.local.dir.cleaner.file.modify.time.threshold=60s
hive.llap.local.dir.cleaner.cleanup.interval=30s
```

checked logs:
```
query-executor <14>1 2024-02-15T07:37:59.351Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Cleaning up files older than 2024-02-15T07:36:59.351485Z from /apps/llap/work
query-executor <14>1 2024-02-15T07:38:29.351Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Cleaning up files older than 2024-02-15T07:37:29.351488Z from /apps/llap/work
query-executor <14>1 2024-02-15T07:38:59.351Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Cleaning up files older than 2024-02-15T07:37:59.351487Z from /apps/llap/work
query-executor <14>1 2024-02-15T07:38:59.352Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Delete old file: /apps/llap/work/usercache/hive/appcache/application_1707917402901_0001/3/output/file.out
query-executor <14>1 2024-02-15T07:39:29.351Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Cleaning up files older than 2024-02-15T07:38:29.351486Z from /apps/llap/work
query-executor <14>1 2024-02-15T07:39:59.351Z query-executor-0-0 query-executor 1 79184f83-fdb0-4982-9bd9-4e297438f8be [mdc@18060 class="impl.LocalDirCleaner" level="INFO" thread="pool-14-thread-1"] Cleaning up files older than 2024-02-15T07:38:59.351485Z from /apps/llap/work

```