### PR TITLE
HIVE-28057: Iceberg: Branches with non-lowercase characters can't be accessed.

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergBranchOperation.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergBranchOperation.java
@@ -238,4 +238,18 @@ public class TestHiveIcebergBranchOperation extends HiveIcebergStorageHandlerWit
             "ALTER TABLE customers CREATE BRANCH %s FOR TAG AS OF %s", branchName2, branchName1)))
         .isInstanceOf(IllegalArgumentException.class).hasMessageEndingWith("does not exist");
   }
+
+  @Test
+  public void testCreateBranchWithNonLowerCase() throws InterruptedException, IOException {
+    Table table =
+        testTables.createTableWithVersions(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+            fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 2);
+
+    String branchName = "test_Branch_1";
+    Long snapshotId = table.history().get(0).snapshotId();
+    shell.executeStatement(
+        String.format("ALTER TABLE customers CREATE BRANCH %s FOR SYSTEM_VERSION AS OF %d", branchName, snapshotId));
+    // Select with non-lower case branch name shouldn't throw exception.
+    shell.executeStatement(String.format("SELECT * FROM default.customers.branch_%s", branchName));
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
@@ -472,7 +472,7 @@ public final class HiveUtils {
   public static String getLowerCaseTableName(String refName) {
     String[] refParts = refName.split("\\.");
     if (refParts.length == 3 && SNAPSHOT_REF.matcher(refParts[2]).matches()) {
-      return (refParts[0].toLowerCase() + "." + refParts[1]).toLowerCase() + "." + refParts[2];
+      return (refParts[0] + "." + refParts[1]).toLowerCase() + "." + refParts[2];
     }
     return refName.toLowerCase();
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveUtils.java
@@ -468,4 +468,12 @@ public final class HiveUtils {
     Matcher ref = TAG.matcher(refName);
     return ref.matches();
   }
+
+  public static String getLowerCaseTableName(String refName) {
+    String[] refParts = refName.split("\\.");
+    if (refParts.length == 3 && SNAPSHOT_REF.matcher(refParts[2]).matches()) {
+      return (refParts[0].toLowerCase() + "." + refParts[1]).toLowerCase() + "." + refParts[2];
+    }
+    return refName.toLowerCase();
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1137,7 +1137,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     ASTNode tableTree = (ASTNode) (tabref.getChild(0));
 
-    String tabIdName = getUnescapedName(tableTree).toLowerCase();
+    String tabIdName = HiveUtils.getLowerCaseTableName(getUnescapedName(tableTree));
 
     String alias = findSimpleTableName(tabref, aliasIndex);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make branches with non lowercase characters accessible.

### Why are the changes needed?

You can create/have branches with lower cases, but can't query them

### Does this PR introduce _any_ user-facing change?

Yes, they can now query branches with non lowercase characters.

### Is the change a dependency upgrade?

No

### How was this patch tested?

UT