### PR TITLE
HIVE-28078: TestTxnDbUtil should generate csv files when we query the metastore database

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestTxnDbUtil.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestTxnDbUtil.java
@@ -338,10 +338,24 @@ public final class TestTxnDbUtil {
       closeResources(conn, stmt, rs);
     }
   }
+
   public static String queryToString(Configuration conf, String query) throws Exception {
     return queryToString(conf, query, true);
   }
-  public static String queryToString(Configuration conf, String query, boolean includeHeader)
+
+  public static String queryToString(Configuration conf, String query, boolean includeHeader) throws Exception {
+    return queryToString(conf, query, includeHeader, "   ");
+  }
+
+  public static String queryToCsv(Configuration conf, String query) throws Exception {
+    return queryToString(conf, query, true, ",");
+  }
+
+  public static String queryToCsv(Configuration conf, String query, boolean includeHeader) throws Exception {
+    return queryToString(conf, query, includeHeader, ",");
+  }
+
+  public static String queryToString(Configuration conf, String query, boolean includeHeader, String columnSeparator)
       throws Exception {
     Connection conn = null;
     Statement stmt = null;
@@ -354,13 +368,13 @@ public final class TestTxnDbUtil {
       ResultSetMetaData rsmd = rs.getMetaData();
       if(includeHeader) {
         for (int colPos = 1; colPos <= rsmd.getColumnCount(); colPos++) {
-          sb.append(rsmd.getColumnName(colPos)).append("   ");
+          sb.append(rsmd.getColumnName(colPos)).append(columnSeparator);
         }
         sb.append('\n');
       }
       while(rs.next()) {
         for (int colPos = 1; colPos <= rsmd.getColumnCount(); colPos++) {
-          sb.append(rs.getObject(colPos)).append("   ");
+          sb.append(rs.getObject(colPos)).append(columnSeparator);
         }
         sb.append('\n');
       }
@@ -369,6 +383,8 @@ public final class TestTxnDbUtil {
     }
     return sb.toString();
   }
+
+
 
   /**
    * This is only for testing, it does not use the connectionPool from TxnHandler!

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestTxnDbUtil.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestTxnDbUtil.java
@@ -383,9 +383,7 @@ public final class TestTxnDbUtil {
     }
     return sb.toString();
   }
-
-
-
+  
   /**
    * This is only for testing, it does not use the connectionPool from TxnHandler!
    * @param conf


### PR DESCRIPTION
queryToString separates the columns with 3 spaces. It would improve the debugging experience if we have a method that shows the data in CSV format so that the output can be easily imported into a spreadsheet.

### What changes were proposed in this pull request?
Two new method in TestTxnDbUtil: queryToCsv (with or without header). 

### Why are the changes needed?
To easily be able to import the output into a sheet during a debugging session.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Manually
