### PR TITLE
HIVE-27405 - Throw out the detail error Invalid partition name to the…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.metastore.MsckInfo;
 import org.apache.hadoop.hive.metastore.PartitionManagementTask;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.MetastoreException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
@@ -51,7 +52,7 @@ public class MsckOperation extends DDLOperation<MsckDesc> {
   }
 
   @Override
-  public int execute() throws HiveException, IOException, TException {
+  public int execute() throws HiveException, IOException, TException, MetastoreException {
     try {
       Msck msck = new Msck(false, false);
       msck.init(Msck.getMsckConf(context.getDb().getConf()));
@@ -75,9 +76,9 @@ public class MsckOperation extends DDLOperation<MsckDesc> {
           desc.getFilterExp(), desc.getResFile(), desc.isRepairPartitions(),
           desc.isAddPartitions(), desc.isDropPartitions(), partitionExpirySeconds);
       return msck.repair(msckInfo);
-    } catch (MetaException e) {
+    } catch (MetaException | MetastoreException e) {
       LOG.error("Unable to create msck instance.", e);
-      return 1;
+      throw e;
     } catch (SemanticException e) {
       LOG.error("Msck failed.", e);
       return 1;

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMSCKRepairOnAcid.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMSCKRepairOnAcid.java
@@ -507,4 +507,19 @@ public class TestMSCKRepairOnAcid extends TxnCommandsBaseForTests {
 
     runStatementOnDriver("drop table if exists " + acidTblMsck);
   }
+
+  @Test
+  public void testInvalidPartitionNameErrorMessage() throws Exception {
+    runStatementOnDriver("drop table if exists " + acidTblPartMsck);
+    runStatementOnDriver("create table " + acidTblPartMsck
+            + " (a int, b int) partitioned by (p string) clustered by (a) into 2 buckets"
+            + " stored as orc TBLPROPERTIES ('transactional'='true')");
+    FileSystem fs = FileSystem.get(hiveConf);
+    fs.mkdirs(new Path(getWarehouseDir(), acidTblPartMsck+ "/part"));
+    try {
+      runStatementOnDriver("msck repair table " + acidTblPartMsck);
+    } catch (Exception e){
+      Assert.assertEquals("Error message did not match",true,e.getMessage().contains("Invalid partition name"));
+    }
+  }
 }

--- a/ql/src/test/queries/clientnegative/msck_repair_7.q
+++ b/ql/src/test/queries/clientnegative/msck_repair_7.q
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS repairtable;
+
+CREATE TABLE repairtable(col STRING) PARTITIONED BY (p1 STRING);
+
+dfs ${system:test.dfs.mkdir} ${hiveconf:hive.metastore.warehouse.dir}/repairtable/p1a;
+
+MSCK REPAIR TABLE default.repairtable;

--- a/ql/src/test/queries/clientnegative/msck_repair_8.q
+++ b/ql/src/test/queries/clientnegative/msck_repair_8.q
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS repairtable;
+
+CREATE TABLE repairtable(col STRING) PARTITIONED BY (p1 STRING);
+
+MSCK REPAIR TABLE default.repairtable.p1;

--- a/ql/src/test/results/clientnegative/msck_repair_1.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_1.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK is missing partition columns under hdfs://### HDFS PATH ###
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/msck_repair_1.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_1.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK is missing partition columns under hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/msck_repair_2.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_2.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK finds a file rather than a directory when it searches for hdfs://### HDFS PATH ###
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/msck_repair_2.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_2.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK finds a file rather than a directory when it searches for hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/msck_repair_3.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_3.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK finds a file rather than a directory when it searches for hdfs://### HDFS PATH ###
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/msck_repair_3.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_3.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: MSCK finds a file rather than a directory when it searches for hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/msck_repair_4.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_4.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK REPAIR TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: Unexpected partition key p2 found at hdfs://### HDFS PATH ###
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/msck_repair_4.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_4.q.out
@@ -21,4 +21,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK REPAIR TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: Unexpected partition key p2 found at hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/msck_repair_5.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_5.q.out
@@ -29,4 +29,4 @@ Partitions not in metastore:	repairtable:p1=A
 PREHOOK: query: MSCK REPAIR TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. Found two paths for same partition 'repairtable:p1=a' for table repairtable

--- a/ql/src/test/results/clientnegative/msck_repair_7.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_7.q.out
@@ -15,18 +15,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK REPAIR TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-POSTHOOK: query: MSCK REPAIR TABLE default.repairtable
-POSTHOOK: type: MSCK
-POSTHOOK: Output: default@repairtable
-PREHOOK: query: MSCK REPAIR TABLE default.repairtable
-PREHOOK: type: MSCK
-PREHOOK: Output: default@repairtable
-POSTHOOK: query: MSCK REPAIR TABLE default.repairtable
-POSTHOOK: type: MSCK
-POSTHOOK: Output: default@repairtable
-Partitions not in metastore:	repairtable:p1=a
-#### A masked pattern was here ####
-PREHOOK: query: MSCK REPAIR TABLE default.repairtable
-PREHOOK: type: MSCK
-PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. The partition 'repairtable:p1=a' already exists for tablerepairtable
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: Invalid partition name hdfs://### HDFS PATH ###

--- a/ql/src/test/results/clientnegative/msck_repair_7.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_7.q.out
@@ -15,4 +15,4 @@ POSTHOOK: Output: default@repairtable
 PREHOOK: query: MSCK REPAIR TABLE default.repairtable
 PREHOOK: type: MSCK
 PREHOOK: Output: default@repairtable
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. org.apache.hadoop.hive.metastore.api.MetastoreException: Invalid partition name hdfs://### HDFS PATH ###
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientnegative/msck_repair_8.q.out
+++ b/ql/src/test/results/clientnegative/msck_repair_8.q.out
@@ -1,0 +1,15 @@
+PREHOOK: query: DROP TABLE IF EXISTS repairtable
+PREHOOK: type: DROPTABLE
+PREHOOK: Output: database:default
+POSTHOOK: query: DROP TABLE IF EXISTS repairtable
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Output: database:default
+PREHOOK: query: CREATE TABLE repairtable(col STRING) PARTITIONED BY (p1 STRING)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@repairtable
+POSTHOOK: query: CREATE TABLE repairtable(col STRING) PARTITIONED BY (p1 STRING)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@repairtable
+FAILED: SemanticException [Error 10431]: Table Meta Ref extension is not supported for table repairtable.

--- a/ql/src/test/results/clientnegative/table_nonprintable_negative.q.out
+++ b/ql/src/test/results/clientnegative/table_nonprintable_negative.q.out
@@ -17,4 +17,4 @@ POSTHOOK: Output: default@table_external
 PREHOOK: query: msck repair table table_external
 PREHOOK: type: MSCK
 PREHOOK: Output: default@table_external
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. Repair: Cannot add partition table_external:day=Foo due to invalid characters in the name

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Msck.java
@@ -125,7 +125,7 @@ public class Msck {
    * @param msckInfo Information about the tables and partitions we want to check for.
    * @return Returns 0 when execution succeeds and above 0 if it fails.
    */
-  public int repair(MsckInfo msckInfo) {
+  public int repair(MsckInfo msckInfo) throws TException, MetastoreException, IOException {
     CheckResult result = null;
     List<String> repairOutput = new ArrayList<>();
     String qualifiedTableName = null;
@@ -271,6 +271,7 @@ public class Msck {
     } catch (Exception e) {
       LOG.warn("Failed to run metacheck: ", e);
       success = false;
+      throw e;
     } finally {
       if (result != null) {
         logResult(result);


### PR DESCRIPTION
… clients

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When try to MSCK TABLE, if there is a directory that doesn't match the partition format, the query fails. However, it doesn't thrown out the detail error information to the client. Rethrowing exception coming from msck.repair call

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, change in error message thrown when there is an issue with msck repair command execution
### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Junit test case added