### PR TITLE
HIVE-26818: Beeline module misses transitive dependencies due to shading

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -243,6 +243,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -494,12 +494,6 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>net.sf.supercsv</groupId>
-      <artifactId>super-csv</artifactId>
-      <version>${super-csv.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -105,10 +105,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
       <artifactId>hive-standalone-metastore-common</artifactId>
       <classifier>tests</classifier>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Do not generate the dependency-reduced-pom.xml and publish the regular pom.xml file along with the main jar file.
2. Remove some redundant explicit dependency declarations that were added to workaround the missing dependency problem from the beeline module.

### Why are the changes needed?
Due to shading, the dependecy-reduced-pom.xml file is installed in the local maven repository (~/.m2/repository/org/apache/hive/hive-beeline/4.0.0-SNAPSHOT/) for beeline. The latter indicates that the module doesn't have any transitive dependencies. If we were publishing the shaded jar that would be true but we publish the regular jar. At this point, modules which include hive-beeline as a maven dependency are broken leading to build problems and classpath errors.

For more details see HIVE-26818.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
1. Build separately main and itest modules
```
mvn clean install -DskipTests
cd itests && mvn clean install -DskipTests
```
2. Check that `TestBeelineDriver` does not throw `NoClassDefFoundError`
```
cd itests/qtest && mvn test -Dtest=TestBeeLineDriver -Dqfile=smb_mapjoin_1.q
```