### PR TITLE
HIVE-28062: Optimize get_partitions_by_names in direct sql

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestMetaStoreLimitPartitionRequest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/TestMetaStoreLimitPartitionRequest.java
@@ -73,6 +73,9 @@ public class TestMetaStoreLimitPartitionRequest {
     conf.setBoolVar(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL, true);
     conf.setBoolVar(HiveConf.ConfVars.DYNAMIC_PARTITIONING, true);
     conf.setBoolVar(HiveConf.ConfVars.HIVE_CBO_ENABLED, false);
+    // Disable loading dynamic partitions from partition names in this test
+    // because get_partitions_by_names will also hit partition limit since HIVE-28062.
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_LOAD_DYNAMIC_PARTITIONS_SCAN_SPECIFIC_PARTITIONS, false);
 
     miniHS2 = new MiniHS2.Builder().withConf(conf).build();
     Map<String, String> overlayProps = new HashMap<String, String>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -3199,24 +3199,19 @@ private void constructOneLBLocationMap(FileStatus fSta,
           partitionNames.add(Warehouse.makeDynamicPartNameNoTrailingSeperator(details.fullSpec));
         }
       }
-      try {
-        List<Partition> partitions = Hive.get().getPartitionsByNames(tbl, partitionNames);
-        for(Partition partition : partitions) {
-          LOG.debug("HMS partition spec: {}", partition.getSpec());
-          partitionDetailsMap.entrySet().parallelStream()
-              .filter(entry -> entry.getValue().fullSpec.equals(partition.getSpec()))
-              .findAny().ifPresent(entry -> {
-            entry.getValue().partition = partition;
-            entry.getValue().hasOldPartition = true;
-          });
-        }
-        // no need to fetch partition again in tasks since we have already fetched partitions
-        // info in getPartitionsByNames()
-        fetchPartitionInfo = false;
-      } catch (HiveException e) {
-        // Failed to fetch partitions in some cases (e.g., partition number limit)
-        LOG.warn("Fetching partitions by names failed.", e);
+      List<Partition> partitions = Hive.get().getPartitionsByNames(tbl, partitionNames);
+      for(Partition partition : partitions) {
+        LOG.debug("HMS partition spec: {}", partition.getSpec());
+        partitionDetailsMap.entrySet().parallelStream()
+            .filter(entry -> entry.getValue().fullSpec.equals(partition.getSpec()))
+            .findAny().ifPresent(entry -> {
+          entry.getValue().partition = partition;
+          entry.getValue().hasOldPartition = true;
+        });
       }
+      // no need to fetch partition again in tasks since we have already fetched partitions
+      // info in getPartitionsByNames()
+      fetchPartitionInfo = false;
     }
 
     boolean isTxnTable = AcidUtils.isTransactionalTable(tbl);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1049,6 +1049,7 @@ public class MetastoreConf {
         "This limits the number of partitions (whole partition objects) that can be requested " +
         "from the metastore for a give table. MetaStore API methods using this are: \n" +
                 "get_partitions, \n" +
+                "get_partitions_by_names, \n" +
                 "get_partitions_with_auth, \n" +
                 "get_partitions_by_filter, \n" +
                 "get_partitions_spec_by_filter, \n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -7466,7 +7466,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     return result;
   }
 
-  public List<Partition> get_partitions_by_names(final String dbName, final String tblName,
+  private List<Partition> get_partitions_by_names(final String dbName, final String tblName,
       boolean getColStats, String engine,
       List<String> processorCapabilities, String processorId,
       GetPartitionsArgs args) throws TException {
@@ -7478,14 +7478,14 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     Table table = null;
     Exception ex = null;
     boolean success = false;
-    startTableFunction("get_partitions_by_names", parsedCatName, parsedDbName,
-        tblName);
+    startTableFunction("get_partitions_by_names", parsedCatName, parsedDbName, tblName);
     try {
       getMS().openTransaction();
       authorizeTableForPartitionMetadata(parsedCatName, parsedDbName, tblName);
 
       fireReadTablePreEvent(parsedCatName, parsedDbName, tblName);
 
+      checkLimitNumberOfPartitions(tblName, args.getPartNames().size(), -1);
       ret = getMS().getPartitionsByNames(parsedCatName, parsedDbName, tblName, args);
       ret = FilterUtils.filterPartitionsIfEnabled(isServerFilterEnabled, filterHook, ret);
       table = getTable(parsedCatName, parsedDbName, tblName);


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add partition number check in `get_partitions_by_names`
2. Skipping get partition ids in `MetaStoreDirectSql#getPartitionsViaPartNames` to reduce the Database calls.

### Why are the changes needed?
1. `get_partitions_by_names` also need check partition number in case the request number is too large
2. remove unnecessary db calls can improve the performance.

### Does this PR introduce _any_ user-facing change?
Yes, `get_partitions_by_names` api could also hit partition limit after this PR.

### Is the change a dependency upgrade?
No.


### How was this patch tested?
1. Passing all existing tests.
2. Run the `getPartitionsByNames` benchmark tests:
```bash
java -jar ./hmsbench-jar-with-dependencies.jar -H localhost --savedata /tmp/benchdata --sanitize -N 100 -N 10000 -o bench_results_direct.csv -C -d testbench_http --params=100  -E 'drop.*' -E 'renameTable.*' -E 'getTableObjectsByName.*' -E 'listTables.*' -E 'listPartitions.*' -E 'getPartitionNames.*' -E 'listPartition' -E 'getPartition' -E 'getPartitions' -E 'getPartitions.100' -E 'getPartitions.10000' -E 'getPartitionsByFilter.*' -E 'addPartition.*' -E 'addPartitions.*' -E 'alterPartitions.*' -E 'getNid' -E 'listDatabases' -E 'getTable' -E 'createTable' -E 'openTxn.*'
```
- Before this patch:
```bash
Operation       Mean    Med     Min     Max     Err%
getPartitionsByNames    7.47374 7.31857 6.96766 10.2396 7.39022
getPartitionsByNames.100        14.4165 14.2468 13.6072 17.9526 4.67421
getPartitionsByNames.10000      524.812 524.127 504.923 555.049 2.02143
```
- After this patch:
```bash
Operation       Mean    Med     Min     Max     Err%
getPartitionsByNames    7.11728 7.02464 6.78734 8.59082 4.32347
getPartitionsByNames.100        13.4596 13.3253 12.8197 16.3828 3.77006
getPartitionsByNames.10000      460.498 459.805 438.384 500.921 2.57908
```