### PR TITLE
HIVE-28061: Fix PerfLogger for recursive methods

### DIFF
--- a/common/src/test/org/apache/hadoop/hive/ql/log/PerfLoggerTest.java
+++ b/common/src/test/org/apache/hadoop/hive/ql/log/PerfLoggerTest.java
@@ -35,6 +35,26 @@ public class PerfLoggerTest {
     }
   }
 
+  private static void snoozeRecursive(int ms, int depth) {
+    if (depth <= 0) {
+      return;
+    }
+    final PerfLogger pl = PerfLogger.getPerfLogger(null, false);
+    pl.perfLogBegin(PerfLoggerTest.class.getName(), "snoozeRecursive");
+    snooze(ms);
+    snoozeRecursive(ms, depth-1);
+    pl.perfLogEnd(PerfLoggerTest.class.getName(), "snoozeRecursive");
+  }
+
+  @Test
+  public void testRecursive() {
+    final PerfLogger pl = PerfLogger.getPerfLogger(null, false);
+    int depth = 3;
+    snoozeRecursive(100, depth);
+    long duration = pl.getDuration("snoozeRecursive");
+    Assert.assertTrue(duration >= depth * 100);
+  }
+
   @Test
   public void testBasic() {
     final PerfLogger pl = PerfLogger.getPerfLogger(null, true);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added a Map in `PerfLogger` that tracks recursion stack (calls) to `perfLogBegin` and `perfLogEnd` for recursive methods.
This fixes the issue described in HIVE-28061.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If we surround a recursive method with `perfLogBegin` and `perfLogEnd`, since the `method` doesn't change for each stack, `perfLogBegin` will overwrite the value in `startTimes`, and then for all `perfLogEnd`, the start value will be same, giving us wrong results. With this change, we compute the duration of the whole recursion stack, and output it in a single log.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
`mvn test -Dtest=org.apache.hadoop.hive.ql.log.PerfLoggerTest#testRecursive`

Here are the relevant logs from my local machine
`2024-02-05T23:18:37,907 DEBUG [main] log.PerfLogger: <PERFLOG method=snoozeRecursive from=org.apache.hadoop.hive.ql.log.PerfLoggerTest>`
`2024-02-05T23:18:38,219 DEBUG [main] log.PerfLogger: </PERFLOG method=snoozeRecursive start=1707203917907 end=1707203918219 duration=312 from=org.apache.hadoop.hive.ql.log.PerfLoggerTest>`