### PR TITLE
HIVE-21219: Remove redundant Maven repository definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,27 +227,6 @@
     <spring.version>5.3.21</spring.version>
   </properties>
   <repositories>
-    <!-- This needs to be removed before checking in-->
-    <repository>
-      <id>central</id>
-      <name>central</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <checksumPolicy>warn</checksumPolicy>
-      </releases>
-    </repository>
-    <repository>
-      <id>repository-release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
     <repository>
       <!-- shibboleth doesn't publish artifacts on maven central
         See https://wiki.shibboleth.net/confluence/display/DEV/Use+of+Maven+Central -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Drop central and repository-release repositories from pom.xml

### Why are the changes needed?
central is implicitly inherited from Super POM so no need to declare it twice. Previously it was added to enforce fetching artifacts first from there, but now it is not necessary.

repository-release is not necessary cause all ASF releases can be found in Maven central. Moreover, the project should not rely on snapshots so altogether the repository can be removed.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
mvn clean install -DskipTests -Pitests,iceberg