### PR TITLE
HIVE-28064: Add cause to ParseException for diagnosability purposes

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseDriver.java
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseDriver.java
@@ -122,7 +122,7 @@ public class ParseDriver {
     try {
       r = parser.statement();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
 
     if (lexer.getErrors().size() == 0 && parser.errors.size() == 0) {
@@ -152,7 +152,7 @@ public class ParseDriver {
     try {
       r = parser.hint();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
 
     if (lexer.getErrors().size() == 0 && parser.errors.size() == 0) {
@@ -191,7 +191,7 @@ public class ParseDriver {
     try {
       r = parser.selectClause();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
 
     if (lexer.getErrors().size() == 0 && parser.errors.size() == 0) {
@@ -215,7 +215,7 @@ public class ParseDriver {
     try {
       r = parser.expression();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
 
     if (lexer.getErrors().size() == 0 && parser.errors.size() == 0) {
@@ -238,7 +238,7 @@ public class ParseDriver {
     try {
       r = parser.triggerExpressionStandalone();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
     if (lexer.getErrors().size() != 0) {
       throw new ParseException(lexer.getErrors());
@@ -258,7 +258,7 @@ public class ParseDriver {
     try {
       r = parser.triggerActionExpressionStandalone();
     } catch (RecognitionException e) {
-      throw new ParseException(parser.errors);
+      throw new ParseException(parser.errors, e);
     }
     if (lexer.getErrors().size() != 0) {
       throw new ParseException(lexer.getErrors());

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseException.java
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseException.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
-import java.util.ArrayList;
-
 /**
  * ParseException.
  *
@@ -27,10 +25,15 @@ import java.util.ArrayList;
 public class ParseException extends Exception {
 
   private static final long serialVersionUID = 1L;
-  ArrayList<ParseError> errors;
+  private final Iterable<ParseError> errors;
 
-  public ParseException(ArrayList<ParseError> errors) {
+  public ParseException(Iterable<ParseError> errors) {
     super();
+    this.errors = errors;
+  }
+
+  public ParseException(Iterable<ParseError> errors, Throwable cause) {
+    super(cause);
     this.errors = errors;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
The ParseException contains high level information about problems encountered during parsing but currently the stacktrace is pretty shallow. The end-user gets a hint about what the error might be but the developer has no way to tell how far we went into parsing the given statement and which grammar rule failed to pass.

Add RecognitionException (when available) as cause in ParseException to provide better insights around the origin of the problem and grammar rules that were invoked till the crash.

### Does this PR introduce _any_ user-facing change?
People who read the HS2 logs will see the additional stacktrace from the cause of the ParseException.

### Is the change a dependency upgrade?
No

### How was this patch tested?
Run queries with parse errors via `TestMiniLlapLocalCliDriver` and inspect logs.