### PR TITLE
HIVE-28053: Incorrect shading configuration for beeline jar-with-dependencies

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -243,14 +243,11 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
               <finalName>jar-with-dependencies</finalName>
               <transformers>
                 <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                  <mainClass>org.apache.hive.beeline.BeeLine</mainClass>
                 </transformer>
               </transformers>
               <filters>


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
1. Remove descriptorRefs cause it is not valid configuration parameter for maven-shade-plugin and has no effect on the build.
2. Set correct mainClass in the MANIFEST file making the jar runnable without extra options and avoid errors due to missing jmh class.

### Does this PR introduce _any_ user-facing change?
1. Developers will not see errors when browsing the respective pom.xml in the IDE
2. java -jar jar-with-dependencies now works and launches correctly beeline

### Is the change a dependency upgrade?
No

### How was this patch tested?
Build and then run:
```
cd beeline && java -jar target/jar-with-dependencies
```