### PR TITLE
HIVE-28071: Sync jetty version across modules

### DIFF
--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -33,7 +33,7 @@
     <druid.avatica.version>1.15.0</druid.avatica.version>
     <druid.curator.version>4.0.0</druid.curator.version>
     <druid.jersey.version>1.19.3</druid.jersey.version>
-    <druid.jetty.version>9.4.40.v20210413</druid.jetty.version>
+    <druid.jetty.version>9.4.45.v20220203</druid.jetty.version>
     <druid.derby.version>10.11.1.1</druid.derby.version>
     <druid.guava.version>16.0.1</druid.guava.version>
     <druid.guice.version>4.1.0</druid.guice.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -108,7 +108,7 @@
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <pac4j-core.version>4.5.5</pac4j-core.version>
     <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
-    <jetty.version>9.4.40.v20210413</jetty.version>
+    <jetty.version>9.4.45.v20220203</jetty.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <!-- If upgrading, upgrade atlas as well in ql/pom.xml, which brings in some springframework dependencies transitively -->
     <spring.version>5.3.21</spring.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sync jetty version across the standalone-metastore/pom.xml and itests/qtest-druid/pom.xml


### Why are the changes needed?
Looks like this was skipped in HIVE-27757. As in HIVE-24484, it was upgraded uniformly


### Does this PR introduce _any_ user-facing change?
NO

### Is the change a dependency upgrade?
Yes


### How was this patch tested?
Will see the outcome of CI
