### PR TITLE
HIVE-26445: Use tez.local.mode.without.network for qtests

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -209,8 +209,7 @@ public class TestHiveShell {
 
     // Tez configuration
     hiveConf.setBoolean("tez.local.mode", true);
-    // TODO: enable below option once HIVE-26445 is investigated
-    // hiveConf.setBoolean("tez.local.mode.without.network", true);
+    hiveConf.setBoolean("tez.local.mode.without.network", true);
 
     // Disable vectorization for HiveIcebergInputFormat
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED, false);

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -367,8 +367,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     @Override
     public void setupConfiguration(Configuration conf) {
       conf.setBoolean(TezConfiguration.TEZ_LOCAL_MODE, true);
-      // TODO: enable below option once HIVE-26445 is investigated
-      // hiveConf.setBoolean("tez.local.mode.without.network", true);
+      conf.setBoolean("tez.local.mode.without.network", true);
       conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_OPTIMIZE_LOCAL_FETCH, true);
 
       conf.setBoolean(TezConfiguration.TEZ_IGNORE_LIB_URIS, true);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is to utilize the RPC free local DAGAppMaster introduced in TEZ-4236.


### Why are the changes needed?
Because it makes unit tests stable by not starting a useless RPC in tez local mode.

### Does this PR introduce _any_ user-facing change?
No.

### Is the change a dependency upgrade?
No.

### How was this patch tested?
All tez based qtests.
